### PR TITLE
feat(server): let the dashboard's API target be configured separately from NANGO_SERVER_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,11 @@ NANGO_PUBLIC_SERVER_URL=http://localhost:3000
 #   Set this when self-hosting and you want the dashboard to reach Nango over an internal host, while
 #   NANGO_SERVER_URL stays the public one that OAuth callbacks and webhooks must reach. It only changes
 #   where the dashboard sends requests; callback and webhook URLs keep using NANGO_SERVER_URL.
-#   The dashboard origin must be an allowed CORS origin on that host (see NANGO_PUBLIC_SERVER_URL).
+#   `/` keeps requests on whichever host served the dashboard (same-origin). Use this when you front
+#   one Nango process with two ingresses. An absolute URL is for a dashboard hosted separately from
+#   the API; that origin must be an allowed CORS origin on the API host (see NANGO_PUBLIC_SERVER_URL).
 #
+# NANGO_DASHBOARD_API_URL=/
 # NANGO_DASHBOARD_API_URL=https://nango.example.internal
 CSP_REPORT_ONLY=false
 # FLAG_AUTH_ENABLED=false

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,13 @@ NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='["169.254.169.254","metadata.google.inte
 # token endpoints keep working; loopback/metadata/link-local stay blocked. Set blockPrivateIps to lock down.
 # Example (block private IPs for OAuth too): NANGO_OUTBOUND_URL_POLICY_OAUTH='{"blockPrivateIps":true}'
 NANGO_PUBLIC_SERVER_URL=http://localhost:3000
+# - Where the dashboard sends its API requests. If unset, NANGO_SERVER_URL is used.
+#   Set this when self-hosting and you want the dashboard to reach Nango over an internal host, while
+#   NANGO_SERVER_URL stays the public one that OAuth callbacks and webhooks must reach. It only changes
+#   where the dashboard sends requests; callback and webhook URLs keep using NANGO_SERVER_URL.
+#   The dashboard origin must be an allowed CORS origin on that host (see NANGO_PUBLIC_SERVER_URL).
+#
+# NANGO_DASHBOARD_API_URL=https://nango.example.internal
 CSP_REPORT_ONLY=false
 # FLAG_AUTH_ENABLED=false
 #

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -192,6 +192,14 @@ The resulting OAuth callback URL is `<INSTANCE-URL>/oauth/callback`.
 If you are using a custom domain, update `NANGO_SERVER_URL` to match it.
 </Note>
 
+If you front one Nango process with two ingresses (a public host for OAuth callbacks and webhooks, an internal host for the dashboard), set:
+
+```sh
+NANGO_DASHBOARD_API_URL=/
+```
+
+`/` keeps dashboard API requests on whichever host served the page. Callback and webhook URLs still use `NANGO_SERVER_URL`. Set an absolute URL instead if the dashboard is hosted separately from the API.
+
 ### Management MCP server
 
 The [Management MCP server](/reference/backend/management-mcp) runs as part of the main Nango server. To enable it, configure a dedicated hostname and route traffic for that hostname to the Nango server:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6857,6 +6857,14 @@ The resulting OAuth callback URL is `<INSTANCE-URL>/oauth/callback`.
 If you are using a custom domain, update `NANGO_SERVER_URL` to match it.
 </Note>
 
+If you front one Nango process with two ingresses (a public host for OAuth callbacks and webhooks, an internal host for the dashboard), set:
+
+```sh
+NANGO_DASHBOARD_API_URL=/
+```
+
+`/` keeps dashboard API requests on whichever host served the page. Callback and webhook URLs still use `NANGO_SERVER_URL`. Set an absolute URL instead if the dashboard is hosted separately from the API.
+
 ### Management MCP server
 
 The [Management MCP server](/reference/backend/management-mcp) runs as part of the main Nango server. To enable it, configure a dedicated hostname and route traffic for that hostname to the Nango server:

