### PR TITLE
fix(connections): don't surface refresh-lock timeouts as credential failures

### DIFF
--- a/packages/kvstore/lib/Locking.ts
+++ b/packages/kvstore/lib/Locking.ts
@@ -4,6 +4,22 @@ export interface Lock {
     readonly key: string;
 }
 
+export class LockAcquisitionTimeoutError extends Error {
+    constructor(key: string, acquisitionTimeoutMs: number) {
+        super(`Acquiring lock for key: ${key} timed out after ${acquisitionTimeoutMs}ms`);
+        this.name = 'LockAcquisitionTimeoutError';
+    }
+}
+
+// Thrown when the lock is genuinely held by someone else (expected contention), as opposed to the
+// backing store failing outright. Only this case should be retried/eventually reported as a timeout.
+export class LockAlreadyHeldError extends Error {
+    constructor(key: string) {
+        super(`Lock for key: ${key} is already held`);
+        this.name = 'LockAlreadyHeldError';
+    }
+}
+
 export class Locking {
     private store: KVStore;
 
@@ -24,11 +40,17 @@ export class Locking {
             try {
                 await this.acquire(key, ttlMs);
                 return { key };
-            } catch {
+            } catch (err) {
+                if (!(err instanceof LockAlreadyHeldError)) {
+                    // A genuine backing-store failure (e.g. a Redis outage), not lock contention: fail
+                    // fast instead of retrying for the whole acquisition window and mislabeling it as a
+                    // timeout once it's just as likely someone else legitimately holds the lock.
+                    throw err;
+                }
                 await new Promise((resolve) => setTimeout(resolve, 50));
             }
         }
-        throw new Error(`Acquiring lock for key: ${key} timed out after ${acquisitionTimeoutMs}ms`);
+        throw new LockAcquisitionTimeoutError(key, acquisitionTimeoutMs);
     }
 
     public async acquire(key: string, ttlMs: number): Promise<Lock> {
@@ -38,6 +60,9 @@ export class Locking {
         try {
             await this.store.set(key, '1', { canOverride: false, ttlMs: ttlMs });
         } catch (err) {
+            if (err instanceof Error && err.message === 'set_key_already_exists') {
+                throw new LockAlreadyHeldError(key);
+            }
             throw new Error(`Failed to acquire lock for key: ${key}`, { cause: err });
         }
         return { key };

--- a/packages/kvstore/lib/Locking.unit.test.ts
+++ b/packages/kvstore/lib/Locking.unit.test.ts
@@ -1,7 +1,7 @@
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { InMemoryKVStore } from './InMemoryStore.js';
-import { Locking } from './Locking.js';
+import { LockAcquisitionTimeoutError, LockAlreadyHeldError, Locking } from './Locking.js';
 
 describe('Locking', () => {
     let store: InMemoryKVStore;
@@ -29,7 +29,17 @@ describe('Locking', () => {
 
     it('should prevents acquisition of existing lock', async () => {
         await locking.acquire(KEY, 1000);
-        await expect(locking.acquire(KEY, 1000)).rejects.toThrowError('Failed to acquire lock for key: key');
+        await expect(locking.acquire(KEY, 1000)).rejects.toThrowError(new LockAlreadyHeldError(KEY));
+    });
+
+    it('should fail fast on a genuine store error instead of retrying until timeout', async () => {
+        const setSpy = vi.spyOn(store, 'set').mockRejectedValue(new Error('connection refused'));
+        try {
+            await expect(locking.tryAcquire(KEY, 1000, 2000)).rejects.not.toBeInstanceOf(LockAcquisitionTimeoutError);
+            expect(setSpy).toHaveBeenCalledOnce();
+        } finally {
+            setSpy.mockRestore();
+        }
     });
 
     it('should acquire an expired lock', async () => {

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -11,7 +11,7 @@ import type { NangoRedisClient, RedisBoundary } from './redisClient.js';
 export { InMemoryKVStore } from './InMemoryStore.js';
 export { RedisKVStore } from './RedisStore.js';
 export type { DeleteIfValueEqualsWithCompanionArgs, KVStore, SetIfValueEqualsWithCompanionArgs, SetNxWithCompanionArgs } from './KVStore.js';
-export { type Lock, Locking } from './Locking.js';
+export { type Lock, LockAcquisitionTimeoutError, LockAlreadyHeldError, Locking } from './Locking.js';
 export { type NangoRedisClient, type RedisBoundary, getCustomerRedisUrl, getRedisClientOptions, getRedisUrl } from './redisClient.js';
 
 type KvBoundary = RedisBoundary;

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.integration.test.ts
@@ -1,6 +1,7 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db from '@nangohq/database';
+import { LockAcquisitionTimeoutError, Locking } from '@nangohq/kvstore';
 import { connectionService, seeders } from '@nangohq/shared';
 import { MAX_CONSECUTIVE_DAYS_FAILED_REFRESH } from '@nangohq/shared/lib/services/connections/utils.js';
 
@@ -335,5 +336,32 @@ describe(`GET ${endpoint}`, () => {
                 }
             }
         });
+    });
+
+    it('should return refresh_lock_timeout instead of invalid_credentials if the refresh lock times out', async () => {
+        const provider = 'hubspot';
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, provider, provider);
+        const conn = await seeders.createConnectionSeed({
+            env,
+            provider,
+            rawCredentials: { type: 'OAUTH2', access_token: 'test_access_token', refresh_token: 'not_working', raw: {} }
+        });
+
+        const lockSpy = vi.spyOn(Locking.prototype, 'tryAcquire').mockRejectedValue(new LockAcquisitionTimeoutError('lock:refresh:test', 12000));
+        try {
+            const res = await api.fetch(endpoint, {
+                method: 'GET',
+                token: apiKey.secret,
+                params: { connectionId: conn.connection_id },
+                query: { provider_config_key: provider, force_refresh: true }
+            });
+
+            expect(res.res.status).toBe(424);
+            isError(res.json);
+            expect(res.json.error.code).toBe('refresh_lock_timeout');
+        } finally {
+            lockSpy.mockRestore();
+        }
     });
 });

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.ts
@@ -106,9 +106,10 @@ export const getPublicConnection = asyncWrapper<GetPublicConnection>(async (req,
     if (credentialResponse.isErr()) {
         const { connection, ...payload } = credentialResponse.error.payload || {};
         const apiPublicConnection = await getApiPublicConnection();
+        const code = credentialResponse.error.type === 'refresh_lock_timeout' ? 'refresh_lock_timeout' : 'invalid_credentials';
         res.status(credentialResponse.error.status).send({
             error: {
-                code: 'invalid_credentials',
+                code,
                 message: credentialResponse.error.message || 'Failed to refresh or test credentials',
                 payload: {
                     ...payload,

--- a/packages/shared/lib/services/connections/credentials/refresh.integration.test.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
+import { LockAcquisitionTimeoutError, Locking } from '@nangohq/kvstore';
 import { logContextGetter, migrateLogsMapping } from '@nangohq/logs';
 import { Err, Ok, wait } from '@nangohq/utils';
 
@@ -338,6 +339,59 @@ describe('refreshOrTestCredentials', () => {
         });
         expect(decryptedUpdatedConnection.last_fetched_at?.getTime()).toBeGreaterThan(decryptedConnection.last_fetched_at!.getTime());
         expect(decryptedUpdatedConnection.updated_at?.getTime()).toBeGreaterThan(decryptedConnection.updated_at.getTime());
+    });
+
+    it('should not call onRefreshFailed nor increment refresh_attempts if the refresh lock times out', async () => {
+        const { env, account } = await seedAccountEnvAndUser();
+        const integration = await createConfigSeed(env, 'airtable', 'airtable');
+        const connection = await createConnectionSeed({
+            env,
+            provider: 'airtable',
+            rawCredentials: { type: 'OAUTH2', access_token: 'foobar', refresh_token: 'barfoo', expires_at: new Date(Date.now() - 1000), raw: {} }
+        });
+        const decryptedConnection = encryptionManager.decryptConnection(connection);
+        if (!decryptedConnection) {
+            throw new Error('Failed to decrypt connection');
+        }
+
+        await wait(2);
+        const lockSpy = vi.spyOn(Locking.prototype, 'tryAcquire').mockRejectedValue(new LockAcquisitionTimeoutError('lock:refresh:test', 12000));
+        const onFailed = vi.fn();
+        const onSuccess = vi.fn();
+        let res: Awaited<ReturnType<typeof refreshOrTestCredentials>>;
+        try {
+            res = await refreshOrTestCredentials({
+                account,
+                environment: env,
+                integration,
+                instantRefresh: false,
+                connection: decryptedConnection,
+                onRefreshFailed: onFailed,
+                onRefreshSuccess: onSuccess,
+                logContextGetter: logContextGetter
+            });
+        } finally {
+            lockSpy.mockRestore();
+        }
+
+        if (res.isOk()) {
+            throw new Error('should not succeed');
+        }
+        expect(res.error.type).toBe('refresh_lock_timeout');
+
+        expect(onFailed).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+
+        // Lock contention must not count as a failed refresh attempt: no failure timestamp, no attempt increment
+        const updatedConnection = await connectionService.getConnectionById(connection.id);
+        const decryptedUpdatedConnection = encryptionManager.decryptConnection(updatedConnection!);
+        if (!decryptedUpdatedConnection) {
+            throw new Error('Failed to decrypt updated connection');
+        }
+        expect(decryptedUpdatedConnection).toStrictEqual({
+            ...decryptedConnection,
+            last_fetched_at: expect.any(Date)
+        });
     });
 
     it('should return early with connection_refresh_exhausted if refresh_exhausted is set', async () => {

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -455,34 +455,22 @@ export async function refreshCredentialsIfNeeded({
             const ttlInMs = 10000;
             const acquisitionTimeoutMs = ttlInMs * 1.2; // giving some extra time for the lock to be released
 
-            let connectionToRefresh: DBConnectionDecrypted;
-            try {
-                const lockKey = `lock:refresh:${environment_id}:${providerConfigKey}:${connectionId}`;
-                lock = await locking.tryAcquire(lockKey, ttlInMs, acquisitionTimeoutMs);
+            // If the lock times out here, let it propagate straight to the outer catch below, which
+            // already matches on the error type (LockAcquisitionTimeoutError -> 'refresh_lock_timeout')
+            // to decide how to handle it. No need to duplicate that decision here.
+            const lockKey = `lock:refresh:${environment_id}:${providerConfigKey}:${connectionId}`;
+            lock = await locking.tryAcquire(lockKey, ttlInMs, acquisitionTimeoutMs);
 
-                // Another refresh was potentially being executed so we check if the credentials were refreshed
-                // If yes, we return the new credentials
-                // If not, we proceed with the refresh
-                const { connection, freshCredentials, shouldRefresh } = await getConnectionAndFreshCredentials();
-                if (freshCredentials) {
-                    return Ok({ connection, refreshed: false, credentials: freshCredentials });
-                }
-
-                logger.info('Refreshing connection', { connectionId: connection.id, reason: shouldRefresh.reason });
-                connectionToRefresh = connection;
-            } catch (err) {
-                // lock acquisition might have timed out
-                // but refresh might have been successfully performed by another execution
-                // while we were waiting for the lock
-                // so we check if the credentials were refreshed
-                // if yes, we return the new credentials
-                // if not, we actually fail the refresh
-                const { connection, freshCredentials } = await getConnectionAndFreshCredentials();
-                if (freshCredentials) {
-                    return Ok({ connection, refreshed: false, credentials: freshCredentials });
-                }
-                throw err;
+            // Another refresh was potentially being executed so we check if the credentials were refreshed
+            // If yes, we return the new credentials
+            // If not, we proceed with the refresh
+            const { connection, freshCredentials, shouldRefresh } = await getConnectionAndFreshCredentials();
+            if (freshCredentials) {
+                return Ok({ connection, refreshed: false, credentials: freshCredentials });
             }
+
+            logger.info('Refreshing connection', { connectionId: connection.id, reason: shouldRefresh.reason });
+            let connectionToRefresh: DBConnectionDecrypted = connection;
 
             const {
                 success,
@@ -563,14 +551,19 @@ export async function refreshCredentialsIfNeeded({
                 credentials: newCredentials as RefreshableCredentials
             });
         } catch (err) {
-            let error: NangoError;
             if (err instanceof LockAcquisitionTimeoutError) {
-                error = new NangoError('refresh_lock_timeout', { message: err.message });
-            } else {
-                error = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });
+                // The lock might have timed out because another execution was already refreshing this
+                // connection. Check if it completed in the meantime before failing: if credentials are
+                // fresh now, this is a genuine success, not a lock-contention failure.
+                const { connection, freshCredentials } = await getConnectionAndFreshCredentials();
+                if (freshCredentials) {
+                    return Ok({ connection, refreshed: false, credentials: freshCredentials });
+                }
+
+                return Err(new NangoError('refresh_lock_timeout', { message: err.message }));
             }
 
-            return Err(error);
+            return Err(new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' }));
         } finally {
             if (lock) {
                 try {

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -1,6 +1,6 @@
 import tracer from 'dd-trace';
 
-import { getLocking } from '@nangohq/kvstore';
+import { getLocking, LockAcquisitionTimeoutError } from '@nangohq/kvstore';
 import { getProvider } from '@nangohq/providers';
 import { Err, FixedSizeMap, getLogger, metrics, Ok } from '@nangohq/utils';
 
@@ -134,12 +134,19 @@ export async function refreshOrTestCredentials(props: RefreshProps): Promise<Res
         }
 
         if (res.isErr()) {
-            span.setTag('error', res.error);
-            await connectionService.setRefreshFailure({
-                id: props.connection.id,
-                lastRefreshFailure: props.connection.last_refresh_failure,
-                currentAttempt: props.connection.refresh_attempts || 0
-            });
+            // A lock timeout is not a genuine refresh failure (another execution may already be refreshing
+            // this connection), so it should not be traced as an error nor count towards the connection's
+            // refresh-exhaustion attempts.
+            if (res.error.type === 'refresh_lock_timeout') {
+                span.setTag('refreshLockTimeout', true);
+            } else {
+                span.setTag('error', res.error);
+                await connectionService.setRefreshFailure({
+                    id: props.connection.id,
+                    lastRefreshFailure: props.connection.last_refresh_failure,
+                    currentAttempt: props.connection.refresh_attempts || 0
+                });
+            }
             return res;
         }
 
@@ -220,23 +227,33 @@ async function refreshCredentials(
         );
         logCtx.merge(logsBuffer);
 
-        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FAILED);
-        void logCtx.error('Failed to refresh credentials', err);
-        await logCtx.failed();
+        if (err.type === 'refresh_lock_timeout') {
+            // Failing to acquire the refresh lock does not mean the credentials are actually invalid:
+            // another execution is (or was) already refreshing the same connection. Treat it as a skipped
+            // attempt rather than a genuine refresh failure: don't alert the end user, don't count it
+            // towards the failure metric, and don't mark the log entry as failed.
+            metrics.increment(metrics.Types.REFRESH_CONNECTIONS_LOCK_TIMEOUT);
+            void logCtx.warn('Refresh skipped: could not acquire the refresh lock in time', { error: err });
+            await logCtx.cancel();
+        } else {
+            metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FAILED);
+            void logCtx.error('Failed to refresh credentials', err);
+            await logCtx.failed();
 
-        await onRefreshFailed({
-            connection: oldConnection,
-            logCtx,
-            authError: {
-                type: err.type,
-                description: err.message
-            },
-            environment,
-            provider,
-            account,
-            config: integration as ProviderConfig,
-            action: 'token_refresh'
-        });
+            await onRefreshFailed({
+                connection: oldConnection,
+                logCtx,
+                authError: {
+                    type: err.type,
+                    description: err.message
+                },
+                environment,
+                provider,
+                account,
+                config: integration as ProviderConfig,
+                action: 'token_refresh'
+            });
+        }
 
         const { credentials, ...connectionWithoutCredentials } = oldConnection;
         const errorWithPayload = new NangoError(err.type, { connection: connectionWithoutCredentials });
@@ -546,7 +563,12 @@ export async function refreshCredentialsIfNeeded({
                 credentials: newCredentials as RefreshableCredentials
             });
         } catch (err) {
-            const error = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });
+            let error: NangoError;
+            if (err instanceof LockAcquisitionTimeoutError) {
+                error = new NangoError('refresh_lock_timeout', { message: err.message });
+            } else {
+                error = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });
+            }
 
             return Err(error);
         } finally {

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -384,6 +384,11 @@ export class NangoError extends NangoInternalError {
                 this.message = 'A recent refresh attempt failed. Backing off before retrying.';
                 break;
 
+            case 'refresh_lock_timeout':
+                this.status = 424;
+                this.message = 'Another refresh was already in progress for this connection. Skipping this attempt.';
+                break;
+
             case 'connection_test_failed':
                 this.status = status || 400;
                 this.message = `The given credentials were found to be invalid${status ? ` and received a ${status} on a test API call` : ''}. Please check the credentials and try again.`;

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -161,7 +161,7 @@ export type GetPublicConnection = ApiEndpoint<{
         refresh_github_app_jwt_token?: boolean | undefined;
     };
     Path: '/connection/:connectionId';
-    Error: ApiError<'unknown_provider_config' | 'invalid_credentials'>;
+    Error: ApiError<'unknown_provider_config' | 'invalid_credentials' | 'refresh_lock_timeout'>;
     Success: ApiPublicConnectionFull;
 }>;
 

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -53,6 +53,7 @@ export enum Types {
     REFRESH_CONNECTIONS_SUCCESS = 'nango.server.refreshConnections.success',
     REFRESH_CONNECTIONS_FRESH = 'nango.server.refreshConnections.fresh',
     REFRESH_CONNECTIONS_UNKNOWN = 'nango.server.refreshConnections.unknown',
+    REFRESH_CONNECTIONS_LOCK_TIMEOUT = 'nango.server.refreshConnections.lockTimeout',
 
     RUNNER_SDK = 'nango.runner.sdk',
     RUNNER_INVALID_SYNCS_RECORDS = 'nango.runner.invalidSyncsRecords',


### PR DESCRIPTION
## Describe the problem and your solution

- Refresh-lock acquisition timeouts were treated as genuine credential failures: they fired the customer `webhook/error` notification, logged as a failed activity entry, and made GET `/connection` return code: `invalid_credentials`. Now lock timeouts are classified separately (`refresh_lock_timeout`) - no webhook, log entry is cancelled instead of failed, and GET `/connection` returns code: `refresh_lock_timeout` instead of `invalid_credentials`.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

