### PR TITLE
feat(integrations): add MYOB Business API

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1469,6 +1469,7 @@
               "api-integrations/monday",
               "integrations/all/momentum-io",
               "integrations/all/mural",
+              "integrations/all/myob",
               "api-integrations/n8n",
               "api-integrations/nable-ncentral",
               "integrations/all/nationbuilder",

--- a/docs/integrations/all/myob.mdx
+++ b/docs/integrations/all/myob.mdx
@@ -1,0 +1,45 @@
+---
+title: MYOB Business
+sidebarTitle: MYOB Business
+---
+
+<Overview />
+
+## Access requirements
+| Pre-Requisites | Status | Comment|
+| - | - | - |
+| Paid dev account | ✅ Not required | Free developer registration at my.myob (Developer tab access is granted on approval). |
+| Paid test account | ❓ |  |
+| Partnership | ✅ Not required | |
+| App review | ✅ Not required | |
+| Security audit | ✅ Not required | |
+
+
+## Setup guide
+
+1. Register as a developer with MYOB, then open the **Developer** tab in [my.myob](https://my.myob.com).
+2. Create an app: give it a name, set your **Redirect URL** (must be https), and copy the generated **API key** (client id) and **secret**.
+3. Use the API key and secret as the OAuth client credentials in Nango.
+
+Note: every MYOB API call also requires the `x-myobapi-key` header set to your API key and `x-myobapi-version: v2`, in addition to the bearer token.
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+<Note>Contribute improvements to the setup guide by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/myob.mdx)</Note>
+
+## Useful links
+
+-   [MYOB developer centre](https://developer.myob.com)
+-   [OAuth authentication guide](https://developer.myob.com/api/myob-business-api/api-overview/authentication/)
+-   [List of scopes](https://developer.myob.com/api/myob-business-api/api-overview/scopes/)
+-   [MYOB Business API docs](https://developer.myob.com/api/myob-business-api/v2/)
+
+<Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/myob.mdx)</Note>
+
+## API gotchas
+
+-   The token endpoint is `https://secure.myob.com/oauth2/v1/authorize` (yes, `authorize`), posted as `application/x-www-form-urlencoded`.
+-   Every API request needs `x-myobapi-key` (your API key) and `x-myobapi-version: v2` headers alongside the bearer token.
+-   MYOB has announced endpoint upgrades from 1 September 2026 affecting how company file ids (businessId) are obtained; check the developer centre for current guidance.
+
+<Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/myob.mdx)</Note>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -14363,6 +14363,23 @@ mural:
         base_url: https://app.mural.co
     docs: https://nango.dev/docs/integrations/all/mural
 
+myob:
+    display_name: MYOB Business
+    categories:
+        - accounting
+    auth_mode: OAUTH2
+    authorization_url: https://secure.myob.com/oauth2/account/authorize
+    token_url: https://secure.myob.com/oauth2/v1/authorize
+    authorization_params:
+        response_type: code
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
+    proxy:
+        base_url: https://api.myob.com
+    docs: https://nango.dev/docs/integrations/all/myob
+
 n8n:
     display_name: n8n
     categories:


### PR DESCRIPTION
Adds MYOB Business (the MYOB SME accounting platform, dominant in Australia and New Zealand alongside Xero) as an OAuth2 provider.

Endpoints follow MYOB's published OAuth guide: authorization at `secure.myob.com/oauth2/account/authorize`, token exchange at `secure.myob.com/oauth2/v1/authorize` (their documented, if oddly named, token URL), refresh via standard `refresh_token` grant, proxy base `api.myob.com`. Docs page includes the setup guide for registering an app in the my.myob Developer tab and the `x-myobapi-key`/`x-myobapi-version` header gotcha.

Config validated against `scripts/validation/providers/schema.json` (whole providers map parses and passes with the new entry). We run a production Nango Cloud account (Nuromi, an Australian business dashboard) with a live MYOB use case queued behind this template, so it will get real-world exercise as soon as it ships.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