--- a/packages/server/lib/controllers/v1/getEnvJs.ts
+++ b/packages/server/lib/controllers/v1/getEnvJs.ts
@@ -3,6 +3,7 @@ import {
     basePublicUrl,
     baseUrl,
     connectUrl,
+    dashboardApiUrl,
     flagHasAuth,
     flagHasManagedAuth,
     flagHasPlan,
@@ -20,6 +21,7 @@ import type { RequestHandler } from 'express';
 export const getEnvJs: RequestHandler = (_, res) => {
     const configObject: WindowEnv = {
         apiUrl: baseUrl,
+        dashboardApiUrl,
         publicUrl: basePublicUrl,
         connectUrl: connectUrl,
         gitHash: envs.GIT_HASH,

--- a/packages/server/lib/controllers/v1/getEnvJs.unit.test.ts
+++ b/packages/server/lib/controllers/v1/getEnvJs.unit.test.ts
@@ -67,6 +67,11 @@ describe('getEnvJs', () => {
             name: 'moves only dashboardApiUrl when NANGO_DASHBOARD_API_URL is set, leaving apiUrl on NANGO_SERVER_URL',
             env: { NANGO_DASHBOARD_API_URL: DASHBOARD_API_URL },
             expected: { apiUrl: SERVER_URL, dashboardApiUrl: DASHBOARD_API_URL }
+        },
+        {
+            name: 'emits `/` when NANGO_DASHBOARD_API_URL is `/`, leaving apiUrl on NANGO_SERVER_URL',
+            env: { NANGO_DASHBOARD_API_URL: '/' },
+            expected: { apiUrl: SERVER_URL, dashboardApiUrl: '/' }
         }
     ];
 

--- a/packages/server/lib/controllers/v1/getEnvJs.unit.test.ts
+++ b/packages/server/lib/controllers/v1/getEnvJs.unit.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { WindowEnv } from '@nangohq/types';
+import type { Request, Response } from 'express';
+
+// getEnvJs only reads `envs` from @nangohq/logs. Stubbing it keeps the module graph light so the
+// dynamic re-imports below stay cheap.
+vi.mock('@nangohq/logs', () => ({
+    envs: {
+        GIT_HASH: undefined,
+        PUBLIC_SENTRY_KEY: '',
+        PUBLIC_POSTHOG_KEY: '',
+        PUBLIC_POSTHOG_HOST: '',
+        PUBLIC_LOGODEV_KEY: '',
+        PUBLIC_STRIPE_KEY: '',
+        PLAIN_APP_ID: '',
+        NANGO_LOGS_ENABLED: false,
+        AUTH_ALLOW_SIGNUP: true
+    }
+}));
+
+const SERVER_URL = 'https://nango.example.com';
+const DASHBOARD_API_URL = 'https://nango.internal.example.com';
+
+/**
+ * @nangohq/utils computes `baseUrl` / `dashboardApiUrl` from process.env at module load, so the env
+ * has to be stubbed before a fresh import of the whole chain.
+ */
+async function renderEnvJs(env: Record<string, string | undefined>): Promise<WindowEnv> {
+    vi.resetModules();
+    vi.stubEnv('NANGO_SERVER_URL', SERVER_URL);
+    for (const [key, value] of Object.entries(env)) {
+        vi.stubEnv(key, value);
+    }
+
+    const { getEnvJs } = await import('./getEnvJs.js');
+
+    let body = '';
+    const res = {
+        setHeader: vi.fn(),
+        set: vi.fn(),
+        send: vi.fn((payload: string) => {
+            body = payload;
+        })
+    } as unknown as Response;
+
+    // getEnvJs is synchronous, but RequestHandler is typed as possibly returning a promise.
+    void getEnvJs({} as Request, res, vi.fn());
+
+    const json = body.replace(/^window\._env = /, '').replace(/;$/, '');
+    return JSON.parse(json) as WindowEnv;
+}
+
+describe('getEnvJs', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+    });
+
+    const testCases = [
+        {
+            name: 'falls back to apiUrl when NANGO_DASHBOARD_API_URL is not set',
+            env: { NANGO_DASHBOARD_API_URL: undefined },
+            expected: { apiUrl: SERVER_URL, dashboardApiUrl: SERVER_URL }
+        },
+        {
+            name: 'moves only dashboardApiUrl when NANGO_DASHBOARD_API_URL is set, leaving apiUrl on NANGO_SERVER_URL',
+            env: { NANGO_DASHBOARD_API_URL: DASHBOARD_API_URL },
+            expected: { apiUrl: SERVER_URL, dashboardApiUrl: DASHBOARD_API_URL }
+        }
+    ];
+
+    for (const testCase of testCases) {
+        it(testCase.name, async () => {
+            const config = await renderEnvJs(testCase.env);
+
+            expect(config.apiUrl).toBe(testCase.expected.apiUrl);
+            expect(config.dashboardApiUrl).toBe(testCase.expected.dashboardApiUrl);
+        });
+    }
+});

