### PR TITLE
fix: /connect/telemetry fails if timestamp is outside of allowed range

### DIFF
--- a/packages/server/lib/controllers/connect/postTelemetry.integration.test.ts
+++ b/packages/server/lib/controllers/connect/postTelemetry.integration.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { seeders } from '@nangohq/shared';
+
+import { getConnectSessionToken, isError, runServer } from '../../utils/tests.js';
+import { MAX_CLOCK_SKEW_MS } from './postTelemetry.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+let connectSessionToken: string;
+
+const endpoint = '/connect/telemetry';
+
+describe(`POST ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+        connectSessionToken = await getConnectSessionToken(api, apiKey.secret);
+    });
+
+    beforeEach(() => {
+        const now = Date.now();
+        vi.spyOn(Date, 'now').mockReturnValue(now);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it.each([
+        ['a current timestamp', 0],
+        ['a timestamp at the maximum allowed clock skew in the past', -MAX_CLOCK_SKEW_MS],
+        ['a timestamp at the maximum allowed clock skew in the future', MAX_CLOCK_SKEW_MS]
+    ])('accepts telemetry with %s', async (_description, offset) => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            body: {
+                token: connectSessionToken,
+                event: 'open',
+                timestamp: new Date(Date.now() + offset)
+            }
+        });
+
+        expect(res.res.status).toBe(204);
+    });
+
+    it.each([
+        ['older than the maximum allowed clock skew', -MAX_CLOCK_SKEW_MS - 60_000],
+        ['further ahead than the maximum allowed clock skew', MAX_CLOCK_SKEW_MS + 60_000]
+    ])('rejects telemetry with a timestamp %s', async (_description, offset) => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            body: {
+                token: connectSessionToken,
+                event: 'open',
+                timestamp: new Date(Date.now() + offset)
+            }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'invalid_body',
+                errors: [{ code: 'custom', message: `timestamp is more than ${MAX_CLOCK_SKEW_MS}ms away from the current time`, path: ['timestamp'] }]
+            }
+        });
+        expect(res.res.status).toBe(400);
+    });
+});

--- a/packages/server/lib/controllers/connect/postTelemetry.ts
+++ b/packages/server/lib/controllers/connect/postTelemetry.ts
@@ -9,6 +9,8 @@ import { asyncWrapper } from '../../utils/asyncWrapper.js';
 
 import type { PostPublicConnectTelemetry } from '@nangohq/types';
 
+export const MAX_CLOCK_SKEW_MS = 2 * 60 * 60 * 1000;
+
 export const bodySchema = z
     .object({
         token: z.string(),
@@ -29,7 +31,10 @@ export const bodySchema = z
             'popup:blocked_by_browser',
             'popup:closed_early'
         ]),
-        timestamp: z.coerce.date(),
+        // Discard dates too far from the current time to deal with clients with a misconfigured clock
+        timestamp: z.coerce.date().refine((date) => Math.abs(date.getTime() - Date.now()) <= MAX_CLOCK_SKEW_MS, {
+            message: `timestamp is more than ${MAX_CLOCK_SKEW_MS}ms away from the current time`
+        }),
         dimensions: z.object({ integration: providerConfigKeySchema.optional() }).optional()
     })
     .strict();


### PR DESCRIPTION
Clients with skew clocks could submit telemetry events that are too far in the past or too much in the future.
This commit returns a 400 response if timestamp isn't within a 2 hours range around current time.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

