### PR TITLE
refactor(mcp): rename control plane server to management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,7 @@ All notable changes to this project will be documented in this file.
 - *(providers)* Add Auvik us6 region (#6707) by @mayankj
 - *(design-system)* Add focus ring to input fields (#6698) by @macko911
 - *(design-system)* Reduce default form-control height to 32px (#6699) by @macko911
-- *(mcp)* Register Management MCP server (#6659) by @marcindobry
+- *(mcp)* Register control-plane MCP server (#6659) by @marcindobry
 - *(function)* Tweak function input and concurrency (#6697) by @TBonnin
 - Add HTTP API reference pages for function endpoints (#6526) by @kaposke
 - *(mcp)* Support client ID metadata documents (CIMD) (#6708) by @agusayerza
@@ -249,7 +249,7 @@ All notable changes to this project will be documented in this file.
 - *(audit)* Add audit_trail_events ClickHouse table (NAN-6272) (#6787) by @pfreixes
 - *(integrations)* Add support for sage-member (#6717) by @hassan254-prog
 - *(integrations)* Allow client credentials for sage intacct to be defined at integration level (#6751) by @hassan254-prog
-- Add Management MCP reference (#6757) by @marcindobry
+- Add Control Plane MCP reference (#6757) by @marcindobry
 - *(integrations)* Add support for odoo-api-key (#6807) by @hassan254-prog
 - *(auth)* Add MFA factor storage (#6792) by @agusayerza
 - *(integrations)* Add support for datadog oauth (#6796) by @hassan254-prog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,7 @@ All notable changes to this project will be documented in this file.
 - *(providers)* Add Auvik us6 region (#6707) by @mayankj
 - *(design-system)* Add focus ring to input fields (#6698) by @macko911
 - *(design-system)* Reduce default form-control height to 32px (#6699) by @macko911
-- *(mcp)* Register control-plane MCP server (#6659) by @marcindobry
+- *(mcp)* Register Management MCP server (#6659) by @marcindobry
 - *(function)* Tweak function input and concurrency (#6697) by @TBonnin
 - Add HTTP API reference pages for function endpoints (#6526) by @kaposke
 - *(mcp)* Support client ID metadata documents (CIMD) (#6708) by @agusayerza
@@ -249,7 +249,7 @@ All notable changes to this project will be documented in this file.
 - *(audit)* Add audit_trail_events ClickHouse table (NAN-6272) (#6787) by @pfreixes
 - *(integrations)* Add support for sage-member (#6717) by @hassan254-prog
 - *(integrations)* Allow client credentials for sage intacct to be defined at integration level (#6751) by @hassan254-prog
-- Add Control Plane MCP reference (#6757) by @marcindobry
+- Add Management MCP reference (#6757) by @marcindobry
 - *(integrations)* Add support for odoo-api-key (#6807) by @hassan254-prog
 - *(auth)* Add MFA factor storage (#6792) by @agusayerza
 - *(integrations)* Add support for datadog oauth (#6796) by @hassan254-prog

--- a/packages/server/lib/controllers/mcp/audit.ts
+++ b/packages/server/lib/controllers/mcp/audit.ts
@@ -8,12 +8,12 @@ import type { AuditActor, AuditContext, AuditOutcome, AuditPolicy, AuditTarget, 
 
 const logger = getLogger('Server.ManagementMcpAudit');
 
-export interface ControlPlaneMcpAuditContext {
+export interface ManagementMcpAuditContext {
     actor: AuditActor;
     context: AuditContext;
 }
 
-export function recordControlPlaneMcpAudit({
+export function recordManagementMcpAudit({
     account,
     environment,
     auditContext,
@@ -24,7 +24,7 @@ export function recordControlPlaneMcpAudit({
 }: {
     account: DBTeam;
     environment: DBEnvironment;
-    auditContext: ControlPlaneMcpAuditContext;
+    auditContext: ManagementMcpAuditContext;
     policy: AuditPolicy;
     outcome: AuditOutcome;
     target?: AuditTarget | AuditTarget[] | undefined;

--- a/packages/server/lib/controllers/mcp/integrations/create.ts
+++ b/packages/server/lib/controllers/mcp/integrations/create.ts
@@ -8,7 +8,7 @@ import {
     providerSchema
 } from '../../../helpers/validation.js';
 import integrationService from '../../../services/integration.service.js';
-import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
+import { defineManagementMcpTool } from '../managementTool.js';
 import { PublicMcpError } from '../utils.js';
 import { integrationToMcp } from './formatter.js';
 import { createIntegrationsOutputSchema } from './schema.js';
@@ -40,7 +40,7 @@ const createIntegrationArgumentsSchema = z.discriminatedUnion('credential_source
         .strict()
 ]);
 
-export const createIntegrationsTool = defineControlPlaneMcpTool<typeof createIntegrationArgumentsSchema, CreateIntegrationsOutput>({
+export const createIntegrationsTool = defineManagementMcpTool<typeof createIntegrationArgumentsSchema, CreateIntegrationsOutput>({
     name: 'integrations_create',
     description: 'Create an integration in Nango using caller-supplied or Nango-provided developer-app credentials.',
     inputSchema: createIntegrationArgumentsSchema,

--- a/packages/server/lib/controllers/mcp/integrations/create.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/create.unit.test.ts
@@ -8,7 +8,7 @@ import integrationService, { IntegrationServiceError } from '../../../services/i
 import { PublicMcpError } from '../utils.js';
 import { createIntegrationsTool } from './create.js';
 
-import type { ControlPlaneMcpContext } from '../controlPlaneTool.js';
+import type { ManagementMcpContext } from '../managementTool.js';
 import type { Config } from '@nangohq/shared';
 import type { Provider } from '@nangohq/types';
 
@@ -16,7 +16,7 @@ const context = {
     account: {},
     environment: { id: 42 },
     grantedScopes: ['environment:integrations:create']
-} as ControlPlaneMcpContext;
+} as ManagementMcpContext;
 
 const createdAt = new Date('2026-01-01T00:00:00.000Z');
 const updatedAt = new Date('2026-01-02T00:00:00.000Z');
@@ -180,7 +180,7 @@ describe('createIntegrationsTool', () => {
                 actor: { type: 'api_key', id: '7', display: 'Management key' },
                 context: { ip: '127.0.0.1', userAgent: 'test-client' }
             }
-        } as ControlPlaneMcpContext;
+        } as ManagementMcpContext;
 
         const result = await createIntegrationsTool.handler(
             {

--- a/packages/server/lib/controllers/mcp/integrations/get.ts
+++ b/packages/server/lib/controllers/mcp/integrations/get.ts
@@ -3,7 +3,7 @@ import * as z from 'zod/v4';
 import { providerConfigKeySchema } from '../../../helpers/validation.js';
 import { hasScope } from '../../../middleware/scope.middleware.js';
 import integrationService from '../../../services/integration.service.js';
-import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
+import { defineManagementMcpTool } from '../managementTool.js';
 import { PublicMcpError } from '../utils.js';
 import { integrationToMcp } from './formatter.js';
 import { getIntegrationOutputSchema } from './schema.js';
@@ -20,7 +20,7 @@ const getIntegrationArgumentsSchema = z
     })
     .strict();
 
-export const getIntegrationsTool = defineControlPlaneMcpTool<typeof getIntegrationArgumentsSchema, GetIntegrationOutput>({
+export const getIntegrationsTool = defineManagementMcpTool<typeof getIntegrationArgumentsSchema, GetIntegrationOutput>({
     name: 'integrations_get',
     description: 'Get a configured integration by ID.',
     inputSchema: getIntegrationArgumentsSchema,

--- a/packages/server/lib/controllers/mcp/integrations/get.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/get.unit.test.ts
@@ -6,7 +6,7 @@ import integrationService, { IntegrationServiceError } from '../../../services/i
 import { PublicMcpError } from '../utils.js';
 import { getIntegrationsTool } from './get.js';
 
-import type { ControlPlaneMcpContext } from '../controlPlaneTool.js';
+import type { ManagementMcpContext } from '../managementTool.js';
 import type { Config } from '@nangohq/shared';
 import type { Provider } from '@nangohq/types';
 
@@ -124,12 +124,12 @@ describe('getIntegrationsTool', () => {
     });
 });
 
-function context(grantedScopes: string[]): ControlPlaneMcpContext {
+function context(grantedScopes: string[]): ManagementMcpContext {
     return {
         account: {},
         environment: { id: 42, uuid: 'environment-uuid' },
         grantedScopes
-    } as ControlPlaneMcpContext;
+    } as ManagementMcpContext;
 }
 
 function integrationFixture(): Config {

--- a/packages/server/lib/controllers/mcp/integrations/list.ts
+++ b/packages/server/lib/controllers/mcp/integrations/list.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod/v4';
 
 import integrationService from '../../../services/integration.service.js';
-import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
+import { defineManagementMcpTool } from '../managementTool.js';
 import { integrationToMcp } from './formatter.js';
 import { listIntegrationsOutputSchema } from './schema.js';
 
@@ -9,7 +9,7 @@ import type { ListIntegrationsOutput } from './schema.js';
 
 const listIntegrationsArgumentsSchema = z.object({}).strict();
 
-export const listIntegrationsTool = defineControlPlaneMcpTool<typeof listIntegrationsArgumentsSchema, ListIntegrationsOutput>({
+export const listIntegrationsTool = defineManagementMcpTool<typeof listIntegrationsArgumentsSchema, ListIntegrationsOutput>({
     name: 'integrations_list',
     description: 'List integrations configured in the authenticated Nango environment.',
     inputSchema: listIntegrationsArgumentsSchema,

--- a/packages/server/lib/controllers/mcp/integrations/list.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/list.unit.test.ts
@@ -5,7 +5,7 @@ import { basePublicUrl, Ok } from '@nangohq/utils';
 import integrationService from '../../../services/integration.service.js';
 import { listIntegrationsTool } from './list.js';
 
-import type { ControlPlaneMcpContext } from '../controlPlaneTool.js';
+import type { ManagementMcpContext } from '../managementTool.js';
 import type { Config } from '@nangohq/shared';
 import type { Provider } from '@nangohq/types';
 
@@ -13,7 +13,7 @@ const context = {
     account: {},
     environment: { id: 42 },
     grantedScopes: ['environment:integrations:list']
-} as ControlPlaneMcpContext;
+} as ManagementMcpContext;
 
 const createdAt = new Date('2026-01-01T00:00:00.000Z');
 const updatedAt = new Date('2026-01-02T00:00:00.000Z');

--- a/packages/server/lib/controllers/mcp/logs/getOperation.ts
+++ b/packages/server/lib/controllers/mcp/logs/getOperation.ts
@@ -2,7 +2,7 @@ import * as z from 'zod/v4';
 
 import { isLogsNotFoundError, LogsDisabledError, logsOperationsService, operationIdRegex } from '@nangohq/logs';
 
-import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
+import { defineManagementMcpTool } from '../managementTool.js';
 import { PublicMcpError } from '../utils.js';
 import { defaultLimit, logsReadScope, maxLimit, normalizePeriod, periodSchema } from './utils.js';
 
@@ -38,7 +38,7 @@ const getOperationOutputSchema = z
 
 type ParsedGetOperationArguments = Omit<GetLogOperationParams, 'accountId' | 'environmentId'>;
 
-export const getLogOperationTool = defineControlPlaneMcpTool<typeof getOperationArgumentsSchema, GetLogOperationResult>({
+export const getLogOperationTool = defineManagementMcpTool<typeof getOperationArgumentsSchema, GetLogOperationResult>({
     name: 'logs_get_operation',
     description: 'Get one Nango log operation and a page of its message rows for the authenticated environment. Messages are returned newest first.',
     inputSchema: getOperationArgumentsSchema,

--- a/packages/server/lib/controllers/mcp/logs/listOperations.ts
+++ b/packages/server/lib/controllers/mcp/logs/listOperations.ts
@@ -2,7 +2,7 @@ import * as z from 'zod/v4';
 
 import { LogsDisabledError, logsOperationsService } from '@nangohq/logs';
 
-import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
+import { defineManagementMcpTool } from '../managementTool.js';
 import { PublicMcpError } from '../utils.js';
 import { defaultLimit, logsReadScope, maxLimit, normalizePeriod, periodSchema } from './utils.js';
 
@@ -168,7 +168,7 @@ const listOperationsOutputSchema = z
 type ListOperationsArguments = z.infer<typeof listOperationsArgumentsSchema>;
 type ParsedListOperationsArguments = Omit<ListLogOperationsParams, 'accountId' | 'environmentId'>;
 
-export const listLogOperationsTool = defineControlPlaneMcpTool<typeof listOperationsArgumentsSchema, ListLogOperationsResult>({
+export const listLogOperationsTool = defineManagementMcpTool<typeof listOperationsArgumentsSchema, ListLogOperationsResult>({
     name: 'logs_list_operations',
     description: [
         'List Nango log operations.',

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -133,7 +133,7 @@ function parseToolText(res: any) {
     return JSON.parse(res.json.result.content[0].text);
 }
 
-describe('POST /mcp control-plane server', () => {
+describe('POST /mcp management server', () => {
     beforeAll(async () => {
         api = await runServer();
         auditSpy = vi.spyOn(audit, 'record');

--- a/packages/server/lib/controllers/mcp/management.ts
+++ b/packages/server/lib/controllers/mcp/management.ts
@@ -2,12 +2,12 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 
 import { contextFromRequest, resolveActor } from '../../middleware/audit.middleware.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { createControlPlaneMcpServer } from './controlPlaneServer.js';
+import { createManagementMcpServer } from './managementServer.js';
 
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { GetControlPlaneMcp, PostControlPlaneMcp } from '@nangohq/types';
+import type { GetManagementMcp, PostManagementMcp } from '@nangohq/types';
 
-export const postControlPlaneMcp = asyncWrapper<PostControlPlaneMcp>(async (req, res) => {
+export const postManagementMcp = asyncWrapper<PostManagementMcp>(async (req, res) => {
     const { account, environment } = res.locals;
     const context = {
         account,
@@ -18,7 +18,7 @@ export const postControlPlaneMcp = asyncWrapper<PostControlPlaneMcp>(async (req,
             context: contextFromRequest(req)
         }
     };
-    const server = createControlPlaneMcpServer(context, req.body);
+    const server = createManagementMcpServer(context, req.body);
     const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport();
 
     res.on('close', () => {
@@ -31,7 +31,7 @@ export const postControlPlaneMcp = asyncWrapper<PostControlPlaneMcp>(async (req,
 });
 
 // We have to be explicit about not supporting SSE
-export const getControlPlaneMcp = asyncWrapper<GetControlPlaneMcp>((_, res) => {
+export const getManagementMcp = asyncWrapper<GetManagementMcp>((_, res) => {
     res.writeHead(405).end(
         JSON.stringify({
             jsonrpc: '2.0',

--- a/packages/server/lib/controllers/mcp/managementServer.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { hasScope } from '../../middleware/scope.middleware.js';
-import { recordControlPlaneMcpAudit } from './audit.js';
+import { recordManagementMcpAudit } from './audit.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { getIntegrationsTool } from './integrations/get.js';
 import { listIntegrationsTool } from './integrations/list.js';
@@ -9,22 +9,16 @@ import { getLogOperationTool } from './logs/getOperation.js';
 import { listLogOperationsTool } from './logs/listOperations.js';
 import { handleMcpToolError, jsonStructuredContent } from './utils.js';
 
-import type { ControlPlaneMcpContext, ControlPlaneMcpRequiredScopes, ControlPlaneMcpTool } from './controlPlaneTool.js';
+import type { ManagementMcpContext, ManagementMcpRequiredScopes, ManagementMcpTool } from './managementTool.js';
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ApiKeyScope } from '@nangohq/types';
 
-const controlPlaneMcpTools: ControlPlaneMcpTool[] = [
-    listIntegrationsTool,
-    getIntegrationsTool,
-    createIntegrationsTool,
-    listLogOperationsTool,
-    getLogOperationTool
-];
+const managementMcpTools: ManagementMcpTool[] = [listIntegrationsTool, getIntegrationsTool, createIntegrationsTool, listLogOperationsTool, getLogOperationTool];
 
-export function createControlPlaneMcpServer(context: ControlPlaneMcpContext, requestBody?: unknown): McpServer {
+export function createManagementMcpServer(context: ManagementMcpContext, requestBody?: unknown): McpServer {
     const server = new McpServer(
         {
-            name: 'Nango Control Plane MCP server',
+            name: 'Nango Management MCP server',
             version: '1.0.0'
         },
         {
@@ -34,7 +28,7 @@ export function createControlPlaneMcpServer(context: ControlPlaneMcpContext, req
         }
     );
 
-    for (const toolDefinition of controlPlaneMcpTools) {
+    for (const toolDefinition of managementMcpTools) {
         // Need to cast because we have a different Zod version than the MCP SDK
         const config = {
             description: toolDefinition.description,
@@ -65,7 +59,7 @@ export function createControlPlaneMcpServer(context: ControlPlaneMcpContext, req
     return server;
 }
 
-function auditDeniedCallsForTool({ requestBody, context, tool }: { requestBody: unknown; context: ControlPlaneMcpContext; tool: ControlPlaneMcpTool }): void {
+function auditDeniedCallsForTool({ requestBody, context, tool }: { requestBody: unknown; context: ManagementMcpContext; tool: ManagementMcpTool }): void {
     if (!context.audit || tool.audit.kind === 'no-audit') {
         return;
     }
@@ -85,7 +79,7 @@ function auditDeniedCallsForTool({ requestBody, context, tool }: { requestBody: 
             continue;
         }
 
-        recordControlPlaneMcpAudit({
+        recordManagementMcpAudit({
             account: context.account,
             environment: context.environment,
             auditContext: context.audit,
@@ -95,7 +89,7 @@ function auditDeniedCallsForTool({ requestBody, context, tool }: { requestBody: 
     }
 }
 
-function hasRequiredScopes({ grantedScopes, requiredScopes }: { grantedScopes: string[] | undefined; requiredScopes: ControlPlaneMcpRequiredScopes }): boolean {
+function hasRequiredScopes({ grantedScopes, requiredScopes }: { grantedScopes: string[] | undefined; requiredScopes: ManagementMcpRequiredScopes }): boolean {
     const hasRequiredScope = (scope: ApiKeyScope) => hasScope({ grantedScopes, requiredScope: scope });
     return 'every' in requiredScopes ? requiredScopes.every.every(hasRequiredScope) : requiredScopes.anyOf.some(hasRequiredScope);
 }

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -7,15 +7,15 @@ import { envs as logsEnvs } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
 import { audit } from '../../audit.js';
-import { createControlPlaneMcpServer } from './controlPlaneServer.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { listLogOperationsTool } from './logs/listOperations.js';
+import { createManagementMcpServer } from './managementServer.js';
 import { PublicMcpError } from './utils.js';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DBEnvironment, DBTeam } from '@nangohq/types';
 
-describe('createControlPlaneMcpServer', () => {
+describe('createManagementMcpServer', () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
@@ -135,7 +135,7 @@ describe('createControlPlaneMcpServer', () => {
                 arguments: { credentials: { client_secret: 'credential-secret-value' } }
             }
         };
-        const server = createControlPlaneMcpServer(
+        const server = createManagementMcpServer(
             {
                 account: fakeAccount(),
                 environment: fakeEnvironment(),
@@ -336,7 +336,7 @@ describe('createControlPlaneMcpServer', () => {
 
 async function createTestClient(grantedScopes: string[]): Promise<{ client: Client; server: McpServer }> {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    const server = createControlPlaneMcpServer({ account: fakeAccount(), environment: fakeEnvironment(), grantedScopes });
+    const server = createManagementMcpServer({ account: fakeAccount(), environment: fakeEnvironment(), grantedScopes });
     const client = new Client({ name: 'test-client', version: '1.0.0' });
 
     await server.connect(serverTransport);

--- a/packages/server/lib/controllers/mcp/managementTool.ts
+++ b/packages/server/lib/controllers/mcp/managementTool.ts
@@ -1,9 +1,9 @@
 import { Err, getLogger } from '@nangohq/utils';
 
-import { recordControlPlaneMcpAudit } from './audit.js';
+import { recordManagementMcpAudit } from './audit.js';
 import { PublicMcpError } from './utils.js';
 
-import type { ControlPlaneMcpAuditContext } from './audit.js';
+import type { ManagementMcpAuditContext } from './audit.js';
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { ApiKeyScope, AuditPolicy, AuditTarget, DBEnvironment, DBTeam, EndpointAudit, NoAudit } from '@nangohq/types';
@@ -12,46 +12,46 @@ import type * as z from 'zod/v4';
 
 const logger = getLogger('Server.ManagementMcpTool');
 
-export interface ControlPlaneMcpContext {
+export interface ManagementMcpContext {
     account: DBTeam;
     environment: DBEnvironment;
     grantedScopes: string[] | undefined;
-    audit?: ControlPlaneMcpAuditContext | undefined;
+    audit?: ManagementMcpAuditContext | undefined;
 }
 
-export type ControlPlaneMcpSchema = AnySchema | z.ZodType;
-export type ControlPlaneMcpRequiredScopes = { every: ApiKeyScope[] } | { anyOf: ApiKeyScope[] };
+export type ManagementMcpSchema = AnySchema | z.ZodType;
+export type ManagementMcpRequiredScopes = { every: ApiKeyScope[] } | { anyOf: ApiKeyScope[] };
 
-export interface ControlPlaneMcpTool<TResponse extends object = object> {
+export interface ManagementMcpTool<TResponse extends object = object> {
     name: string;
     description: string;
-    inputSchema: ControlPlaneMcpSchema;
-    outputSchema?: ControlPlaneMcpSchema;
+    inputSchema: ManagementMcpSchema;
+    outputSchema?: ManagementMcpSchema;
     annotations?: ToolAnnotations;
-    requiredScopes: ControlPlaneMcpRequiredScopes;
+    requiredScopes: ManagementMcpRequiredScopes;
     audit: EndpointAudit;
-    handler: (args: unknown, context: ControlPlaneMcpContext) => Promise<Result<TResponse>>;
+    handler: (args: unknown, context: ManagementMcpContext) => Promise<Result<TResponse>>;
 }
 
-type ControlPlaneMcpAuditedTool<TArgs, TResponse extends object> = AuditPolicy & {
-    metadata?: ((context: ControlPlaneMcpContext & { args: TArgs }) => Record<string, unknown> | undefined) | undefined;
-    targetFromOutput?: ((context: ControlPlaneMcpContext & { args: TArgs; output: TResponse }) => AuditTarget | AuditTarget[] | undefined) | undefined;
+type ManagementMcpAuditedTool<TArgs, TResponse extends object> = AuditPolicy & {
+    metadata?: ((context: ManagementMcpContext & { args: TArgs }) => Record<string, unknown> | undefined) | undefined;
+    targetFromOutput?: ((context: ManagementMcpContext & { args: TArgs; output: TResponse }) => AuditTarget | AuditTarget[] | undefined) | undefined;
 };
 
-type ControlPlaneMcpToolAudit<TArgs, TResponse extends object> = NoAudit<string> | ControlPlaneMcpAuditedTool<TArgs, TResponse>;
+type ManagementMcpToolAudit<TArgs, TResponse extends object> = NoAudit<string> | ManagementMcpAuditedTool<TArgs, TResponse>;
 
-type ControlPlaneMcpToolDefinition<TInputSchema extends z.ZodType, TResponse extends object> = Omit<
-    ControlPlaneMcpTool<TResponse>,
+type ManagementMcpToolDefinition<TInputSchema extends z.ZodType, TResponse extends object> = Omit<
+    ManagementMcpTool<TResponse>,
     'audit' | 'handler' | 'inputSchema'
 > & {
     inputSchema: TInputSchema;
-    audit: ControlPlaneMcpToolAudit<z.output<TInputSchema>, TResponse>;
-    handler: (context: ControlPlaneMcpContext & { args: z.output<TInputSchema> }) => Result<TResponse> | Promise<Result<TResponse>>;
+    audit: ManagementMcpToolAudit<z.output<TInputSchema>, TResponse>;
+    handler: (context: ManagementMcpContext & { args: z.output<TInputSchema> }) => Result<TResponse> | Promise<Result<TResponse>>;
 };
 
-export function defineControlPlaneMcpTool<TInputSchema extends z.ZodType, TResponse extends object>(
-    tool: ControlPlaneMcpToolDefinition<TInputSchema, TResponse>
-): ControlPlaneMcpTool<TResponse> {
+export function defineManagementMcpTool<TInputSchema extends z.ZodType, TResponse extends object>(
+    tool: ManagementMcpToolDefinition<TInputSchema, TResponse>
+): ManagementMcpTool<TResponse> {
     return {
         ...tool,
         async handler(args, context) {
@@ -87,8 +87,8 @@ function recordToolAudit<TInputSchema extends z.ZodType, TResponse extends objec
     output,
     outcome
 }: {
-    tool: ControlPlaneMcpToolDefinition<TInputSchema, TResponse>;
-    context: ControlPlaneMcpContext;
+    tool: ManagementMcpToolDefinition<TInputSchema, TResponse>;
+    context: ManagementMcpContext;
     args?: z.output<TInputSchema> | undefined;
     output?: TResponse | undefined;
     outcome: 'success' | 'failure';
@@ -101,7 +101,7 @@ function recordToolAudit<TInputSchema extends z.ZodType, TResponse extends objec
         const typedContext = args === undefined ? undefined : { ...context, args };
         const metadata = typedContext && tool.audit.metadata ? tool.audit.metadata(typedContext) : undefined;
         const target = typedContext && output && tool.audit.targetFromOutput ? tool.audit.targetFromOutput({ ...typedContext, output }) : undefined;
-        recordControlPlaneMcpAudit({
+        recordManagementMcpAudit({
             account: context.account,
             environment: context.environment,
             auditContext: context.audit,

--- a/packages/server/lib/controllers/mcp/managementTool.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementTool.unit.test.ts
@@ -5,17 +5,17 @@ import { getFlags } from '@nangohq/feature-flags';
 import { Err, Ok } from '@nangohq/utils';
 
 import { audit } from '../../audit.js';
-import { defineControlPlaneMcpTool } from './controlPlaneTool.js';
+import { defineManagementMcpTool } from './managementTool.js';
 import { PublicMcpError } from './utils.js';
 
-import type { ControlPlaneMcpContext } from './controlPlaneTool.js';
+import type { ManagementMcpContext } from './managementTool.js';
 import type { Result } from '@nangohq/utils';
 
 const context = {
     account: {},
     environment: {},
     grantedScopes: ['environment:mcp']
-} as ControlPlaneMcpContext;
+} as ManagementMcpContext;
 
 const auditedContext = {
     account: { id: 1, uuid: 'account-uuid' },
@@ -25,18 +25,18 @@ const auditedContext = {
         actor: { type: 'api_key', id: '7', display: 'Management key' },
         context: { ip: '127.0.0.1', userAgent: 'test-client' }
     }
-} as ControlPlaneMcpContext;
+} as ManagementMcpContext;
 
 const auditedToolArgumentsSchema = z.object({ provider: z.string() }).strict();
 type AuditedToolOutput = { data: { unique_key: string } };
 
-describe('defineControlPlaneMcpTool', () => {
+describe('defineManagementMcpTool', () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
     it('passes parsed arguments to the tool handler', async () => {
-        const tool = defineControlPlaneMcpTool({
+        const tool = defineManagementMcpTool({
             name: 'test_tool',
             description: 'Test tool',
             inputSchema: z.object({ limit: z.number().default(10) }).strict(),
@@ -56,7 +56,7 @@ describe('defineControlPlaneMcpTool', () => {
     });
 
     it('returns a public error for invalid arguments', async () => {
-        const tool = defineControlPlaneMcpTool({
+        const tool = defineManagementMcpTool({
             name: 'test_tool',
             description: 'Test tool',
             inputSchema: z.object({ limit: z.number().min(1) }).strict(),
@@ -172,7 +172,7 @@ describe('defineControlPlaneMcpTool', () => {
     it('does not audit tools that explicitly opt out', async () => {
         const flagSpy = vi.spyOn(getFlags(), 'isAuditTrailEnabled');
         const auditSpy = vi.spyOn(audit, 'record');
-        const tool = defineControlPlaneMcpTool({
+        const tool = defineManagementMcpTool({
             name: 'test_read_tool',
             description: 'Test read-only tool',
             inputSchema: z.object({}).strict(),
@@ -206,7 +206,7 @@ function enableAudit() {
 }
 
 function auditedTool(handler: () => Result<AuditedToolOutput>) {
-    return defineControlPlaneMcpTool<typeof auditedToolArgumentsSchema, AuditedToolOutput>({
+    return defineManagementMcpTool<typeof auditedToolArgumentsSchema, AuditedToolOutput>({
         name: 'test_create_tool',
         description: 'Test audited tool',
         inputSchema: auditedToolArgumentsSchema,

--- a/packages/server/lib/routes.management-mcp.ts
+++ b/packages/server/lib/routes.management-mcp.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-import { getControlPlaneMcp, postControlPlaneMcp } from './controllers/mcp/controlPlane.js';
+import { getManagementMcp, postManagementMcp } from './controllers/mcp/management.js';
 import { envs } from './env.js';
 import authMiddleware from './middleware/access.middleware.js';
 import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
@@ -11,9 +11,9 @@ import type { Request, RequestHandler } from 'express';
 
 const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
 const bodyLimit = envs.NANGO_SERVER_PUBLIC_BODY_LIMIT;
-const controlPlaneMcpRouter = express.Router();
+const managementMcpRouter = express.Router();
 
-controlPlaneMcpRouter.use(
+managementMcpRouter.use(
     '/mcp',
     express.json({
         limit: bodyLimit,
@@ -23,22 +23,22 @@ controlPlaneMcpRouter.use(
     }),
     jsonContentTypeMiddleware
 );
-controlPlaneMcpRouter.route('/mcp').post(apiAuth, postControlPlaneMcp);
-controlPlaneMcpRouter.route('/mcp').get(apiAuth, getControlPlaneMcp);
-controlPlaneMcpRouter.use((_, res) => {
+managementMcpRouter.route('/mcp').post(apiAuth, postManagementMcp);
+managementMcpRouter.route('/mcp').get(apiAuth, getManagementMcp);
+managementMcpRouter.use((_, res) => {
     res.status(404).json({ error: { code: 'not_found', message: 'Not found' } });
 });
 
-export const controlPlaneMcpAPI: RequestHandler = (req, res, next) => {
-    if (!isControlPlaneMcpHost(req.get('host') || '')) {
+export const managementMcpAPI: RequestHandler = (req, res, next) => {
+    if (!isManagementMcpHost(req.get('host') || '')) {
         next();
         return;
     }
 
-    controlPlaneMcpRouter(req, res, next);
+    managementMcpRouter(req, res, next);
 };
 
-function isControlPlaneMcpHost(host: string): boolean {
+function isManagementMcpHost(host: string): boolean {
     if (!envs.NANGO_MANAGEMENT_MCP_SERVER_URL) {
         return false;
     }
@@ -48,6 +48,6 @@ function isControlPlaneMcpHost(host: string): boolean {
         return false;
     }
 
-    const controlPlaneMcpHostname = new URL(envs.NANGO_MANAGEMENT_MCP_SERVER_URL).hostname.toLowerCase();
-    return hostname === controlPlaneMcpHostname;
+    const managementMcpHostname = new URL(envs.NANGO_MANAGEMENT_MCP_SERVER_URL).hostname.toLowerCase();
+    return hostname === managementMcpHostname;
 }

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -9,8 +9,8 @@ import { getProvidersJSON } from './controllers/v1/getProvidersJSON.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import { securityMiddlewares } from './middleware/security.js';
 import { getReady } from './ready.js';
-import { controlPlaneMcpAPI } from './routes.control-plane-mcp.js';
 import { internalApi } from './routes.internal.js';
+import { managementMcpAPI } from './routes.management-mcp.js';
 import { privateApi } from './routes.private.js';
 import { publicAPI } from './routes.public.js';
 import { dirname } from './utils/utils.js';
@@ -33,7 +33,7 @@ router.get('/providers.json', rateLimiterMiddleware, getProvidersJSON);
 
 // Import main routers
 // Order is important because public API has no prefix
-router.use(controlPlaneMcpAPI);
+router.use(managementMcpAPI);
 router.use('/api/v1', privateApi);
 router.use('/internal', internalApi);
 router.use('/', publicAPI);

--- a/packages/types/lib/mcp/api.ts
+++ b/packages/types/lib/mcp/api.ts
@@ -20,7 +20,7 @@ export type GetConnectionToolsMcp = ApiEndpoint<{
     Success: Record<string, unknown>;
 }>;
 
-export type PostControlPlaneMcp = ApiEndpoint<{
+export type PostManagementMcp = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'audited-per-tool' };
     Method: 'POST';
     Path: '/mcp';
@@ -28,7 +28,7 @@ export type PostControlPlaneMcp = ApiEndpoint<{
     Success: Record<string, unknown>;
 }>;
 
-export type GetControlPlaneMcp = ApiEndpoint<{
+export type GetManagementMcp = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/mcp';


### PR DESCRIPTION
Rename Control Plane MCP to Management MCP (mostly filename and directory changes)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

