### PR TITLE
fix(proxy): drop unresolved headers

### DIFF
--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -807,7 +807,9 @@ export function buildProxyHeaders({
                     ...stableReplacers,
                     ...baseReplacers
                 });
-                if (interpolated && !interpolated.includes('${')) {
+                const templatePlaceholders = value.match(/\$\{[^{}]*\}/g) ?? [];
+                const hasUnresolvedPlaceholder = templatePlaceholders.some((placeholder) => interpolated.includes(placeholder));
+                if (interpolated && !hasUnresolvedPlaceholder) {
                     headers[key] = interpolated;
                 }
                 continue;

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -799,7 +799,7 @@ export function buildProxyHeaders({
 
         for (const [key, value] of Object.entries(config.provider.proxy.headers) as [Lowercase<string>, string][]) {
             if (value.includes('connectionConfig')) {
-                headers[key] = interpolateIfNeeded(value, {
+                const interpolated = interpolateIfNeeded(value, {
                     connectionConfig: connection.connection_config,
                     credentials: connection.credentials,
                     ...(connection.credentials as Record<string, string>),
@@ -807,6 +807,9 @@ export function buildProxyHeaders({
                     ...stableReplacers,
                     ...baseReplacers
                 });
+                if (interpolated && !interpolated.includes('${')) {
+                    headers[key] = interpolated;
+                }
                 continue;
             }
 

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -412,6 +412,93 @@ describe('buildProxyHeaders', () => {
         expect(result['x-bar']).toBeUndefined();
     });
 
+    it('keeps a resolved header whose connectionConfig value literally contains a ${...} sequence', () => {
+        const config = getDefaultProxy({
+            provider: {
+                auth_mode: 'API_KEY',
+                proxy: {
+                    base_url: '',
+                    headers: {
+                        'x-foo': '${connectionConfig.foo}'
+                    }
+                }
+            }
+        });
+
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getTestConnection({
+                credentials: { type: 'API_KEY', apiKey: 'api-key-value' },
+                connection_config: {
+                    foo: 'literal-${not-a-placeholder}-value'
+                }
+            })
+        });
+
+        expect(result).toEqual({
+            'x-foo': 'literal-${not-a-placeholder}-value'
+        });
+    });
+
+    it('keeps a resolved header whose value literally contains a different ${connectionConfig.X}-shaped string', () => {
+        const config = getDefaultProxy({
+            provider: {
+                auth_mode: 'API_KEY',
+                proxy: {
+                    base_url: '',
+                    headers: {
+                        'x-foo': '${connectionConfig.foo}'
+                    }
+                }
+            }
+        });
+
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getTestConnection({
+                credentials: { type: 'API_KEY', apiKey: 'api-key-value' },
+                connection_config: {
+                    // foo's own resolved value happens to mention a *different* connectionConfig field name
+                    foo: 'prefix-${connectionConfig.bar}-suffix'
+                }
+            })
+        });
+
+        expect(result).toEqual({
+            'x-foo': 'prefix-${connectionConfig.bar}-suffix'
+        });
+    });
+
+    it('drops a header mixing a resolved connectionConfig value with an unresolved non-connectionConfig placeholder', () => {
+        const config = getDefaultProxy({
+            provider: {
+                auth_mode: 'API_KEY',
+                proxy: {
+                    base_url: '',
+                    headers: {
+                        'x-foo': '${connectionConfig.foo}-${credentials.missingField}'
+                    }
+                }
+            }
+        });
+
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getTestConnection({
+                credentials: { type: 'API_KEY', apiKey: 'api-key-value' },
+                connection_config: {
+                    foo: 'foo-value'
+                    // credentials.missingField does not exist on API_KEY credentials
+                }
+            })
+        });
+
+        expect(result['x-foo']).toBeUndefined();
+    });
+
     it('should correctly insert headers with dynamic values for signature based', () => {
         const config = getDefaultProxy({
             provider: {

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -381,6 +381,37 @@ describe('buildProxyHeaders', () => {
         });
     });
 
+    it('drops a header entirely when its optional connectionConfig value is missing', () => {
+        const config = getDefaultProxy({
+            provider: {
+                auth_mode: 'API_KEY',
+                proxy: {
+                    base_url: '',
+                    headers: {
+                        'x-foo': '${connectionConfig.foo}',
+                        'x-bar': '${connectionConfig.bar}'
+                    }
+                }
+            }
+        });
+
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.nangostarter.com',
+            connection: getTestConnection({
+                credentials: { type: 'API_KEY', apiKey: 'api-key-value' },
+                connection_config: {
+                    foo: 'foo-value'
+                }
+            })
+        });
+
+        expect(result).toEqual({
+            'x-foo': 'foo-value'
+        });
+        expect(result['x-bar']).toBeUndefined();
+    });
+
     it('should correctly insert headers with dynamic values for signature based', () => {
         const config = getDefaultProxy({
             provider: {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

- Drop unresolved headers after interpolating from connection config, useful for optional connectionConfig fields.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

