### PR TITLE
feat(email): add generic HTTP API email provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,7 @@ GOOGLE_APPLICATION_CREDENTIALS=
 # MAILGUN_API_KEY=
 # MAILGUN_URL=
 # Or send email through any JSON-over-HTTP mail API (SendGrid, Resend, ...)
+# EMAIL_HTTP_BODY is required whenever EMAIL_HTTP_URL is set, and must be a JSON object.
 # EMAIL_HTTP_URL=
 # EMAIL_HTTP_HEADERS=
 # EMAIL_HTTP_BODY=

--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,7 @@ GOOGLE_APPLICATION_CREDENTIALS=
 # EMAIL_HTTP_URL=
 # EMAIL_HTTP_HEADERS=
 # EMAIL_HTTP_BODY=
+# EMAIL_HTTP_TIMEOUT_MS=10000
 
 # Sender address for all providers. SendGrid wants a bare address, not "Name <addr>".
 # SMTP_FROM=

--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,13 @@ GOOGLE_APPLICATION_CREDENTIALS=
 # Key to send email
 # MAILGUN_API_KEY=
 # MAILGUN_URL=
+# Or send email through any JSON-over-HTTP mail API (SendGrid, Resend, ...)
+# EMAIL_HTTP_URL=
+# EMAIL_HTTP_HEADERS=
+# EMAIL_HTTP_BODY=
+
+# Sender address for all providers. SendGrid wants a bare address, not "Name <addr>".
+# SMTP_FROM=
 
 # Redis (optional)
 #NANGO_REDIS_URL=

--- a/packages/email/lib/client.ts
+++ b/packages/email/lib/client.ts
@@ -1,17 +1,20 @@
 import { envs } from './env.js';
