### PR TITLE
feat(mcp): add connections list tool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -12778,6 +12778,14 @@ Use the Integrations tools to inspect and manage integrations in the authenticat
 | `integrations_get`    | Get a configured integration by ID.                                                               | `environment:integrations:read` or `environment:integrations:read_credentials` |
 | `integrations_create` | Create an integration with caller-supplied or Nango-provided developer application credentials. | `environment:integrations:create`                                             |
 
+### Connections
+
+Use the Connections tools to inspect connections in the authenticated Nango environment. Connection credentials are only returned when the API key grants the credential-list scope.
+
+| Tool               | Description                  | Required API key scope                                                        |
+| ------------------ | ---------------------------- | ----------------------------------------------------------------------------- |
+| `connections_list` | List and filter connections. | `environment:connections:list` or `environment:connections:list_credentials` |
+
 ### Logs
 
 Use the Logs tools to find activity in the authenticated Nango environment and inspect the messages for a specific operation.

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -45,6 +45,14 @@ Use the Integrations tools to inspect and manage integrations in the authenticat
 | `integrations_get`    | Get a configured integration by ID.                                                               | `environment:integrations:read` or `environment:integrations:read_credentials` |
 | `integrations_create` | Create an integration with caller-supplied or Nango-provided developer application credentials. | `environment:integrations:create`                                             |
 
+### Connections
+
+Use the Connections tools to inspect connections in the authenticated Nango environment. Connection credentials are only returned when the API key grants the credential-list scope.
+
+| Tool               | Description                  | Required API key scope                                                        |
+| ------------------ | ---------------------------- | ----------------------------------------------------------------------------- |
+| `connections_list` | List and filter connections. | `environment:connections:list` or `environment:connections:list_credentials` |
+
 ### Logs
 
 Use the Logs tools to find activity in the authenticated Nango environment and inspect the messages for a specific operation.

