### PR TITLE
feat(integrations): add Deputy

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1155,6 +1155,7 @@
               "integrations/all/deel",
               "integrations/all/deel-sandbox",
               "api-integrations/dentally",
+              "integrations/all/deputy",
               "integrations/all/devin",
               "api-integrations/demodesk",
               "integrations/all/dialpad",

--- a/docs/integrations/all/deputy.mdx
+++ b/docs/integrations/all/deputy.mdx
@@ -1,0 +1,42 @@
+---
+title: Deputy
+sidebarTitle: Deputy
+---
+
+<Overview />
+
+## Access requirements
+| Pre-Requisites | Status | Comment|
+| - | - | - |
+| Paid dev account | ✅ Not required | Any Deputy account can register an OAuth client. |
+| Paid test account | ❓ | Deputy offers free trials. |
+| Partnership | ✅ Not required | |
+| App review | ✅ Not required | |
+| Security audit | ✅ Not required | |
+
+
+## Setup guide
+
+1. Sign in to Deputy, then open `https://{yourinstall}.{geo}.deputy.com/exec/devapp/oauth_clients`.
+2. Create a new OAuth client: set a name and your **Redirect URI**.
+3. Copy the **Client ID** and **Client Secret** into Nango.
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+<Note>Contribute improvements to the setup guide by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/deputy.mdx)</Note>
+
+## Useful links
+
+-   [Authenticating with Deputy overview](https://developer.deputy.com/docs/authenticating-with-deputy)
+-   [Using OAuth 2.0](https://developer.deputy.com/docs/using-oauth-20)
+-   [Deputy API docs](https://developer.deputy.com/deputy-docs/reference)
+
+<Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/deputy.mdx)</Note>
+
+## API gotchas
+
+-   The scope is always `longlife_refresh_token`; without it the refresh token is short-lived.
+-   The token response carries an `endpoint` field naming the customer's installation host (e.g. `myinstall.au.deputy.com`). All API calls and token refreshes go to that host, not to once.deputy.com; the template captures it automatically into the connection config.
+-   Access tokens last 24 hours.
+
+<Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/deputy.mdx)</Note>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -6275,6 +6275,39 @@ dentally:
                 - api.ca.dentally.com
             doc_section: '#step-1-choose-your-environment'
 
+deputy:
+    display_name: Deputy
+    categories:
+        - hr
+    auth_mode: OAUTH2
+    authorization_url: https://once.deputy.com/my/oauth/login
+    token_url: https://once.deputy.com/my/oauth/access_token
+    refresh_url: https://${connectionConfig.endpoint}/oauth/access_token
+    default_scopes:
+        - longlife_refresh_token
+    authorization_params:
+        response_type: code
+    token_params:
+        grant_type: authorization_code
+        scope: longlife_refresh_token
+    refresh_params:
+        grant_type: refresh_token
+    token_response_metadata:
+        - endpoint
+    proxy:
+        base_url: https://${connectionConfig.endpoint}
+        verification:
+            method: GET
+            endpoints:
+                - /api/v1/me
+    connection_config:
+        endpoint:
+            type: string
+            title: Deputy installation host
+            description: Your Deputy installation host, e.g. myinstall.au.deputy.com. Captured automatically during sign-in.
+            automated: true
+    docs: https://nango.dev/docs/integrations/all/deputy
+
 devin:
     display_name: Devin
     categories:


### PR DESCRIPTION
Adds Deputy (workforce management: rosters, timesheets, leave) as an OAuth2 provider.

Endpoints follow Deputy's published OAuth 2.0 guide: authorization at `once.deputy.com/my/oauth/login`, token exchange at `once.deputy.com/my/oauth/access_token` with the mandatory `longlife_refresh_token` scope. Deputy returns the customer's installation host in the token response's `endpoint` field; the template captures it via `token_response_metadata` and uses it for both the proxy base URL and the refresh URL, since refreshes happen against the customer's install rather than once.deputy.com. Verification pings `GET /api/v1/me`.

Config validated against `scripts/validation/providers/schema.json` (whole providers map parses and passes with the new entry). We run a production Nango Cloud account (Nuromi) with a live Deputy use case queued behind this template.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

