### PR TITLE
feat(server): introspect salesforce tokens on error

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -268,6 +268,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
             integration,
             logContextGetter,
             instantRefresh: false,
+            skipIntrospection: true,
             onRefreshSuccess: connectionRefreshSuccess,
             onRefreshFailed: connectionRefreshFailed
         });
@@ -354,6 +355,29 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
             logger: (msg) => {
                 void logCtx?.log(msg);
             },
+            onRefreshToken: async () => {
+                let refreshed = false;
+                const credentialResponse = await refreshOrTestCredentials({
+                    account,
+                    environment,
+                    connection: freshConnection,
+                    integration,
+                    logContextGetter,
+                    instantRefresh: false,
+                    skipIntrospection: false,
+                    onRefreshSuccess: async (args) => {
+                        refreshed = true;
+                        await connectionRefreshSuccess(args);
+                    },
+                    onRefreshFailed: connectionRefreshFailed
+                });
+                if (credentialResponse.isErr()) {
+                    throw new ProxyError('failed_to_refresh_connection', 'Failed to refresh credentials', credentialResponse.error);
+                }
+                freshConnection = credentialResponse.value;
+                lastConnectionRefresh = Date.now();
+                return refreshed;
+            },
             getConnection: async () => {
                 if (Date.now() - lastConnectionRefresh < MEMOIZED_CONNECTION_TTL) {
                     return freshConnection;
@@ -367,6 +391,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     integration,
                     logContextGetter,
                     instantRefresh: false,
+                    skipIntrospection: false,
                     onRefreshSuccess: connectionRefreshSuccess,
                     onRefreshFailed: connectionRefreshFailed
                 });

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -421,7 +421,8 @@ export async function credentialsTest({
             provider,
             providerName: config.provider,
             providerConfigKey: config.unique_key,
-            decompress: false
+            decompress: false,
+            refreshTokenOn: null
         };
 
         if (headers) {

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -58,6 +58,7 @@ interface RefreshProps {
           }) => Promise<Result<{ tested: boolean }, NangoError>>)
         | undefined;
     refreshGithubAppJwtToken?: boolean;
+    skipIntrospection?: boolean;
 }
 
 const logger = getLogger('connectionRefresh');
@@ -188,6 +189,7 @@ async function refreshCredentials(
         account,
         connection: oldConnection,
         instantRefresh,
+        skipIntrospection,
         logContextGetter,
         onRefreshFailed,
         onRefreshSuccess,
@@ -203,6 +205,7 @@ async function refreshCredentials(
         provider: provider,
         environment_id: environment.id,
         instantRefresh,
+        ...(skipIntrospection !== undefined ? { skipIntrospection } : {}),
         logCtx: logsBuffer,
         refreshGithubAppJwtToken
     });
