### PR TITLE
perf(ci): shard the unit test job (NAN-6501)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,9 +50,13 @@ jobs:
                   fi
 
                   echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
-    tests-unit:
+    tests-unit-shards:
         needs: should-run
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        strategy:
+            fail-fast: false
+            matrix:
+                shard: [1, 2, 3, 4]
         steps:
             - name: Checkout
               if: needs.should-run.outputs.should_skip != 'true'
@@ -70,8 +74,25 @@ jobs:
             - run: npm run ts-build -- --noCheck
               if: needs.should-run.outputs.should_skip != 'true'
 
-            - run: npm run test:unit -- --exclude packages/cli/
+            - run: npm run test:unit -- --exclude packages/cli/ --shard=${{ matrix.shard }}/4
               if: needs.should-run.outputs.should_skip != 'true'
+
+    # Aggregates the sharded runs into the single `tests-unit` required status check.
+    tests-unit:
+        needs: [should-run, tests-unit-shards]
+        if: always()
+        runs-on: ubuntu-latest
+        permissions: {}
+        steps:
+            - name: Verify all unit shards passed
+              run: |
+                  result="${{ needs.tests-unit-shards.result }}"
+                  if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+                      echo "Unit shards: $result"
+                      exit 0
+                  fi
+                  echo "Unit shards did not pass: $result"
+                  exit 1
 
     # Integration tests run fully serially within a process (shared Postgres/ES),
     # so we shard the file set across parallel runners to cut wall-clock time.


### PR DESCRIPTION
`tests-unit` is now the critical path of the tests workflow, at 11.6 to 14.1m against 3.2 to 4.7m for each integration shard. It gates the PR run and the merge queue run, so it costs roughly twice per merge.

Vitest reports `import 1890s` against `tests 21.6s` for 225 files, because every file runs in its own process and re-imports the workspace graph. Sharding across four runners parallelises that without changing how any test behaves.

`tests-unit` becomes an aggregator over `tests-unit-shards`, mirroring `tests-integration`, so the required status check keeps its name.

Shards split by file count rather than import cost, so expect the four durations to be uneven, as the integration shards are.

Related to NAN-6488.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

