### PR TITLE
fix: ipv6 classification

### DIFF
--- a/packages/egress/lib/egress.unit.test.ts
+++ b/packages/egress/lib/egress.unit.test.ts
@@ -69,6 +69,32 @@ describe('egress IP classification', () => {
         expect(classifyBlockedIp('fea0::1')).toBe('link_local');
         expect(classifyBlockedIp('feb0::1')).toBe('link_local');
     });
+
+    it('blocks NAT64 well-known prefix when the embedded IPv4 is blocked (RFC 6052)', () => {
+        expect(classifyBlockedIp('64:ff9b::127.0.0.1')).toBe('loopback');
+        expect(classifyBlockedIp('64:ff9b::7f00:1')).toBe('loopback');
+        expect(classifyBlockedIp('64:ff9b::a9fe:a9fe')).toBe('link_local');
+        expect(classifyBlockedIp('64:ff9b::a00:1')).toBe('private');
+    });
+
+    it('blocks NAT64 local-use prefix wholesale (RFC 8215)', () => {
+        expect(classifyBlockedIp('64:ff9b:1::1')).toBe('private');
+    });
+
+    it('blocks 6to4 when the embedded IPv4 is blocked (RFC 3056)', () => {
+        expect(classifyBlockedIp('2002:7f00:0001::')).toBe('loopback');
+        expect(classifyBlockedIp('2002:a9fe:a9fe::')).toBe('link_local');
+    });
+
+    it('blocks Teredo prefix wholesale (RFC 4380)', () => {
+        expect(classifyBlockedIp('2001:0000:4136:e378:8000:63bf:56ff:fefe')).toBe('private');
+    });
+
+    it('still classifies IPv4-mapped forms and allows public IPv6', () => {
+        expect(classifyBlockedIp('::ffff:127.0.0.1')).toBe('loopback');
+        expect(classifyBlockedIp('::ffff:169.254.169.254')).toBe('link_local');
+        expect(classifyBlockedIp('2606:4700:4700::1111')).toBeNull();
+    });
 });
 
 describe('egress validateOutboundUrl', () => {
@@ -89,6 +115,14 @@ describe('egress validateOutboundUrl', () => {
         expect(result.ok).toBe(false);
     });
 
+    it('blocks IPv6 transition IP literals sync via shared classifier', () => {
+        expect(validateOutboundUrlSync('http://[64:ff9b::127.0.0.1]/', policy).ok).toBe(false);
+        expect(validateOutboundUrlSync('http://[64:ff9b::a9fe:a9fe]/', policy).ok).toBe(false);
+        expect(validateOutboundUrlSync('http://[2002:7f00:1::]/', policy).ok).toBe(false);
+        expect(validateOutboundUrlSync('http://[2001:0:4136:e378:8000:63bf:56ff:fefe]/', policy).ok).toBe(false);
+        expect(validateOutboundUrlSync('http://[::ffff:169.254.169.254]/', policy).ok).toBe(false);
+    });
+
     it('allows public hostname sync', () => {
         const result = validateOutboundUrlSync('https://api.example.com/v1', policy);
         expect(result.ok).toBe(true);
@@ -96,6 +130,15 @@ describe('egress validateOutboundUrl', () => {
 
     it('blocks DNS rebinding to private IP', async () => {
         vi.spyOn(dns, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+        const result = await validateOutboundUrlAsync('https://allowed.example.com/path', policy);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('denied_dns');
+        }
+    });
+
+    it('blocks DNS rebinding to IPv6 transition addresses via shared classifier', async () => {
+        vi.spyOn(dns, 'lookup').mockResolvedValue([{ address: '64:ff9b::a9fe:a9fe', family: 6 }] as never);
         const result = await validateOutboundUrlAsync('https://allowed.example.com/path', policy);
         expect(result.ok).toBe(false);
         if (!result.ok) {

--- a/packages/egress/lib/ip.ts
+++ b/packages/egress/lib/ip.ts
@@ -170,6 +170,32 @@ function classifyBlockedIpv6(ip: string): BlockedIpReason | null {
         }
     }
 
+    // NAT64 well-known prefix 64:ff9b::/96 (RFC 6052) and local-use 64:ff9b:1::/48 (RFC 8215)
+    if (h0 === 0x64 && h1 === 0xff9b) {
+        if (h2 === 1) {
+            return 'private';
+        }
+        if (h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+            const nat64 = classifyBlockedIpv4(hextetsToIpv4(h6, h7));
+            if (nat64) {
+                return nat64;
+            }
+        }
+    }
+
+    // 6to4 2002::/16 (RFC 3056): IPv4 is embedded in bits 16–47
+    if (h0 === 0x2002) {
+        const sixToFour = classifyBlockedIpv4(hextetsToIpv4(h1, h2));
+        if (sixToFour) {
+            return sixToFour;
+        }
+    }
+
+    // Teredo 2001:0000::/32 (RFC 4380)
+    if (h0 === 0x2001 && h1 === 0) {
+        return 'private';
+    }
+
     if ((h0 & 0xffc0) === 0xfe80) {
         return 'link_local';
     }


### PR DESCRIPTION
## Summary
- Extend `classifyBlockedIpv6` to handle IPv6 transition addresses that embed IPv4: NAT64 (`64:ff9b::/96`, `64:ff9b:1::/48`), 6to4 (`2002::/16`), and Teredo (`2001:0::/32`).
- Reuse `hextetsToIpv4` / `classifyBlockedIpv4` for prefixes that carry an embedded IPv4; block the local-use NAT64 and Teredo ranges wholesale.
- Add unit tests for classification, sync IP literals, and DNS resolution through the shared classifier.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