--- a/packages/server/lib/middleware/security.ts
+++ b/packages/server/lib/middleware/security.ts
@@ -7,17 +7,20 @@ import type { RequestHandler } from 'express';
 // CSP path matching: no trailing slash = exact match (URL older SDKs load), with = prefix match (assets/routes).
 const connectUrlCspSources = [...new Set([connectUrl, connectUrlAsDocumentBase().toString()])];
 
+function websocketOrigin(url: string): string {
+    const parsed = new URL(url);
+    parsed.protocol = url.startsWith('https') ? 'wss' : 'ws';
+    return parsed.href;
+}
+
 export function securityMiddlewares(): RequestHandler[] {
     const hostPublic = basePublicUrl;
     const hostApi = baseUrl;
-    const hostWs = new URL(hostApi);
-    hostWs.protocol = hostApi.startsWith('https') ? 'wss' : 'ws';
-    // The dashboard may talk to a different host than the public API one. Falls back to it, hence the dedup.
-    const hostDashboardApi = dashboardApiUrl;
-    const hostDashboardApiWs = new URL(hostDashboardApi);
-    hostDashboardApiWs.protocol = hostDashboardApi.startsWith('https') ? 'wss' : 'ws';
-    const apiCspSources = [...new Set([hostApi, hostDashboardApi])];
-    const apiWsCspSources = [...new Set([hostWs.href, hostDashboardApiWs.href])];
+    const hostWs = websocketOrigin(hostApi);
+    // `/` means same-origin dashboard fetches; `'self'` already covers that.
+    // An absolute dashboard host may differ from the public API one (Set dedups when they match).
+    const apiCspSources = dashboardApiUrl === '/' ? [hostApi] : [...new Set([hostApi, dashboardApiUrl])];
+    const apiWsCspSources = dashboardApiUrl === '/' ? [hostWs] : [...new Set([hostWs, websocketOrigin(dashboardApiUrl)])];
     const reportOnly = process.env['CSP_REPORT_ONLY'];
 
     return [

--- a/packages/server/lib/middleware/security.ts
+++ b/packages/server/lib/middleware/security.ts
@@ -1,6 +1,6 @@
 import helmet from 'helmet';
 
-import { basePublicUrl, baseUrl, connectUrl, connectUrlAsDocumentBase } from '@nangohq/utils';
+import { basePublicUrl, baseUrl, connectUrl, connectUrlAsDocumentBase, dashboardApiUrl } from '@nangohq/utils';
 
 import type { RequestHandler } from 'express';
 
@@ -12,6 +12,12 @@ export function securityMiddlewares(): RequestHandler[] {
     const hostApi = baseUrl;
     const hostWs = new URL(hostApi);
     hostWs.protocol = hostApi.startsWith('https') ? 'wss' : 'ws';
+    // The dashboard may talk to a different host than the public API one. Falls back to it, hence the dedup.
+    const hostDashboardApi = dashboardApiUrl;
+    const hostDashboardApiWs = new URL(hostDashboardApi);
+    hostDashboardApiWs.protocol = hostDashboardApi.startsWith('https') ? 'wss' : 'ws';
+    const apiCspSources = [...new Set([hostApi, hostDashboardApi])];
+    const apiWsCspSources = [...new Set([hostWs.href, hostDashboardApiWs.href])];
     const reportOnly = process.env['CSP_REPORT_ONLY'];
 
     return [
@@ -27,15 +33,15 @@ export function securityMiddlewares(): RequestHandler[] {
         helmet.contentSecurityPolicy({
             reportOnly: reportOnly !== 'false',
             directives: {
-                defaultSrc: ["'self'", hostPublic, hostApi, ...connectUrlCspSources],
+                defaultSrc: ["'self'", hostPublic, ...apiCspSources, ...connectUrlCspSources],
                 childSrc: "'self'",
                 connectSrc: [
                     "'self'",
                     'https://*.google-analytics.com',
                     'https://*.sentry.io',
                     hostPublic,
-                    hostApi,
-                    hostWs.href,
+                    ...apiCspSources,
+                    ...apiWsCspSources,
                     ...connectUrlCspSources,
                     'https://*.posthog.com',
                     'https://*.stripe.com',

--- a/packages/types/lib/web/env.ts
+++ b/packages/types/lib/web/env.ts
@@ -1,5 +1,8 @@
 export interface WindowEnv {
+    /** Public API host: OAuth callbacks, webhooks, and the `apiURL` handed to the SDK / Connect UI. */
     apiUrl: string;
+    /** Where the dashboard sends its own API requests. Equals `apiUrl` unless NANGO_DASHBOARD_API_URL is set. */
+    dashboardApiUrl: string;
     publicUrl: string;
     connectUrl: string;
     gitHash: string | undefined;

--- a/packages/types/lib/web/env.ts
+++ b/packages/types/lib/web/env.ts
@@ -1,7 +1,7 @@
 export interface WindowEnv {
     /** Public API host: OAuth callbacks, webhooks, and the `apiURL` handed to the SDK / Connect UI. */
     apiUrl: string;
-    /** Where the dashboard sends its own API requests. Equals `apiUrl` unless NANGO_DASHBOARD_API_URL is set. */
+    /** Where the dashboard sends its own API requests. Equals `apiUrl` unless NANGO_DASHBOARD_API_URL is set. `/` means same-origin. */
     dashboardApiUrl: string;
     publicUrl: string;
     connectUrl: string;

--- a/packages/utils/lib/environment/detection.ts
+++ b/packages/utils/lib/environment/detection.ts
@@ -2,6 +2,9 @@ import { localhostUrl, NodeEnv } from './constants.js';
 
 export const baseUrl = process.env['NANGO_SERVER_URL'] || localhostUrl;
 export const basePublicUrl = process.env['NANGO_PUBLIC_SERVER_URL'] || baseUrl;
+// Where the dashboard sends its API requests. Defaults to NANGO_SERVER_URL so self-hosters who
+// don't split the two keep the current behavior.
+export const dashboardApiUrl = process.env['NANGO_DASHBOARD_API_URL'] || baseUrl;
 export const connectUrl = process.env['NANGO_PUBLIC_CONNECT_URL'] || 'http://localhost:3009';
 
 export const isDocker = process.env['SERVER_RUN_MODE'] === 'DOCKERIZED';

--- a/packages/utils/lib/environment/detection.ts
+++ b/packages/utils/lib/environment/detection.ts
@@ -2,8 +2,6 @@ import { localhostUrl, NodeEnv } from './constants.js';
 
 export const baseUrl = process.env['NANGO_SERVER_URL'] || localhostUrl;
 export const basePublicUrl = process.env['NANGO_PUBLIC_SERVER_URL'] || baseUrl;
-// Where the dashboard sends its API requests. Defaults to NANGO_SERVER_URL so self-hosters who
-// don't split the two keep the current behavior. `/` means same-origin (resolved in the webapp).
 export const dashboardApiUrl = process.env['NANGO_DASHBOARD_API_URL'] || baseUrl;
 export const connectUrl = process.env['NANGO_PUBLIC_CONNECT_URL'] || 'http://localhost:3009';
 

--- a/packages/utils/lib/environment/detection.ts
+++ b/packages/utils/lib/environment/detection.ts
@@ -3,7 +3,7 @@ import { localhostUrl, NodeEnv } from './constants.js';
 export const baseUrl = process.env['NANGO_SERVER_URL'] || localhostUrl;
 export const basePublicUrl = process.env['NANGO_PUBLIC_SERVER_URL'] || baseUrl;
 // Where the dashboard sends its API requests. Defaults to NANGO_SERVER_URL so self-hosters who
-// don't split the two keep the current behavior.
+// don't split the two keep the current behavior. `/` means same-origin (resolved in the webapp).
 export const dashboardApiUrl = process.env['NANGO_DASHBOARD_API_URL'] || baseUrl;
 export const connectUrl = process.env['NANGO_PUBLIC_CONNECT_URL'] || 'http://localhost:3009';
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -66,7 +66,8 @@ export const ENVS = z.object({
     SERVER_PORT: z.coerce.number().optional().default(3003),
     NANGO_SERVER_URL: z.url().optional(),
     // Where the dashboard sends its API requests. Defaults to NANGO_SERVER_URL when unset.
-    NANGO_DASHBOARD_API_URL: z.url().optional(),
+    // `/` keeps requests on whichever host served the dashboard (same-origin).
+    NANGO_DASHBOARD_API_URL: z.url().or(z.literal('/')).optional(),
     NANGO_MANAGEMENT_MCP_SERVER_URL: z.url().optional(),
     NANGO_SERVER_KEEP_ALIVE_TIMEOUT: z.coerce.number().optional().default(61_000),
     DEFAULT_RATE_LIMIT_PER_MIN: z.coerce.number().min(1).optional().default(200),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -65,6 +65,8 @@ export const ENVS = z.object({
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?
     SERVER_PORT: z.coerce.number().optional().default(3003),
     NANGO_SERVER_URL: z.url().optional(),
+    // Where the dashboard sends its API requests. Defaults to NANGO_SERVER_URL when unset.
+    NANGO_DASHBOARD_API_URL: z.url().optional(),
     NANGO_MANAGEMENT_MCP_SERVER_URL: z.url().optional(),
     NANGO_SERVER_KEEP_ALIVE_TIMEOUT: z.coerce.number().optional().default(61_000),
     DEFAULT_RATE_LIMIT_PER_MIN: z.coerce.number().min(1).optional().default(200),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -29,6 +29,17 @@ describe('parse', () => {
         expect(res.NANGO_MANAGEMENT_MCP_SERVER_URL).toBe('https://mcp-development.nango.dev');
     });
 
+    it('should accept `/` as NANGO_DASHBOARD_API_URL', () => {
+        const res = parseEnvs(ENVS, { NANGO_DASHBOARD_API_URL: '/' });
+        expect(res.NANGO_DASHBOARD_API_URL).toBe('/');
+    });
+
+    it('should reject a path other than `/` for NANGO_DASHBOARD_API_URL', () => {
+        expect(() => {
+            parseEnvs(ENVS, { NANGO_DASHBOARD_API_URL: '/nango-api' });
+        }).toThrow();
+    });
+
     it('should parse E2B sandbox metric settings', () => {
         const res = parseEnvs(ENVS, {
             E2B_SANDBOX_METRICS_POLL_INTERVAL_MS: '120000',

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -20,7 +20,9 @@ export async function publicApiFetch(
     { connectionId, providerConfigKey, secretKey }: { connectionId: string; providerConfigKey: string; secretKey: string },
     init?: RequestInit
 ) {
-    return await fetch(new URL(input as string, globalEnv.dashboardApiUrl), {
+    // Public API (e.g. /proxy), not dashboard admin. Keep this on apiUrl so split-host
+    // self-hosted setups still hit the public host the SDK would use.
+    return await fetch(new URL(input as string, globalEnv.apiUrl), {
         ...init,
         headers: {
             'Content-Type': 'application/json',

--- a/packages/webapp/src/utils/api.tsx
+++ b/packages/webapp/src/utils/api.tsx
@@ -5,7 +5,7 @@ import { globalEnv } from './env';
 import type { ApiError } from '@nangohq/types';
 
 export async function apiFetch(input: string | URL | Request, init?: RequestInit) {
-    return await fetch(new URL(input as string, globalEnv.apiUrl), {
+    return await fetch(new URL(input as string, globalEnv.dashboardApiUrl), {
         ...init,
         headers: {
             'Content-Type': 'application/json',
@@ -20,7 +20,7 @@ export async function publicApiFetch(
     { connectionId, providerConfigKey, secretKey }: { connectionId: string; providerConfigKey: string; secretKey: string },
     init?: RequestInit
 ) {
-    return await fetch(new URL(input as string, globalEnv.apiUrl), {
+    return await fetch(new URL(input as string, globalEnv.dashboardApiUrl), {
         ...init,
         headers: {
             'Content-Type': 'application/json',

--- a/packages/webapp/src/utils/env.ts
+++ b/packages/webapp/src/utils/env.ts
@@ -1,14 +1,7 @@
 // Runtime configuration snapshot. window._env is set by /env.js before the app bundle runs.
 // See packages/webapp/src/utils/loadRuntimeEnv.ts and packages/server/lib/controllers/v1/getEnvJs.ts.
 
-/** `/` means same-origin: use whichever host served the dashboard. */
-function resolveDashboardApiUrl(value: string | undefined, origin: string, apiUrl: string): string {
-    if (value === '/') {
-        return origin;
-    }
-    // Stale cached /env.js from before this field existed has no dashboardApiUrl.
-    return value || apiUrl;
-}
+import { resolveDashboardApiUrl } from './resolveDashboardApiUrl';
 
 export const globalEnv = {
     ...window._env,

--- a/packages/webapp/src/utils/env.ts
+++ b/packages/webapp/src/utils/env.ts
@@ -1,3 +1,12 @@
 // Runtime configuration snapshot. window._env is set by /env.js before the app bundle runs.
 // See packages/webapp/src/utils/loadRuntimeEnv.ts and packages/server/lib/controllers/v1/getEnvJs.ts.
-export const globalEnv = { ...window._env };
+
+/** `/` means same-origin: use whichever host served the dashboard. */
+function resolveDashboardApiUrl(value: string, origin: string): string {
+    return value === '/' ? origin : value;
+}
+
+export const globalEnv = {
+    ...window._env,
+    dashboardApiUrl: resolveDashboardApiUrl(window._env.dashboardApiUrl, window.location.origin)
+};

--- a/packages/webapp/src/utils/env.ts
+++ b/packages/webapp/src/utils/env.ts
@@ -2,11 +2,15 @@
 // See packages/webapp/src/utils/loadRuntimeEnv.ts and packages/server/lib/controllers/v1/getEnvJs.ts.
 
 /** `/` means same-origin: use whichever host served the dashboard. */
-function resolveDashboardApiUrl(value: string, origin: string): string {
-    return value === '/' ? origin : value;
+function resolveDashboardApiUrl(value: string | undefined, origin: string, apiUrl: string): string {
+    if (value === '/') {
+        return origin;
+    }
+    // Stale cached /env.js from before this field existed has no dashboardApiUrl.
+    return value || apiUrl;
 }
 
 export const globalEnv = {
     ...window._env,
-    dashboardApiUrl: resolveDashboardApiUrl(window._env.dashboardApiUrl, window.location.origin)
+    dashboardApiUrl: resolveDashboardApiUrl(window._env.dashboardApiUrl, window.location.origin, window._env.apiUrl)
 };

--- a/packages/webapp/src/utils/resolveDashboardApiUrl.ts
+++ b/packages/webapp/src/utils/resolveDashboardApiUrl.ts
@@ -1,0 +1,10 @@
+/**
+ * `/` means same-origin: use whichever host served the dashboard.
+ * Stale cached /env.js from before this field existed has no dashboardApiUrl.
+ */
+export function resolveDashboardApiUrl(value: string | undefined, origin: string, apiUrl: string): string {
+    if (value === '/') {
+        return origin;
+    }
+    return value || apiUrl;
+}

--- a/packages/webapp/src/utils/resolveDashboardApiUrl.unit.test.ts
+++ b/packages/webapp/src/utils/resolveDashboardApiUrl.unit.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDashboardApiUrl } from './resolveDashboardApiUrl.js';
+
+const ORIGIN = 'https://nango.internal.example.com';
+const API_URL = 'https://nango.example.com';
+const DASHBOARD_API_URL = 'https://nango.dashboard-api.example.com';
+
+describe('resolveDashboardApiUrl', () => {
+    it('resolves `/` to the page origin', () => {
+        expect(resolveDashboardApiUrl('/', ORIGIN, API_URL)).toBe(ORIGIN);
+    });
+
+    it('falls back to apiUrl when the value is missing', () => {
+        expect(resolveDashboardApiUrl(undefined, ORIGIN, API_URL)).toBe(API_URL);
+        expect(resolveDashboardApiUrl('', ORIGIN, API_URL)).toBe(API_URL);
+    });
+
+    it('returns an absolute URL unchanged', () => {
+        expect(resolveDashboardApiUrl(DASHBOARD_API_URL, ORIGIN, API_URL)).toBe(DASHBOARD_API_URL);
+    });
+});

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -18,10 +18,11 @@ const REMOTE_API_URLS: Record<string, string> = {
     prod: 'https://api.nango.dev'
 };
 
-// REMOTE_API mode only: fetch /env.js from the remote API and rewrite apiUrl to the local
-// Vite origin, so API calls route through Vite's proxy instead of cross-origin to a backend
-// whose CORS we don't control. Port is read at request time (after bind) to track Vite's
-// automatic port increment.
+// REMOTE_API mode only: fetch /env.js from the remote API and rewrite apiUrl and dashboardApiUrl
+// to the local Vite origin, so API calls route through Vite's proxy instead of cross-origin to a
+// backend whose CORS we don't control. Both keys matter: the dashboard's own fetches resolve
+// against dashboardApiUrl, everything else against apiUrl. Port is read at request time (after
+// bind) to track Vite's automatic port increment.
 function apiEnvProxyPlugin(apiUrl: string): Plugin {
     return {
         name: 'api-env-proxy',
@@ -34,7 +35,7 @@ function apiEnvProxyPlugin(apiUrl: string): Plugin {
                 try {
                     const body = await fetch(`${apiUrl}/env.js`).then((r) => r.text());
                     res.setHeader('Content-Type', 'text/javascript');
-                    res.end(body.replace(/"apiUrl": "[^"]*"/, `"apiUrl": "${origin}"`));
+                    res.end(body.replace(/"(apiUrl|dashboardApiUrl)": "[^"]*"/g, `"$1": "${origin}"`));
                 } catch {
                     // The backend may not be listening yet (e.g. it boots slower than Vite).
                     // Respond with a retryable error instead of letting the rejection crash Vite.
@@ -67,7 +68,7 @@ function apiProxyConfig() {
         };
     }
 
-    // REMOTE_API mode: proxy all API traffic to the remote backend and rewrite apiUrl.
+    // REMOTE_API mode: proxy all API traffic to the remote backend and rewrite the API URLs.
     const proxyOpts = { target: remoteUrl, changeOrigin: true };
     return {
         envProxyPlugin: apiEnvProxyPlugin(remoteUrl),


### PR DESCRIPTION
Fixes NangoHQ/nango#7052.

## Problem

`NANGO_SERVER_URL` decides two things at once: the public API host (OAuth callbacks, webhooks, the `apiURL` handed to the SDK and Connect UI) and the base URL the dashboard sends its own requests to. Self-hosted deployments need the first publicly reachable and the second internal, so they can't share a value — blocking `/api` at the public gateway breaks the dashboard, while leaving it open exposes the unauthenticated `signin` / `signup` / `forgot-password` routes on the public host.

## Solution

Add `NANGO_DASHBOARD_API_URL`, surfaced on `window._env` as `dashboardApiUrl` and used by `apiFetch` / `publicApiFetch`. It falls back to `NANGO_SERVER_URL`, so leaving it unset changes nothing — including the CSP header, where the fallback is deduplicated against the public host (same `new Set` idiom as `connectUrlCspSources`) so the rendered directives stay byte-identical.

`apiUrl` deliberately keeps its meaning. The other nine `globalEnv.apiUrl` reads — displayed OAuth callback URLs, the SDK `host`, and the `apiURL` passed to Connect UI — all need the public host; repointing it would show internal URLs that can't be registered with a provider. `utils/cors.ts` is unchanged: `allowedOrigins` lists request *origins*, and the dashboard's origin (`basePublicUrl`) is already on it.

## Testing

`packages/server/lib/controllers/v1/getEnvJs.unit.test.ts` (new) covers both directions: unset means `dashboardApiUrl === apiUrl`, and when set only `dashboardApiUrl` moves while `apiUrl` stays on `NANGO_SERVER_URL`.

`npm run lint`, `npm run format:check`, and unit tests for `packages/server` and `packages/webapp` all pass; `tsc --noEmit` output is unchanged from master.

## One thing worth flagging

`getEnvJs` sends `Cache-Control: max-age=3600`, so a browser holding a stale `env.js` next to a new bundle would see `dashboardApiUrl === undefined` and `new URL(path, undefined)` would throw. `loadRuntimeEnv.ts`'s `nango-env-hash` param busts that on deploy, so I left the two call sites without an `|| globalEnv.apiUrl` guard — happy to add one if you'd rather be defensive.

The issue also mentions allowing a relative value (e.g. `/`) so the dashboard can address its own origin. That needs a looser zod schema and relative-base handling in `apiFetch`, so I kept it out of this PR — glad to follow up if you prefer that shape.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)