### PR TITLE
refactor: move flow service to server

### DIFF
--- a/packages/server/lib/controllers/flow.controller.ts
+++ b/packages/server/lib/controllers/flow.controller.ts
@@ -1,4 +1,6 @@
-import { configService, flowService, getSyncConfigsAsStandardConfig } from '@nangohq/shared';
+import { configService, getSyncConfigsAsStandardConfig } from '@nangohq/shared';
+
+import flowService from '../services/flow.service.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { NextFunction, Request, Response } from 'express';

--- a/packages/server/lib/controllers/v1/flows/preBuilt/helpers.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/helpers.ts
@@ -1,7 +1,8 @@
 import db from '@nangohq/database';
 import { logContextGetter } from '@nangohq/logs';
-import { configService, deployTemplate, flowService, productTracking, startTrial, syncManager } from '@nangohq/shared';
+import { configService, deployTemplate, productTracking, startTrial, syncManager } from '@nangohq/shared';
 
+import flowService from '../../../../services/flow.service.js';
 import { getOrchestrator } from '../../../../utils/utils.js';
 
 import type { DBEnvironment, DBPlan, DBTeam, DBUser, RunnableFunctionType, ScriptTypeLiteral, SyncDeploymentResult } from '@nangohq/types';

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
@@ -1,8 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { flowService, getSyncConfigRaw, remoteFileService, seeders, updatePlan } from '@nangohq/shared';
+import { getSyncConfigRaw, remoteFileService, seeders, updatePlan } from '@nangohq/shared';
 
 import db from '../../../../../../database/lib/index.js';
+import flowService from '../../../../services/flow.service.js';
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
 
 let api: Awaited<ReturnType<typeof runServer>>;

--- a/packages/server/lib/controllers/v1/flows/preBuilt/putUpgrade.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/putUpgrade.ts
@@ -1,10 +1,11 @@
 import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
-import { configService, flowService, getSyncConfigById, upgradeTemplate } from '@nangohq/shared';
+import { configService, getSyncConfigById, upgradeTemplate } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { providerConfigKeySchema, providerSchema, scriptNameSchema } from '../../../../helpers/validation.js';
+import flowService from '../../../../services/flow.service.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { flowConfig } from '../../../sync/deploy/validation.js';
 

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.integration.test.ts
@@ -1,7 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { flowService, seeders } from '@nangohq/shared';
+import { seeders } from '@nangohq/shared';
 
