### PR TITLE
feat(shared-credentials): allow for github-app to be added as a shared credential

### DIFF
--- a/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.integration.test.ts
@@ -41,9 +41,11 @@ describe(`DELETE ${endpoint}`, () => {
 
         // Getting started meta expects a preprovisioned provider config
         await seeders.createPreprovisionedProviderConfigSeed(env, 'github-getting-started', 'github', 'github-getting-started', {
-            oauth_client_id: 'foo',
-            oauth_client_secret: 'bar',
-            oauth_scopes: 'hello, world'
+            rest: {
+                oauth_client_id: 'foo',
+                oauth_client_secret: 'bar',
+                oauth_scopes: 'hello, world'
+            }
         });
 
         const metaResult = await gettingStartedService.getOrCreateMeta(db.knex, account.id, env.id);

--- a/packages/server/lib/controllers/sharedCredentials/id/patchSharedCredential.integration.test.ts
+++ b/packages/server/lib/controllers/sharedCredentials/id/patchSharedCredential.integration.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { sharedCredentialsService } from '@nangohq/shared';
+
+import { envs } from '../../../env.js';
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/internal/shared-credentials/:id';
+const internalKey = 'test-internal-api-key';
+
+describe(`PATCH ${endpoint}`, () => {
+    const originalKey = envs.NANGO_INTERNAL_API_KEY;
+
+    beforeAll(async () => {
+        api = await runServer();
+        envs.NANGO_INTERNAL_API_KEY = internalKey;
+    });
+    afterAll(() => {
+        envs.NANGO_INTERNAL_API_KEY = originalKey;
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            params: { id: 1 },
+            body: { name: 'github-app', client_id: 'id', client_secret: 'secret', app_link: 'https://github.com/apps/some-app' }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should update app_link for an APP-mode provider', async () => {
+        const created = (
+            await sharedCredentialsService.createSharedCredentials({
+                name: 'github-app',
+                client_id: 'app-id',
+                client_secret: 'private-key',
+                app_link: 'https://github.com/apps/original'
+            })
+        ).unwrap();
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            token: internalKey,
+            params: { id: created },
+            body: { name: 'github-app', client_id: 'app-id', client_secret: 'private-key', app_link: 'https://github.com/apps/updated' }
+        });
+
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({ success: true });
+
+        const fetched = (await sharedCredentialsService.getSharedCredentialsById(created)).unwrap();
+        expect(fetched.credentials.app_link).toBe('https://github.com/apps/updated');
+    });
+
+    it('should reject a missing app_link for an APP-mode provider', async () => {
+        const created = (
+            await sharedCredentialsService.createSharedCredentials({
+                name: 'github-app',
+                client_id: 'app-id',
+                client_secret: 'private-key',
+                app_link: 'https://github.com/apps/original'
+            })
+        ).unwrap();
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            token: internalKey,
+            params: { id: created },
+            body: { name: 'github-app', client_id: 'app-id', client_secret: 'private-key' }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_body',
+                errors: [{ code: 'custom', message: 'app_link is required for providers with auth_mode APP', path: ['app_link'] }]
+            }
+        });
+    });
+
+    it('should reject an app_link for a non-APP-mode provider', async () => {
+        const created = (
+            await sharedCredentialsService.createSharedCredentials({
+                name: 'github',
+                client_id: 'client-id',
+                client_secret: 'client-secret'
+            })
+        ).unwrap();
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            token: internalKey,
+            params: { id: created },
+            body: { name: 'github', client_id: 'client-id', client_secret: 'client-secret', app_link: 'https://example.com' }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_body',
+                errors: [{ code: 'custom', message: 'app_link is only supported for providers with auth_mode APP', path: ['app_link'] }]
+            }
+        });
+    });
+});

--- a/packages/server/lib/controllers/sharedCredentials/id/patchSharedCredential.ts
+++ b/packages/server/lib/controllers/sharedCredentials/id/patchSharedCredential.ts
@@ -53,7 +53,8 @@ export const patchSharedCredentialsProvider = asyncWrapper<PatchSharedCredential
         name: providerData.name,
         client_id: providerData.client_id,
         client_secret: providerData.client_secret,