+import { HttpEmailProvider } from './providers/http.provider.js';
 import { MailgunEmailProvider } from './providers/mailgun.provider.js';
 import { NoEmailProvider } from './providers/no-email.provider.js';
 import { SmtpEmailProvider } from './providers/smtp.provider.js';
 
 export class EmailClient {
     private static instance: EmailClient | undefined;
-    private provider: MailgunEmailProvider | SmtpEmailProvider | NoEmailProvider; // Mailgun specific provider is here for legacy reason
+    private provider: MailgunEmailProvider | SmtpEmailProvider | HttpEmailProvider | NoEmailProvider; // Mailgun specific provider is here for legacy reason
 
     private constructor() {
         if (envs.MAILGUN_API_KEY) {
             this.provider = new MailgunEmailProvider();
         } else if (envs.SMTP_URL) {
             this.provider = new SmtpEmailProvider();
+        } else if (envs.EMAIL_HTTP_URL) {
+            this.provider = new HttpEmailProvider();
         } else {
             this.provider = new NoEmailProvider();
         }

--- a/packages/email/lib/client.ts
+++ b/packages/email/lib/client.ts
@@ -13,9 +13,9 @@ export class EmailClient {
             this.provider = new MailgunEmailProvider();
         } else if (envs.SMTP_URL) {
             this.provider = new SmtpEmailProvider();
+        } else if (envs.EMAIL_HTTP_URL) {
             // EMAIL_HTTP_BODY is guaranteed alongside the URL: ENVS rejects one without the other,
             // so a half-configured HTTP provider fails at startup rather than on the first email.
-        } else if (envs.EMAIL_HTTP_URL) {
             this.provider = new HttpEmailProvider();
         } else {
             this.provider = new NoEmailProvider();

--- a/packages/email/lib/client.ts
+++ b/packages/email/lib/client.ts
@@ -13,6 +13,8 @@ export class EmailClient {
             this.provider = new MailgunEmailProvider();
         } else if (envs.SMTP_URL) {
             this.provider = new SmtpEmailProvider();
+            // EMAIL_HTTP_BODY is guaranteed alongside the URL: ENVS rejects one without the other,
+            // so a half-configured HTTP provider fails at startup rather than on the first email.
         } else if (envs.EMAIL_HTTP_URL) {
             this.provider = new HttpEmailProvider();
         } else {

--- a/packages/email/lib/providers/http.provider.ts
+++ b/packages/email/lib/providers/http.provider.ts
@@ -48,7 +48,8 @@ export class HttpEmailProvider implements EmailProvider<void> {
         const res = await fetch(this.url, {
             method: 'POST',
             headers: { 'content-type': 'application/json', ...this.headers },
-            body: JSON.stringify(body)
+            body: JSON.stringify(body),
+            signal: AbortSignal.timeout(envs.EMAIL_HTTP_TIMEOUT_MS)
         });
 
         if (!res.ok) {

--- a/packages/email/lib/providers/http.provider.ts
+++ b/packages/email/lib/providers/http.provider.ts
@@ -1,0 +1,58 @@
+import { envs } from '../env.js';
+
+import type { EmailProvider } from '../provider.js';
+
+type Placeholder = 'to' | 'from' | 'subject' | 'html';
+
+const PLACEHOLDER = /\{\{(to|from|subject|html)\}\}/g;
+
+/**
+ * Fills {{to}}, {{from}}, {{subject}} and {{html}} into every string of an already parsed
+ * JSON template. Substituting into the parsed structure rather than into the raw text keeps
+ * values escaped correctly whatever the HTML body contains.
+ */
+export function renderBody(template: unknown, values: Record<Placeholder, string>): unknown {
+    if (typeof template === 'string') {
+        return template.replace(PLACEHOLDER, (_match, key: Placeholder) => values[key]);
+    }
+    if (Array.isArray(template)) {
+        return template.map((entry) => renderBody(entry, values));
+    }
+    if (template !== null && typeof template === 'object') {
+        return Object.fromEntries(Object.entries(template).map(([key, value]) => [key, renderBody(value, values)]));
+    }
+    return template;
+}
+
+/**
+ * Sends through any mail API that accepts a JSON payload over HTTP (SendGrid, Resend,
+ * Postmark, ...), the shape of the payload being described by EMAIL_HTTP_BODY.
+ */
+export class HttpEmailProvider implements EmailProvider<void> {
+    private url: string;
+    private headers: Record<string, string>;
+    private bodyTemplate: unknown;
+
+    constructor() {
+        if (!envs.EMAIL_HTTP_URL || envs.EMAIL_HTTP_BODY === undefined) {
+            throw new Error('EMAIL_HTTP_URL and EMAIL_HTTP_BODY are both required to send emails over HTTP');
+        }
+        this.url = envs.EMAIL_HTTP_URL;
+        this.headers = envs.EMAIL_HTTP_HEADERS;
+        this.bodyTemplate = envs.EMAIL_HTTP_BODY;
+    }
+
+    async send(email: string, subject: string, html: string): Promise<void> {
+        const body = renderBody(this.bodyTemplate, { to: email, from: envs.SMTP_FROM, subject, html });
+
+        const res = await fetch(this.url, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', ...this.headers },
+            body: JSON.stringify(body)
+        });
+
+        if (!res.ok) {
+            throw new Error(`Email API responded with ${res.status}: ${(await res.text()).slice(0, 200)}`);
+        }
+    }
+}

--- a/packages/email/lib/providers/http.provider.unit.test.ts
+++ b/packages/email/lib/providers/http.provider.unit.test.ts
@@ -54,11 +54,11 @@ describe('renderBody', () => {
         });
     }
 
-    it('produces valid JSON for HTML containing quotes and newlines', () => {
+    it('substitutes HTML containing quotes, ampersands and newlines verbatim', () => {
         const html = '<a href="https://example.com/a?b=1&c=2">link</a>\n<p>"quoted"</p>';
         const rendered = renderBody({ content: '{{html}}' }, { ...values, html });
 
-        expect(JSON.parse(JSON.stringify(rendered))).toStrictEqual({ content: html });
+        expect(rendered).toStrictEqual({ content: html });
     });
 });
 

--- a/packages/email/lib/providers/http.provider.unit.test.ts
+++ b/packages/email/lib/providers/http.provider.unit.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { HttpEmailProvider, renderBody } from './http.provider.js';
+
+vi.mock('../env.js', () => ({
+    envs: {
+        EMAIL_HTTP_URL: 'https://api.example.com/v3/mail/send',
+        EMAIL_HTTP_HEADERS: { authorization: 'Bearer test-key' },
+        EMAIL_HTTP_BODY: {
+            personalizations: [{ to: [{ email: '{{to}}' }] }],
+            from: { email: '{{from}}' },
+            subject: '{{subject}}',
+            content: [{ type: 'text/html', value: '{{html}}' }],
+            tracking: { enabled: true }
+        },
+        SMTP_FROM: 'Nango <noreply@example.com>'
+    }
+}));
+
+const values = { to: 'user@example.com', from: 'Nango <noreply@example.com>', subject: 'Verify your email', html: '<p>Hi</p>' };
+
+describe('renderBody', () => {
+    const testCases = [
+        {
+            name: 'replaces a string that is only a placeholder with the value',
+            template: '{{subject}}',
+            expected: 'Verify your email'
+        },
+        {
+            name: 'replaces placeholders embedded in a longer string',
+            template: 'Subject: {{subject}}',
+            expected: 'Subject: Verify your email'
+        },
+        {
+            name: 'replaces placeholders nested in objects and arrays',
+            template: { personalizations: [{ to: [{ email: '{{to}}' }] }] },
+            expected: { personalizations: [{ to: [{ email: 'user@example.com' }] }] }
+        },
+        {
+            name: 'leaves non-string values untouched',
+            template: { enabled: true, retries: 3, tags: null },
+            expected: { enabled: true, retries: 3, tags: null }
+        },
+        {
+            name: 'leaves unknown placeholders in place',
+            template: '{{unknown}}',
+            expected: '{{unknown}}'
+        }
+    ];
+
+    for (const testCase of testCases) {
+        it(testCase.name, () => {
+            expect(renderBody(testCase.template, values)).toStrictEqual(testCase.expected);
+        });
+    }
+
+    it('produces valid JSON for HTML containing quotes and newlines', () => {
+        const html = '<a href="https://example.com/a?b=1&c=2">link</a>\n<p>"quoted"</p>';
+        const rendered = renderBody({ content: '{{html}}' }, { ...values, html });
+
+        expect(JSON.parse(JSON.stringify(rendered))).toStrictEqual({ content: html });
+    });
+});
+
+describe('HttpEmailProvider.send', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('posts the filled-in template to the configured URL and headers', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }));
+
+        await new HttpEmailProvider().send('user@example.com', 'Verify your email', '<p>Hi</p>');
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0] ?? [];
+        expect(url).toBe('https://api.example.com/v3/mail/send');
+        expect(init?.method).toBe('POST');
+        expect(init?.headers).toStrictEqual({ 'content-type': 'application/json', authorization: 'Bearer test-key' });
+        expect(JSON.parse(init?.body as string)).toStrictEqual({
+            personalizations: [{ to: [{ email: 'user@example.com' }] }],
+            from: { email: 'Nango <noreply@example.com>' },
+            subject: 'Verify your email',
+            content: [{ type: 'text/html', value: '<p>Hi</p>' }],
+            tracking: { enabled: true }
+        });
+    });
+
+    it('throws with the status and response body when the API rejects the request', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{"errors":["unauthorized"]}', { status: 401 }));
+
+        await expect(new HttpEmailProvider().send('user@example.com', 'Verify your email', '<p>Hi</p>')).rejects.toThrow(
+            'Email API responded with 401: {"errors":["unauthorized"]}'
+        );
+    });
+});