+import flowService from '../../../../../services/flow.service.js';
 import { isError, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../../utils/tests.js';
 
 const route = '/api/v1/integrations/:providerConfigKey/flows';

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.ts
@@ -1,6 +1,7 @@
-import { configService, flowService, getSyncConfigsAsStandardConfig } from '@nangohq/shared';
+import { configService, getSyncConfigsAsStandardConfig } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import flowService from '../../../../../services/flow.service.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 import { validationParams } from '../getIntegration.js';
 

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
@@ -4,12 +4,13 @@ import * as z from 'zod';
 
 import { permissions } from '@nangohq/authz';
 import { getProviderScopes } from '@nangohq/providers';
-import { configService, connectionService, flowService, getGlobalWebhookReceiveUrl, getProvider } from '@nangohq/shared';
+import { configService, connectionService, getGlobalWebhookReceiveUrl, getProvider } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { resolve } from '../../../../authz/resolve.js';
 import { integrationToApi } from '../../../../formatters/integration.js';
 import { providerConfigKeySchema } from '../../../../helpers/validation.js';
+import flowService from '../../../../services/flow.service.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { GetIntegration } from '@nangohq/types';

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/templates/getTemplates.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/templates/getTemplates.ts
@@ -1,7 +1,8 @@
-import { configService, flowService, legacyFunctionService } from '@nangohq/shared';
+import { configService, legacyFunctionService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { toNangoFunction } from '../../../../../formatters/function.js';
+import flowService from '../../../../../services/flow.service.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 import { validationParams } from '../getIntegration.js';
 

--- a/packages/server/lib/controllers/v1/providers/providerConfigKey/templates/helpers.ts
+++ b/packages/server/lib/controllers/v1/providers/providerConfigKey/templates/helpers.ts
@@ -1,6 +1,5 @@
-import { flowService } from '@nangohq/shared';
-
 import { toNangoFunction } from '../../../../../formatters/function.js';
+import flowService from '../../../../../services/flow.service.js';
 
 import type { RequestLocals } from '../../../../../utils/express.js';
 import type { GetProviderTemplates } from '@nangohq/types';

--- a/packages/server/lib/services/flow.service.ts
+++ b/packages/server/lib/services/flow.service.ts
@@ -1,11 +1,16 @@
-import { filterJsonSchemaForModels } from '@nangohq/utils';
+import { createRequire } from 'node:module';
 
-import flowsJson from '../../flows.zero.json' with { type: 'json' };
+import { filterJsonSchemaForModels } from '@nangohq/utils';
 
 import type { FlowsZeroJson, ScriptTypeLiteral, StandardNangoConfig } from '@nangohq/types';
 
+// Only load the flow catalog when this service is imported.
+const nodeRequire = createRequire(import.meta.url);
+// TODO: move flows.zero.json from shared to server. But this will require refactoring how templates are pushed to the nango repository.
+const flowsJson = nodeRequire('../../../shared/flows.zero.json') as FlowsZeroJson;
+
 class FlowService {
-    flowsJson: FlowsZeroJson = flowsJson as FlowsZeroJson;
+    flowsJson: FlowsZeroJson = flowsJson;
     flowsStandard: StandardNangoConfig[] | undefined;
 
     public getAllAvailableFlowsAsStandardConfig(): StandardNangoConfig[] {

--- a/packages/server/lib/services/flow.service.unit.test.ts
+++ b/packages/server/lib/services/flow.service.unit.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import FlowService from './flow.service.js';
+import flowService from './flow.service.js';
 
 describe('Flow service tests', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         // Reset the cache before each test
-        (FlowService as any).flowsStandard = undefined;
+        flowService.flowsStandard = undefined;
     });
 
     afterEach(() => {
@@ -14,7 +14,7 @@ describe('Flow service tests', () => {
     });
 
     it('should get all available flows as standard config', () => {
-        const result = FlowService.getAllAvailableFlowsAsStandardConfig();
+        const result = flowService.getAllAvailableFlowsAsStandardConfig();
 
         expect(result).toBeDefined();
         expect(Array.isArray(result)).toBe(true);
@@ -31,7 +31,7 @@ describe('Flow service tests', () => {
 
     it('should get flow by integration and name', () => {
         // Get all flows first to find a valid provider and flow
-        const allFlows = FlowService.getAllAvailableFlowsAsStandardConfig();
+        const allFlows = flowService.getAllAvailableFlowsAsStandardConfig();
         expect(allFlows.length).toBeGreaterThan(0);
 
         const firstIntegration = allFlows[0];
@@ -39,7 +39,7 @@ describe('Flow service tests', () => {
 
         // Test with a sync if available
         if (firstIntegration && firstIntegration?.syncs?.length > 0) {
-            const syncFlow = FlowService.getFlowByIntegrationAndName({
+            const syncFlow = flowService.getFlowByIntegrationAndName({
                 provider: firstIntegration?.providerConfigKey || '',
                 type: 'sync',
                 scriptName: firstIntegration.syncs[0]?.name || ''
@@ -52,7 +52,7 @@ describe('Flow service tests', () => {
 
         // Test with an action if available
         if (firstIntegration && firstIntegration?.actions?.length > 0) {
-            const actionFlow = FlowService.getFlowByIntegrationAndName({
+            const actionFlow = flowService.getFlowByIntegrationAndName({
                 provider: firstIntegration?.providerConfigKey || '',
                 type: 'action',
                 scriptName: firstIntegration.actions[0]?.name || ''
@@ -66,7 +66,7 @@ describe('Flow service tests', () => {
 
     it('should get flow by name across all integrations', () => {
         // Get all flows first to find a valid flow name
-        const allFlows = FlowService.getAllAvailableFlowsAsStandardConfig();
+        const allFlows = flowService.getAllAvailableFlowsAsStandardConfig();
         expect(allFlows.length).toBeGreaterThan(0);
 
         // Find a sync flow
@@ -79,7 +79,7 @@ describe('Flow service tests', () => {
         }
 
         if (syncFlowName) {
-            const syncFlow = FlowService.getFlow(syncFlowName);
+            const syncFlow = flowService.getFlow(syncFlowName);
             expect(syncFlow).not.toBeNull();
             expect(syncFlow?.name).toBe(syncFlowName);
             expect(syncFlow?.type).toBe('sync');
@@ -95,7 +95,7 @@ describe('Flow service tests', () => {
         }
 
         if (actionFlowName) {
-            const actionFlow = FlowService.getFlow(actionFlowName);
+            const actionFlow = flowService.getFlow(actionFlowName);
             expect(actionFlow).not.toBeNull();
             expect(actionFlow?.name).toBe(actionFlowName);
             expect(actionFlow?.type).toBe('action');
@@ -104,7 +104,7 @@ describe('Flow service tests', () => {
 
     it('should get single flow as standard config', () => {
         // Get all flows first to find valid flow names
-        const allFlows = FlowService.getAllAvailableFlowsAsStandardConfig();
+        const allFlows = flowService.getAllAvailableFlowsAsStandardConfig();
         expect(allFlows.length).toBeGreaterThan(0);
 
         // Find a sync flow
@@ -117,7 +117,7 @@ describe('Flow service tests', () => {
         }
 
         if (syncFlowName) {
-            const syncConfig = FlowService.getSingleFlowAsStandardConfig(syncFlowName);
+            const syncConfig = flowService.getSingleFlowAsStandardConfig(syncFlowName);
             expect(syncConfig).not.toBeNull();
             expect(syncConfig?.syncs).toHaveLength(1);
             expect(syncConfig?.syncs[0]?.name).toBe(syncFlowName);
@@ -134,7 +134,7 @@ describe('Flow service tests', () => {
         }
 
         if (actionFlowName) {
-            const actionConfig = FlowService.getSingleFlowAsStandardConfig(actionFlowName);
+            const actionConfig = flowService.getSingleFlowAsStandardConfig(actionFlowName);
             expect(actionConfig).not.toBeNull();
             expect(actionConfig?.actions).toHaveLength(1);
             expect(actionConfig?.actions[0]?.name).toBe(actionFlowName);
@@ -143,25 +143,25 @@ describe('Flow service tests', () => {
     });
 
     it('should resolve the symlink target name for symlinked providers and return null otherwise', () => {
-        const symlinked = FlowService.flowsJson.find((flow) => flow.symLinkTargetName);
+        const symlinked = flowService.flowsJson.find((flow) => flow.symLinkTargetName);
         expect(symlinked, 'expected at least one symlinked provider in flows.zero.json').toBeDefined();
 
         const provider = symlinked!.providerConfigKey;
         const target = symlinked!.symLinkTargetName!;
 
-        expect(FlowService.getSymLinkTargetName(provider)).toBe(target);
+        expect(flowService.getSymLinkTargetName(provider)).toBe(target);
         // The target folder is canonical, so it must not itself be a symlink.
-        expect(FlowService.getSymLinkTargetName(target)).toBeNull();
-        expect(FlowService.getSymLinkTargetName('this-provider-does-not-exist')).toBeNull();
+        expect(flowService.getSymLinkTargetName(target)).toBeNull();
+        expect(flowService.getSymLinkTargetName('this-provider-does-not-exist')).toBeNull();
     });
 
     it('should cache flows standard config after first call', () => {
         // First call should populate cache
-        const result1 = FlowService.getAllAvailableFlowsAsStandardConfig();
+        const result1 = flowService.getAllAvailableFlowsAsStandardConfig();
         expect(result1).toBeDefined();
 
         // Second call should use cached version
-        const result2 = FlowService.getAllAvailableFlowsAsStandardConfig();
+        const result2 = flowService.getAllAvailableFlowsAsStandardConfig();
         expect(result2).toBeDefined();
 
         // Both should be the same reference due to caching

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -9,7 +9,6 @@ import environmentService from './services/environment.service.js';
 import * as externalWebhookService from './services/external-webhook.service.js';
 import localFileService from './services/file/local.service.js';
 import remoteFileService from './services/file/remote.service.js';
-import flowService from './services/flow.service.js';
 import hmacService from './services/hmac.service.js';
 import mfaService from './services/mfa.service.js';
 import { errorNotificationService } from './services/notification/error.service.js';
@@ -82,7 +81,6 @@ export {
     errorManager,
     errorNotificationService,
     externalWebhookService,
-    flowService,
     generateSlackConnectionId,
     getEncryptionManager,
     hmacService,


### PR DESCRIPTION
- moving flow service from shared to server since this is the only package where it is used.
- lazy load the massive flows.zero.json

Other than code organization, lazily loading flows.zero.json and only doing it in server prevents each apps and tests than don't require the flow service to load the file which is very resource intensive. Vitest imports locally goes from `1781s` to `134s`  

Note: the flows.zero.json file isn't being moved out of shared yet since it would break the templates import workflow

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

