### PR TITLE
fix: retain peer dependencies in docker images 

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -72,6 +72,7 @@ jobs:
                   SERVER=$(docker ps -q -f status=running -f name=^/${CONTAINER_NAME}$)
                   if [ ! "${SERVER}" ]; then
                     echo "Server container doesn't exist"
+                    docker compose logs --no-color
                     exit 1
                   fi
 
@@ -79,6 +80,7 @@ jobs:
                   DB=$(docker ps -q -f status=running -f name=^/${CONTAINER_NAME}$)
                   if [ ! "${DB}" ]; then
                     echo "DB container doesn't exist"
+                    docker compose logs --no-color
                     exit 1
                   fi
               shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN true \
 
 # Clean dev dependencies
 RUN true \
-  && npm prune --omit=dev --omit=peer --omit=optional
+  && npm prune --omit=dev --omit=optional
 
 # ---- Web ----
 # Resulting new, minimal image

--- a/packages/lambda-runner/Dockerfile.lambda
+++ b/packages/lambda-runner/Dockerfile.lambda
@@ -75,7 +75,7 @@ RUN true \
 
 # Clean dev dependencies
 RUN true \
-  && npm prune --omit=dev --omit=peer --omit=optional
+  && npm prune --omit=dev --omit=optional
 
 RUN npm install -g npm@11.10.1
 


### PR DESCRIPTION
Surfacing docker logs when running server docker image fails



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

