### PR TITLE
feat(providers): add Awin and impact.com

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -2501,6 +2501,29 @@ avoma:
             example: '1awcbx0njh:02k6er2pld4q5irffn23'
             doc_section: '#step-1-generating-your-api-key'
 
+awin:
+    display_name: Awin
+    categories:
+        - marketing
+    auth_mode: API_KEY
+    proxy:
+        base_url: https://api.awin.com
+        headers:
+            authorization: Bearer ${apiKey}
+        verification:
+            method: GET
+            endpoints:
+                - /accounts
+    docs: https://nango.dev/docs/api-integrations/awin
+    docs_connect: https://nango.dev/docs/api-integrations/awin/connect
+    credentials:
+        apiKey:
+            type: string
+            title: API Token
+            description: The API token for your Awin user account, from ui.awin.com/awin-api
+            secret: true
+            example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
 axiom:
     display_name: Axiom
     categories:
@@ -10980,6 +11003,38 @@ incident-io:
             example: 'inc_************************************f2c5e6a7b3d4**********'
             pattern: 'inc_[a-f0-9]{64}$'
             doc_section: '#step-1-generating-your-api-key'
+
+impact:
+    display_name: impact.com
+    categories:
+        - marketing
+    auth_mode: BASIC
+    proxy:
+        base_url: https://api.impact.com/Advertisers/${connectionConfig.accountSid}
+        verification:
+            method: GET
+            endpoints:
+                - /Campaigns
+    docs: https://nango.dev/docs/api-integrations/impact
+    docs_connect: https://nango.dev/docs/api-integrations/impact/connect
+    connection_config:
+        accountSid:
+            type: string
+            title: Account SID
+            description: The Account SID of your impact.com account, from Settings > API Access
+            order: 1
+            example: 'IRabc123XYZ456def789'
+    credentials:
+        username:
+            type: string
+            title: Account SID
+            description: Your impact.com Account SID, used as the Basic auth username
+            example: 'IRabc123XYZ456def789'
+        password:
+            type: string
+            title: Auth Token
+            description: Your impact.com Auth Token, used as the Basic auth password
+            secret: true
 
 ingenious-build:
     display_name: INGENIOUS.BUILD


### PR DESCRIPTION
Two affiliate networks that are not currently among Nango's providers.

Awin — API_KEY. Awin's docs describe the token as OAuth 2.0, but it is a static personal API token generated at ui.awin.com/awin-api and sent as a bearer header; there is no authorization flow, so API_KEY is the accurate auth mode. Base URL https://api.awin.com serves both the publisher and advertiser endpoints, and GET /accounts is used for verification because it answers for either side — it returns the accounts the token can reach.

impact.com — BASIC. The REST API authenticates with an Account SID as the username and an Auth Token as the password. The SID also appears in the path, so it is taken as connection config and interpolated into the base URL. The Advertisers path is used rather than Mediapartners: this is the brand-side view of an affiliate programme.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

