### PR TITLE
feat(mcp): add integrations get tool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -12772,9 +12772,10 @@ Keep the API key server-side and only configure it in MCP clients you trust. Do 
 
 Use the Integrations tools to inspect and manage integrations in the authenticated Nango environment.
 
-| Tool                | Description                                      | Required API key scope          |
-| ------------------- | ------------------------------------------------ | ------------------------------- |
-| `integrations_list` | List integrations configured in the environment. | `environment:integrations:list` |
+| Tool                | Description                                      | Required API key scope                                                        |
+| ------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `integrations_list` | List integrations configured in the environment. | `environment:integrations:list`                                               |
+| `integrations_get`  | Get a configured integration by ID.               | `environment:integrations:read` or `environment:integrations:read_credentials` |
 
 ### Logs
 

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -39,9 +39,10 @@ Keep the API key server-side and only configure it in MCP clients you trust. Do 
 
 Use the Integrations tools to inspect and manage integrations in the authenticated Nango environment.
 
-| Tool                | Description                                      | Required API key scope          |
-| ------------------- | ------------------------------------------------ | ------------------------------- |
-| `integrations_list` | List integrations configured in the environment. | `environment:integrations:list` |
+| Tool                | Description                                      | Required API key scope                                                        |
+| ------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `integrations_list` | List integrations configured in the environment. | `environment:integrations:list`                                               |
+| `integrations_get`  | Get a configured integration by ID.               | `environment:integrations:read` or `environment:integrations:read_credentials` |
 
 ### Logs
 

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -1,11 +1,11 @@
 import * as z from 'zod';
 
-import { configService, getGlobalWebhookReceiveUrl, getProvider } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
-import { integrationToPublicApi } from '../../../formatters/integration.js';
+import { integrationCredentialsToPublicApi, integrationToPublicApi } from '../../../formatters/integration.js';
 import { providerConfigKeySchema } from '../../../helpers/validation.js';
 import { hasScope } from '../../../middleware/scope.middleware.js';
+import integrationService from '../../../services/integration.service.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
 import type { ApiPublicIntegrationInclude, GetPublicIntegration } from '@nangohq/types';
@@ -50,56 +50,32 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
         return;
     }
 
