### PR TITLE
fix(webapp): properly handle oauth_scopes_override

### DIFF
--- a/packages/webapp/src/pages/Connection/components/ConnectionExtras.tsx
+++ b/packages/webapp/src/pages/Connection/components/ConnectionExtras.tsx
@@ -123,7 +123,11 @@ export const ConnectionExtras = ({
             {config.oauth_scopes_override && (
                 <div className="flex flex-col gap-2">
                     <FieldLabel>OAuth scopes override</FieldLabel>
-                    <ScopesInput scopesString={config.oauth_scopes_override.join(',')} placeholder="Scopes override" readOnly />
+                    <ScopesInput
+                        scopesString={Array.isArray(config.oauth_scopes_override) ? config.oauth_scopes_override.join(',') : config.oauth_scopes_override}
+                        placeholder="Scopes override"
+                        readOnly
+                    />
                 </div>
             )}
 


### PR DESCRIPTION
## Describe the problem and your solution

- handle non-array `oauth_scopes_override` on connection details page.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