-        scopes: providerData.scopes
+        scopes: providerData.scopes,
+        app_link: providerData.app_link
     });
 
     if (result.isErr()) {

--- a/packages/server/lib/controllers/sharedCredentials/postSharedCredential.integration.test.ts
+++ b/packages/server/lib/controllers/sharedCredentials/postSharedCredential.integration.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { envs } from '../../env.js';
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/internal/shared-credentials';
+const internalKey = 'test-internal-api-key';
+
+describe(`POST ${endpoint}`, () => {
+    const originalKey = envs.NANGO_INTERNAL_API_KEY;
+
+    beforeAll(async () => {
+        api = await runServer();
+        envs.NANGO_INTERNAL_API_KEY = internalKey;
+    });
+    afterAll(() => {
+        envs.NANGO_INTERNAL_API_KEY = originalKey;
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            body: { name: 'github', client_id: 'id', client_secret: 'secret' }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should create shared credentials with app_link for an APP-mode provider', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: internalKey,
+            body: { name: 'github-app', client_id: 'app-id', client_secret: 'private-key', app_link: 'https://github.com/apps/some-app' }
+        });
+
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({ success: true });
+    });
+
+    it('should reject a missing app_link for an APP-mode provider', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: internalKey,
+            body: { name: 'github-app', client_id: 'app-id', client_secret: 'private-key' }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_body',
+                errors: [{ code: 'custom', message: 'app_link is required for providers with auth_mode APP', path: ['app_link'] }]
+            }
+        });
+    });
+
+    it('should reject an app_link for a non-APP-mode provider', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: internalKey,
+            body: { name: 'github', client_id: 'client-id', client_secret: 'client-secret', app_link: 'https://example.com' }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_body',
+                errors: [{ code: 'custom', message: 'app_link is only supported for providers with auth_mode APP', path: ['app_link'] }]
+            }
+        });
+    });
+});

--- a/packages/server/lib/controllers/sharedCredentials/postSharedCredential.ts
+++ b/packages/server/lib/controllers/sharedCredentials/postSharedCredential.ts
@@ -57,6 +57,7 @@ export const postSharedCredentialsProvider = asyncWrapper<PostSharedCredentialsP
                 message: result.error.message
             }
         });
+        return;
     }
 
     res.status(200).send({ success: true });

--- a/packages/server/lib/controllers/sharedCredentials/postSharedCredential.ts
+++ b/packages/server/lib/controllers/sharedCredentials/postSharedCredential.ts
@@ -36,7 +36,8 @@ export const postSharedCredentialsProvider = asyncWrapper<PostSharedCredentialsP
         name: providerData.name,
         client_id: providerData.client_id,
         client_secret: providerData.client_secret,
