### PR TITLE
feat(cli): deploy functions

### DIFF
--- a/packages/cli/lib/services/model.service.unit.test.ts
+++ b/packages/cli/lib/services/model.service.unit.test.ts
@@ -1,11 +1,14 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { removeVersion } from '../tests/helpers.js';
 import { parse } from './config.service.js';
-import { buildModelsTS, fieldsToTypescript, fieldToTypescript } from './model.service.js';
+import { buildModelsTS, fieldsToTypescript, fieldToTypescript, generateFunctionsJson } from './model.service.js';
 
+import type { FunctionConfig } from '../zeroYaml/definitions.js';
 import type { NangoModel } from '@nangohq/types';
 
 describe('buildModelTs', () => {
@@ -250,3 +253,53 @@ describe('fieldToTypescript', () => {
         ).toStrictEqual('User[] | string');
     });
 });
+
+describe('generateFunctionsJson', () => {
+    let fullPath: string;
+
+    beforeEach(async () => {
+        fullPath = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-cli-model-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(fullPath, { recursive: true, force: true });
+    });
+
+    it('should not write anything when there is no function', async () => {
+        generateFunctionsJson({ fullPath, functions: [], debug: false });
+
+        await expect(fs.stat(path.join(fullPath, '.nango', 'functions.json'))).rejects.toThrow('ENOENT');
+    });
+
+    it('should remove the artifact when the last function is removed', async () => {
+        generateFunctionsJson({ fullPath, functions: [functionConfig()], debug: false });
+        generateFunctionsJson({ fullPath, functions: [], debug: false });
+
+        await expect(fs.stat(path.join(fullPath, '.nango', 'functions.json'))).rejects.toThrow('ENOENT');
+    });
+
+    it('should write functions', async () => {
+        generateFunctionsJson({ fullPath, functions: [functionConfig()], debug: false });
+
+        const content = await fs.readFile(path.join(fullPath, '.nango', 'functions.json'), 'utf8');
+        expect(JSON.parse(content)).toMatchObject([{ integrationId: 'github', name: 'fetch' }]);
+    });
+});
+
+function functionConfig(): FunctionConfig {
+    return {
+        name: 'fetch',
+        integrationId: 'github',
+        description: 'Function',
+        trigger: { kind: 'none' },
+        requires: { connection: true, outbound: true, invoke: false },
+        capabilities: { usesRecords: false, usesOutbound: true, usesCheckpoints: false, usesMetadata: false, usesInvoke: false },
+        limits: { concurrency: { perConnection: 'max' } },
+        input_schema_ref: null,
+        output_schema_ref: null,
+        model_schema_refs: [],
+        metadata_schema_ref: null,
+        checkpoint_schema_ref: null,
+        json_schema: { definitions: {} }
+    };
+}

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -13,6 +13,7 @@ import { parseIntegrationDefinitions } from './definitions.js';
 import { ReadableError } from './utils.js';
 
 import type { DeployOptions } from '../types.js';