--- a/packages/server/lib/controllers/connection/getConnections.integration.test.ts
+++ b/packages/server/lib/controllers/connection/getConnections.integration.test.ts
@@ -57,6 +57,7 @@ describe(`GET ${endpoint}`, () => {
                 {
                     connection_id: conn.connection_id,
                     created: expect.toBeIsoDateTimezone(),
+                    credentials: {},
                     end_user: null,
                     errors: [],
                     id: conn.id,
@@ -86,6 +87,7 @@ describe(`GET ${endpoint}`, () => {
                 {
                     connection_id: conn.connection_id,
                     created: expect.toBeIsoDateTimezone(),
+                    credentials: {},
                     end_user: null,
                     errors: [],
                     id: conn.id,

--- a/packages/server/lib/controllers/connection/getConnections.ts
+++ b/packages/server/lib/controllers/connection/getConnections.ts
@@ -1,9 +1,11 @@
 import * as z from 'zod';
 
-import { connectionService, connectionTagsSchema } from '@nangohq/shared';
+import { connectionTagsSchema } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionSimpleToPublicApi } from '../../formatters/connection.js';
+import { hasScope } from '../../middleware/scope.middleware.js';
+import connectionService from '../../services/connection.service.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import { bodySchema } from '../connect/postSessions.js';
 
@@ -34,7 +36,7 @@ export const getPublicConnections = asyncWrapper<GetPublicConnections>(async (re
     const { environment } = res.locals;
     const queryParam = queryParamValues.data;
 
-    const connections = await connectionService.listConnections({
+    const connections = await connectionService.list({
         environmentId: environment.id,
         connectionId: queryParam.connectionId,
         search: queryParam.search,
@@ -43,17 +45,17 @@ export const getPublicConnections = asyncWrapper<GetPublicConnections>(async (re
         endUserOrganizationId: queryParam.endUserOrganizationId,
         tags: queryParam.tags,
         page: queryParam.page,
-        limit: queryParam.limit || 10_000 // 10_000 to avoid breaking changes. TODO: set to more reasonable default like 1000 in the future
+        limit: queryParam.limit,
+        includeCredentials: hasScope({
+            grantedScopes: res.locals['apiKeyScopes'],
+            requiredScope: 'environment:connections:list_credentials'
+        })
     });
+    if (connections.isErr()) {
+        throw connections.error;
+    }
 
     res.status(200).send({
-        connections: connections.map((data) => {
-            return connectionSimpleToPublicApi({
-                data: data.connection,
-                activeLog: data.active_logs,
-                provider: data.provider,
-                endUser: data.end_user
-            });
-        })
+        connections: connections.value.map((connection) => connectionSimpleToPublicApi(connection))
     });
 });

--- a/packages/server/lib/controllers/mcp/connections/formatter.ts
+++ b/packages/server/lib/controllers/mcp/connections/formatter.ts
@@ -1,0 +1,53 @@
+import cloneDeepWith from 'lodash-es/cloneDeepWith.js';
+import isDate from 'lodash-es/isDate.js';
+
+import type { ListedConnection } from '../../../services/connection.service.js';
+import type { McpConnection } from './schema.js';
+
+export function connectionToMcp({
+    id,
+    connectionId,
+    integrationId,
+    provider,
+    createdAt,
+    metadata,
+    tags,
+    errors,
+    endUser,
+    ...connection
+}: ListedConnection): McpConnection {
+    return {
+        id,
+        connection_id: connectionId,
+        provider_config_key: integrationId,
+        provider,
+        created: createdAt.toISOString(),
+        metadata,
+        tags,
+        errors: errors.map((error) => ({ type: error.type, log_id: error.logId })),
+        end_user: endUser
+            ? {
+                  id: endUser.id,
+                  display_name: endUser.displayName,
+                  email: endUser.email,
+                  tags: endUser.tags,
+                  organization: endUser.organization
+                      ? {
+                            id: endUser.organization.id,
+                            display_name: endUser.organization.displayName
+                        }
+                      : null
+              }
+            : null,
+        ...('credentials' in connection
+            ? {
+                  credentials: cloneDeepWith(connection.credentials, (value) => {
+                      if (isDate(value)) {
+                          return value.toISOString();
+                      }
+                      return undefined;
+                  }) as McpConnection['credentials']
+              }
+            : {})
+    };
+}

--- a/packages/server/lib/controllers/mcp/connections/list.ts
+++ b/packages/server/lib/controllers/mcp/connections/list.ts
@@ -1,0 +1,56 @@
+import * as z from 'zod/v4';
+
+import { connectionTagsSchema } from '@nangohq/shared';
+
+import { connectionIdSchema, endUserSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
+import { hasScope } from '../../../middleware/scope.middleware.js';
+import connectionService from '../../../services/connection.service.js';
+import { defineManagementMcpTool } from '../managementTool.js';
+import { connectionToMcp } from './formatter.js';
+import { listConnectionsOutputSchema } from './schema.js';
+
+import type { ListConnectionsOutput } from './schema.js';
+
+const listConnectionsArgumentsSchema = z
+    .object({
+        connection_id: connectionIdSchema.min(1).optional(),
+        search: z.string().min(1).max(255).optional(),
+        end_user_id: endUserSchema.shape.id.optional(),
+        integration_id: providerConfigKeySchema.min(1).optional(),
+        end_user_organization_id: z.string().min(1).max(255).optional(),
+        tags: connectionTagsSchema.optional(),
+        limit: z.number().int().min(1).max(2000).optional(),
+        page: z.number().int().min(0).optional()
+    })
+    .strict();
+
+export const listConnectionsTool = defineManagementMcpTool<typeof listConnectionsArgumentsSchema, ListConnectionsOutput>({
+    name: 'connections_list',
+    description: 'List and filter connections in the authenticated Nango environment.',
+    inputSchema: listConnectionsArgumentsSchema,
+    outputSchema: listConnectionsOutputSchema,
+    annotations: { readOnlyHint: true },
+    requiredScopes: { anyOf: ['environment:connections:list', 'environment:connections:list_credentials'] },
+    audit: { kind: 'no-audit', reason: 'read-only' },
+    async handler({ args, environment, grantedScopes }) {
+        const result = await connectionService.list({
+            environmentId: environment.id,
+            connectionId: args.connection_id,
+            search: args.search,
+            endUserId: args.end_user_id,
+            integrationIds: args.integration_id ? [args.integration_id] : undefined,
+            endUserOrganizationId: args.end_user_organization_id,
+            tags: args.tags,
+            limit: args.limit,
+            page: args.page,
+            includeCredentials: hasScope({
+                grantedScopes,
+                requiredScope: 'environment:connections:list_credentials'
+            })
+        });
+
+        return result.map((connections) => ({
+            connections: connections.map((connection) => connectionToMcp(connection))
+        }));
+    }
+});

--- a/packages/server/lib/controllers/mcp/connections/list.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/connections/list.unit.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import connectionService, { ConnectionServiceError } from '../../../services/connection.service.js';
+import { PublicMcpError } from '../utils.js';
+import { listConnectionsTool } from './list.js';
+
+import type { ListedConnection } from '../../../services/connection.service.js';
+import type { ManagementMcpContext } from '../managementTool.js';
+
+describe('listConnectionsTool', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('maps MCP filters to the connection service and formats its domain result', async () => {
+        const listSpy = vi.spyOn(connectionService, 'list').mockResolvedValue(Ok([connectionFixture()]));
+
+        const result = await listConnectionsTool.handler(
+            {
+                connection_id: 'connection-id',
+                search: 'acme',
+                end_user_id: 'end-user-id',
+                integration_id: 'github',
+                end_user_organization_id: 'organization-id',
+                tags: { Team: 'platform' },
+                limit: 25,
+                page: 2
+            },
+            context(['environment:connections:list'])
+        );
+
+        expect(listSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            connectionId: 'connection-id',
+            search: 'acme',
+            endUserId: 'end-user-id',
+            integrationIds: ['github'],
+            endUserOrganizationId: 'organization-id',
+            tags: { team: 'platform' },
+            limit: 25,
+            page: 2,
+            includeCredentials: false
+        });
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({
+                connections: [
+                    {
+                        id: 1,
+                        connection_id: 'connection-id',
+                        provider_config_key: 'github',
+                        provider: 'github',
+                        created: '2026-01-01T00:00:00.000Z',
+                        metadata: { tenant: 'acme' },
+                        tags: { team: 'platform' },
+                        errors: [{ type: 'auth', log_id: 'log-id' }],
+                        end_user: {
+                            id: 'end-user-id',
+                            display_name: 'End User',
+                            email: 'end-user@example.com',
+                            tags: { tier: 'enterprise' },
+                            organization: { id: 'organization-id', display_name: 'Acme' }
+                        }
+                    }
+                ]
+            });
+        }
+    });
+
+    it.each(['environment:connections:list_credentials', 'environment:connections:*', 'environment:*'])('requests credentials with %s', async (scope) => {
+        const listSpy = vi
+            .spyOn(connectionService, 'list')
+            .mockResolvedValue(Ok([{ ...connectionFixture(), credentials: { type: 'API_KEY', apiKey: 'secret' } }]));
+
+        const result = await listConnectionsTool.handler({}, context([scope]));
+
+        expect(listSpy).toHaveBeenCalledWith(expect.objectContaining({ includeCredentials: true }));
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value.connections[0]?.credentials).toStrictEqual({ type: 'API_KEY', apiKey: 'secret' });
+        }
+    });
+
+    it('rejects invalid arguments before calling the connection service', async () => {
+        const listSpy = vi.spyOn(connectionService, 'list');
+
+        const result = await listConnectionsTool.handler({ limit: 0, unexpected: true }, context(['environment:connections:list']));
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toContain('Invalid connections_list arguments:');
+        }
+        expect(listSpy).not.toHaveBeenCalled();
+    });
+
+    it('preserves internal connection service errors for the MCP error boundary', async () => {
+        const error = new ConnectionServiceError({ message: 'Failed to list connections' });
+        vi.spyOn(connectionService, 'list').mockResolvedValue(Err(error));
+
+        const result = await listConnectionsTool.handler({}, context(['environment:connections:list']));
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBe(error);
+            expect(result.error).not.toBeInstanceOf(PublicMcpError);
+        }
+    });
+});
+
+function context(grantedScopes: string[]): ManagementMcpContext {
+    return {
+        account: {},
+        environment: { id: 42 },
+        grantedScopes
+    } as ManagementMcpContext;
+}
+
+function connectionFixture(): ListedConnection {
+    return {
+        id: 1,
+        connectionId: 'connection-id',
+        integrationId: 'github',
+        provider: 'github',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        metadata: { tenant: 'acme' },
+        tags: { team: 'platform' },
+        errors: [{ type: 'auth', logId: 'log-id' }],
+        endUser: {
+            id: 'end-user-id',
+            displayName: 'End User',
+            email: 'end-user@example.com',
+            tags: { tier: 'enterprise' },
+            organization: { id: 'organization-id', displayName: 'Acme' }
+        }
+    };
+}

--- a/packages/server/lib/controllers/mcp/connections/schema.ts
+++ b/packages/server/lib/controllers/mcp/connections/schema.ts
@@ -1,0 +1,48 @@
+import * as z from 'zod/v4';
+
+const mcpEndUserSchema = z
+    .object({
+        id: z.string(),
+        display_name: z.string().nullable(),
+        email: z.string().nullable(),
+        tags: z.record(z.string(), z.string()).nullable(),
+        organization: z
+            .object({
+                id: z.string(),
+                display_name: z.string().nullable()
+            })
+            .strict()
+            .nullable()
+    })
+    .strict();
+
+export const mcpConnectionSchema = z
+    .object({
+        id: z.number(),
+        connection_id: z.string(),
+        provider_config_key: z.string(),
+        provider: z.string(),
+        created: z.string(),
+        metadata: z.record(z.string(), z.unknown()).nullable(),
+        tags: z.record(z.string(), z.string()),
+        errors: z.array(
+            z
+                .object({
+                    type: z.string(),
+                    log_id: z.string()
+                })
+                .strict()
+        ),
+        end_user: mcpEndUserSchema.nullable(),
+        credentials: z.record(z.string(), z.unknown()).optional()
+    })
+    .strict();
+
+export const listConnectionsOutputSchema = z
+    .object({
+        connections: z.array(mcpConnectionSchema)
+    })
+    .strict();
+
+export type McpConnection = z.infer<typeof mcpConnectionSchema>;
+export type ListConnectionsOutput = z.infer<typeof listConnectionsOutputSchema>;

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -161,6 +161,7 @@ describe('POST /mcp management server', () => {
             'integrations_list',
             'integrations_get',
             'integrations_create',
+            'connections_list',
             'logs_list_operations',
             'logs_get_operation'
         ]);
@@ -168,7 +169,7 @@ describe('POST /mcp management server', () => {
 
     it('rejects each management tool when its required scope is missing', async () => {
         const { secret } = await createKeyWithScopes(['environment:mcp']);
-        const toolNames = ['integrations_list', 'integrations_get', 'integrations_create', 'logs_list_operations', 'logs_get_operation'];
+        const toolNames = ['integrations_list', 'integrations_get', 'integrations_create', 'connections_list', 'logs_list_operations', 'logs_get_operation'];
 
         for (const toolName of toolNames) {
             const res = await mcpPost({
@@ -253,6 +254,80 @@ describe('POST /mcp management server', () => {
 
         expect(res.status).toBe(200);
         expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['integrations_list']);
+    });
+
+    it.each(['environment:connections:list', 'environment:connections:list_credentials'] as const)('lists the connections tool with %s', async (scope) => {
+        const { secret } = await createKeyWithScopes([scope]);
+        const res = await mcpPost({
+            token: secret,
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools).toHaveLength(1);
+        expect(res.json.result.tools[0]).toMatchObject({
+            name: 'connections_list',
+            annotations: { readOnlyHint: true }
+        });
+    });
+
+    it('lists filtered connections without credentials using the list scope', async () => {
+        const { secret, env } = await createKeyWithScopes(['environment:connections:list']);
+        await seeders.createConfigSeed(env, 'github', 'github');
+        await seeders.createConnectionSeed({
+            env,
+            provider: 'github',
+            connectionId: 'mcp-list-connection',
+            rawCredentials: { type: 'API_KEY', apiKey: 'connection-secret' }
+        });
+
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: { name: 'connections_list', arguments: { connection_id: 'mcp-list-connection', integration_id: 'github' } }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        expect(parseToolText(res)).toStrictEqual(res.json.result.structuredContent);
+        expect(res.json.result.structuredContent.connections).toHaveLength(1);
+        expect(res.json.result.structuredContent.connections[0]).toMatchObject({
+            connection_id: 'mcp-list-connection',
+            provider_config_key: 'github',
+            provider: 'github'
+        });
+        expect(res.json.result.structuredContent.connections[0]).not.toHaveProperty('credentials');
+    });
+
+    it('includes connection credentials using the credential-list scope', async () => {
+        const { secret, env } = await createKeyWithScopes(['environment:connections:list_credentials']);
+        await seeders.createConfigSeed(env, 'github', 'github');
+        await seeders.createConnectionSeed({
+            env,
+            provider: 'github',
+            connectionId: 'mcp-list-connection-with-credentials',
+            rawCredentials: { type: 'API_KEY', apiKey: 'connection-secret' }
+        });
+
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: { name: 'connections_list', arguments: { connection_id: 'mcp-list-connection-with-credentials' } }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.structuredContent.connections).toHaveLength(1);
+        expect(res.json.result.structuredContent.connections[0].credentials).toStrictEqual({
+            type: 'API_KEY',
+            apiKey: 'connection-secret'
+        });
     });
 
     it('lists the integration get tool with integrations:read scope', async () => {

--- a/packages/server/lib/controllers/mcp/managementServer.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { hasScope } from '../../middleware/scope.middleware.js';
 import { recordManagementMcpAudit } from './audit.js';
+import { listConnectionsTool } from './connections/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { getIntegrationsTool } from './integrations/get.js';
 import { listIntegrationsTool } from './integrations/list.js';
@@ -13,7 +14,14 @@ import type { ManagementMcpContext, ManagementMcpRequiredScopes, ManagementMcpTo
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ApiKeyScope } from '@nangohq/types';
 
-const managementMcpTools: ManagementMcpTool[] = [listIntegrationsTool, getIntegrationsTool, createIntegrationsTool, listLogOperationsTool, getLogOperationTool];
+const managementMcpTools: ManagementMcpTool[] = [
+    listIntegrationsTool,
+    getIntegrationsTool,
+    createIntegrationsTool,
+    listConnectionsTool,
+    listLogOperationsTool,
+    getLogOperationTool
+];
 
 export function createManagementMcpServer(context: ManagementMcpContext, requestBody?: unknown): McpServer {
     const server = new McpServer(

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -7,6 +7,7 @@ import { envs as logsEnvs } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
 import { audit } from '../../audit.js';
+import { listConnectionsTool } from './connections/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { listLogOperationsTool } from './logs/listOperations.js';
 import { createManagementMcpServer } from './managementServer.js';
@@ -30,6 +31,7 @@ describe('createManagementMcpServer', () => {
                 'integrations_list',
                 'integrations_get',
                 'integrations_create',
+                'connections_list',
                 'logs_list_operations',
                 'logs_get_operation'
             ]);
@@ -98,6 +100,108 @@ describe('createManagementMcpServer', () => {
             const result = await client.listTools();
 
             expect(result.tools.map((tool) => tool.name)).toStrictEqual(['integrations_list', 'integrations_get', 'integrations_create']);
+        } finally {
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it.each(['environment:connections:list', 'environment:connections:list_credentials'])(
+        'exposes the read-only connections list tool with %s',
+        async (scope) => {
+            const { client, server } = await createTestClient([scope]);
+
+            try {
+                const result = await client.listTools();
+
+                expect(result.tools).toHaveLength(1);
+                expect(result.tools[0]).toMatchObject({
+                    name: 'connections_list',
+                    annotations: { readOnlyHint: true }
+                });
+            } finally {
+                await client.close();
+                await server.close();
+            }
+        }
+    );
+
+    it('recognizes the connections wildcard scope', async () => {
+        const { client, server } = await createTestClient(['environment:connections:*']);
+
+        try {
+            const result = await client.listTools();
+
+            expect(result.tools.map((tool) => tool.name)).toStrictEqual(['connections_list']);
+        } finally {
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('authorizes connection listing before invoking the tool', async () => {
+        const handlerSpy = vi.spyOn(listConnectionsTool, 'handler');
+        const { client, server } = await createTestClient(['environment:mcp']);
+
+        try {
+            const result = await client.callTool({ name: 'connections_list', arguments: {} });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: 'MCP error -32602: Tool connections_list disabled' }],
+                isError: true
+            });
+            expect(handlerSpy).not.toHaveBeenCalled();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('returns connection lists as JSON text and structured content', async () => {
+        const response = {
+            connections: [
+                {
+                    id: 1,
+                    connection_id: 'connection-id',
+                    provider_config_key: 'github',
+                    provider: 'github',
+                    created: '2026-01-01T00:00:00.000Z',
+                    metadata: null,
+                    tags: {},
+                    errors: [],
+                    end_user: null
+                }
+            ]
+        };
+        const handlerSpy = vi.spyOn(listConnectionsTool, 'handler').mockResolvedValueOnce(Ok(response));
+        const { client, server } = await createTestClient(['environment:connections:list']);
+
+        try {
+            const result = await client.callTool({ name: 'connections_list', arguments: { integration_id: 'github' } });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],
+                structuredContent: response
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('returns invalid connection list arguments as a public tool error', async () => {
+        const { client, server } = await createTestClient(['environment:connections:list']);
+
+        try {
+            const result = await client.callTool({ name: 'connections_list', arguments: { limit: 0 } });
+
+            expect(result).toMatchObject({
+                content: [{ type: 'text', text: expect.stringContaining('Invalid arguments for tool connections_list') }],
+                isError: true
+            });
         } finally {
             await client.close();
             await server.close();

--- a/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
@@ -4,7 +4,7 @@ import { seeders } from '@nangohq/shared';
 
 import { authenticateUser, isSuccess, runServer } from '../../../utils/tests.js';
 
-import type { ApiKeyScope } from '@nangohq/types';
+import type { ApiKeyScope, GetPublicConnections } from '@nangohq/types';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -467,6 +467,44 @@ describe('Scope enforcement on public API routes', () => {
     // ── Credential stripping ─────────────────────────────────────────
 
     describe('credential stripping based on scope', () => {
+        it('GET /connections with list scope should omit credentials', async () => {
+            const { secret, env } = await createKeyWithScopesAndEnv(['environment:connections:list']);
+            await seeders.createConfigSeed(env, 'github', 'github');
+            await seeders.createConnectionSeed({
+                env,
+                provider: 'github',
+                connectionId: 'list-without-credentials',
+                rawCredentials: { type: 'API_KEY', apiKey: 'secret-key' }
+            });
+
+            const res = await api.fetch('/connections', { method: 'GET', token: secret } as any);
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            const response = res.json as unknown as GetPublicConnections['Success'];
+            expect(response.connections).toHaveLength(1);
+            expect(response.connections[0]).not.toHaveProperty('credentials');
+        });
+
+        it('GET /connections with list_credentials scope should include credentials', async () => {
+            const { secret, env } = await createKeyWithScopesAndEnv(['environment:connections:list_credentials']);
+            await seeders.createConfigSeed(env, 'github', 'github');
+            await seeders.createConnectionSeed({
+                env,
+                provider: 'github',
+                connectionId: 'list-with-credentials',
+                rawCredentials: { type: 'API_KEY', apiKey: 'secret-key' }
+            });
+
+            const res = await api.fetch('/connections', { method: 'GET', token: secret } as any);
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            const response = res.json as unknown as GetPublicConnections['Success'];
+            expect(response.connections).toHaveLength(1);
+            expect(response.connections[0]?.credentials).toStrictEqual({ type: 'API_KEY', apiKey: 'secret-key' });
+        });
+
         it('GET /connections/:id with read scope should strip credentials', async () => {
             const { env, user } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');

--- a/packages/server/lib/formatters/connection.ts
+++ b/packages/server/lib/formatters/connection.ts
@@ -99,7 +99,7 @@ export function connectionSimpleToPublicApi({
             : null,
         tags,
         metadata,
-        created: createdAt.toISOString(),
+        created: createdAt.toISOString().replace(/Z$/, '+00:00'),
         ...('credentials' in connection
             ? {
                   credentials: cloneDeepWith(connection.credentials, (value) => {

--- a/packages/server/lib/formatters/connection.ts
+++ b/packages/server/lib/formatters/connection.ts
@@ -3,6 +3,7 @@ import isDate from 'lodash-es/isDate.js';
 
 import { endUserToApi } from './endUser.js';
 
+import type { ListedConnection } from '../services/connection.service.js';
 import type {
     ApiConnectionFull,
     ApiConnectionSimple,
@@ -23,7 +24,7 @@ export function connectionSimpleToApi({
 }: {
     data: Omit<DBConnection | DBConnectionAsJSONRow, 'credentials'>;
     provider: string;
-    activeLog: [{ type: string; log_id: string }];
+    activeLog: { type: string; log_id: string }[];
     endUser: DBEndUser | null;
     pausedSyncs: string[];
 }): ApiConnectionSimple {
@@ -65,26 +66,50 @@ export function connectionFullToApi(connection: DBConnectionDecrypted, options?:
 }
 
 export function connectionSimpleToPublicApi({
-    data,
+    id,
+    connectionId,
+    integrationId,
     provider,
-    activeLog,
-    endUser
-}: {
-    data: Omit<DBConnection | DBConnectionAsJSONRow, 'credentials'>;
-    provider: string;
-    activeLog: { type: string; log_id: string }[];
-    endUser: DBEndUser | null;
-}): ApiPublicConnection {
+    createdAt,
+    metadata,
+    tags,
+    errors,
+    endUser,
+    ...connection
+}: ListedConnection): ApiPublicConnection {
     return {
-        id: data.id,
-        connection_id: data.connection_id,
-        provider_config_key: data.provider_config_key,
+        id,
+        connection_id: connectionId,
+        provider_config_key: integrationId,
         provider,
-        errors: activeLog,
-        end_user: endUser ? endUserToApi(endUser) : null,
-        tags: data.tags,
-        metadata: data.metadata || null,
-        created: data.created_at instanceof Date ? data.created_at.toISOString() : String(data.created_at)
+        errors: errors.map((error) => ({ type: error.type, log_id: error.logId })),
+        end_user: endUser
+            ? {
+                  id: endUser.id,
+                  display_name: endUser.displayName,
+                  email: endUser.email,
+                  tags: endUser.tags,
+                  organization: endUser.organization
+                      ? {
+                            id: endUser.organization.id,
+                            display_name: endUser.organization.displayName
+                        }
+                      : null
+              }
+            : null,
+        tags,
+        metadata,
+        created: createdAt.toISOString(),
+        ...('credentials' in connection
+            ? {
+                  credentials: cloneDeepWith(connection.credentials, (value) => {
+                      if (isDate(value)) {
+                          return value.toISOString();
+                      }
+                      return undefined;
+                  }) as ApiPublicConnection['credentials']
+              }
+            : {})
     };
 }
 

--- a/packages/server/lib/formatters/connection.unit.test.ts
+++ b/packages/server/lib/formatters/connection.unit.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { redactCredentials } from './connection.js';
+import { connectionSimpleToPublicApi, redactCredentials } from './connection.js';
+
+import type { ListedConnection } from '../services/connection.service.js';
 
 describe('redactCredentials', () => {
     it('keeps type and redacts secret fields for ApiKeyCredentials', () => {
@@ -115,3 +117,67 @@ describe('redactCredentials', () => {
         expect(result).toEqual({});
     });
 });
+
+describe('connectionSimpleToPublicApi', () => {
+    it('formats the connection list domain model for the public API', () => {
+        const result = connectionSimpleToPublicApi(connectionFixture());
+
+        expect(result).toStrictEqual({
+            id: 1,
+            connection_id: 'connection-id',
+            provider_config_key: 'github',
+            provider: 'github',
+            created: '2026-01-01T00:00:00.000Z',
+            metadata: { tenant: 'acme' },
+            tags: { team: 'platform' },
+            errors: [{ type: 'auth', log_id: 'log-id' }],
+            end_user: {
+                id: 'end-user-id',
+                display_name: 'End User',
+                email: 'end-user@example.com',
+                tags: { tier: 'enterprise' },
+                organization: { id: 'organization-id', display_name: 'Acme' }
+            }
+        });
+    });
+
+    it('only formats credentials when the domain service returned them', () => {
+        const expiresAt = new Date('2026-02-01T00:00:00.000Z');
+        const result = connectionSimpleToPublicApi({
+            ...connectionFixture(),
+            credentials: {
+                type: 'OAUTH2',
+                access_token: 'access-token',
+                expires_at: expiresAt,
+                raw: { expires_at: expiresAt }
+            }
+        });
+
+        expect(result.credentials).toStrictEqual({
+            type: 'OAUTH2',
+            access_token: 'access-token',
+            expires_at: expiresAt.toISOString(),
+            raw: { expires_at: expiresAt.toISOString() }
+        });
+    });
+});
+
+function connectionFixture(): ListedConnection {
+    return {
+        id: 1,
+        connectionId: 'connection-id',
+        integrationId: 'github',
+        provider: 'github',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        metadata: { tenant: 'acme' },
+        tags: { team: 'platform' },
+        errors: [{ type: 'auth', logId: 'log-id' }],
+        endUser: {
+            id: 'end-user-id',
+            displayName: 'End User',
+            email: 'end-user@example.com',
+            tags: { tier: 'enterprise' },
+            organization: { id: 'organization-id', displayName: 'Acme' }
+        }
+    };
+}

--- a/packages/server/lib/formatters/connection.unit.test.ts
+++ b/packages/server/lib/formatters/connection.unit.test.ts
@@ -127,7 +127,7 @@ describe('connectionSimpleToPublicApi', () => {
             connection_id: 'connection-id',
             provider_config_key: 'github',
             provider: 'github',
-            created: '2026-01-01T00:00:00.000Z',
+            created: '2026-01-01T00:00:00.000+00:00',
             metadata: { tenant: 'acme' },
             tags: { team: 'platform' },
             errors: [{ type: 'auth', log_id: 'log-id' }],

--- a/packages/server/lib/services/connection.service.ts
+++ b/packages/server/lib/services/connection.service.ts
@@ -1,0 +1,117 @@
+import { getEncryptionManager, connectionService as sharedConnectionService } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import type { AllAuthCredentials, Metadata, Tags } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+export interface ConnectionListFilters {
+    environmentId: number;
+    connectionId?: string | undefined;
+    search?: string | undefined;
+    endUserId?: string | undefined;
+    integrationIds?: string[] | undefined;
+    endUserOrganizationId?: string | undefined;
+    tags?: Record<string, string> | undefined;
+    limit?: number | undefined;
+    page?: number | undefined;
+    includeCredentials?: boolean | undefined;
+}
+
+export interface ListedConnectionEndUser {
+    id: string;
+    displayName: string | null;
+    email: string | null;
+    tags: Record<string, string> | null;
+    organization: {
+        id: string;
+        displayName: string | null;
+    } | null;
+}
+
+export interface ListedConnection {
+    id: number;
+    connectionId: string;
+    integrationId: string;
+    provider: string;
+    createdAt: Date;
+    metadata: Metadata | null;
+    tags: Tags;
+    errors: { type: string; logId: string }[];
+    endUser: ListedConnectionEndUser | null;
+    credentials?: AllAuthCredentials | undefined;
+}
+
+export class ConnectionServiceError extends Error {
+    public code = 'list_failed' as const;
+
+    constructor({ message, cause }: { message: string; cause?: unknown }) {
+        super(message, { cause });
+        this.name = 'ConnectionServiceError';
+    }
+}
+
+export class ConnectionService {
+    public async list({
+        environmentId,
+        connectionId,
+        search,
+        endUserId,
+        integrationIds,
+        endUserOrganizationId,
+        tags,
+        limit = 10_000,
+        page = 0,
+        includeCredentials = false
+    }: ConnectionListFilters): Promise<Result<ListedConnection[], ConnectionServiceError>> {
+        try {
+            const connections = await sharedConnectionService.listConnections({
+                environmentId,
+                connectionId,
+                search,
+                endUserId,
+                integrationIds,
+                endUserOrganizationId,
+                tags,
+                limit,
+                page
+            });
+
+            return Ok(
+                connections.map(({ connection, active_logs, end_user, provider }) => ({
+                    id: connection.id,
+                    connectionId: connection.connection_id,
+                    integrationId: connection.provider_config_key,
+                    provider,
+                    createdAt: new Date(connection.created_at),
+                    metadata: connection.metadata,
+                    tags: connection.tags,
+                    errors: active_logs.map((error) => ({ type: error.type, logId: error.log_id })),
+                    endUser: end_user
+                        ? {
+                              id: end_user.end_user_id,
+                              displayName: end_user.display_name,
+                              email: end_user.email,
+                              tags: end_user.tags,
+                              organization: end_user.organization_id
+                                  ? {
+                                        id: end_user.organization_id,
+                                        displayName: end_user.organization_display_name
+                                    }
+                                  : null
+                          }
+                        : null,
+                    ...(includeCredentials ? { credentials: getEncryptionManager().decryptConnection(connection).credentials } : {})
+                }))
+            );
+        } catch (err) {
+            return Err(
+                new ConnectionServiceError({
+                    message: 'Failed to list connections',
+                    cause: err
+                })
+            );
+        }
+    }
+}
+
+export default new ConnectionService();

--- a/packages/server/lib/services/connection.service.unit.test.ts
+++ b/packages/server/lib/services/connection.service.unit.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { connectionService as sharedConnectionService } from '@nangohq/shared';
+
+import connectionService from './connection.service.js';
+
+import type { DBConnectionAsJSONRow, DBEndUser } from '@nangohq/types';
+
+describe('connectionService', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('lists domain connections using the public filters and defaults', async () => {
+        const rawConnection = connectionFixture();
+        const endUser = endUserFixture();
+        const listSpy = vi.spyOn(sharedConnectionService, 'listConnections').mockResolvedValue([
+            {
+                connection: rawConnection,
+                provider: 'github',
+                active_logs: [{ type: 'auth', log_id: 'log-id' }],
+                end_user: endUser
+            }
+        ]);
+
+        const result = await connectionService.list({
+            environmentId: 42,
+            connectionId: 'connection-id',
+            search: 'acme',
+            endUserId: 'end-user-id',
+            integrationIds: ['github'],
+            endUserOrganizationId: 'organization-id',
+            tags: { team: 'platform' },
+            includeCredentials: true
+        });
+
+        expect(listSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            connectionId: 'connection-id',
+            search: 'acme',
+            endUserId: 'end-user-id',
+            integrationIds: ['github'],
+            endUserOrganizationId: 'organization-id',
+            tags: { team: 'platform' },
+            limit: 10_000,
+            page: 0
+        });
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual([
+                {
+                    id: 1,
+                    connectionId: 'connection-id',
+                    integrationId: 'github',
+                    provider: 'github',
+                    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+                    metadata: { tenant: 'acme' },
+                    tags: { team: 'platform' },
+                    errors: [{ type: 'auth', logId: 'log-id' }],
+                    endUser: {
+                        id: 'end-user-id',
+                        displayName: 'End User',
+                        email: 'end-user@example.com',
+                        tags: { tier: 'enterprise' },
+                        organization: { id: 'organization-id', displayName: 'Acme' }
+                    },
+                    credentials: { type: 'API_KEY', apiKey: 'secret' }
+                }
+            ]);
+        }
+    });
+
+    it('omits credentials from domain results unless requested', async () => {
+        vi.spyOn(sharedConnectionService, 'listConnections').mockResolvedValue([
+            {
+                connection: connectionFixture(),
+                provider: 'github',
+                active_logs: [],
+                end_user: null
+            }
+        ]);
+
+        const result = await connectionService.list({ environmentId: 42, limit: 25, page: 2 });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value[0]).not.toHaveProperty('credentials');
+        }
+    });
+
+    it('wraps connection listing failures as service errors', async () => {
+        const cause = new Error('database unavailable');
+        vi.spyOn(sharedConnectionService, 'listConnections').mockRejectedValue(cause);
+
+        const result = await connectionService.list({ environmentId: 42 });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({
+                code: 'list_failed',
+                message: 'Failed to list connections',
+                cause
+            });
+        }
+    });
+});
+
+function connectionFixture(): DBConnectionAsJSONRow {
+    return {
+        id: 1,
+        config_id: 2,
+        end_user_id: 3,
+        tags: { team: 'platform' },
+        provider_config_key: 'github',
+        connection_id: 'connection-id',
+        connection_config: {},
+        webhook_url_override: null,
+        environment_id: 42,
+        metadata: { tenant: 'acme' },
+        credentials: { type: 'API_KEY', apiKey: 'secret' } as unknown as DBConnectionAsJSONRow['credentials'],
+        credentials_iv: null,
+        credentials_tag: null,
+        last_fetched_at: null,
+        credentials_expires_at: null,
+        last_refresh_failure: null,
+        last_refresh_success: null,
+        refresh_attempts: null,
+        refresh_exhausted: false,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-02T00:00:00.000Z',
+        deleted: false,
+        deleted_at: null
+    };
+}
+
+function endUserFixture(): DBEndUser {
+    return {
+        id: 3,
+        end_user_id: 'end-user-id',
+        account_id: 4,
+        environment_id: 42,
+        email: 'end-user@example.com',
+        display_name: 'End User',
+        organization_id: 'organization-id',
+        organization_display_name: 'Acme',
+        tags: { tier: 'enterprise' },
+        created_at: new Date('2026-01-01T00:00:00.000Z'),
+        updated_at: null
+    };
+}

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -877,7 +877,7 @@ class ConnectionService {
         tags?: Record<string, string> | undefined;
         limit?: number;
         page?: number | undefined;
-    }): Promise<{ connection: DBConnectionAsJSONRow; end_user: DBEndUser | null; active_logs: [{ type: string; log_id: string }]; provider: string }[]> {
+    }): Promise<{ connection: DBConnectionAsJSONRow; end_user: DBEndUser | null; active_logs: { type: string; log_id: string }[]; provider: string }[]> {
         const query = db.readOnly
             // Filter and paginate connections
             .with('filtered_connections', (qb) => {

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -63,6 +63,7 @@ export type ApiPublicConnection = Pick<DBConnection, 'id' | 'connection_id'> & {
     errors: { type: string; log_id: string }[];
     end_user: ApiEndUser | null;
     tags: Tags;
+    credentials?: ApiPublicAllAuthCredentials | undefined;
 };
 export type GetPublicConnections = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };


### PR DESCRIPTION
This draft is stacked on the Management MCP tooling work, including the server rename, typed tool abstraction, auditing, and integration list/get/create support.\nIt adds  with strict filters, structured responses, read-only metadata, and scope-aware credential shaping.\nConnection-list business logic now lives in a transport-neutral service shared by the public API and MCP, with independent response formatters and comprehensive scope and validation coverage.\n\nNAN-6304: https://linear.app/nango/issue/NAN-6304/mcp-tool-connections-list

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