-        scopes: providerData.scopes || ''
+        scopes: providerData.scopes || '',
+        app_link: providerData.app_link
     });
 
     if (result.isErr()) {

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.integration.test.ts
@@ -56,7 +56,7 @@ describe(`GET ${endpoint}`, () => {
         const provider = getProvider('github');
         expect(provider).toBeTruthy();
         const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'github-getting-started', 'github', 'github-getting-started', {
-            display_name: 'Github (Getting Started)'
+            rest: { display_name: 'Github (Getting Started)' }
         });
 
         // Create meta without progress
@@ -94,7 +94,7 @@ describe(`GET ${endpoint}`, () => {
 
         // Create integration
         const integration = await seeders.createPreprovisionedProviderConfigSeed(env, 'github-getting-started', 'github', 'github-getting-started', {
-            display_name: 'Github (Getting Started)'
+            rest: { display_name: 'Github (Getting Started)' }
         });
 
         // Create meta and and progress

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.integration.test.ts
@@ -312,4 +312,26 @@ describe(`PATCH ${endpoint}`, () => {
         const stored = await configService.getProviderConfig('sage-intacct-cc', env.id);
         expect(stored?.custom).toMatchObject({ clientId: 'first-client-id', clientSecret: 'second-secret' });
     });
+
+    it('rejects credential updates on an integration using Nango-provided (shared) credentials', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createPreprovisionedProviderConfigSeed(env, 'github-app-shared', 'github-app', 'github-app-shared-patch-test');
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            query: { env: 'dev' },
+            token: apiKey.secret,
+            params: { providerConfigKey: 'github-app-shared' },
+            body: { authType: 'APP', appId: 'attacker-app-id' }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: { code: 'invalid_body', message: "Can't edit credentials on an integration using Nango-provided credentials" }
+        });
+
+        // The rejected PATCH must not have written through: the shared credential's app_id should be unchanged.
+        const stored = await configService.getProviderConfig('github-app-shared', env.id);
+        expect(stored?.oauth_client_id).toBe('test');
+    });
 });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -85,6 +85,11 @@ export const patchIntegration = asyncWrapperWithEnvironment<PatchIntegration>(as
 
     // Credentials
     if ('authType' in body) {
+        if (integration.shared_credentials_id) {
+            res.status(400).send({ error: { code: 'invalid_body', message: "Can't edit credentials on an integration using Nango-provided credentials" } });
+            return;
+        }
+
         if (body.authType !== provider.auth_mode) {
             res.status(400).send({ error: { code: 'invalid_body', message: 'incompatible credentials auth type and provider auth' } });
             return;

--- a/packages/server/lib/formatters/sharedCredentials.ts
+++ b/packages/server/lib/formatters/sharedCredentials.ts
@@ -7,7 +7,8 @@ export function sharedCredentialsToApi(provider: DBSharedCredentials): SharedCre
         credentials: {
             client_id: provider.credentials.oauth_client_id,
             client_secret: provider.credentials.oauth_client_secret,
-            scopes: provider.credentials.oauth_scopes
+            scopes: provider.credentials.oauth_scopes,
+            app_link: provider.credentials.app_link
         },
         created_at: provider.created_at.toISOString(),
         updated_at: provider.updated_at.toISOString()

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -2,6 +2,7 @@ import { URL } from 'url';
 
 import * as z from 'zod';
 
+import { getProvider } from '@nangohq/providers';
 import {
     connectionTagsKeySchema,
     connectionTagsSchema,
@@ -147,9 +148,26 @@ export const sharedCredentialsSchema = z
         name: providerNameSchema,
         client_id: z.string().min(1).max(255),
         client_secret: z.string().min(1),
-        scopes: z.union([z.string().regex(/^[0-9a-zA-Z:/_.-]+(,[0-9a-zA-Z:/_.-]+)*$/), z.string().max(0)]).optional()
+        scopes: z.union([z.string().regex(/^[0-9a-zA-Z:/_.-]+(,[0-9a-zA-Z:/_.-]+)*$/), z.string().max(0)]).optional(),
+        app_link: z.url().max(2048).optional()
     })
-    .strict();
+    .strict()
+    .check((ctx) => {
+        const provider = getProvider(ctx.value.name);
+        if (!provider) {
+            return;
+        }
+        if (provider.auth_mode === 'APP' && !ctx.value.app_link) {
+            ctx.issues.push({ code: 'custom', path: ['app_link'], message: 'app_link is required for providers with auth_mode APP', input: ctx.value });
+        } else if (provider.auth_mode !== 'APP' && ctx.value.app_link) {
+            ctx.issues.push({
+                code: 'custom',
+                path: ['app_link'],
+                message: 'app_link is only supported for providers with auth_mode APP',
+                input: ctx.value
+            });
+        }
+    });
 
 export const connectionCredentialsOauth2Schema = z.strictObject({
     access_token: z.string().min(1).max(envs.NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH),

--- a/packages/server/lib/services/integration.service.ts
+++ b/packages/server/lib/services/integration.service.ts
@@ -109,7 +109,7 @@ export interface UpdateIntegrationParams {
     custom?: Record<string, string> | undefined;
 }
 
-const nangoCredentialsAuthModes = new Set(['OAUTH1', 'OAUTH2']);
+const nangoCredentialsAuthModes = new Set(['OAUTH1', 'OAUTH2', 'APP']);
 const credentialsRequiredAuthModes = new Set(['OAUTH1', 'OAUTH2', 'APP', 'CUSTOM']);
 const machineErrorCodePattern = /^(?:E[A-Z0-9_]{2,63}|[0-9A-Z]{5})$/;
 const defaultLogger = getLogger('Server.IntegrationService');

--- a/packages/server/lib/services/integration.service.unit.test.ts
+++ b/packages/server/lib/services/integration.service.unit.test.ts
@@ -285,6 +285,33 @@ describe('integrationService', () => {
             );
         });
 
+        it('creates an integration with Nango-provided credentials for an APP-mode provider', async () => {
+            const provider = providerFixture('GitHub App', 'APP');
+            const sharedCredentials = sharedCredentialsFixture({ app_link: 'https://github.com/apps/some-shared-app' });
+            const createdIntegration = integrationFixture({ uniqueKey: 'github-app-nango', provider: 'github-app' });
+            vi.spyOn(shared, 'getProvider').mockReturnValue(provider);
+            vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue(null);
+            vi.spyOn(shared.sharedCredentialsService, 'getLatestSharedCredentialsByName').mockResolvedValue(Ok(sharedCredentials));
+            const createSpy = vi.spyOn(shared.configService, 'createProviderConfig').mockResolvedValue(createdIntegration);
+
+            const result = await integrationService.create({
+                environmentId: 42,
+                provider: 'github-app',
+                uniqueKey: 'github-app-nango',
+                credentialSource: 'nango'
+            });
+
+            expect(result.isOk()).toBe(true);
+            expect(createSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    unique_key: 'github-app-nango',
+                    shared_credentials_id: sharedCredentials.id,
+                    forward_webhooks: true
+                }),
+                provider
+            );
+        });
+
         it('creates an integration with free-form custom properties', async () => {
             const provider = providerFixture('Generic', 'API_KEY');
             const createdIntegration = integrationFixture({ uniqueKey: 'generic', provider: 'generic' });
@@ -743,7 +770,7 @@ function configurableProviderFixture(): Provider {
     } as Provider;
 }
 
-function sharedCredentialsFixture(): DBSharedCredentials {
+function sharedCredentialsFixture(credentialOverrides?: { app_link?: string }): DBSharedCredentials {
     return {
         id: 12,
         name: 'github',
@@ -751,7 +778,8 @@ function sharedCredentialsFixture(): DBSharedCredentials {
             oauth_client_id: 'client-id',
             oauth_client_secret: 'client-secret',
             oauth_client_secret_iv: 'iv',
-            oauth_client_secret_tag: 'tag'
+            oauth_client_secret_tag: 'tag',
+            ...credentialOverrides
         },
         created_at: createdAt,
         updated_at: updatedAt

--- a/packages/shared/lib/seeders/config.seeder.ts
+++ b/packages/shared/lib/seeders/config.seeder.ts
@@ -84,21 +84,21 @@ export async function createPreprovisionedProviderConfigSeed(
     unique_key: string,
     providerName: string,
     shared_credentials_name?: string,
-    rest?: Partial<IntegrationConfig>
+    options?: { rest?: Partial<IntegrationConfig>; shared_credentials_app_link?: string }
 ): Promise<IntegrationConfig> {
     const provider = getProvider(providerName);
     if (!provider) {
         throw new Error(`createPreprovisionedProviderSeed: ${providerName} provider not found`);
     }
 
-    const sharedCredentials = await createSharedCredentialsSeed(shared_credentials_name ?? providerName);
+    const sharedCredentials = await createSharedCredentialsSeed(shared_credentials_name ?? providerName, options?.shared_credentials_app_link);
 
     const created = await configService.createProviderConfig(
         {
             unique_key,
             provider: providerName,
             environment_id: env.id,
-            ...rest,
+            ...options?.rest,
             forward_webhooks: true,
             shared_credentials_id: sharedCredentials.id
         },
@@ -110,11 +110,12 @@ export async function createPreprovisionedProviderConfigSeed(
     return created;
 }
 
-export async function createSharedCredentialsSeed(providerName: string): Promise<DBSharedCredentials> {
+export async function createSharedCredentialsSeed(providerName: string, app_link?: string): Promise<DBSharedCredentials> {
     const credentials = {
         oauth_client_id: 'test',
         oauth_client_secret: 'test',
-        oauth_scopes: 'test'
+        oauth_scopes: 'test',
+        ...(app_link ? { app_link } : {})
     };
 
     // Create shared credentials

--- a/packages/shared/lib/services/config.service.integration.test.ts
+++ b/packages/shared/lib/services/config.service.integration.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 import { multipleMigrations } from '@nangohq/database';
 
-import { createConfigSeed } from '../seeders/config.seeder.js';
+import { createConfigSeed, createPreprovisionedProviderConfigSeed } from '../seeders/config.seeder.js';
 import { createEnvironmentSeed } from '../seeders/environment.seeder.js';
 import configService from './config.service.js';
 
@@ -18,6 +18,32 @@ describe('Config service integration tests', () => {
             const config = await createConfigSeed(env, 'google', 'google');
 
             expect(config.missing_fields).toEqual(expect.arrayContaining(['oauth_client_id', 'oauth_client_secret']));
+        });
+    });
+
+    describe('getProviderConfig', () => {
+        it('should resolve app_link from shared credentials when set', async () => {
+            const env = await createEnvironmentSeed();
+
+            const created = await createPreprovisionedProviderConfigSeed(env, 'github-app-shared', 'github-app', 'github-app-shared', {
+                shared_credentials_app_link: 'https://github.com/apps/some-shared-app'
+            });
+
+            const resolved = await configService.getProviderConfig(created.unique_key, env.id);
+
+            expect(resolved?.app_link).toBe('https://github.com/apps/some-shared-app');
+        });
+
+        it('should keep its own app_link when the shared row does not set one', async () => {
+            const env = await createEnvironmentSeed();
+
+            const created = await createPreprovisionedProviderConfigSeed(env, 'github-app-own-link', 'github-app', 'github-app-no-link', {
+                rest: { app_link: 'https://github.com/apps/own-app' }
+            });
+
+            const resolved = await configService.getProviderConfig(created.unique_key, env.id);
+
+            expect(resolved?.app_link).toBe('https://github.com/apps/own-app');
         });
     });
 

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -75,6 +75,9 @@ class ConfigService {
             result.oauth_scopes = result.credentials.oauth_scopes;
             result.oauth_client_secret_iv = result.credentials.oauth_client_secret_iv;
             result.oauth_client_secret_tag = result.credentials.oauth_client_secret_tag;
+            if (result.credentials.app_link) {
+                result.app_link = result.credentials.app_link;
+            }
         }
         delete result.credentials;
 
@@ -98,6 +101,9 @@ class ConfigService {
                     result.oauth_scopes = result.credentials.oauth_scopes;
                     result.oauth_client_secret_iv = result.credentials.oauth_client_secret_iv;
                     result.oauth_client_secret_tag = result.credentials.oauth_client_secret_tag;
+                    if (result.credentials.app_link) {
+                        result.app_link = result.credentials.app_link;
+                    }
                 }
                 delete result.credentials;
                 return getEncryptionManager().decryptProviderConfig(result);

--- a/packages/shared/lib/services/shared-credentials.service.integration.test.ts
+++ b/packages/shared/lib/services/shared-credentials.service.integration.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db, { multipleMigrations } from '@nangohq/database';
+
+import sharedCredentialsService from './shared-credentials.service.js';
+
+import type { SharedCredentialsBodyInput } from '@nangohq/types';
+
+describe('Shared credentials service integration tests', () => {
+    const createdIds: number[] = [];
+
+    async function create(input: SharedCredentialsBodyInput) {
+        const id = (await sharedCredentialsService.createSharedCredentials(input)).unwrap();
+        createdIds.push(id);
+        return id;
+    }
+
+    beforeAll(async () => {
+        await multipleMigrations();
+    });
+
+    afterAll(async () => {
+        if (createdIds.length > 0) {
+            await db.knex('providers_shared_credentials').whereIn('id', createdIds).delete();
+        }
+    });
+
+    describe('createSharedCredentials', () => {
+        it('should round-trip app_link through create and getSharedCredentialsById', async () => {
+            const created = await create({
+                name: 'github-app-test',
+                client_id: 'app-id-123',
+                client_secret: 'private-key-content',
+                app_link: 'https://github.com/apps/some-app'
+            });
+
+            const fetched = (await sharedCredentialsService.getSharedCredentialsById(created)).unwrap();
+
+            expect(fetched.name).toBe('github-app-test');
+            expect(fetched.credentials.app_link).toBe('https://github.com/apps/some-app');
+            expect(fetched.credentials.oauth_client_id).toBe('app-id-123');
+            expect(fetched.credentials.oauth_client_secret).toBe('private-key-content');
+        });
+
+        it('should not set app_link when not provided (oauth2-style provider)', async () => {
+            const created = await create({
+                name: 'oauth2-test',
+                client_id: 'client-id-123',
+                client_secret: 'client-secret-123'
+            });
+
+            const fetched = (await sharedCredentialsService.getSharedCredentialsById(created)).unwrap();
+
+            expect(fetched.credentials.app_link).toBeUndefined();
+        });
+    });
+
+    describe('editSharedCredentials', () => {
+        it('should update app_link through edit and getSharedCredentialsById', async () => {
+            const created = await create({
+                name: 'github-app-edit-test',
+                client_id: 'app-id-456',
+                client_secret: 'private-key-content',
+                app_link: 'https://github.com/apps/original-app'
+            });
+
+            (
+                await sharedCredentialsService.editSharedCredentials(created, {
+                    name: 'github-app-edit-test',
+                    client_id: 'app-id-456',
+                    client_secret: 'private-key-content',
+                    app_link: 'https://github.com/apps/updated-app'
+                })
+            ).unwrap();
+
+            const fetched = (await sharedCredentialsService.getSharedCredentialsById(created)).unwrap();
+
+            expect(fetched.credentials.app_link).toBe('https://github.com/apps/updated-app');
+        });
+    });
+
+    describe('listSharedCredentials', () => {
+        it('should include app_link in listed results', async () => {
+            const created = await create({
+                name: 'github-app-list-test',
+                client_id: 'app-id-789',
+                client_secret: 'private-key-content',
+                app_link: 'https://github.com/apps/listed-app'
+            });
+
+            const list = (await sharedCredentialsService.listSharedCredentials()).unwrap();
+
+            const found = list.find((item) => item.id === created);
+            expect(found?.credentials.app_link).toBe('https://github.com/apps/listed-app');
+        });
+    });
+});

--- a/packages/shared/lib/services/shared-credentials.service.ts
+++ b/packages/shared/lib/services/shared-credentials.service.ts
@@ -147,7 +147,8 @@ class SharedCredentialsService {
         const configForEncryption: SharedCredentialsInputDto = {
             oauth_client_id: config.client_id,
             oauth_client_secret: config.client_secret,
-            oauth_scopes: config.scopes || ''
+            oauth_scopes: config.scopes || '',
+            ...(config.app_link ? { app_link: config.app_link } : {})
         };
 
         const [encryptedClientSecret, iv, authTag] = getEncryptionManager().encryptSync(configForEncryption.oauth_client_secret);
@@ -186,7 +187,8 @@ class SharedCredentialsService {
             const configForEncryption: SharedCredentialsInputDto = {
                 oauth_client_id: config.client_id,
                 oauth_client_secret: config.client_secret,
-                oauth_scopes: config.scopes ?? ''
+                oauth_scopes: config.scopes ?? '',
+                ...(config.app_link ? { app_link: config.app_link } : {})
             };
 
             const [encryptedClientSecret, iv, authTag] = getEncryptionManager().encryptSync(configForEncryption.oauth_client_secret);

--- a/packages/types/lib/sharedCredentials/api.ts
+++ b/packages/types/lib/sharedCredentials/api.ts
@@ -45,6 +45,7 @@ export interface SharedCredentialsBodyInput {
     client_id: string;
     client_secret: string;
     scopes?: string | undefined;
+    app_link?: string | undefined;
 }
 
 export interface SharedCredentialsOutput {
@@ -54,6 +55,7 @@ export interface SharedCredentialsOutput {
         client_id: string;
         client_secret: string;
         scopes?: string | undefined;
+        app_link?: string | undefined;
     };
     created_at: string;
     updated_at: string;

--- a/packages/types/lib/sharedCredentials/db.ts
+++ b/packages/types/lib/sharedCredentials/db.ts
@@ -6,6 +6,7 @@ export interface SharedCredentials {
     oauth_scopes?: string;
     oauth_client_secret_iv: string;
     oauth_client_secret_tag: string;
+    app_link?: string;
 }
 
 export interface DBSharedCredentials extends Timestamps {

--- a/packages/types/lib/sharedCredentials/dto.ts
+++ b/packages/types/lib/sharedCredentials/dto.ts
@@ -1,3 +1,3 @@
 import type { SharedCredentials } from './db.js';
 
-export type SharedCredentialsInputDto = Pick<SharedCredentials, 'oauth_client_id' | 'oauth_client_secret' | 'oauth_scopes'>;
+export type SharedCredentialsInputDto = Pick<SharedCredentials, 'oauth_client_id' | 'oauth_client_secret' | 'oauth_scopes' | 'app_link'>;

--- a/packages/webapp/src/pages/Integrations/components/forms/AppAuthCreateForm.tsx
+++ b/packages/webapp/src/pages/Integrations/components/forms/AppAuthCreateForm.tsx
@@ -1,12 +1,17 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { ExternalLinkIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
 
-import { Button, InputGroup, InputGroupInput, InputGroupTextarea } from '@nangohq/design-system';
+import { Button, FieldLabel, InputGroup, InputGroupInput, InputGroupTextarea } from '@nangohq/design-system';
 
+import { Alert, AlertActions, AlertButtonLink, AlertDescription, AlertTitle } from '@/components/ui/Alert';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
+import { Navigation, NavigationContent, NavigationList, NavigationTrigger } from '@/components/ui/Navigation';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
+import { NangoProvidedInput } from '../NangoProvidedInput';
 
 import type { ApiProviderListItem, PostIntegration } from '@nangohq/types';
 
@@ -28,6 +33,18 @@ export const AppAuthCreateForm: React.FC<{ provider: ApiProviderListItem; onSubm
 
     const [loading, setLoading] = useState(false);
 
+    const onCreatePreProvisioned = async () => {
+        setLoading(true);
+        try {
+            await onSubmit?.({
+                provider: provider.name,
+                useSharedCredentials: true
+            });
+        } finally {
+            setLoading(false);
+        }
+    };
+
     const onSubmitForm = async (formData: FormData) => {
         setLoading(true);
 
@@ -48,78 +65,139 @@ export const AppAuthCreateForm: React.FC<{ provider: ApiProviderListItem; onSubm
     };
 
     return (
-        <div className="flex flex-col gap-8">
-            <Form {...form}>
-                <form onSubmit={form.handleSubmit(onSubmitForm)} className="flex flex-col gap-8">
+        <Navigation defaultValue={provider.preConfigured ? 'template' : 'custom'} orientation="horizontal">
+            <NavigationList>
+                {provider.preConfigured ? (
+                    <NavigationTrigger value="template">Nango developer app</NavigationTrigger>
+                ) : (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span>
+                                <NavigationTrigger value="template" disabled>
+                                    Nango developer app
+                                </NavigationTrigger>
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">Nango doesn&apos;t provide test credentials for this API yet</TooltipContent>
+                    </Tooltip>
+                )}
+                <NavigationTrigger value="custom">Custom developer app</NavigationTrigger>
+            </NavigationList>
+            <NavigationContent value="template">
+                <div className="flex flex-col gap-8">
+                    <Alert variant="info">
+                        <AlertDescription>Nango provides developer apps for testing. Use your own developer app for production.</AlertDescription>
+                    </Alert>
+
                     <div className="flex flex-col gap-5">
-                        <FormField
-                            control={form.control}
-                            name="appId"
-                            render={({ field, fieldState }) => (
-                                <FormItem>
-                                    <div className="flex gap-2 items-center">
-                                        <FormLabel>App ID</FormLabel>
-                                        <InfoTooltip>Obtain the app id from the app page.</InfoTooltip>
-                                    </div>
-                                    <FormControl>
-                                        <InputGroup>
-                                            <InputGroupInput {...field} aria-invalid={!!fieldState.error} />
-                                        </InputGroup>
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                        <div className="flex flex-col gap-2">
+                            <FieldLabel htmlFor="app_id">App ID</FieldLabel>
+                            <NangoProvidedInput id="app_id" fakeValueSize={12} />
+                        </div>
 
-                        <FormField
-                            control={form.control}
-                            name="appLink"
-                            render={({ field, fieldState }) => (
-                                <FormItem>
-                                    <div className="flex gap-2 items-center">
-                                        <FormLabel>App public link</FormLabel>
-                                        <InfoTooltip>Obtain the app public link from the app page.</InfoTooltip>
-                                    </div>
-                                    <FormControl>
-                                        <InputGroup>
-                                            <InputGroupInput {...field} aria-invalid={!!fieldState.error} />
-                                        </InputGroup>
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                        <div className="flex flex-col gap-2">
+                            <FieldLabel htmlFor="app_link">App public link</FieldLabel>
+                            <NangoProvidedInput fakeValueSize={24} />
+                        </div>
 
-                        <FormField
-                            control={form.control}
-                            name="privateKey"
-                            render={({ field, fieldState }) => (
-                                <FormItem>
-                                    <div className="flex gap-2 items-center">
-                                        <FormLabel>App private key</FormLabel>
-                                        <InfoTooltip>
-                                            Obtain the app private key from the app page by downloading the private key and pasting the entirety of its contents
-                                            here.
-                                        </InfoTooltip>
-                                    </div>
-                                    <FormControl>
-                                        <InputGroup>
-                                            <InputGroupTextarea {...field} aria-invalid={!!fieldState.error} />
-                                        </InputGroup>
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                        <div className="flex flex-col gap-2">
+                            <FieldLabel htmlFor="private_key">App private key</FieldLabel>
+                            <NangoProvidedInput fakeValueSize={48} />
+                        </div>
                     </div>
 
                     <div>
-                        <Button type="submit" loading={loading}>
+                        <Button loading={loading} onClick={onCreatePreProvisioned}>
                             Create
                         </Button>
                     </div>
-                </form>
-            </Form>
-        </div>
+                </div>
+            </NavigationContent>
+            <NavigationContent value="custom">
+                <div className="flex flex-col gap-8">
+                    <Alert variant="info">
+                        <AlertTitle>Developer app setup guide</AlertTitle>
+                        <AlertDescription>Follow our step by step guide to use your own GitHub App.</AlertDescription>
+                        <AlertActions>
+                            <AlertButtonLink to={provider.docs} target="_blank" variant="info-secondary">
+                                Go <ExternalLinkIcon />
+                            </AlertButtonLink>
+                        </AlertActions>
+                    </Alert>
+
+                    <Form {...form}>
+                        <form onSubmit={form.handleSubmit(onSubmitForm)} className="flex flex-col gap-8">
+                            <div className="flex flex-col gap-5">
+                                <FormField
+                                    control={form.control}
+                                    name="appId"
+                                    render={({ field, fieldState }) => (
+                                        <FormItem>
+                                            <div className="flex gap-2 items-center">
+                                                <FormLabel>App ID</FormLabel>
+                                                <InfoTooltip>Obtain the app id from the app page.</InfoTooltip>
+                                            </div>
+                                            <FormControl>
+                                                <InputGroup>
+                                                    <InputGroupInput {...field} aria-invalid={!!fieldState.error} />
+                                                </InputGroup>
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+
+                                <FormField
+                                    control={form.control}
+                                    name="appLink"
+                                    render={({ field, fieldState }) => (
+                                        <FormItem>
+                                            <div className="flex gap-2 items-center">
+                                                <FormLabel>App public link</FormLabel>
+                                                <InfoTooltip>Obtain the app public link from the app page.</InfoTooltip>
+                                            </div>
+                                            <FormControl>
+                                                <InputGroup>
+                                                    <InputGroupInput {...field} aria-invalid={!!fieldState.error} />
+                                                </InputGroup>
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+
+                                <FormField
+                                    control={form.control}
+                                    name="privateKey"
+                                    render={({ field, fieldState }) => (
+                                        <FormItem>
+                                            <div className="flex gap-2 items-center">
+                                                <FormLabel>App private key</FormLabel>
+                                                <InfoTooltip>
+                                                    Obtain the app private key from the app page by downloading the private key and pasting the entirety of its
+                                                    contents here.
+                                                </InfoTooltip>
+                                            </div>
+                                            <FormControl>
+                                                <InputGroup>
+                                                    <InputGroupTextarea {...field} aria-invalid={!!fieldState.error} />
+                                                </InputGroup>
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
+
+                            <div>
+                                <Button type="submit" loading={loading}>
+                                    Create
+                                </Button>
+                            </div>
+                        </form>
+                    </Form>
+                </div>
+            </NavigationContent>
+        </Navigation>
     );
 };

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AppAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AppAuthSettings.tsx
@@ -5,6 +5,7 @@ import { CopyButton } from '@/components/ui/CopyButton';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
+import { NangoProvidedInput } from '@/pages/Integrations/components/NangoProvidedInput';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
 import { defaultCallback } from '@/utils/cloud';
@@ -20,6 +21,7 @@ export const AppAuthSettings: React.FC<{ data: GetIntegration['Success']['data']
     const { toast } = useToast();
     const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
 
+    const isSharedCredentials = Boolean(integration.shared_credentials_id);
     const setupUrl = (environment.callback_url || defaultCallback()).replace('oauth/callback', 'app-auth/connect');
 
     const onSave = async (field: Partial<PatchIntegration['Body']>) => {
@@ -61,7 +63,11 @@ export const AppAuthSettings: React.FC<{ data: GetIntegration['Success']['data']
                     <FieldLabel htmlFor="app_id">App ID</FieldLabel>
                     <InfoTooltip>Obtain the app id from the app page.</InfoTooltip>
                 </div>
-                <EditableInput initialValue={integration.oauth_client_id || ''} onSave={(value) => onSave({ appId: value })} validate={validateNotEmpty} />
+                {isSharedCredentials ? (
+                    <NangoProvidedInput fakeValueSize={12} />
+                ) : (
+                    <EditableInput initialValue={integration.oauth_client_id || ''} onSave={(value) => onSave({ appId: value })} validate={validateNotEmpty} />
+                )}
             </div>
 
             {/* App Public Link */}
@@ -70,11 +76,24 @@ export const AppAuthSettings: React.FC<{ data: GetIntegration['Success']['data']
                     <FieldLabel htmlFor="app_link">App Public Link</FieldLabel>
                     <InfoTooltip>Obtain the app public link from the app page.</InfoTooltip>
                 </div>
-                <EditableInput initialValue={integration.app_link || ''} onSave={(value) => onSave({ appLink: value })} validate={validateUrl} />
+                {isSharedCredentials ? (
+                    <NangoProvidedInput fakeValueSize={24} />
+                ) : (
+                    <EditableInput initialValue={integration.app_link || ''} onSave={(value) => onSave({ appLink: value })} validate={validateUrl} />
+                )}
             </div>
 
             {/* App Private Key */}
-            <AppPrivateKeyInput initialValue={integration.oauth_client_secret || ''} onSave={(value) => onSave({ privateKey: value })} />
+            {isSharedCredentials ? (
+                <div className="flex flex-col gap-2">
+                    <div className="flex gap-2 items-center">
+                        <FieldLabel htmlFor="private_key">App Private Key</FieldLabel>
+                    </div>
+                    <NangoProvidedInput fakeValueSize={48} />
+                </div>
+            ) : (
+                <AppPrivateKeyInput initialValue={integration.oauth_client_secret || ''} onSave={(value) => onSave({ privateKey: value })} />
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## Describe the problem and your solution

- Shared credentials only supported OAuth2 providers with `(client_id + client_secret)`. `auth_mode: APP` providers like `GitHub App` also require an `app_link` , so they couldn't be onboarded as shared credentials, this adds that support end-to-end.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