@@ -359,6 +362,7 @@ export async function refreshCredentialsIfNeeded({
     provider,
     environment_id,
     instantRefresh = false,
+    skipIntrospection = false,
     logCtx,
     refreshGithubAppJwtToken
 }: {
@@ -368,12 +372,15 @@ export async function refreshCredentialsIfNeeded({
     provider: RefreshableProvider;
     environment_id: number;
     instantRefresh?: boolean;
+    skipIntrospection?: boolean;
     logCtx: LogContextStateless;
     refreshGithubAppJwtToken?: boolean | undefined;
 }): Promise<Result<{ connection: DBConnectionDecrypted; refreshed: boolean; credentials: RefreshableCredentials }, NangoInternalError>> {
     const providerConfigKey = providerConfig.unique_key;
 
-    const cacheKey = `${environment_id}:${providerConfigKey}:${connectionId}`;
+    // skipIntrospection=true forces a direct refresh without checking token validity first,
+    // so it must not collapse onto an in-flight refresh that may decide "no refresh needed"
+    const cacheKey = `${environment_id}:${providerConfigKey}:${connectionId}:${skipIntrospection ? 'skip' : 'full'}`;
 
     // if a refresh is already in-flight for this connection, return the existing promise
     const existingPromise = inFlightRefreshes.get(cacheKey);
@@ -418,6 +425,7 @@ export async function refreshCredentialsIfNeeded({
                 providerConfig,
                 provider,
                 instantRefresh,
+                skipIntrospection,
                 refreshGithubAppJwtToken
             });
 
@@ -570,6 +578,7 @@ export async function shouldRefreshCredentials({
     providerConfig,
     provider,
     instantRefresh,
+    skipIntrospection = false,
     refreshGithubAppJwtToken
 }: {
     connection: DBConnectionDecrypted;
@@ -577,6 +586,7 @@ export async function shouldRefreshCredentials({
     providerConfig: ProviderConfig;
     provider: RefreshableProvider;
     instantRefresh: boolean;
+    skipIntrospection?: boolean;
     refreshGithubAppJwtToken?: boolean | undefined;
 }): Promise<{ should: boolean; reason: string }> {
     const expirationBufferInSeconds = provider.token_expiration_buffer || REFRESH_MARGIN_MS / 1000;
@@ -620,7 +630,7 @@ export async function shouldRefreshCredentials({
     }
 
     if (!instantRefresh) {
-        if (providerClient.shouldIntrospectToken(providerConfig.provider)) {
+        if (!skipIntrospection && providerClient.shouldIntrospectToken(providerConfig.provider)) {
             if (await providerClient.introspectedTokenExpired(providerConfig, connection)) {
                 return { should: true, reason: 'expired_introspected_token' };
             }

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -17,11 +17,18 @@ import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 const logger = getLogger('proxy:metering');
 
+const MAX_REFRESH_TOKEN_ATTEMPTS = 1;
+
 interface Props {
     proxyConfig: ApplicationConstructedProxyConfiguration;
     logger: (msg: MessageRowInsert) => MaybePromise<void>;
     onError?: (args: { err: unknown; max: number; attempt: number; retry: RetryReason }) => RetryReason;
     onBytes?: (bytes: MeteredBytes) => MaybePromise<void>;
+    /**
+     * Called when retry reason is refresh_token; use to introspect and refresh credentials before the next attempt.
+     * Return true if a refresh actually happened (retry is worthwhile), false if token is still active (stop retrying).
+     */
+    onRefreshToken?: () => Promise<boolean>;
     getConnection: () => MaybePromise<ConnectionForProxy>;
     getIntegrationConfig: () => MaybePromise<IntegrationConfigForProxy>;
     outboundPolicy?: OutboundUrlPolicy | undefined;
@@ -58,6 +65,10 @@ export class ProxyRequest {
      */
     onBytes?: Props['onBytes'];
 
+    onRefreshToken?: Props['onRefreshToken'];
+
+    private refreshTokenAttempts = 0;
+
     /**
      * Build at each iteration
      */
@@ -83,6 +94,7 @@ export class ProxyRequest {
         this.logger = props.logger;
         this.onError = props.onError;
         this.onBytes = props.onBytes;
+        this.onRefreshToken = props.onRefreshToken;
         this.getConnection = props.getConnection;
         this.getIntegrationConfig = props.getIntegrationConfig;
         this.outboundPolicy = props.outboundPolicy;
@@ -158,9 +170,25 @@ export class ProxyRequest {
                     }
                 },
                 {
-                    max: this.config.retries || 0,
+                    max: Math.max(this.config.retries || 0, this.config.refreshTokenOn?.length && this.onRefreshToken ? MAX_REFRESH_TOKEN_ATTEMPTS + 1 : 0),
                     onError: async ({ err, nextWait, max, attempt }) => {
                         let retry = getProxyRetryFromErr({ err, proxyConfig: this.config });
+
+                        if (retry.retry && retry.reason === 'refresh_token') {
+                            if (this.refreshTokenAttempts >= MAX_REFRESH_TOKEN_ATTEMPTS) {
+                                retry = { retry: false, reason: 'refresh_token_max_attempts' };
+                            } else {
+                                this.refreshTokenAttempts++;
+                                if (this.onRefreshToken) {
+                                    const refreshed = await this.onRefreshToken();
+                                    if (!refreshed) {
+                                        retry = { retry: false, reason: 'token_still_active' };
+                                    }
+                                }
+                            }
+                        } else if (retry.retry && attempt > (this.config.retries || 0)) {
+                            retry = { retry: false, reason: retry.reason };
+                        }
 
                         // Only call onError if it's an actionable error
                         if (retry.reason !== 'unknown_error' && this.onError) {

--- a/packages/shared/lib/services/proxy/request.unit.test.ts
+++ b/packages/shared/lib/services/proxy/request.unit.test.ts
@@ -5,7 +5,7 @@ import { getTestConnection } from '../../seeders/connection.seeder.js';
 import { ProxyRequest } from './request.js';
 import { getDefaultProxy } from './utils.test.js';
 
-import type { InternalAxiosRequestConfig } from 'axios';
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 function makeAxiosError(status: number): AxiosError {
     const err = new AxiosError(`Request failed with status code ${status}`);
@@ -17,6 +17,16 @@ function makeAxiosError(status: number): AxiosError {
         config: {} as InternalAxiosRequestConfig
     };
     return err;
+}
+
+function createAxiosError(status: number): AxiosError {
+    const err = new AxiosError(`HTTP ${status}`);
+    err.response = { status, data: {}, headers: {}, statusText: 'Error', config: {} as InternalAxiosRequestConfig };
+    return err;
+}
+
+function createSuccessResponse(): AxiosResponse {
+    return { status: 200, data: {}, headers: {}, config: {} as InternalAxiosRequestConfig, statusText: 'OK' };
 }
 
 describe('call', () => {
@@ -127,5 +137,87 @@ describe('call', () => {
 
         // should dynamically rebuild proxy config on each iteration
         expect(getConnection).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('Salesforce introspect-on-error (refreshTokenOn)', () => {
+    it('should call onRefreshToken on 401 and succeed on retry', async () => {
+        const onRefreshToken = vi.fn().mockResolvedValue(true);
+        const proxy = new ProxyRequest({
+            logger: vi.fn(),
+            proxyConfig: getDefaultProxy({
+                provider: { auth_mode: 'OAUTH2', proxy: { base_url: 'https://example.com' } },
+                endpoint: '/api',
+                refreshTokenOn: [401, 403]
+            }),
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            onRefreshToken
+        });
+        vi.spyOn(proxy, 'httpCall').mockRejectedValueOnce(createAxiosError(401)).mockResolvedValueOnce(createSuccessResponse());
+
+        const res = await proxy.request();
+        expect(res.isOk()).toBe(true);
+        expect(onRefreshToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cap onRefreshToken at 1 attempt then stop retrying', { timeout: 15000 }, async () => {
+        const onRefreshToken = vi.fn().mockResolvedValue(true);
+        const proxy = new ProxyRequest({
+            logger: vi.fn(),
+            proxyConfig: getDefaultProxy({
+                provider: { auth_mode: 'OAUTH2', proxy: { base_url: 'https://example.com' } },
+                endpoint: '/api',
+                refreshTokenOn: [401, 403]
+            }),
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            onRefreshToken
+        });
+        vi.spyOn(proxy, 'httpCall').mockRejectedValue(createAxiosError(401));
+
+        const res = await proxy.request();
+        expect(res.isErr()).toBe(true);
+        expect(onRefreshToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop retrying immediately when onRefreshToken returns false (token still active)', async () => {
+        const onRefreshToken = vi.fn().mockResolvedValue(false);
+        const proxy = new ProxyRequest({
+            logger: vi.fn(),
+            proxyConfig: getDefaultProxy({
+                provider: { auth_mode: 'OAUTH2', proxy: { base_url: 'https://example.com' } },
+                endpoint: '/api',
+                refreshTokenOn: [401, 403]
+            }),
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            onRefreshToken
+        });
+        vi.spyOn(proxy, 'httpCall').mockRejectedValue(createAxiosError(401));
+
+        const res = await proxy.request();
+        expect(res.isErr()).toBe(true);
+        expect(onRefreshToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call onRefreshToken for non-Salesforce provider (refreshTokenOn is null)', async () => {
+        const onRefreshToken = vi.fn();
+        const proxy = new ProxyRequest({
+            logger: vi.fn(),
+            proxyConfig: getDefaultProxy({
+                provider: { auth_mode: 'OAUTH2', proxy: { base_url: 'https://example.com' } },
+                endpoint: '/api',
+                refreshTokenOn: null
+            }),
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            onRefreshToken
+        });
+        vi.spyOn(proxy, 'httpCall').mockRejectedValue(createAxiosError(401));
+
+        const res = await proxy.request();
+        expect(res.isErr()).toBe(true);
+        expect(onRefreshToken).not.toHaveBeenCalled();
     });
 });

--- a/packages/shared/lib/services/proxy/retry.ts
+++ b/packages/shared/lib/services/proxy/retry.ts
@@ -55,6 +55,13 @@ export function getProxyRetryFromErr({ err, proxyConfig }: { err: unknown; proxy
         }
     }
 
+    // Mark for token refresh but don't return yet — Retry-After headers take priority
+    // so a rate-limited response with a backoff header is respected before refreshing
+    const isRefreshToken = proxyConfig.refreshTokenOn?.some((code) => matchesStatusCode(status, String(code))) ?? false;
+    if (isRefreshToken) {
+        isRetryable = true;
+    }
+
     if (!isRetryable && customHeaderConf?.remaining && err.response?.headers[customHeaderConf.remaining] === '0') {
         // Custom header in providers.yaml
         isRetryable = true;
@@ -127,7 +134,7 @@ export function getProxyRetryFromErr({ err, proxyConfig }: { err: unknown; proxy
         }
     }
 
-    return { retry: true, reason: reason || `status_code_${status}` };
+    return { retry: true, reason: isRefreshToken ? 'refresh_token' : reason || `status_code_${status}` };
 }
 
 /**

--- a/packages/shared/lib/services/proxy/retry.unit.test.ts
+++ b/packages/shared/lib/services/proxy/retry.unit.test.ts
@@ -98,6 +98,53 @@ describe('getProxyRetryFromErr', () => {
         expect(res).toStrictEqual({ retry: false, reason: 'not_retryable' });
     });
 
+    describe('refresh_token (Salesforce introspect-on-error)', () => {
+        it.each([401, 403])('should return refresh_token reason when status %d matches refreshTokenOn', (status) => {
+            const err = getDefaultError({ response: { status } });
+            const res = getProxyRetryFromErr({
+                err,
+                proxyConfig: getDefaultProxy({ refreshTokenOn: [401, 403], provider: { auth_mode: 'OAUTH2' } })
+            });
+            expect(res).toStrictEqual({ retry: true, reason: 'refresh_token' });
+        });
+
+        it.each([500, 502, 429, 404, 422])('should not return refresh_token reason when status %d does not match refreshTokenOn', (status) => {
+            const err = getDefaultError({ response: { status } });
+            const res = getProxyRetryFromErr({
+                err,
+                proxyConfig: getDefaultProxy({ refreshTokenOn: [401, 403], provider: { auth_mode: 'OAUTH2' } })
+            });
+            expect(res).not.toStrictEqual({ retry: true, reason: 'refresh_token' });
+        });
+
+        it('should not return refresh_token when status is not in refreshTokenOn', () => {
+            const err = getDefaultError({ response: { status: 200 } });
+            const res = getProxyRetryFromErr({
+                err,
+                proxyConfig: getDefaultProxy({ refreshTokenOn: [401, 403], provider: { auth_mode: 'OAUTH2' } })
+            });
+            expect(res).toStrictEqual({ retry: false, reason: 'not_retryable' });
+        });
+
+        it('should return status_code_401 for 401 when refreshTokenOn is null (non-Salesforce)', () => {
+            const err = getDefaultError({ response: { status: 401 } });
+            const res = getProxyRetryFromErr({
+                err,
+                proxyConfig: getDefaultProxy({ refreshTokenOn: null })
+            });
+            expect(res).toStrictEqual({ retry: true, reason: 'status_code_401' });
+        });
+
+        it('should not return refresh_token for 403 when refreshTokenOn is null (non-Salesforce)', () => {
+            const err = getDefaultError({ response: { status: 403 } });
+            const res = getProxyRetryFromErr({
+                err,
+                proxyConfig: getDefaultProxy({ refreshTokenOn: null })
+            });
+            expect(res).toStrictEqual({ retry: false, reason: 'not_retryable' });
+        });
+    });
+
     it.each([500, 501, 429])('should retry some status code "%d"', (value) => {
         const mockAxiosError = getDefaultError({ response: { status: value } });
         const res = getProxyRetryFromErr({ err: mockAxiosError, proxyConfig: getDefaultProxy({}) });

--- a/packages/shared/lib/services/proxy/utils.test.ts
+++ b/packages/shared/lib/services/proxy/utils.test.ts
@@ -12,6 +12,7 @@ export function getDefaultProxy(
         providerConfigKey: 'freshteam',
         providerName: 'freshteam',
         decompress: false,
+        refreshTokenOn: null,
         ...override,
         provider: {
             auth_mode: 'API_KEY',

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -7,6 +7,7 @@ import OAuth from 'oauth-1.0a';
 import { assertSafeOutboundUrlSync, getSafeHttpAgents, getSafeLookup } from '@nangohq/egress';
 import { Err, isBaseUrlOverrideDenied, Ok, SIGNATURE_METHOD } from '@nangohq/utils';
 
+import providerClient from '../../clients/provider.client.js';
 import {
     connectionCopyWithParsedConnectionConfig,
     formatPem,
@@ -32,6 +33,8 @@ import type {
 import type { Result } from '@nangohq/utils';
 import type { AxiosRequestConfig } from 'axios';
 
+const SALESFORCE_INTROSPECT_ON_ERRORS: (number | string)[] = [401, 403];
+
 type ProxyErrorCode =
     | 'missing_api_url'
     | 'missing_provider'
@@ -41,6 +44,7 @@ type ProxyErrorCode =
     | 'invalid_query_params'
     | 'unknown_error'
     | 'failed_to_get_connection'
+    | 'failed_to_refresh_connection'
     | 'invalid_certificate_or_key_format'
     | 'proxy_redirect_to_denied_host'
     | 'base_url_override_disabled'
@@ -293,6 +297,7 @@ export function getProxyConfiguration({
         params: externalConfig.params as Record<string, string>, // TODO: fix this
         responseType: externalConfig.responseType,
         retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null,
+        refreshTokenOn: providerClient.shouldIntrospectToken(providerName) ? SALESFORCE_INTROSPECT_ON_ERRORS : null,
         ...(forwardHeadersOnRedirect !== undefined ? { forwardHeadersOnRedirect } : {}),
         ...(validateProxyRequestUrl !== undefined ? { validateProxyRequestUrl } : {}),
         ...(validateProxyRedirectUrl !== undefined ? { validateProxyRedirectUrl } : {})

--- a/packages/types/lib/proxy/api.ts
+++ b/packages/types/lib/proxy/api.ts
@@ -63,6 +63,7 @@ export interface ApplicationConstructedProxyConfiguration extends BaseProxyConfi
     method: HTTP_METHOD;
     providerName: string;
     provider: Provider;
+    refreshTokenOn: (number | string)[] | null;
 }
 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';


### PR DESCRIPTION
## Describe the problem and your solution

- introspect salesforce tokens on error

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