-    const integration = await configService.getProviderConfig(params.uniqueKey, environment.id);
-    if (!integration) {
-        res.status(404).send({ error: { code: 'not_found', message: `Integration "${params.uniqueKey}" does not exist` } });
-        return;
-    }
-
-    const provider = getProvider(integration.provider);
-    if (!provider) {
-        res.status(404).send({ error: { code: 'not_found', message: `Unknown provider ${integration.provider}` } });
-        return;
-    }
-
-    const include: ApiPublicIntegrationInclude = {};
-    if (queryInclude.has('webhook')) {
-        include.webhook_url = provider.webhook_routing_script
-            ? `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${encodeURIComponent(integration.unique_key)}`
-            : null;
-    }
-    if (
-        queryInclude.has('credentials') &&
-        hasScope({ grantedScopes: res.locals['apiKeyScopes'] as string[] | undefined, requiredScope: 'environment:integrations:read_credentials' })
-    ) {
-        if (provider.auth_mode === 'OAUTH1' || provider.auth_mode === 'OAUTH2' || provider.auth_mode === 'TBA') {
-            include.credentials = {
-                type: provider.auth_mode,
-                client_id: integration.shared_credentials_id ? '' : integration.oauth_client_id,
-                client_secret: integration.shared_credentials_id ? '' : integration.oauth_client_secret,
-                scopes: integration.oauth_scopes || null,
-                webhook_secret: integration?.custom?.['webhookSecret'] || null
-            };
-        } else if (provider.auth_mode === 'APP') {
-            include.credentials = {
-                type: provider.auth_mode,
-                app_id: integration.shared_credentials_id ? '' : integration.oauth_client_id,
-                private_key: integration.shared_credentials_id ? '' : integration.oauth_client_secret,
-                app_link: integration.app_link || null
-            };
-        } else if (provider.auth_mode === 'CUSTOM') {
-            const rawPrivateKey = integration.custom?.['private_key'];
-            include.credentials = {
-                type: provider.auth_mode,
-                client_id: integration.shared_credentials_id ? '' : integration.oauth_client_id,
-                client_secret: integration.shared_credentials_id ? '' : integration.oauth_client_secret,
-                app_id: integration.shared_credentials_id ? '' : integration.custom?.['app_id'] || null,
-                app_link: integration.app_link || null,
-                private_key: integration.shared_credentials_id ? '' : rawPrivateKey ? Buffer.from(rawPrivateKey, 'base64').toString('utf8') : null
-            };
-        } else {
-            include.credentials = null;
+    const result = await integrationService.get({
+        environmentId: environment.id,
+        environmentUuid: environment.uuid,
+        integrationId: params.uniqueKey,
+        includeWebhook: queryInclude.has('webhook'),
+        includeCredentials:
+            queryInclude.has('credentials') &&
+            hasScope({ grantedScopes: res.locals['apiKeyScopes'], requiredScope: 'environment:integrations:read_credentials' })
+    });
+    if (result.isErr()) {
+        if (result.error.code === 'not_found') {
+            res.status(404).send({ error: { code: 'not_found', message: result.error.message } });
+            return;
         }
+
+        res.status(500).send({ error: { code: 'server_error', message: result.error.message } });
+        return;
+    }
+
+    const { integration, provider, webhookUrl, credentials } = result.value;
+    const include: ApiPublicIntegrationInclude = {};
+    if (webhookUrl !== undefined) {
+        include.webhook_url = webhookUrl;
+    }
+    if (credentials !== undefined) {
+        include.credentials = integrationCredentialsToPublicApi(credentials);
     }
 
     res.status(200).send({

--- a/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
@@ -3,7 +3,7 @@ import { request } from 'node:http';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { logContextGetter } from '@nangohq/logs';
-import { seeders } from '@nangohq/shared';
+import { getGlobalWebhookReceiveUrl, seeders } from '@nangohq/shared';
 
 import type { authenticateUser as authenticateUserType, runServer as runServerType } from '../../utils/tests.js';
 import type { ApiKeyScope } from '@nangohq/types';
@@ -163,6 +163,7 @@ describe('POST /mcp control-plane server', () => {
         expect(res.status).toBe(200);
         expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual([
             'integrations_list',
+            'integrations_get',
             'logs_list_operations',
             'logs_get_operation'
         ]);
@@ -170,7 +171,7 @@ describe('POST /mcp control-plane server', () => {
 
     it('rejects each management tool when its required scope is missing', async () => {
         const { secret } = await createKeyWithScopes(['environment:mcp']);
-        const toolNames = ['integrations_list', 'logs_list_operations', 'logs_get_operation'];
+        const toolNames = ['integrations_list', 'integrations_get', 'logs_list_operations', 'logs_get_operation'];
 
         for (const toolName of toolNames) {
             const res = await mcpPost({
@@ -211,6 +212,21 @@ describe('POST /mcp control-plane server', () => {
 
         expect(res.status).toBe(200);
         expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['integrations_list']);
+    });
+
+    it('lists the integration get tool with integrations:read scope', async () => {
+        const { secret } = await createKeyWithScopes(['environment:integrations:read']);
+        const res = await mcpPost({
+            token: secret,
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools).toHaveLength(1);
+        expect(res.json.result.tools[0]).toMatchObject({
+            name: 'integrations_get',
+            annotations: { readOnlyHint: true }
+        });
     });
 
     it('returns the legacy MCP JSON-RPC error shape for GET requests', async () => {
@@ -279,6 +295,116 @@ describe('POST /mcp control-plane server', () => {
             unique_key: 'github',
             display_name: 'GitHub (User OAuth)',
             forward_webhooks: true
+        });
+    });
+
+    it('gets an integration with read scope and omits unauthorized credentials', async () => {
+        const { secret, env } = await createKeyWithScopes(['environment:integrations:read']);
+        await seeders.createConfigSeed(env, 'github', 'github', { oauth_client_id: 'client-id', oauth_client_secret: 'client-secret' });
+
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'integrations_get',
+                    arguments: { integration_id: 'github', include: ['credentials'] }
+                }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        const payload = parseToolText(res);
+        expect(payload.data).toMatchObject({
+            provider: 'github',
+            unique_key: 'github',
+            display_name: 'GitHub (User OAuth)',
+            forward_webhooks: true
+        });
+        expect(payload.data).not.toHaveProperty('credentials');
+    });
+
+    it('gets requested includes with an integration wildcard scope', async () => {
+        const { secret, env } = await createKeyWithScopes(['environment:integrations:*']);
+        await seeders.createConfigSeed(env, 'platform-google', 'google', {
+            oauth_client_id: 'client-id',
+            oauth_client_secret: 'client-secret',
+            oauth_scopes: 'openid,email'
+        });
+
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'integrations_get',
+                    arguments: { integration_id: 'platform-google', include: ['webhook', 'credentials'] }
+                }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        const payload = parseToolText(res);
+        expect(payload.data).toMatchObject({
+            provider: 'google',
+            unique_key: 'platform-google',
+            webhook_url: `${getGlobalWebhookReceiveUrl()}/${env.uuid}/platform-google`,
+            credentials: {
+                type: 'OAUTH2',
+                client_id: 'client-id',
+                client_secret: 'client-secret',
+                scopes: 'openid,email',
+                webhook_secret: null
+            }
+        });
+        expect(res.json.result.structuredContent).toStrictEqual(payload);
+    });
+
+    it('rejects invalid integration get arguments', async () => {
+        const { secret } = await createKeyWithScopes(['environment:integrations:read']);
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'integrations_get',
+                    arguments: { integration_id: 'github', unexpected: true }
+                }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result).toMatchObject({
+            content: [{ type: 'text', text: expect.stringContaining('Invalid integrations_get arguments: arguments:') }],
+            isError: true
+        });
+    });
+
+    it('returns public errors from the integration get tool', async () => {
+        const { secret } = await createKeyWithScopes(['environment:integrations:read']);
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'integrations_get',
+                    arguments: { integration_id: 'missing' }
+                }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result).toStrictEqual({
+            content: [{ type: 'text', text: 'Integration "missing" does not exist' }],
+            isError: true
         });
     });
 

--- a/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
@@ -381,7 +381,7 @@ describe('POST /mcp control-plane server', () => {
 
         expect(res.status).toBe(200);
         expect(res.json.result).toMatchObject({
-            content: [{ type: 'text', text: expect.stringContaining('Invalid integrations_get arguments: arguments:') }],
+            content: [{ type: 'text', text: expect.stringContaining('Invalid arguments for tool integrations_get') }],
             isError: true
         });
     });

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.ts
@@ -1,16 +1,17 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { hasScope } from '../../middleware/scope.middleware.js';
+import { integrationsGetTool } from './integrations/get.js';
 import { integrationsListTool } from './integrations/list.js';
 import { logsGetOperationTool } from './logs/getOperation.js';
 import { logsListOperationsTool } from './logs/listOperations.js';
 import { handleMcpToolError, jsonStructuredContent } from './utils.js';
 
-import type { ControlPlaneMcpTool } from './controlPlaneTool.js';
+import type { ControlPlaneMcpRequiredScopes, ControlPlaneMcpTool } from './controlPlaneTool.js';
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ApiKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
 
-const controlPlaneMcpTools: ControlPlaneMcpTool[] = [integrationsListTool, logsListOperationsTool, logsGetOperationTool];
+const controlPlaneMcpTools: ControlPlaneMcpTool[] = [integrationsListTool, integrationsGetTool, logsListOperationsTool, logsGetOperationTool];
 
 export function createControlPlaneMcpServer(account: DBTeam, environment: DBEnvironment, grantedScopes: string[] | undefined): McpServer {
     const server = new McpServer(
@@ -31,7 +32,8 @@ export function createControlPlaneMcpServer(account: DBTeam, environment: DBEnvi
         const config = {
             description: toolDefinition.description,
             inputSchema: toolDefinition.inputSchema as unknown as AnySchema,
-            ...(toolDefinition.outputSchema ? { outputSchema: toolDefinition.outputSchema as unknown as AnySchema } : {})
+            ...(toolDefinition.outputSchema ? { outputSchema: toolDefinition.outputSchema as unknown as AnySchema } : {}),
+            ...(toolDefinition.annotations ? { annotations: toolDefinition.annotations } : {})
         };
         const registeredTool = server.registerTool(toolDefinition.name, config, async (args: unknown) => {
             try {
@@ -55,6 +57,7 @@ export function createControlPlaneMcpServer(account: DBTeam, environment: DBEnvi
     return server;
 }
 
-function hasRequiredScopes({ grantedScopes, requiredScopes }: { grantedScopes: string[] | undefined; requiredScopes: ApiKeyScope[] }): boolean {
-    return requiredScopes.every((scope) => hasScope({ grantedScopes, requiredScope: scope }));
+function hasRequiredScopes({ grantedScopes, requiredScopes }: { grantedScopes: string[] | undefined; requiredScopes: ControlPlaneMcpRequiredScopes }): boolean {
+    const hasRequiredScope = (scope: ApiKeyScope) => hasScope({ grantedScopes, requiredScope: scope });
+    return 'every' in requiredScopes ? requiredScopes.every.every(hasRequiredScope) : requiredScopes.anyOf.some(hasRequiredScope);
 }

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
@@ -26,6 +26,36 @@ describe('createControlPlaneMcpServer', () => {
         }
     });
 
+    it.each(['environment:integrations:read', 'environment:integrations:read_credentials'])('exposes the integrations get tool with %s', async (scope) => {
+        const { client, server } = await createTestClient([scope]);
+
+        try {
+            const result = await client.listTools();
+
+            expect(result.tools).toHaveLength(1);
+            expect(result.tools[0]).toMatchObject({
+                name: 'integrations_get',
+                annotations: { readOnlyHint: true }
+            });
+        } finally {
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('recognizes wildcard scopes for integration tools', async () => {
+        const { client, server } = await createTestClient(['environment:integrations:*']);
+
+        try {
+            const result = await client.listTools();
+
+            expect(result.tools.map((tool) => tool.name)).toStrictEqual(['integrations_list', 'integrations_get']);
+        } finally {
+            await client.close();
+            await server.close();
+        }
+    });
+
     it('disables tools when required scopes are missing', async () => {
         const handlerSpy = vi.spyOn(logsListOperationsTool, 'handler');
         const { client, server } = await createTestClient(['environment:mcp']);

--- a/packages/server/lib/controllers/mcp/controlPlaneTool.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneTool.ts
@@ -3,6 +3,7 @@ import { Err } from '@nangohq/utils';
 import { PublicMcpError } from './utils.js';
 
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { ApiKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type * as z from 'zod/v4';
@@ -14,13 +15,15 @@ export interface ControlPlaneMcpContext {
 }
 
 export type ControlPlaneMcpSchema = AnySchema | z.ZodType;
+export type ControlPlaneMcpRequiredScopes = { every: ApiKeyScope[] } | { anyOf: ApiKeyScope[] };
 
 export interface ControlPlaneMcpTool<TResponse extends object = object> {
     name: string;
     description: string;
     inputSchema: ControlPlaneMcpSchema;
     outputSchema?: ControlPlaneMcpSchema;
-    requiredScopes: ApiKeyScope[];
+    annotations?: ToolAnnotations;
+    requiredScopes: ControlPlaneMcpRequiredScopes;
     handler: (args: unknown, context: ControlPlaneMcpContext) => Promise<Result<TResponse>>;
 }
 

--- a/packages/server/lib/controllers/mcp/controlPlaneTool.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneTool.unit.test.ts
@@ -20,7 +20,7 @@ describe('defineControlPlaneMcpTool', () => {
             name: 'test_tool',
             description: 'Test tool',
             inputSchema: z.object({ limit: z.number().default(10) }).strict(),
-            requiredScopes: ['environment:mcp'],
+            requiredScopes: { every: ['environment:mcp'] },
             handler({ args }) {
                 return Ok({ limit: args.limit });
             }
@@ -39,7 +39,7 @@ describe('defineControlPlaneMcpTool', () => {
             name: 'test_tool',
             description: 'Test tool',
             inputSchema: z.object({ limit: z.number().min(1) }).strict(),
-            requiredScopes: ['environment:mcp'],
+            requiredScopes: { every: ['environment:mcp'] },
             handler({ args }) {
                 return Ok({ limit: args.limit });
             }

--- a/packages/server/lib/controllers/mcp/integrations/formatter.ts
+++ b/packages/server/lib/controllers/mcp/integrations/formatter.ts
@@ -38,31 +38,32 @@ export function integrationCredentialsToMcp(credentials: IntegrationCredentials)
         return null;
     }
 
-    if ('webhookSecret' in credentials) {
-        return {
-            type: credentials.type,
-            client_id: credentials.clientId,
-            client_secret: credentials.clientSecret,
-            scopes: credentials.scopes,
-            webhook_secret: credentials.webhookSecret
-        };
+    switch (credentials.type) {
+        case 'OAUTH1':
+        case 'OAUTH2':
+        case 'TBA':
+            return {
+                type: credentials.type,
+                client_id: credentials.clientId,
+                client_secret: credentials.clientSecret,
+                scopes: credentials.scopes,
+                webhook_secret: credentials.webhookSecret
+            };
+        case 'APP':
+            return {
+                type: credentials.type,
+                app_id: credentials.appId,
+                private_key: credentials.privateKey,
+                app_link: credentials.appLink
+            };
+        case 'CUSTOM':
+            return {
+                type: credentials.type,
+                client_id: credentials.clientId,
+                client_secret: credentials.clientSecret,
+                app_id: credentials.appId,
+                app_link: credentials.appLink,
+                private_key: credentials.privateKey
+            };
     }
-
-    if (credentials.type === 'APP') {
-        return {
-            type: credentials.type,
-            app_id: credentials.appId,
-            private_key: credentials.privateKey,
-            app_link: credentials.appLink
-        };
-    }
-
-    return {
-        type: credentials.type,
-        client_id: credentials.clientId,
-        client_secret: credentials.clientSecret,
-        app_id: credentials.appId,
-        app_link: credentials.appLink,
-        private_key: credentials.privateKey
-    };
 }

--- a/packages/server/lib/controllers/mcp/integrations/formatter.ts
+++ b/packages/server/lib/controllers/mcp/integrations/formatter.ts
@@ -2,9 +2,20 @@ import { basePublicUrl } from '@nangohq/utils';
 
 import { getPreconfiguredCredentials } from '../../../utils/integrations.js';
 
+import type { IntegrationCredentials } from '../../../utils/integrations.js';
 import type { IntegrationConfig, Provider } from '@nangohq/types';
 
-export function integrationToMcp({ integration, provider }: { integration: IntegrationConfig; provider: Provider }) {
+export function integrationToMcp({
+    integration,
+    provider,
+    webhookUrl,
+    credentials
+}: {
+    integration: IntegrationConfig;
+    provider: Provider;
+    webhookUrl?: string | null;
+    credentials?: IntegrationCredentials;
+}) {
     const preconfiguredCredentials = getPreconfiguredCredentials(integration.custom, provider);
 
     return {
@@ -14,8 +25,44 @@ export function integrationToMcp({ integration, provider }: { integration: Integ
         logo: `${basePublicUrl}/images/template-logos/${integration.provider}.svg`,
         ...(provider.integration_config && integration.custom?.['keyLabel'] ? { credentials_label: { apiKey: integration.custom['keyLabel'] } } : {}),
         ...(preconfiguredCredentials.length > 0 ? { preconfigured_credentials: preconfiguredCredentials } : {}),
+        ...(webhookUrl !== undefined ? { webhook_url: webhookUrl } : {}),
+        ...(credentials !== undefined ? { credentials: integrationCredentialsToMcp(credentials) } : {}),
         forward_webhooks: integration.forward_webhooks === undefined ? true : integration.forward_webhooks,
         created_at: integration.created_at.toISOString(),
         updated_at: integration.updated_at.toISOString()
+    };
+}
+
+export function integrationCredentialsToMcp(credentials: IntegrationCredentials) {
+    if (!credentials) {
+        return null;
+    }
+
+    if ('webhookSecret' in credentials) {
+        return {
+            type: credentials.type,
+            client_id: credentials.clientId,
+            client_secret: credentials.clientSecret,
+            scopes: credentials.scopes,
+            webhook_secret: credentials.webhookSecret
+        };
+    }
+
+    if (credentials.type === 'APP') {
+        return {
+            type: credentials.type,
+            app_id: credentials.appId,
+            private_key: credentials.privateKey,
+            app_link: credentials.appLink
+        };
+    }
+
+    return {
+        type: credentials.type,
+        client_id: credentials.clientId,
+        client_secret: credentials.clientSecret,
+        app_id: credentials.appId,
+        app_link: credentials.appLink,
+        private_key: credentials.privateKey
     };
 }

--- a/packages/server/lib/controllers/mcp/integrations/formatter.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/formatter.unit.test.ts
@@ -68,6 +68,32 @@ describe('integrationToMcp', () => {
             }
         });
     });
+
+    it('formats APP credentials for the MCP transport', () => {
+        const provider = getProvider('github-app');
+        if (!provider) {
+            throw new Error('Expected github-app provider');
+        }
+        const integration = integrationFixture({ provider: 'github-app', custom: null });
+
+        const result = integrationToMcp({
+            integration,
+            provider,
+            credentials: {
+                type: 'APP',
+                appId: 'app-id',
+                privateKey: 'private-key',
+                appLink: 'https://github.com/apps/example'
+            }
+        });
+
+        expect(result.credentials).toStrictEqual({
+            type: 'APP',
+            app_id: 'app-id',
+            private_key: 'private-key',
+            app_link: 'https://github.com/apps/example'
+        });
+    });
 });
 
 function integrationFixture({ provider, custom }: { provider: string; custom: IntegrationConfig['custom'] }): IntegrationConfig {

--- a/packages/server/lib/controllers/mcp/integrations/formatter.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/formatter.unit.test.ts
@@ -36,6 +36,38 @@ describe('integrationToMcp', () => {
 
         expect(result.credentials_label).toStrictEqual({ apiKey: 'Workspace token' });
     });
+
+    it('formats explicitly requested domain includes for the MCP transport', () => {
+        const provider = getProvider('github');
+        if (!provider) {
+            throw new Error('Expected github provider');
+        }
+        const integration = integrationFixture({ provider: 'github', custom: null });
+
+        const result = integrationToMcp({
+            integration,
+            provider,
+            webhookUrl: 'https://example.com/webhook',
+            credentials: {
+                type: 'OAUTH2',
+                clientId: 'client-id',
+                clientSecret: 'client-secret',
+                scopes: 'repo,user',
+                webhookSecret: 'webhook-secret'
+            }
+        });
+
+        expect(result).toMatchObject({
+            webhook_url: 'https://example.com/webhook',
+            credentials: {
+                type: 'OAUTH2',
+                client_id: 'client-id',
+                client_secret: 'client-secret',
+                scopes: 'repo,user',
+                webhook_secret: 'webhook-secret'
+            }
+        });
+    });
 });
 
 function integrationFixture({ provider, custom }: { provider: string; custom: IntegrationConfig['custom'] }): IntegrationConfig {

--- a/packages/server/lib/controllers/mcp/integrations/get.ts
+++ b/packages/server/lib/controllers/mcp/integrations/get.ts
@@ -1,0 +1,101 @@
+import * as z from 'zod/v4';
+
+import { providerConfigKeySchema } from '../../../helpers/validation.js';
+import { hasScope } from '../../../middleware/scope.middleware.js';
+import integrationService from '../../../services/integration.service.js';
+import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
+import { PublicMcpError } from '../utils.js';
+import { integrationToMcp } from './formatter.js';
+
+const integrationCredentialsSchema = z.discriminatedUnion('type', [
+    z
+        .object({
+            type: z.enum(['OAUTH1', 'OAUTH2', 'TBA']),
+            client_id: z.string().nullable(),
+            client_secret: z.string().nullable(),
+            scopes: z.string().nullable(),
+            webhook_secret: z.string().nullable()
+        })
+        .strict(),
+    z
+        .object({
+            type: z.literal('APP'),
+            app_id: z.string().nullable(),
+            private_key: z.string().nullable(),
+            app_link: z.string().nullable()
+        })
+        .strict(),
+    z
+        .object({
+            type: z.literal('CUSTOM'),
+            client_id: z.string().nullable(),
+            client_secret: z.string().nullable(),
+            app_id: z.string().nullable(),
+            app_link: z.string().nullable(),
+            private_key: z.string().nullable()
+        })
+        .strict()
+]);
+
+const getIntegrationArgumentsSchema = z
+    .object({
+        integration_id: providerConfigKeySchema,
+        include: z
+            .array(z.enum(['webhook', 'credentials']))
+            .max(2)
+            .optional()
+    })
+    .strict();
+
+const getIntegrationOutputSchema = z
+    .object({
+        data: z
+            .object({
+                unique_key: z.string(),
+                provider: z.string(),
+                display_name: z.string(),
+                logo: z.string(),
+                credentials_label: z.record(z.string(), z.string()).optional(),
+                preconfigured_credentials: z.array(z.string()).optional(),
+                webhook_url: z.string().nullable().optional(),
+                credentials: integrationCredentialsSchema.nullable().optional(),
+                forward_webhooks: z.boolean(),
+                created_at: z.string(),
+                updated_at: z.string()
+            })
+            .strict()
+    })
+    .strict();
+
+type GetIntegrationOutput = z.infer<typeof getIntegrationOutputSchema>;
+
+export const integrationsGetTool = defineControlPlaneMcpTool<typeof getIntegrationArgumentsSchema, GetIntegrationOutput>({
+    name: 'integrations_get',
+    description: 'Get a configured integration by ID.',
+    inputSchema: getIntegrationArgumentsSchema,
+    outputSchema: getIntegrationOutputSchema,
+    annotations: { readOnlyHint: true },
+    requiredScopes: { anyOf: ['environment:integrations:read', 'environment:integrations:read_credentials'] },
+    async handler({ args, environment, grantedScopes }) {
+        const requestedIncludes = new Set(args.include);
+        const result = await integrationService.get({
+            environmentId: environment.id,
+            environmentUuid: environment.uuid,
+            integrationId: args.integration_id,
+            includeWebhook: requestedIncludes.has('webhook'),
+            includeCredentials: requestedIncludes.has('credentials') && hasScope({ grantedScopes, requiredScope: 'environment:integrations:read_credentials' })
+        });
+
+        return result
+            .map((integration) => ({
+                data: integrationToMcp(integration)
+            }))
+            .mapError((error) => {
+                if (error.code === 'not_found') {
+                    return new PublicMcpError(error.message);
+                }
+
+                return error;
+            });
+    }
+});

--- a/packages/server/lib/controllers/mcp/integrations/get.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/get.unit.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import integrationService, { IntegrationServiceError } from '../../../services/integration.service.js';
+import { PublicMcpError } from '../utils.js';
+import { integrationsGetTool } from './get.js';
+
+import type { ControlPlaneMcpContext } from '../controlPlaneTool.js';
+import type { Config } from '@nangohq/shared';
+import type { Provider } from '@nangohq/types';
+
+const createdAt = new Date('2026-01-01T00:00:00.000Z');
+const updatedAt = new Date('2026-01-02T00:00:00.000Z');
+
+describe('integrationsGetTool', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns an integration without credentials when only the read scope is granted', async () => {
+        const integration = integrationFixture();
+        const provider = providerFixture();
+        vi.spyOn(integrationService, 'get').mockImplementation(({ includeWebhook, includeCredentials }) =>
+            Promise.resolve(
+                Ok({
+                    integration,
+                    provider,
+                    ...(includeWebhook ? { webhookUrl: 'https://example.com/webhook' } : {}),
+                    ...(includeCredentials
+                        ? {
+                              credentials: {
+                                  type: 'OAUTH2',
+                                  clientId: 'client-id',
+                                  clientSecret: 'client-secret',
+                                  scopes: null,
+                                  webhookSecret: null
+                              } as const
+                          }
+                        : {})
+                })
+            )
+        );
+
+        const result = await integrationsGetTool.handler(
+            { integration_id: 'github', include: ['webhook', 'credentials'] },
+            context(['environment:integrations:read'])
+        );
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value.data).toMatchObject({
+                unique_key: 'github',
+                webhook_url: 'https://example.com/webhook'
+            });
+            expect(result.value.data).not.toHaveProperty('credentials');
+        }
+    });
+
+    it('returns explicitly requested credentials with the credential-reading scope', async () => {
+        const integration = integrationFixture();
+        const provider = providerFixture();
+        vi.spyOn(integrationService, 'get').mockResolvedValue(
+            Ok({
+                integration,
+                provider,
+                credentials: {
+                    type: 'OAUTH2',
+                    clientId: 'client-id',
+                    clientSecret: 'client-secret',
+                    scopes: 'repo,user',
+                    webhookSecret: null
+                }
+            })
+        );
+
+        const result = await integrationsGetTool.handler(
+            { integration_id: 'github', include: ['credentials'] },
+            context(['environment:integrations:read_credentials'])
+        );
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value.data.credentials).toStrictEqual({
+                type: 'OAUTH2',
+                client_id: 'client-id',
+                client_secret: 'client-secret',
+                scopes: 'repo,user',
+                webhook_secret: null
+            });
+        }
+    });
+
+    it('rejects invalid arguments before calling the integration service', async () => {
+        const getSpy = vi.spyOn(integrationService, 'get');
+
+        const result = await integrationsGetTool.handler({ integration_id: 'github', unexpected: true }, context(['environment:integrations:read']));
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toContain('Invalid integrations_get arguments: arguments:');
+        }
+        expect(getSpy).not.toHaveBeenCalled();
+    });
+
+    it('maps missing integrations to public MCP errors', async () => {
+        vi.spyOn(integrationService, 'get').mockResolvedValue(
+            Err(
+                new IntegrationServiceError({
+                    code: 'not_found',
+                    message: 'Integration "missing" does not exist'
+                })
+            )
+        );
+
+        const result = await integrationsGetTool.handler({ integration_id: 'missing' }, context(['environment:integrations:read']));
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toBe('Integration "missing" does not exist');
+        }
+    });
+});
+
+function context(grantedScopes: string[]): ControlPlaneMcpContext {
+    return {
+        account: {},
+        environment: { id: 42, uuid: 'environment-uuid' },
+        grantedScopes
+    } as ControlPlaneMcpContext;
+}
+
+function integrationFixture(): Config {
+    return {
+        unique_key: 'github',
+        provider: 'github',
+        oauth_client_id: 'client-id',
+        oauth_client_secret: 'client-secret',
+        environment_id: 42,
+        missing_fields: [],
+        display_name: null,
+        forward_webhooks: true,
+        shared_credentials_id: null,
+        created_at: createdAt,
+        updated_at: updatedAt
+    };
+}
+
+function providerFixture(): Provider {
+    return {
+        display_name: 'GitHub',
+        auth_mode: 'OAUTH2',
+        docs: ''
+    };
+}

--- a/packages/server/lib/controllers/mcp/integrations/list.ts
+++ b/packages/server/lib/controllers/mcp/integrations/list.ts
@@ -33,7 +33,7 @@ export const integrationsListTool = defineControlPlaneMcpTool<typeof listIntegra
     description: 'List integrations configured in the authenticated Nango environment.',
     inputSchema: listIntegrationsArgumentsSchema,
     outputSchema: listIntegrationsOutputSchema,
-    requiredScopes: ['environment:integrations:list'],
+    requiredScopes: { every: ['environment:integrations:list'] },
     async handler({ environment }) {
         const result = await integrationService.list({ environmentId: environment.id });
         return result.map((integrations) => ({

--- a/packages/server/lib/controllers/mcp/logs/getOperation.ts
+++ b/packages/server/lib/controllers/mcp/logs/getOperation.ts
@@ -43,7 +43,7 @@ export const logsGetOperationTool = defineControlPlaneMcpTool<typeof getOperatio
     description: 'Get one Nango log operation and a page of its message rows for the authenticated environment. Messages are returned newest first.',
     inputSchema: getOperationArgumentsSchema,
     outputSchema: getOperationOutputSchema,
-    requiredScopes: [logsReadScope],
+    requiredScopes: { every: [logsReadScope] },
     async handler({ args, account, environment }) {
         const result = await logsOperationsService.getOperation({
             accountId: account.id,

--- a/packages/server/lib/controllers/mcp/logs/listOperations.ts
+++ b/packages/server/lib/controllers/mcp/logs/listOperations.ts
@@ -178,7 +178,7 @@ export const logsListOperationsTool = defineControlPlaneMcpTool<typeof listOpera
     ].join(' '),
     inputSchema: listOperationsArgumentsSchema,
     outputSchema: listOperationsOutputSchema,
-    requiredScopes: [logsReadScope],
+    requiredScopes: { every: [logsReadScope] },
     async handler({ args, account, environment }) {
         const result = await logsOperationsService.listOperations({
             accountId: account.id,

--- a/packages/server/lib/formatters/integration.ts
+++ b/packages/server/lib/formatters/integration.ts
@@ -81,31 +81,32 @@ export function integrationCredentialsToPublicApi(credentials: IntegrationCreden
         return null;
     }
 
-    if ('webhookSecret' in credentials) {
-        return {
-            type: credentials.type,
-            client_id: credentials.clientId,
-            client_secret: credentials.clientSecret,
-            scopes: credentials.scopes,
-            webhook_secret: credentials.webhookSecret
-        };
+    switch (credentials.type) {
+        case 'OAUTH1':
+        case 'OAUTH2':
+        case 'TBA':
+            return {
+                type: credentials.type,
+                client_id: credentials.clientId,
+                client_secret: credentials.clientSecret,
+                scopes: credentials.scopes,
+                webhook_secret: credentials.webhookSecret
+            };
+        case 'APP':
+            return {
+                type: credentials.type,
+                app_id: credentials.appId,
+                private_key: credentials.privateKey,
+                app_link: credentials.appLink
+            };
+        case 'CUSTOM':
+            return {
+                type: credentials.type,
+                client_id: credentials.clientId,
+                client_secret: credentials.clientSecret,
+                app_id: credentials.appId,
+                app_link: credentials.appLink,
+                private_key: credentials.privateKey
+            };
     }
-
-    if (credentials.type === 'APP') {
-        return {
-            type: credentials.type,
-            app_id: credentials.appId,
-            private_key: credentials.privateKey,
-            app_link: credentials.appLink
-        };
-    }
-
-    return {
-        type: credentials.type,
-        client_id: credentials.clientId,
-        client_secret: credentials.clientSecret,
-        app_id: credentials.appId,
-        app_link: credentials.appLink,
-        private_key: credentials.privateKey
-    };
 }

--- a/packages/server/lib/formatters/integration.ts
+++ b/packages/server/lib/formatters/integration.ts
@@ -3,6 +3,7 @@ import { basePublicUrl } from '@nangohq/utils';
 
 import { getPreconfiguredCredentials } from '../utils/integrations.js';
 
+import type { IntegrationCredentials } from '../utils/integrations.js';
 import type { ApiIntegration, ApiPublicIntegration, ApiPublicIntegrationInclude, IntegrationConfig, Provider } from '@nangohq/types';
 
 export function integrationToApi(data: IntegrationConfig, options?: { includeCredentials?: boolean }): ApiIntegration {
@@ -72,5 +73,39 @@ export function integrationToPublicApi({
         forward_webhooks: integration.forward_webhooks === undefined ? true : integration.forward_webhooks,
         created_at: integration.created_at.toISOString(),
         updated_at: integration.updated_at.toISOString()
+    };
+}
+
+export function integrationCredentialsToPublicApi(credentials: IntegrationCredentials): Exclude<ApiPublicIntegrationInclude['credentials'], undefined> {
+    if (!credentials) {
+        return null;
+    }
+
+    if ('webhookSecret' in credentials) {
+        return {
+            type: credentials.type,
+            client_id: credentials.clientId,
+            client_secret: credentials.clientSecret,
+            scopes: credentials.scopes,
+            webhook_secret: credentials.webhookSecret
+        };
+    }
+
+    if (credentials.type === 'APP') {
+        return {
+            type: credentials.type,
+            app_id: credentials.appId,
+            private_key: credentials.privateKey,
+            app_link: credentials.appLink
+        };
+    }
+
+    return {
+        type: credentials.type,
+        client_id: credentials.clientId,
+        client_secret: credentials.clientSecret,
+        app_id: credentials.appId,
+        app_link: credentials.appLink,
+        private_key: credentials.privateKey
     };
 }

--- a/packages/server/lib/formatters/integration.unit.test.ts
+++ b/packages/server/lib/formatters/integration.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { getProvider } from '@nangohq/shared';
 
-import { integrationToPublicApi } from './integration.js';
+import { integrationCredentialsToPublicApi, integrationToPublicApi } from './integration.js';
 
 import type { IntegrationConfig } from '@nangohq/types';
 
@@ -51,5 +51,27 @@ describe('integrationToPublicApi preconfigured_credentials', () => {
         const result = integrationToPublicApi({ integration: makeIntegration({ username: 'bob' }), provider });
 
         expect(result.preconfigured_credentials).toBeUndefined();
+    });
+});
+
+describe('integrationCredentialsToPublicApi', () => {
+    it('formats domain credentials for the public API transport', () => {
+        const result = integrationCredentialsToPublicApi({
+            type: 'CUSTOM',
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            appId: 'app-id',
+            appLink: 'https://example.com/app',
+            privateKey: 'private-key'
+        });
+
+        expect(result).toStrictEqual({
+            type: 'CUSTOM',
+            client_id: 'client-id',
+            client_secret: 'client-secret',
+            app_id: 'app-id',
+            app_link: 'https://example.com/app',
+            private_key: 'private-key'
+        });
     });
 });

--- a/packages/server/lib/services/integration.service.integration.test.ts
+++ b/packages/server/lib/services/integration.service.integration.test.ts
@@ -1,0 +1,41 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { multipleMigrations } from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import integrationService from './integration.service.js';
+
+describe('integrationService integration', () => {
+    beforeAll(async () => {
+        await multipleMigrations();
+    });
+
+    it('decodes APP private keys loaded from the database', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+        const privateKey = '-----BEGIN RSA PRIVATE KEY-----\nprivate-key\n-----END RSA PRIVATE KEY-----';
+        const storedPrivateKey = Buffer.from(privateKey).toString('base64');
+        await seeders.createConfigSeed(env, 'github-app', 'github-app', {
+            oauth_client_id: 'app-id',
+            oauth_client_secret: storedPrivateKey,
+            app_link: 'https://github.com/apps/example'
+        });
+
+        const result = await integrationService.get({
+            environmentId: env.id,
+            environmentUuid: env.uuid,
+            integrationId: 'github-app',
+            includeCredentials: true
+        });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value.integration.oauth_client_secret).toBe(storedPrivateKey);
+            expect(result.value.credentials).toStrictEqual({
+                type: 'APP',
+                appId: 'app-id',
+                privateKey,
+                appLink: 'https://github.com/apps/example'
+            });
+        }
+    });
+});

--- a/packages/server/lib/services/integration.service.ts
+++ b/packages/server/lib/services/integration.service.ts
@@ -1,11 +1,14 @@
 import db from '@nangohq/database';
-import { configService, getProviders } from '@nangohq/shared';
+import { configService, getGlobalWebhookReceiveUrl, getProvider, getProviders } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
+import { getIntegrationCredentials } from '../utils/integrations.js';
+
+import type { IntegrationCredentials } from '../utils/integrations.js';
 import type { IntegrationConfig, Provider } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
-type IntegrationServiceErrorCode = 'list_failed';
+type IntegrationServiceErrorCode = 'get_failed' | 'not_found' | 'list_failed';
 
 export class IntegrationServiceError extends Error {
     public code: IntegrationServiceErrorCode;
@@ -22,7 +25,69 @@ export interface ListedIntegration {
     provider: Provider;
 }
 
+export interface RetrievedIntegration extends ListedIntegration {
+    webhookUrl?: string | null;
+    credentials?: IntegrationCredentials;
+}
+
 class IntegrationService {
+    async get({
+        environmentId,
+        environmentUuid,
+        integrationId,
+        includeWebhook = false,
+        includeCredentials = false
+    }: {
+        environmentId: number;
+        environmentUuid: string;
+        integrationId: string;
+        includeWebhook?: boolean;
+        includeCredentials?: boolean;
+    }): Promise<Result<RetrievedIntegration, IntegrationServiceError>> {
+        try {
+            const integration = await configService.getProviderConfig(integrationId, environmentId);
+            if (!integration) {
+                return Err(
+                    new IntegrationServiceError({
+                        code: 'not_found',
+                        message: `Integration "${integrationId}" does not exist`
+                    })
+                );
+            }
+
+            const provider = getProvider(integration.provider);
+            if (!provider) {
+                return Err(
+                    new IntegrationServiceError({
+                        code: 'not_found',
+                        message: `Unknown provider ${integration.provider}`
+                    })
+                );
+            }
+
+            return Ok({
+                integration,
+                provider,
+                ...(includeWebhook
+                    ? {
+                          webhookUrl: provider.webhook_routing_script
+                              ? `${getGlobalWebhookReceiveUrl()}/${environmentUuid}/${encodeURIComponent(integration.unique_key)}`
+                              : null
+                      }
+                    : {}),
+                ...(includeCredentials ? { credentials: getIntegrationCredentials(integration, provider) } : {})
+            });
+        } catch (err) {
+            return Err(
+                new IntegrationServiceError({
+                    code: 'get_failed',
+                    message: 'Failed to get integration',
+                    cause: err
+                })
+            );
+        }
+    }
+
     async list({
         environmentId,
         allowedIntegrations

--- a/packages/server/lib/services/integration.service.unit.test.ts
+++ b/packages/server/lib/services/integration.service.unit.test.ts
@@ -15,6 +15,111 @@ describe('integrationService', () => {
         vi.restoreAllMocks();
     });
 
+    it.each([
+        { name: 'all includes', includeWebhook: true, includeCredentials: true },
+        { name: 'the webhook include only', includeWebhook: true, includeCredentials: false },
+        { name: 'the credentials include only', includeWebhook: false, includeCredentials: true },
+        { name: 'no includes', includeWebhook: false, includeCredentials: false }
+    ])('gets an integration with $name', async ({ includeWebhook, includeCredentials }) => {
+        const integration = integrationFixture({
+            uniqueKey: 'acme:corp',
+            provider: 'github',
+            oauth_client_id: 'client-id',
+            oauth_client_secret: 'client-secret',
+            oauth_scopes: 'repo,user',
+            custom: { webhookSecret: 'webhook-secret' }
+        });
+        const provider = providerFixture('GitHub', { webhook_routing_script: 'webhook.js' });
+
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue(integration);
+        vi.spyOn(shared, 'getProvider').mockReturnValue(provider);
+
+        const result = await integrationService.get({
+            environmentId: 42,
+            environmentUuid: 'environment-uuid',
+            integrationId: 'acme:corp',
+            includeWebhook,
+            includeCredentials
+        });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({
+                integration,
+                provider,
+                ...(includeWebhook ? { webhookUrl: `${shared.getGlobalWebhookReceiveUrl()}/environment-uuid/acme%3Acorp` } : {}),
+                ...(includeCredentials
+                    ? {
+                          credentials: {
+                              type: 'OAUTH2',
+                              clientId: 'client-id',
+                              clientSecret: 'client-secret',
+                              scopes: 'repo,user',
+                              webhookSecret: 'webhook-secret'
+                          }
+                      }
+                    : {})
+            });
+        }
+    });
+
+    it('returns a not found error when the integration does not exist', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue(null);
+
+        const result = await integrationService.get({
+            environmentId: 42,
+            environmentUuid: 'environment-uuid',
+            integrationId: 'missing'
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({
+                code: 'not_found',
+                message: 'Integration "missing" does not exist'
+            });
+        }
+    });
+
+    it('returns a provider not found error when the integration references an unknown provider', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue(integrationFixture({ uniqueKey: 'missing', provider: 'missing' }));
+        vi.spyOn(shared, 'getProvider').mockReturnValue(null);
+
+        const result = await integrationService.get({
+            environmentId: 42,
+            environmentUuid: 'environment-uuid',
+            integrationId: 'missing'
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({
+                code: 'not_found',
+                message: 'Unknown provider missing'
+            });
+        }
+    });
+
+    it('wraps unexpected get failures as service errors', async () => {
+        const cause = new Error('database failed');
+        vi.spyOn(shared.configService, 'getProviderConfig').mockRejectedValue(cause);
+
+        const result = await integrationService.get({
+            environmentId: 42,
+            environmentUuid: 'environment-uuid',
+            integrationId: 'github'
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({
+                code: 'get_failed',
+                message: 'Failed to get integration',
+                cause
+            });
+        }
+    });
+
     it('lists integrations with their providers for an environment', async () => {
         const githubIntegration = integrationFixture({ uniqueKey: 'github', provider: 'github' });
         const slackIntegration = integrationFixture({ uniqueKey: 'slack', provider: 'slack' });
@@ -106,7 +211,7 @@ describe('integrationService', () => {
     });
 });
 
-function integrationFixture({ uniqueKey, provider }: { uniqueKey: string; provider: string }): Config {
+function integrationFixture({ uniqueKey, provider, ...overrides }: { uniqueKey: string; provider: string } & Partial<Config>): Config {
     return {
         unique_key: uniqueKey,
         provider,
@@ -118,14 +223,16 @@ function integrationFixture({ uniqueKey, provider }: { uniqueKey: string; provid
         forward_webhooks: true,
         shared_credentials_id: null,
         created_at: createdAt,
-        updated_at: updatedAt
+        updated_at: updatedAt,
+        ...overrides
     };
 }
 
-function providerFixture(displayName: string): Provider {
+function providerFixture(displayName: string, overrides: { webhook_routing_script?: string } = {}): Provider {
     return {
         display_name: displayName,
         auth_mode: 'OAUTH2',
-        docs: ''
+        docs: '',
+        ...overrides
     };
 }

--- a/packages/server/lib/utils/integrations.ts
+++ b/packages/server/lib/utils/integrations.ts
@@ -44,7 +44,7 @@ export function getIntegrationCredentials(integration: IntegrationConfig, provid
         return {
             type: provider.auth_mode,
             appId: usesSharedCredentials ? '' : integration.oauth_client_id,
-            privateKey: usesSharedCredentials ? '' : integration.oauth_client_secret,
+            privateKey: usesSharedCredentials ? '' : decodePrivateKey(integration.oauth_client_secret),
             appLink: integration.app_link || null
         };
     }
@@ -57,9 +57,13 @@ export function getIntegrationCredentials(integration: IntegrationConfig, provid
             clientSecret: usesSharedCredentials ? '' : integration.oauth_client_secret,
             appId: usesSharedCredentials ? '' : integration.custom?.['app_id'] || null,
             appLink: integration.app_link || null,
-            privateKey: usesSharedCredentials ? '' : rawPrivateKey ? Buffer.from(rawPrivateKey, 'base64').toString('utf8') : null
+            privateKey: usesSharedCredentials ? '' : decodePrivateKey(rawPrivateKey)
         };
     }
 
     return null;
+}
+
+function decodePrivateKey(privateKey: string | null | undefined): string | null {
+    return privateKey === null || privateKey === undefined ? null : Buffer.from(privateKey, 'base64').toString('utf8');
 }

--- a/packages/server/lib/utils/integrations.ts
+++ b/packages/server/lib/utils/integrations.ts
@@ -1,9 +1,65 @@
 import type { IntegrationConfig, Provider } from '@nangohq/types';
 
+export type IntegrationCredentials =
+    | {
+          type: 'OAUTH1' | 'OAUTH2' | 'TBA';
+          clientId: string | null;
+          clientSecret: string | null;
+          scopes: string | null;
+          webhookSecret: string | null;
+      }
+    | { type: 'APP'; appId: string | null; privateKey: string | null; appLink: string | null }
+    | {
+          type: 'CUSTOM';
+          clientId: string | null;
+          clientSecret: string | null;
+          appId: string | null;
+          appLink: string | null;
+          privateKey: string | null;
+      }
+    | null;
+
 export function getPreconfiguredCredentials(custom: IntegrationConfig['custom'], provider: Provider): string[] {
     if (!custom || provider.auth_mode !== 'TWO_STEP' || !provider.integration_config) {
         return [];
     }
 
     return Object.keys(provider.integration_config).filter((field) => Boolean(custom[field]));
+}
+
+export function getIntegrationCredentials(integration: IntegrationConfig, provider: Provider): IntegrationCredentials {
+    const usesSharedCredentials = Boolean(integration.shared_credentials_id);
+
+    if (provider.auth_mode === 'OAUTH1' || provider.auth_mode === 'OAUTH2' || provider.auth_mode === 'TBA') {
+        return {
+            type: provider.auth_mode,
+            clientId: usesSharedCredentials ? '' : integration.oauth_client_id,
+            clientSecret: usesSharedCredentials ? '' : integration.oauth_client_secret,
+            scopes: integration.oauth_scopes || null,
+            webhookSecret: integration.custom?.['webhookSecret'] || null
+        };
+    }
+
+    if (provider.auth_mode === 'APP') {
+        return {
+            type: provider.auth_mode,
+            appId: usesSharedCredentials ? '' : integration.oauth_client_id,
+            privateKey: usesSharedCredentials ? '' : integration.oauth_client_secret,
+            appLink: integration.app_link || null
+        };
+    }
+
+    if (provider.auth_mode === 'CUSTOM') {
+        const rawPrivateKey = integration.custom?.['private_key'];
+        return {
+            type: provider.auth_mode,
+            clientId: usesSharedCredentials ? '' : integration.oauth_client_id,
+            clientSecret: usesSharedCredentials ? '' : integration.oauth_client_secret,
+            appId: usesSharedCredentials ? '' : integration.custom?.['app_id'] || null,
+            appLink: integration.app_link || null,
+            privateKey: usesSharedCredentials ? '' : rawPrivateKey ? Buffer.from(rawPrivateKey, 'base64').toString('utf8') : null
+        };
+    }
+
+    return null;
 }

--- a/packages/server/lib/utils/integrations.unit.test.ts
+++ b/packages/server/lib/utils/integrations.unit.test.ts
@@ -24,16 +24,21 @@ describe('getIntegrationCredentials', () => {
         });
     });
 
-    it('maps app credentials without changing their stored values', () => {
+    it('decodes app private keys', () => {
+        const privateKey = '-----BEGIN RSA PRIVATE KEY-----\nprivate-key\n-----END RSA PRIVATE KEY-----';
         const result = getIntegrationCredentials(
-            integrationFixture({ oauth_client_id: 'app-id', oauth_client_secret: 'private-key', app_link: 'https://example.com/app' }),
+            integrationFixture({
+                oauth_client_id: 'app-id',
+                oauth_client_secret: Buffer.from(privateKey).toString('base64'),
+                app_link: 'https://example.com/app'
+            }),
             providerFixture('APP')
         );
 
         expect(result).toStrictEqual({
             type: 'APP',
             appId: 'app-id',
-            privateKey: 'private-key',
+            privateKey,
             appLink: 'https://example.com/app'
         });
     });

--- a/packages/server/lib/utils/integrations.unit.test.ts
+++ b/packages/server/lib/utils/integrations.unit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { getIntegrationCredentials } from './integrations.js';
+
+import type { IntegrationConfig, Provider } from '@nangohq/types';
+
+describe('getIntegrationCredentials', () => {
+    it('hides credentials supplied by shared credentials', () => {
+        const result = getIntegrationCredentials(
+            integrationFixture({
+                oauth_client_id: 'client-id',
+                oauth_client_secret: 'client-secret',
+                shared_credentials_id: 7
+            }),
+            providerFixture('OAUTH2')
+        );
+
+        expect(result).toStrictEqual({
+            type: 'OAUTH2',
+            clientId: '',
+            clientSecret: '',
+            scopes: null,
+            webhookSecret: null
+        });
+    });
+
+    it('maps app credentials without changing their stored values', () => {
+        const result = getIntegrationCredentials(
+            integrationFixture({ oauth_client_id: 'app-id', oauth_client_secret: 'private-key', app_link: 'https://example.com/app' }),
+            providerFixture('APP')
+        );
+
+        expect(result).toStrictEqual({
+            type: 'APP',
+            appId: 'app-id',
+            privateKey: 'private-key',
+            appLink: 'https://example.com/app'
+        });
+    });
+
+    it('decodes custom private keys', () => {
+        const result = getIntegrationCredentials(
+            integrationFixture({
+                oauth_client_id: 'client-id',
+                oauth_client_secret: 'client-secret',
+                app_link: 'https://example.com/app',
+                custom: { app_id: 'app-id', private_key: Buffer.from('private-key').toString('base64') }
+            }),
+            providerFixture('CUSTOM')
+        );
+
+        expect(result).toStrictEqual({
+            type: 'CUSTOM',
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            appId: 'app-id',
+            appLink: 'https://example.com/app',
+            privateKey: 'private-key'
+        });
+    });
+
+    it('returns null for auth modes without integration credentials', () => {
+        expect(getIntegrationCredentials(integrationFixture(), providerFixture('API_KEY'))).toBeNull();
+    });
+});
+
+function integrationFixture(overrides: Partial<IntegrationConfig> = {}): IntegrationConfig {
+    return {
+        unique_key: 'github',
+        provider: 'github',
+        oauth_client_id: null,
+        oauth_client_secret: null,
+        environment_id: 42,
+        missing_fields: [],
+        display_name: null,
+        forward_webhooks: true,
+        shared_credentials_id: null,
+        created_at: new Date('2026-01-01T00:00:00.000Z'),
+        updated_at: new Date('2026-01-02T00:00:00.000Z'),
+        ...overrides
+    };
+}
+
+function providerFixture(authMode: Provider['auth_mode']): Provider {
+    return {
+        display_name: 'GitHub',
+        auth_mode: authMode,
+        docs: ''
+    };
+}


### PR DESCRIPTION
Adds the `integrations_get` Management MCP tool

Fixes a bug in decoding base64 credentials in the Public API for Github App integrations

NAN-6297: https://linear.app/nango/issue/NAN-6297/mcp-tool-integrations-get

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