--- a/packages/email/lib/providers/http.provider.unit.test.ts
+++ b/packages/email/lib/providers/http.provider.unit.test.ts
@@ -13,7 +13,8 @@ vi.mock('../env.js', () => ({
             content: [{ type: 'text/html', value: '{{html}}' }],
             tracking: { enabled: true }
         },
-        SMTP_FROM: 'Nango <noreply@example.com>'
+        SMTP_FROM: 'Nango <noreply@example.com>',
+        EMAIL_HTTP_TIMEOUT_MS: 10_000
     }
 }));
 
@@ -77,6 +78,7 @@ describe('HttpEmailProvider.send', () => {
         expect(url).toBe('https://api.example.com/v3/mail/send');
         expect(init?.method).toBe('POST');
         expect(init?.headers).toStrictEqual({ 'content-type': 'application/json', authorization: 'Bearer test-key' });
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
         expect(JSON.parse(init?.body as string)).toStrictEqual({
             personalizations: [{ to: [{ email: 'user@example.com' }] }],
             from: { email: 'Nango <noreply@example.com>' },
@@ -92,5 +94,13 @@ describe('HttpEmailProvider.send', () => {
         await expect(new HttpEmailProvider().send('user@example.com', 'Verify your email', '<p>Hi</p>')).rejects.toThrow(
             'Email API responded with 401: {"errors":["unauthorized"]}'
         );
+    });
+
+    it('propagates abort errors when the request times out', async () => {
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(new DOMException('The operation was aborted', 'TimeoutError'));
+
+        await expect(new HttpEmailProvider().send('user@example.com', 'Verify your email', '<p>Hi</p>')).rejects.toMatchObject({
+            name: 'TimeoutError'
+        });
     });
 });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -452,6 +452,39 @@ export const ENVS = z.object({
     SMTP_FROM: z.string().default('Nango <noreply@email.nango.dev>'),
     SMTP_DOMAIN: z.string().default('email.nango.dev'),
 
+    // Generic HTTP email API (SendGrid, Resend, Postmark, ...)
+    EMAIL_HTTP_URL: z.url().optional(),
+    EMAIL_HTTP_HEADERS: z
+        .string()
+        .optional()
+        .transform((s, ctx) => {
+            if (s === undefined || s.trim() === '') {
+                return {};
+            }
+            try {
+                return JSON.parse(s) as unknown;
+            } catch {
+                ctx.addIssue(`Invalid JSON in EMAIL_HTTP_HEADERS`);
+                return z.NEVER; // tells Zod to stop here and mark parse as failed
+            }
+        })
+        .pipe(z.record(z.string(), z.string())),
+    // JSON payload the mail API expects, with {{to}}, {{from}}, {{subject}} and {{html}} as placeholders
+    EMAIL_HTTP_BODY: z
+        .string()
+        .optional()
+        .transform((s, ctx) => {
+            if (s === undefined || s.trim() === '') {
+                return undefined;
+            }
+            try {
+                return JSON.parse(s) as unknown;
+            } catch {
+                ctx.addIssue(`Invalid JSON in EMAIL_HTTP_BODY`);
+                return z.NEVER; // tells Zod to stop here and mark parse as failed
+            }
+        }),
+
     // Postgres
     NANGO_DATABASE_URL: z.url().optional(),
     NANGO_DB_READ_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -35,7 +35,7 @@ function outboundUrlPolicySchema(varName: string) {
         );
 }
 
-export const ENVS = z.object({
+const ENVS_SHAPE = z.object({
     // Node ecosystem
     NODE_ENV: z.enum(['production', 'staging', 'development', 'test']).default('development'), // TODO: a better name would be NANGO_ENV
     CI: z.coerce.boolean().default(false),
@@ -483,7 +483,10 @@ export const ENVS = z.object({
                 ctx.addIssue(`Invalid JSON in EMAIL_HTTP_BODY`);
                 return z.NEVER; // tells Zod to stop here and mark parse as failed
             }
-        }),
+        })
+        // Mail APIs take a JSON object; without this an array/string/number parses fine here and
+        // only surfaces as an opaque API rejection at send time.
+        .pipe(z.record(z.string(), z.unknown()).optional()),
 
     // Postgres
     NANGO_DATABASE_URL: z.url().optional(),
@@ -789,6 +792,20 @@ export const ENVS = z.object({
     NANGO_ADMIN_KEY: z.string().optional(),
     NANGO_INTEGRATIONS_FULL_PATH: z.string().optional(),
     LOG_LEVEL: z.enum(['info', 'debug', 'warn', 'error']).optional().default('info')
+});
+
+export const ENVS = ENVS_SHAPE.check((ctx) => {
+    // EMAIL_HTTP_URL on its own selects the HTTP email provider, which cannot send without a body
+    // template. Fail here so a half-configured provider surfaces at startup instead of on the
+    // first email, and keep the error pointed at the var that is actually missing.
+    if (ctx.value.EMAIL_HTTP_URL && ctx.value.EMAIL_HTTP_BODY === undefined) {
+        ctx.issues.push({
+            code: 'custom',
+            message: 'EMAIL_HTTP_BODY is required when EMAIL_HTTP_URL is set',
+            path: ['EMAIL_HTTP_BODY'],
+            input: ctx.value.EMAIL_HTTP_BODY
+        });
+    }
 });
 
 export function parseEnvs<T extends z.ZodObject<any>>(schema: T, envs: Record<string, unknown> = process.env): z.ZodSafeParseSuccess<z.infer<T>>['data'] {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -487,6 +487,7 @@ const ENVS_SHAPE = z.object({
         // Mail APIs take a JSON object; without this an array/string/number parses fine here and
         // only surfaces as an opaque API rejection at send time.
         .pipe(z.record(z.string(), z.unknown()).optional()),
+    EMAIL_HTTP_TIMEOUT_MS: z.coerce.number().int().positive().optional().default(10_000),
 
     // Postgres
     NANGO_DATABASE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -290,6 +290,56 @@ describe('parse', () => {
         }).toThrow('NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST');
     });
 
+    describe('EMAIL_HTTP_*', () => {
+        const body = JSON.stringify({ from: '{{from}}', subject: '{{subject}}' });
+
+        it('should leave EMAIL_HTTP_BODY undefined when unset', () => {
+            const res = parseEnvs(ENVS, {});
+            expect(res.EMAIL_HTTP_BODY).toBeUndefined();
+        });
+
+        it('should parse EMAIL_HTTP_BODY into an object', () => {
+            const res = parseEnvs(ENVS, { EMAIL_HTTP_BODY: body });
+            expect(res.EMAIL_HTTP_BODY).toEqual({ from: '{{from}}', subject: '{{subject}}' });
+        });
+
+        it('should throw on invalid JSON in EMAIL_HTTP_BODY', () => {
+            expect(() => {
+                parseEnvs(ENVS, { EMAIL_HTTP_BODY: 'not-json' });
+            }).toThrow('Invalid JSON in EMAIL_HTTP_BODY');
+        });
+
+        it('should reject an EMAIL_HTTP_BODY that is valid JSON but not an object', () => {
+            // A mail API takes a JSON object; an array or scalar would only fail at send time.
+            expect(() => parseEnvs(ENVS, { EMAIL_HTTP_BODY: '[]' })).toThrow();
+            expect(() => parseEnvs(ENVS, { EMAIL_HTTP_BODY: '"a string"' })).toThrow();
+            expect(() => parseEnvs(ENVS, { EMAIL_HTTP_BODY: '3' })).toThrow();
+        });
+
+        it('should throw when EMAIL_HTTP_URL is set without EMAIL_HTTP_BODY', () => {
+            expect(() => {
+                parseEnvs(ENVS, { EMAIL_HTTP_URL: 'https://api.example.com/send' });
+            }).toThrow('EMAIL_HTTP_BODY is required when EMAIL_HTTP_URL is set');
+        });
+
+        it('should throw when EMAIL_HTTP_BODY is blank alongside EMAIL_HTTP_URL', () => {
+            expect(() => {
+                parseEnvs(ENVS, { EMAIL_HTTP_URL: 'https://api.example.com/send', EMAIL_HTTP_BODY: '   ' });
+            }).toThrow('EMAIL_HTTP_BODY is required when EMAIL_HTTP_URL is set');
+        });
+
+        it('should accept EMAIL_HTTP_URL together with EMAIL_HTTP_BODY', () => {
+            const res = parseEnvs(ENVS, { EMAIL_HTTP_URL: 'https://api.example.com/send', EMAIL_HTTP_BODY: body });
+            expect(res.EMAIL_HTTP_URL).toBe('https://api.example.com/send');
+            expect(res.EMAIL_HTTP_BODY).toEqual({ from: '{{from}}', subject: '{{subject}}' });
+        });
+
+        it('should allow EMAIL_HTTP_BODY on its own, since it selects no provider', () => {
+            const res = parseEnvs(ENVS, { EMAIL_HTTP_BODY: body });
+            expect(res.EMAIL_HTTP_URL).toBeUndefined();
+        });
+    });
+
     describe('WEBHOOK_INGRESS_USE_DISPATCH_QUEUE', () => {
         it('should default to false', () => {
             const res = parseEnvs(ENVS, {});

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -338,6 +338,16 @@ describe('parse', () => {
             const res = parseEnvs(ENVS, { EMAIL_HTTP_BODY: body });
             expect(res.EMAIL_HTTP_URL).toBeUndefined();
         });
+
+        it('should default EMAIL_HTTP_TIMEOUT_MS to 10000', () => {
+            const res = parseEnvs(ENVS, {});
+            expect(res.EMAIL_HTTP_TIMEOUT_MS).toBe(10_000);
+        });
+
+        it('should accept a custom EMAIL_HTTP_TIMEOUT_MS', () => {
+            const res = parseEnvs(ENVS, { EMAIL_HTTP_TIMEOUT_MS: '30000' });
+            expect(res.EMAIL_HTTP_TIMEOUT_MS).toBe(30_000);
+        });
     });
 
     describe('WEBHOOK_INGRESS_USE_DISPATCH_QUEUE', () => {


### PR DESCRIPTION
Self-hosted instances can only send transactional email through Mailgun's API or SMTP. Where neither fits, `EmailClient` falls back to `NoEmailProvider`, which only logs — so verification and invite emails are silently never delivered.

This adds a provider that posts to any mail API accepting JSON over HTTP (SendGrid, Resend, Postmark, ...), configured by three env vars:

```
EMAIL_HTTP_URL=https://api.sendgrid.com/v3/mail/send
EMAIL_HTTP_HEADERS={"authorization":"Bearer <api-key>"}
EMAIL_HTTP_BODY={"personalizations":[{"to":[{"email":"{{to}}"}]}],"from":{"email":"{{from}}"},"subject":"{{subject}}","content":[{"type":"text/html","value":"{{html}}"}]}
```

`{{to}}`, `{{from}}`, `{{subject}}` and `{{html}}` are substituted into the *parsed* JSON template rather than into raw text, so values stay escaped whatever the HTML body contains. No new dependency — `fetch` is built in on the supported Node (>= 20).

Selection runs after Mailgun and SMTP, so existing setups are untouched. The sender keeps coming from `SMTP_FROM`, as it already does for Mailgun.

Closes #6976

## Testing instructions

`npx vitest run --dir=packages/email` — 8 tests, the first ones in this package. They cover placeholder substitution (nested objects and arrays, non-string values, HTML containing quotes and newlines) and `send` (URL/headers/payload posted, and the error raised on a non-2xx response).

End to end: set the three vars above with a real API key, then sign up locally and check the verification email is delivered.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