+import type { FunctionConfig, ParsedIntegrationDefinitions } from './definitions.js';
 import type {
     CLIDeployFlowConfig,
     NangoConfigMetadata,
@@ -21,12 +22,17 @@ import type {
     OnEventType,
     PostDeploy,
     PostDeployConfirmation,
+    PostFunctionDeploymentBundle,
+    PostFunctionDeploymentBundlePreview,
     Result,
     ScriptDifferences,
     ScriptFileType
 } from '@nangohq/types';
 
-type Package = Pick<PostDeployConfirmation['Body'], 'flowConfigs' | 'onEventScriptsByProvider' | 'deployMode'>;
+type LegacyPackage = Pick<PostDeployConfirmation['Body'], 'flowConfigs' | 'onEventScriptsByProvider' | 'deployMode'>;
+type FunctionsBundle = PostFunctionDeploymentBundle['Body'];
+type Deployment = { kind: 'legacy'; package: LegacyPackage } | { kind: 'functions'; bundle: FunctionsBundle };
+type DeploymentConfirmation = { kind: 'legacy'; value: ScriptDifferences } | { kind: 'functions'; value: PostFunctionDeploymentBundlePreview['Success'] };
 
 export async function deploy({
     fullPath,
@@ -42,7 +48,7 @@ export async function deploy({
     const { env, version, debug } = options;
     const spinnerFactory = new Spinner({ interactive });
 
-    let pkg: Package;
+    let deployment: Deployment;
     const spinnerPackage = spinnerFactory.start('Packaging');
     try {
         const def = await parseIntegrationDefinitions({ fullPath, debug });
@@ -53,22 +59,50 @@ export async function deploy({
             return Err(def.error);
         }
 
-        const postData = await createDeployConfirmationPackage({
+        const deploymentKind = getDeploymentKind({
             parsed: def.value,
-            fullPath,
-            debug,
-            version,
             optionalIntegrationId: options.integration,
             optionalSyncName: options.sync,
             optionalActionName: options.action
         });
-        if (postData.isErr()) {
+        if (deploymentKind === 'mixed') {
             spinnerPackage.fail();
-            console.log(chalk.red(postData.error.message));
+            console.log(chalk.red('Legacy scripts and functions cannot be deployed together.'));
             return Err('no_data');
         }
 
-        pkg = postData.value;
+        if (deploymentKind === 'legacy') {
+            const postData = await createDeployConfirmationPackage({
+                parsed: def.value,
+                fullPath,
+                debug,
+                version,
+                optionalIntegrationId: options.integration,
+                optionalSyncName: options.sync,
+                optionalActionName: options.action
+            });
+            if (postData.isErr()) {
+                spinnerPackage.fail();
+                console.log(chalk.red(postData.error.message));
+                return Err('no_data');
+            }
+            deployment = { kind: 'legacy', package: postData.value };
+        } else {
+            if (options.version) {
+                spinnerPackage.fail();
+                console.log(chalk.red('The --version option can only be used with legacy scripts.'));
+                return Err('no_data');
+            }
+
+            const bundle = await createFunctionsBundle({ fullPath, optionalIntegrationId: options.integration });
+            if (bundle.isErr()) {
+                spinnerPackage.fail();
+                console.log(chalk.red(bundle.error.message));
+                return Err('no_data');
+            }
+            deployment = { kind: 'functions', bundle: bundle.value };
+        }
+
         spinnerPackage.succeed();
     } catch (err) {
         spinnerPackage.fail();
@@ -86,19 +120,28 @@ export async function deploy({
 
     // Check remote state
     const spinnerState = spinnerFactory.start(`Acquiring remote state ${chalk.gray(`(${new URL(hostport).origin})`)}`);
-    let confirmation: ScriptDifferences;
+    let confirmation: DeploymentConfirmation;
     try {
-        const confirmationRes = await postConfirmation({
-            hostport,
-            body: { ...pkg, reconcile: false, debug, sdkVersion }
-        });
-        if (confirmationRes.isErr()) {
-            spinnerState.fail();
-            console.log(chalk.red(confirmationRes.error.message));
-            return Err(confirmationRes.error);
+        if (deployment.kind === 'legacy') {
+            const confirmationRes = await postLegacyConfirmation({
+                hostport,
+                body: { ...deployment.package, reconcile: false, debug, sdkVersion }
+            });
+            if (confirmationRes.isErr()) {
+                spinnerState.fail();
+                console.log(chalk.red(confirmationRes.error.message));
+                return Err(confirmationRes.error);
+            }
+            confirmation = { kind: 'legacy', value: confirmationRes.value };
+        } else {
+            const confirmationRes = await previewFunctionsDeployment({ hostport, body: deployment.bundle });
+            if (confirmationRes.isErr()) {
+                spinnerState.fail();
+                console.log(chalk.red(confirmationRes.error.message));
+                return Err(confirmationRes.error);
+            }
+            confirmation = { kind: 'functions', value: confirmationRes.value };
         }
-
-        confirmation = confirmationRes.value;
         spinnerState.succeed();
     } catch {
         spinnerState.fail();
@@ -107,33 +150,131 @@ export async function deploy({
 
     const deploySource = resolveDeploySource();
     const autoconfirm = process.env['NANGO_DEPLOY_AUTO_CONFIRM'] === 'true' || options.autoConfirm;
-    const confirmed = await handleConfirmation({ autoconfirm, allowDestructive: options.allowDestructive || false, confirmation });
+    const confirmed =
+        confirmation.kind === 'legacy'
+            ? await handleLegacyConfirmation({ autoconfirm, allowDestructive: options.allowDestructive || false, confirmation: confirmation.value })
+            : await handleFunctionsConfirmation({
+                  autoconfirm,
+                  allowDestructive: options.allowDestructive || false,
+                  confirmation: confirmation.value
+              });
     if (confirmed.isErr()) {
         return Err('not_confirmed');
     }
 
     console.log('');
     // Actual deploy
-    const total = pkg.flowConfigs.length + (pkg.onEventScriptsByProvider?.reduce((v, t) => v + t.scripts.length, 0) || 0);
+    const total =
+        deployment.kind === 'legacy'
+            ? deployment.package.flowConfigs.length + (deployment.package.onEventScriptsByProvider?.reduce((v, t) => v + t.scripts.length, 0) || 0)
+            : deployment.bundle.functions.length;
     const spinnerDeploy = spinnerFactory.start(`Deploying ${total} functions`);
     try {
-        const deployRes = await postDeploy({
-            hostport,
-            body: { ...pkg, reconcile: true, debug, nangoYamlBody, sdkVersion, source: deploySource }
-        });
-        if (deployRes.isErr()) {
-            spinnerDeploy.fail();
-            console.log(chalk.red(deployRes.error.message));
-            return Err('failed_to_deploy');
+        if (deployment.kind === 'legacy') {
+            const deployRes = await postLegacyDeploy({
+                hostport,
+                body: { ...deployment.package, reconcile: true, debug, nangoYamlBody, sdkVersion, source: deploySource }
+            });
+            if (deployRes.isErr()) {
+                spinnerDeploy.fail();
+                console.log(chalk.red(deployRes.error.message));
+                return Err('failed_to_deploy');
+            }
+            spinnerDeploy.succeed('Deployed');
+            console.log(chalk.green(deployRes.value));
+        } else {
+            const deployRes = await deployFunctions({ hostport, body: deployment.bundle });
+            if (deployRes.isErr()) {
+                spinnerDeploy.fail();
+                console.log(chalk.red(deployRes.error.message));
+                return Err('failed_to_deploy');
+            }
+            spinnerDeploy.succeed('Deployed');
+            console.log(chalk.green(functionsDeploymentMessage(deployRes.value)));
         }
-
-        spinnerDeploy.succeed('Deployed');
-        console.log(chalk.green(deployRes.value));
         return Ok(true);
     } catch {
         spinnerDeploy.fail();
         return Err('failed');
     }
+}
+
+function getDeploymentKind({
+    parsed,
+    optionalIntegrationId,
+    optionalSyncName,
+    optionalActionName
+}: {
+    parsed: ParsedIntegrationDefinitions;
+    optionalIntegrationId?: string | undefined;
+    optionalSyncName?: string | undefined;
+    optionalActionName?: string | undefined;
+}): 'legacy' | 'functions' | 'mixed' {
+    if (optionalSyncName || optionalActionName) {
+        return 'legacy';
+    }
+
+    const integrations = optionalIntegrationId
+        ? parsed.integrations.filter((integration) => integration.providerConfigKey === optionalIntegrationId)
+        : parsed.integrations;
+    const hasLegacyScripts = integrations.some(
+        (integration) =>
+            integration.syncs.length > 0 || integration.actions.length > 0 || Object.values(integration.onEventScripts).some((scripts) => scripts.length > 0)
+    );
+    const hasFunctions = parsed.functions.some((config) => !optionalIntegrationId || config.integrationId === optionalIntegrationId);
+
+    if (hasLegacyScripts && hasFunctions) {
+        return 'mixed';
+    }
+    if (hasLegacyScripts) {
+        return 'legacy';
+    }
+    return 'functions';
+}
+
+async function createFunctionsBundle({
+    fullPath,
+    optionalIntegrationId
+}: {
+    fullPath: string;
+    optionalIntegrationId?: string | undefined;
+}): Promise<Result<FunctionsBundle>> {
+    const artifactPath = path.join(fullPath, '.nango', 'functions.json');
+    let functionConfigs: FunctionConfig[] = [];
+    if (fs.existsSync(artifactPath)) {
+        try {
+            const content = await fs.promises.readFile(artifactPath, 'utf8');
+            const parsed = JSON.parse(content) as unknown;
+            if (!Array.isArray(parsed)) {
+                return Err(new Error(`Invalid functions artifact ${artifactPath}`));
+            }
+            functionConfigs = parsed as FunctionConfig[];
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return Err(new Error(`Could not read functions artifact ${artifactPath}: ${message}`));
+        }
+    }
+
+    const selectedConfigs = optionalIntegrationId ? functionConfigs.filter((config) => config.integrationId === optionalIntegrationId) : functionConfigs;
+
+    const functions: FunctionsBundle['functions'] = [];
+    for (const config of selectedConfigs) {
+        const fileBody = await loadScriptFiles({
+            fullPath,
+            scriptName: config.name,
+            providerConfigKey: config.integrationId,
+            type: 'functions'
+        });
+        if (!fileBody) {
+            return Err(new Error(`No function files found for "${config.name}"`));
+        }
+        functions.push({ ...config, fileBody });
+    }
+
+    return Ok({
+        reconciliationScope: optionalIntegrationId ? { kind: 'integration', integrationId: optionalIntegrationId } : { kind: 'environment' },
+        functions
+    });
 }
 
 /**
@@ -157,7 +298,7 @@ async function createDeployConfirmationPackage({
     optionalIntegrationId?: string | undefined;
     optionalSyncName?: string | undefined;
     optionalActionName?: string | undefined;
-}): Promise<Result<Package>> {
+}): Promise<Result<LegacyPackage>> {
     printDebug('Packaging', debug);
 
     const postData: CLIDeployFlowConfig[] = [];
@@ -273,7 +414,7 @@ async function createDeployConfirmationPackage({
     }
 
     if (postData.length <= 0) {
-        return Err(new Error('No functions to deploy'));
+        return Err(new Error('No syncs or actions to deploy'));
     }
 
     return Ok({
@@ -364,7 +505,7 @@ async function loadScriptTsFile({
 /**
  * Call Nango api to get the state of the deploy
  */
-async function postConfirmation({
+async function postLegacyConfirmation({
     hostport,
     body
 }: {
@@ -403,7 +544,7 @@ async function postConfirmation({
 /**
  * Call Nango api to actually deploy
  */
-async function postDeploy({ hostport, body }: { hostport: string; body: PostDeploy['Body'] }): Promise<Result<string>> {
+async function postLegacyDeploy({ hostport, body }: { hostport: string; body: PostDeploy['Body'] }): Promise<Result<string>> {
     const url = new URL('/sync/deploy', hostport);
 
     try {
@@ -440,10 +581,81 @@ async function postDeploy({ hostport, body }: { hostport: string; body: PostDepl
     }
 }
 
+async function previewFunctionsDeployment({
+    hostport,
+    body
+}: {
+    hostport: string;
+    body: PostFunctionDeploymentBundlePreview['Body'];
+}): Promise<Result<PostFunctionDeploymentBundlePreview['Success']>> {
+    const url = new URL('/functions/deployments/bundle/preview', hostport);
+
+    try {
+        const res = await fetch(url, {
+            method: 'POST',
+            body: JSON.stringify(body),
+            headers: new Headers({
+                ...getCliHeaders(),
+                authorization: `Bearer ${process.env['NANGO_SECRET_KEY']}`,
+                'content-type': 'application/json'
+            })
+        });
+
+        const json = (await res.json()) as PostFunctionDeploymentBundlePreview['Reply'];
+        if ('error' in json) {
+            return Err(new Error(`Error checking functions state:\n${json.error.message || 'Error'} ${chalk.gray(`(${json.error.code})`)}`));
+        }
+
+        return Ok(json);
+    } catch (err) {
+        return Err(new Error(`Error checking functions state:\n${getFetchError(err)}`));
+    }
+}
+
+async function deployFunctions({
+    hostport,
+    body
+}: {
+    hostport: string;
+    body: PostFunctionDeploymentBundle['Body'];
+}): Promise<Result<PostFunctionDeploymentBundle['Success']>> {
+    const url = new URL('/functions/deployments/bundle', hostport);
+
+    try {
+        const res = await fetch(url, {
+            method: 'POST',
+            body: JSON.stringify(body),
+            headers: new Headers({
+                ...getCliHeaders(),
+                authorization: `Bearer ${process.env['NANGO_SECRET_KEY']}`,
+                'content-type': 'application/json'
+            })
+        });
+
+        const json = (await res.json()) as PostFunctionDeploymentBundle['Reply'];
+        if ('error' in json) {
+            return Err(new Error(`Error deploying functions:\n${json.error.message || 'Error'} ${chalk.gray(`(${json.error.code})`)}`));
+        }
+
+        return Ok(json);
+    } catch (err) {
+        return Err(new Error(`Error deploying functions:\n${getFetchError(err)}`));
+    }
+}
+
+function functionsDeploymentMessage(result: PostFunctionDeploymentBundle['Success']): string {
+    const deployed = [...result.created, ...result.updated];
+    if (deployed.length === 0) {
+        return result.deleted.length > 0 ? 'Successfully removed the functions.' : 'No function changes were deployed.';
+    }
+
+    return `Successfully deployed the functions: \r\n${deployed.map((func) => `- ${func.integrationId} → ${func.name}`).join('\r\n')}`;
+}
+
 /**
  * Handle state, display plan and eventually ask for confirmation if destructive
  */
-async function handleConfirmation({
+async function handleLegacyConfirmation({
     autoconfirm,
     allowDestructive,
     confirmation
@@ -609,6 +821,83 @@ async function handleConfirmation({
     } catch {
         console.log('');
         console.log(chalk.yellow('Deployed aborted. Exiting'));
+        return Err('not_confirmed');
+    }
+
+    return Ok(true);
+}
+
+async function handleFunctionsConfirmation({
+    autoconfirm,
+    allowDestructive,
+    confirmation
+}: {
+    autoconfirm: boolean;
+    allowDestructive: boolean;
+    confirmation: PostFunctionDeploymentBundlePreview['Success'];
+}): Promise<Result<boolean>> {
+    const { created, updated, deleted } = confirmation;
+
+    console.log('');
+    console.log('', chalk.underline('Nango will perform this plan:'));
+
+    if (created.length + updated.length + deleted.length === 0) {
+        console.log('');
+        console.log(chalk.gray.italic('  No changes'));
+        return Ok(true);
+    } else if (created.length > 0 || deleted.length > 0) {
+        console.log('');
+        console.log(shortSummaryMessage({ name: 'Functions', newItems: created, deleteItems: deleted }));
+        for (const func of created) {
+            console.log(` ${chalk.green('+')} ${func.integrationId} → ${func.name}`);
+        }
+        for (const func of deleted) {
+            console.log(` ${chalk.red('-')} ${func.integrationId} → ${func.name}`);
+        }
+    } else if (updated.length > 0) {
+        console.log('');
+        console.log(chalk.gray.italic('  Only updates'));
+    }
+
+    console.log('');
+    console.log('', chalk.underline('Summary'));
+    console.log(
+        columnify([summaryMessageColumns({ name: 'Functions', newItems: created, updatedItems: updated, deleteItems: deleted })], {
+            showHeaders: false,
+            minWidth: 18,
+            config: {
+                name: {
+                    dataTransform: (value) => `\u2063\u2063${value}`
+                }
+            }
+        })
+    );
+    console.log('');
+
+    if (deleted.length === 0) {
+        console.log(chalk.grey('No functions deleted, proceeding without confirmation'));
+        return Ok(true);
+    }
+
+    if (autoconfirm && allowDestructive) {
+        console.log(chalk.yellow('allowDestructive flag is on, proceeding without confirmation'));
+        return Ok(true);
+    }
+
+    if (isCI) {
+        console.log(chalk.red('Functions were not deployed. Confirm the deploy by passing the --auto-confirm and --allow-destructive flags. Exiting'));
+        return Err('is_ci');
+    }
+
+    try {
+        const wait = await promptly.confirm(`Are you sure you want to continue y/n?`);
+        if (!wait) {
+            console.log(chalk.yellow('Deploy aborted. Exiting'));
+            return Err('not_confirmed');
+        }
+    } catch {
+        console.log('');
+        console.log(chalk.yellow('Deploy aborted. Exiting'));
         return Err('not_confirmed');
     }
 

--- a/packages/cli/lib/zeroYaml/deploy.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/deploy.unit.cli-test.ts
@@ -1,0 +1,422 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import promptly from 'promptly';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Ok } from '../utils/result.js';
+import { parseIntegrationDefinitions } from './definitions.js';
+import { deploy } from './deploy.js';
+
+import type { DeployOptions } from '../types.js';
+import type { FunctionConfig, ParsedIntegrationDefinitions } from './definitions.js';
+import type { FunctionDeploymentBundleSuccess, PostDeployConfirmation } from '@nangohq/types';
+
+vi.mock('promptly', () => ({ default: { confirm: vi.fn() } }));
+vi.mock('./definitions.js', () => ({ parseIntegrationDefinitions: vi.fn() }));
+
+const githubFunction = functionConfig({ integrationId: 'github', name: 'fetch' });
+const slackFunction = functionConfig({ integrationId: 'slack', name: 'other' });
+
+const parsed = {
+    yamlVersion: 'v2',
+    models: new Map(),
+    integrations: [
+        {
+            providerConfigKey: 'github',
+            syncs: [],
+            actions: [
+                {
+                    name: 'legacy',
+                    type: 'action',
+                    description: 'Legacy action',
+                    input: null,
+                    output: [],
+                    endpoint: null,
+                    scopes: [],
+                    usedModels: [],
+                    version: '',
+                    json_schema: { definitions: {} },
+                    features: []
+                }
+            ],
+            onEventScripts: {
+                'post-connection-creation': [],
+                'pre-connection-deletion': [],
+                'validate-connection': []
+            }
+        }
+    ],
+    functions: [githubFunction, slackFunction]
+} satisfies ParsedIntegrationDefinitions;
+
+const legacyConfirmation = {
+    newSyncs: [],
+    updatedSyncs: [],
+    deletedSyncs: [],
+    newActions: [],
+    updatedActions: [],
+    deletedActions: [],
+    deletedModels: [],
+    newOnEventScripts: [],
+    updatedOnEventScripts: [],
+    deletedOnEventScripts: []
+} satisfies PostDeployConfirmation['Success'];
+
+const legacyChangeConfirmation = {
+    ...legacyConfirmation,
+    updatedActions: [{ providerConfigKey: 'github', name: 'legacy' }]
+} satisfies PostDeployConfirmation['Success'];
+
+const legacyOnlyParsed = {
+    ...parsed,
+    functions: []
+} satisfies ParsedIntegrationDefinitions;
+
+const functionsOnlyParsed = {
+    ...parsed,
+    integrations: parsed.integrations.map((integration) => ({ ...integration, syncs: [], actions: [] }))
+} satisfies ParsedIntegrationDefinitions;
+
+const noFunctionChanges = {
+    created: [],
+    updated: [],
+    unchanged: [{ integrationId: 'github', name: 'fetch' }],
+    deleted: []
+} satisfies FunctionDeploymentBundleSuccess;
+
+describe('deploy', () => {
+    let fullPath: string;
+    let fetchMock: ReturnType<typeof vi.fn>;
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(async () => {
+        fullPath = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-cli-deploy-'));
+        await writeProject(fullPath);
+
+        vi.mocked(parseIntegrationDefinitions).mockReset();
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok(parsed));
+        vi.mocked(promptly.confirm).mockReset();
+        vi.mocked(promptly.confirm).mockResolvedValue(false);
+        fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        vi.stubEnv('NANGO_SECRET_KEY', 'secret');
+        vi.stubEnv('NANGO_CLI_TELEMETRY', 'false');
+        vi.stubEnv('NANGO_DEPLOY_AUTO_CONFIRM', undefined);
+    });
+
+    afterEach(async () => {
+        vi.unstubAllGlobals();
+        vi.unstubAllEnvs();
+        vi.restoreAllMocks();
+        await fs.rm(fullPath, { recursive: true, force: true });
+    });
+
+    it('prints an error for a mixed deploy', async () => {
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions() });
+
+        const output = logOutput(logSpy);
+        expect(output).toContain('Legacy scripts and functions cannot be deployed together');
+        expect(output).not.toContain('✓ Deployed');
+    });
+
+    it('prints only legacy summary rows for a single action deploy', async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse(legacyChangeConfirmation)).mockResolvedValueOnce(jsonResponse([]));
+
+        await deploy({
+            fullPath,
+            environmentName: 'test',
+            interactive: false,
+            options: deployOptions({ action: 'legacy' })
+        });
+
+        const output = logOutput(logSpy);
+        expect(output).toContain('↳ Syncs');
+        expect(output).toContain('↳ Actions');
+        expect(output).toContain('↳ OnEvents');
+        expect(output).not.toContain('↳ Functions');
+        expect(output).toContain('✓ Deployed');
+    });
+
+    it.each([
+        { flag: '--sync', options: { sync: 'missing' } },
+        { flag: '--action', options: { action: 'missing' } }
+    ] satisfies { flag: string; options: Partial<DeployOptions> }[])(
+        'reports no matching function for an unknown $flag name in a mixed project',
+        async ({ options }) => {
+            await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions(options) });
+
+            const output = logOutput(logSpy);
+            expect(output).toContain('No syncs or actions to deploy');
+            expect(output).not.toContain('The --sync and --action options can only be used with legacy scripts');
+            expect(fetchMock).not.toHaveBeenCalled();
+        }
+    );
+
+    it('deploys functions for a native-only integration in a mixed project', async () => {
+        const functionChanges = {
+            created: [{ integrationId: 'slack', name: 'other' }],
+            updated: [],
+            unchanged: [],
+            deleted: []
+        } satisfies FunctionDeploymentBundleSuccess;
+        fetchMock.mockResolvedValueOnce(jsonResponse(functionChanges)).mockResolvedValueOnce(jsonResponse(functionChanges));
+
+        await deploy({
+            fullPath,
+            environmentName: 'test',
+            interactive: false,
+            options: deployOptions({ integration: 'slack' })
+        });
+
+        const output = logOutput(logSpy);
+        expect(output).toContain('↳ Functions');
+        expect(output).toContain('✓ Deployed');
+
+        const previewRequest = fetchMock.mock.calls[0]?.[1] as RequestInit;
+        const previewBody = JSON.parse(previewRequest.body as string) as { reconciliationScope: unknown; functions: FunctionConfig[] };
+        expect(previewBody.reconciliationScope).toEqual({ kind: 'integration', integrationId: 'slack' });
+        expect(previewBody.functions).toEqual([expect.objectContaining({ integrationId: 'slack', name: 'other' })]);
+    });
+
+    it('deletes the functions of an integration when its last function was removed', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok({ ...functionsOnlyParsed, functions: [githubFunction] }));
+        await fs.writeFile(path.join(fullPath, '.nango', 'functions.json'), JSON.stringify([githubFunction]));
+        const functionChanges = {
+            created: [],
+            updated: [],
+            unchanged: [],
+            deleted: [{ integrationId: 'slack', name: 'other' }]
+        } satisfies FunctionDeploymentBundleSuccess;
+        fetchMock.mockResolvedValueOnce(jsonResponse(functionChanges)).mockResolvedValueOnce(jsonResponse(functionChanges));
+
+        await deploy({
+            fullPath,
+            environmentName: 'test',
+            interactive: false,
+            options: deployOptions({ integration: 'slack', allowDestructive: true })
+        });
+
+        const output = logOutput(logSpy);
+        expect(output).toContain('- slack → other');
+        expect(output).toContain('✓ Deployed');
+        expect(output).toContain('Successfully removed the functions');
+    });
+
+    it('deletes every function of the environment when the last function was removed', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok({ ...functionsOnlyParsed, functions: [] }));
+        await fs.rm(path.join(fullPath, '.nango', 'functions.json'));
+        const functionChanges = {
+            created: [],
+            updated: [],
+            unchanged: [],
+            deleted: [
+                { integrationId: 'github', name: 'fetch' },
+                { integrationId: 'slack', name: 'other' }
+            ]
+        } satisfies FunctionDeploymentBundleSuccess;
+        fetchMock.mockResolvedValueOnce(jsonResponse(functionChanges)).mockResolvedValueOnce(jsonResponse(functionChanges));
+
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions({ allowDestructive: true }) });
+
+        const output = logOutput(logSpy);
+        expect(output).toContain('- github → fetch');
+        expect(output).toContain('- slack → other');
+        expect(output).toContain('✓ Deployed');
+        expect(output).toContain('Successfully removed the functions');
+    });
+
+    it('rejects --version for native function deployments', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok(functionsOnlyParsed));
+
+        await deploy({
+            fullPath,
+            environmentName: 'test',
+            interactive: false,
+            options: deployOptions({ version: 'v1' })
+        });
+
+        expect(logOutput(logSpy)).toContain('The --version option can only be used with legacy scripts');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('prints only the Functions summary row for a functions-only project', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok(functionsOnlyParsed));
+        const functionChanges = {
+            created: [{ integrationId: 'github', name: 'fetch' }],
+            updated: [],
+            unchanged: [{ integrationId: 'slack', name: 'other' }],
+            deleted: []
+        } satisfies FunctionDeploymentBundleSuccess;
+        fetchMock.mockResolvedValueOnce(jsonResponse(functionChanges)).mockResolvedValueOnce(jsonResponse(functionChanges));
+
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions() });
+
+        const output = logOutput(logSpy);
+        expect(output).not.toContain('↳ Syncs');
+        expect(output).not.toContain('↳ Actions');
+        expect(output).not.toContain('↳ OnEvents');
+        expect(output).toContain('↳ Functions');
+        expect(output).toContain('✓ Deployed');
+        expect(output).toContain('- github → fetch');
+        expect(output).not.toContain('- slack → other');
+    });
+
+    it.each([
+        { state: 'malformed', write: async (artifactPath: string) => await fs.writeFile(artifactPath, '{'.repeat(2)) },
+        { state: 'not an array', write: async (artifactPath: string) => await fs.writeFile(artifactPath, JSON.stringify({})) }
+    ])('does not reconcile anything when the functions artifact is $state', async ({ write }) => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok({ ...functionsOnlyParsed, functions: [] }));
+        await write(path.join(fullPath, '.nango', 'functions.json'));
+
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions() });
+
+        const output = logOutput(logSpy);
+        expect(output).not.toContain('↳ Functions');
+        expect(output).toContain('functions artifact');
+        expect(output).not.toContain('✓ Deployed');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('prints only legacy summary rows when no functions bundle', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok(legacyOnlyParsed));
+        await fs.rm(path.join(fullPath, '.nango', 'functions.json'));
+        fetchMock.mockResolvedValueOnce(jsonResponse(legacyConfirmation)).mockResolvedValueOnce(jsonResponse([]));
+
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions() });
+
+        const output = logOutput(logSpy);
+        expect(output).toContain('↳ Syncs');
+        expect(output).toContain('↳ Actions');
+        expect(output).toContain('↳ OnEvents');
+        expect(output).not.toContain('↳ Functions');
+        expect(output).toContain('✓ Deployed');
+    });
+
+    it('prints no summary when functions are unchanged', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok(functionsOnlyParsed));
+        fetchMock.mockResolvedValueOnce(jsonResponse(noFunctionChanges)).mockResolvedValueOnce(jsonResponse(noFunctionChanges));
+
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions() });
+
+        const output = logOutput(logSpy);
+        expect(output).toContain('No changes');
+        expect(output).toContain('No function changes were deployed');
+        expect(output).not.toContain('↳ Functions');
+        expect(output).not.toContain('- github → fetch');
+    });
+
+    it('prints Function preview errors', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok(functionsOnlyParsed));
+        fetchMock.mockResolvedValueOnce(jsonResponse({ error: { code: 'functions_deployment_error', message: 'Preview failed' } }));
+
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions() });
+
+        expect(logOutput(logSpy)).toContain('Error checking functions state:\nPreview failed');
+    });
+
+    it('prints Function deploy errors', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok(functionsOnlyParsed));
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse(noFunctionChanges))
+            .mockResolvedValueOnce(jsonResponse({ error: { code: 'functions_deployment_error', message: 'Apply failed' } }));
+
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions() });
+
+        expect(logOutput(logSpy)).toContain('Error deploying functions');
+    });
+
+    it('prints an aborted deployment when function deletions are not allowed', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok(functionsOnlyParsed));
+        fetchMock.mockResolvedValueOnce(
+            jsonResponse({
+                created: [],
+                updated: [],
+                unchanged: [{ integrationId: 'github', name: 'fetch' }],
+                deleted: [{ integrationId: 'github', name: 'removed' }]
+            } satisfies FunctionDeploymentBundleSuccess)
+        );
+
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions() });
+
+        const output = logOutput(logSpy);
+        expect(output).toContain('↳ Functions');
+        expect(output).toMatch(/Deploy aborted\. Exiting|Functions were not deployed/);
+        expect(output).not.toContain('✓ Deployed');
+    });
+
+    it('prints a successful deployment when function deletions are allowed', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok(functionsOnlyParsed));
+        const functionChanges = {
+            created: [],
+            updated: [],
+            unchanged: [{ integrationId: 'github', name: 'fetch' }],
+            deleted: [{ integrationId: 'github', name: 'removed' }]
+        } satisfies FunctionDeploymentBundleSuccess;
+        fetchMock.mockResolvedValueOnce(jsonResponse(functionChanges)).mockResolvedValueOnce(jsonResponse(functionChanges));
+
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions({ allowDestructive: true }) });
+
+        const output = logOutput(logSpy);
+        expect(output).toContain('allowDestructive flag is on');
+        expect(output).toContain('✓ Deployed');
+        expect(output).toContain('Successfully removed the functions');
+        expect(output).not.toContain('- github → fetch');
+    });
+});
+
+function functionConfig({ integrationId, name }: { integrationId: string; name: string }): FunctionConfig {
+    return {
+        name,
+        integrationId,
+        description: 'Function',
+        trigger: { kind: 'none' },
+        requires: { connection: true, outbound: true, invoke: false },
+        capabilities: { usesRecords: false, usesOutbound: true, usesCheckpoints: false, usesMetadata: false, usesInvoke: false },
+        limits: { concurrency: { perConnection: 'max' } },
+        input_schema_ref: null,
+        output_schema_ref: null,
+        model_schema_refs: [],
+        metadata_schema_ref: null,
+        checkpoint_schema_ref: null,
+        json_schema: { definitions: {} }
+    };
+}
+
+function deployOptions(overrides: Partial<DeployOptions> = {}): DeployOptions {
+    return {
+        autoConfirm: true,
+        debug: false,
+        dependencyUpdate: false,
+        interactive: false,
+        env: 'local',
+        ...overrides
+    };
+}
+
+async function writeProject(fullPath: string): Promise<void> {
+    await fs.mkdir(path.join(fullPath, '.nango'), { recursive: true });
+    await fs.mkdir(path.join(fullPath, 'build'), { recursive: true });
+    await fs.mkdir(path.join(fullPath, 'github', 'actions'), { recursive: true });
+    await fs.mkdir(path.join(fullPath, 'github', 'functions'), { recursive: true });
+    await fs.mkdir(path.join(fullPath, 'slack', 'functions'), { recursive: true });
+    await fs.writeFile(path.join(fullPath, '.nango', 'functions.json'), JSON.stringify([githubFunction, slackFunction]));
+    await fs.writeFile(path.join(fullPath, 'build', 'github_actions_legacy.cjs'), 'compiled legacy');
+    await fs.writeFile(path.join(fullPath, 'github', 'actions', 'legacy.ts'), 'source legacy');
+    await fs.writeFile(path.join(fullPath, 'build', 'github_functions_fetch.cjs'), 'compiled function');
+    await fs.writeFile(path.join(fullPath, 'github', 'functions', 'fetch.ts'), 'source function');
+    await fs.writeFile(path.join(fullPath, 'build', 'slack_functions_other.cjs'), 'compiled other');
+    await fs.writeFile(path.join(fullPath, 'slack', 'functions', 'other.ts'), 'source other');
+}
+
+function jsonResponse(value: unknown): Pick<Response, 'json'> {
+    return { json: vi.fn().mockResolvedValue(value) };
+}
+
+function logOutput(logSpy: ReturnType<typeof vi.spyOn>): string {
+    const calls = (logSpy as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    return calls.map((args) => args.map(String).join(' ')).join('\n');
+}


### PR DESCRIPTION
Migrating from legacy to native functions is gonna require the backend to own and reconcile the state of the deployed code (and their potential models) and potentially move from sync/actions to functions. To simplify, we for now don't allow mixed deployment (ie: containing both legacy and native functions) so we can start beta test functions in isolation. 
Migrations will come later.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

