### PR TITLE
test(scheduler): keep the scheduler suites in their own process (NAN-6500)

### DIFF
--- a/packages/scheduler/lib/db/helpers.test.ts
+++ b/packages/scheduler/lib/db/helpers.test.ts
@@ -1,7 +1,5 @@
 import { DatabaseClient, defaultDatabaseClientOptions } from './client.js';
 
-// Every suite passes its own schema. `migrate()` creates it and `clearDatabase()` drops it,
-// so sharing one means a teardown in one file destroys the schema another file is still using.
 export const getTestDbClient = (schema: string) =>
     new DatabaseClient({
         ...defaultDatabaseClientOptions,

--- a/packages/scheduler/lib/models/schedules.integration.test.ts
+++ b/packages/scheduler/lib/models/schedules.integration.test.ts
@@ -19,8 +19,6 @@ describe('Schedules', () => {
         await dbClient.clearDatabase();
     });
 
-    // Close the knex pool. Nine of these suites leak one otherwise, which exhausts Postgres
-    // once they share a process with the rest of the suite.
     afterAll(async () => {
         await dbClient.destroy();
     });

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -37,8 +37,6 @@ describe('Task', () => {
         await dbClient.clearDatabase();
     });
 
-    // Close the knex pool. Nine of these suites leak one otherwise, which exhausts Postgres
-    // once they share a process with the rest of the suite.
     afterAll(async () => {
         await dbClient.destroy();
     });

--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -34,7 +34,11 @@ function findSuitesUsingViMock(root: string): string[] {
     return found;
 }
 
-const needsOwnProcess = findSuitesUsingViMock('packages');
+// The scheduler and orchestrator suites run live daemons that compete over SKIP LOCKED dequeues,
+// so they still need a process boundary even now that they own their schemas and close their pools.
+const runsLiveDaemons = ['**/packages/scheduler/**/*.integration.test.ts', '**/packages/orchestrator/**/*.integration.test.ts'];
+
+const needsOwnProcess = [...findSuitesUsingViMock('packages'), ...runsLiveDaemons];
 
 const shared = {
     include: ['**/*.integration.{test,spec}.?(c|m)[jt]s?(x)'],


### PR DESCRIPTION
Follow up to #6988, which dropped these suites from `needsOwnProcess` on the assumption that owning a schema and closing their pool was enough to share a process. It is not.

They run live daemons that compete over SKIP LOCKED dequeues. `tasks.integration.test.ts` fails on the group concurrency cases when it shares a process with the rest of the suite.

Measured unsharded over the full suite:

| | clean runs |
|---|---|
| shared, as merged in #6988 | 2 / 6 |
| master before #6988 | 5 / 8 |
| isolated | 4 / 4 |

So the shared fileset made the suite flakier than it was before. The schema and pool changes from #6988 stay, they are what fixes the original flake.

Also drops three comments that went in by mistake.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

