### PR TITLE
feat(server): Allow custom properties on integration import

### DIFF
--- a/packages/server/lib/controllers/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/integrations/postIntegration.ts
@@ -139,7 +139,7 @@ export const postPublicIntegration = asyncWrapper<PostPublicIntegration>(async (
             res.status(400).send({ error: { code: 'invalid_body', message: 'This provider uses integration_config; set its values there instead of custom' } });
             return;
         }
-        newIntegration.custom = { ...body.custom, ...newIntegration.custom };
+        newIntegration.custom = { ...newIntegration.custom, ...body.custom };
     }
 
     const result = await configService.createProviderConfig(newIntegration, provider);

--- a/packages/server/lib/controllers/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/integrations/postIntegration.ts
@@ -139,7 +139,7 @@ export const postPublicIntegration = asyncWrapper<PostPublicIntegration>(async (
             res.status(400).send({ error: { code: 'invalid_body', message: 'This provider uses integration_config; set its values there instead of custom' } });
             return;
         }
-        newIntegration.custom = { ...newIntegration.custom, ...body.custom };
+        newIntegration.custom = { ...body.custom, ...newIntegration.custom };
     }
 
     const result = await configService.createProviderConfig(newIntegration, provider);

--- a/packages/server/lib/controllers/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/integrations/postIntegration.ts
@@ -27,7 +27,8 @@ const baseValidationBody = z
 
 const validationBody = baseValidationBody.extend({
     credentials: integrationCredentialsSchema.optional(),
-    integration_config: z.record(z.string(), z.string().max(8192)).optional()
+    integration_config: z.record(z.string(), z.string().max(8192)).optional(),
+    custom: z.record(z.string(), z.string()).optional()
 });
 
 const quickstartAuthModes = new Set(['OAUTH1', 'OAUTH2']);
@@ -129,6 +130,16 @@ export const postPublicIntegration = asyncWrapper<PostPublicIntegration>(async (
             return;
         }
         newIntegration.custom = { ...newIntegration.custom, ...cfg.value };
+    }
+
+    // Free-form custom values, for providers without an `integration_config` schema. Schema providers must use
+    // `integration_config` (validated) so this path can't write a config the form/v1 API would reject.
+    if (body.custom && Object.keys(body.custom).length > 0) {
+        if (provider.integration_config) {
+            res.status(400).send({ error: { code: 'invalid_body', message: 'This provider uses integration_config; set its values there instead of custom' } });
+            return;
+        }
+        newIntegration.custom = { ...newIntegration.custom, ...body.custom };
     }
 
     const result = await configService.createProviderConfig(newIntegration, provider);

--- a/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.ts
@@ -114,8 +114,8 @@ export const patchPublicIntegration = asyncWrapper<PatchPublicIntegration>(async
             return;
         }
         integration.custom = {
-            ...integration.custom,
-            ...body.custom
+            ...body.custom,
+            ...integration.custom
         };
     }
 

--- a/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.ts
@@ -114,8 +114,8 @@ export const patchPublicIntegration = asyncWrapper<PatchPublicIntegration>(async
             return;
         }
         integration.custom = {
-            ...body.custom,
-            ...integration.custom
+            ...integration.custom,
+            ...body.custom
         };
     }
 

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -61,7 +61,11 @@ export type PostPublicIntegration = ApiEndpoint<{
         display_name?: string | undefined;
         credentials?: ApiPublicIntegrationCredentials | undefined;
         forward_webhooks?: boolean | undefined;
+        // Custom integration configuration (providers that declare `integration_config`, e.g. private-api-generic).
+        // Validated server-side against the provider schema and persisted to the `custom` column.
         integration_config?: Record<string, string> | undefined;
+        // Free-form custom values, for providers without an `integration_config` schema.
+        custom?: Record<string, string> | undefined;
     };
     Success: {
         data: ApiPublicIntegration;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
This field is used for a few provider specific integration details, like setting OAuth client info (logo, name). Right now, it can be set when patching a integration, but not when importing a new integration. Adding support for this per a customer request, but leaving undocumented since the current implementation of custom integration properties may be re-factored (per Robin's note in thread below).

[Customer thread](https://nangohq.slack.com/archives/C0675T9JB09/p1784922314130749)

[Internal thread](https://nangohq.slack.com/archives/C073P0YK5EY/p1785162998160009)

<!-- Issue ticket number and link (if applicable) -->
[NAN-6496: feat(server): Allow setting custom integration properties from import endpoint](https://linear.app/nango/issue/NAN-6496/featserver-allow-setting-custom-integration-properties-from-import)

<!-- Testing instructions (skip if just adding/editing providers) -->
Test with a simple curl:

```
curl -X POST http://localhost:3003/integrations \
  -H "Authorization: Bearer <YOUR_LOCAL_SECRET_KEY>" \
  -H "Content-Type: application/json" \
  -d '{
    "provider": "mcp-generic",
    "unique_key": "mcp-generic-test",
    "custom": {
      "oauth_client_name": "My Test App",
      "oauth_client_uri": "https://example.com",
      "oauth_client_logo_uri": "https://example.com/logo.png"
    }
  }'
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

