### PR TITLE
fix(cli): derive integrationId from path root

### DIFF
--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -167,7 +167,7 @@ export function getEntryPoints(indexContent: string): string[] {
  */
 function typeCheck({ fullPath, entryPoints }: { fullPath: string; entryPoints: string[] }): Result<boolean> {
     const program = ts.createProgram({
-        rootNames: entryPoints.map((file) => path.join(fullPath, file.replace('.js', '.ts'))),
+        rootNames: entryPoints.map((file) => path.join(fullPath, file.replace(/\.js$/, '.ts'))),
         options: tsconfig
     });
 
@@ -192,7 +192,7 @@ function typeCheck({ fullPath, entryPoints }: { fullPath: string; entryPoints: s
  * Bundles the entry file using esbuild and returns the bundled code as a string (in memory).
  */
 export async function bundleFile({ entryPoint, projectRootPath }: { entryPoint: string; projectRootPath: string }): Promise<Result<string>> {
-    const friendlyPath = entryPoint.replace('.js', '.ts').replace(projectRootPath, '.');
+    const friendlyPath = entryPoint.replace(/\.js$/, '.ts').replace(projectRootPath, '.');
     try {
         const { plugin, bag } = nangoPlugin({ entryPoint });
         const res = await build({
@@ -394,7 +394,7 @@ export async function compileFunction({ entryPoint, projectRootPath }: { entryPo
     }
 
     if (bundleResult.value.match(/\bconsole\.\w+/)) {
-        const relPath = path.relative(projectRootPath, entryPoint).replace('.js', '.ts');
+        const relPath = path.relative(projectRootPath, entryPoint).replace(/\.js$/, '.ts');
         console.warn(
             chalk.yellow(
                 `\nWarning: Function '${relPath}' contains console statements (console.log, console.warn, etc.). These logs will not appear in the Nango dashboard. Use await nango.log() instead to see logs in the dashboard.`
@@ -412,7 +412,7 @@ export async function compileFunction({ entryPoint, projectRootPath }: { entryPo
 }
 
 export function tsToJsPath(filePath: string) {
-    return filePath.replace(/^\.\//, '').replaceAll(/[/\\]/g, '_').replace('.js', '.cjs');
+    return filePath.replace(/^\.\//, '').replaceAll(/[/\\]/g, '_').replace(/\.js$/, '.cjs');
 }
 
 /**
@@ -466,7 +466,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
 
     const normalizedEntryPoint = path.resolve(entryPoint);
     // Get actual path even if entryPoint is a symlink
-    const realEntryPoint = fs.realpathSync(normalizedEntryPoint.replace('.js', '.ts')).replace('.ts', '.js');
+    const realEntryPoint = fs.realpathSync(normalizedEntryPoint.replace(/\.js$/, '.ts')).replace(/\.ts$/, '.js');
 
     const allowedExports = {
         createAction: { type: 'action', varName: 'action' },
@@ -588,7 +588,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                         // If you abstract those calls in functions then it's not checking since it's quite hard to determine order
                         const currentFilePath = (astPath.hub as any)?.file?.opts?.filename;
                         if (currentFilePath) {
-                            const normalizedCurrentPath = path.resolve(currentFilePath.replace('.ts', '.js'));
+                            const normalizedCurrentPath = path.resolve(currentFilePath.replace(/\.ts$/, '.js'));
                             if (normalizedCurrentPath === realEntryPoint) {
                                 // Check if we're inside a createSync's exec function
                                 const isInCreateSyncExec = astPath.findParent((parentPath) => {
@@ -646,7 +646,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                         // Skip processing if the current file is not an entry point
                         const currentFilePath = (astPath.hub as any)?.file?.opts?.filename;
                         if (currentFilePath) {
-                            const normalizedCurrentPath = path.resolve(currentFilePath.replace('.ts', '.js'));
+                            const normalizedCurrentPath = path.resolve(currentFilePath.replace(/\.ts$/, '.js'));
                             if (normalizedCurrentPath !== realEntryPoint) {
                                 return;
                             }
@@ -710,7 +710,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                         // Skip processing if the current file is not an entry point
                         const currentFilePath = (astPath.hub as any)?.file?.opts?.filename;
                         if (currentFilePath) {
-                            const normalizedCurrentPath = path.resolve(currentFilePath.replace('.ts', '.js'));
+                            const normalizedCurrentPath = path.resolve(currentFilePath.replace(/\.ts$/, '.js'));
                             if (normalizedCurrentPath !== realEntryPoint) {
                                 return;
                             }

--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -7,7 +7,7 @@ import { assert, describe, expect, it } from 'vitest';
 
 import { copyDirectoryAndContents, fixturesPath, getTestDirectory } from '../tests/helpers.js';
 import { bundleFile, compileAllFunctions, detectFeatures } from './compile.js';
-import { validateFunction } from './definitions.js';
+import { getIntegrationId, validateFunction } from './definitions.js';
 import { CompileError } from './utils.js';
 
 const exec = promisify(execCb);
@@ -54,6 +54,7 @@ describe('compileAll', () => {
         expect(functionsJson[0]).toMatchObject({
             name: 'fetchIssues',
             integrationId: 'github',
+            filePath: './github/functions/fetchIssues.ts',
             description: 'Fetch a GitHub issue on demand',
             trigger: { kind: 'none' },
             requires: { connection: true, outbound: true, invoke: false },
@@ -153,6 +154,23 @@ describe('validateFunction', () => {
         const res = validateFunction({ ...base, params: { requires: { connection: false } } });
         assert(res.isErr());
         expect(res.error.message).toContain('connection-less');
+    });
+});
+
+describe('getIntegrationId', () => {
+    it('uses the first directory after the relative prefix', () => {
+        expect(getIntegrationId('./github/fetchIssues.js').unwrap()).toBe('github');
+        expect(getIntegrationId('./github/custom/nested/fetchIssues.js').unwrap()).toBe('github');
+    });
+
+    it('keeps legacy script paths compatible', () => {
+        expect(getIntegrationId('./github/syncs/fetchIssues.js').unwrap()).toBe('github');
+        expect(getIntegrationId('./github/actions/createIssue.js').unwrap()).toBe('github');
+    });
+
+    it('rejects files outside an integration folder', () => {
+        const result = getIntegrationId('./fetchIssues.js');
+        expect(result.isErr()).toBe(true);
     });
 });
 

--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -32,8 +32,16 @@ describe('compileAll', () => {
         console.log('compiling to ', dir);
         await copyDirectoryAndContents(path.join(fixturesPath, 'zero/valid'), dir);
 
+        const indexPath = path.join(dir, 'index.ts');
+        const indexContent = await fs.promises.readFile(indexPath, 'utf8');
+        await fs.promises.writeFile(indexPath, indexContent.replace('./github/functions/fetchIssues.js', './github/nested/../functions/fetchIssues.js'));
+
         const pkg = { name: 'test', type: 'module', dependencies: { nango: `file:${path.resolve(path.join(fixturesPath, '..'))}`, zod: '4.3.6' } };
 
+        const dottedIntegrationFunctionsPath = path.join(dir, 'github.js', 'functions');
+        await fs.promises.mkdir(dottedIntegrationFunctionsPath, { recursive: true });
+        await fs.promises.copyFile(path.join(dir, 'github', 'functions', 'fetchIssues.ts'), path.join(dottedIntegrationFunctionsPath, 'fetchIssues.ts'));
+        await fs.promises.appendFile(indexPath, "\nimport './github.js/functions/fetchIssues.js';\n");
         await fs.promises.writeFile(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2));
         await exec('npm i', { cwd: dir });
         const result = await compileAllFunctions({ fullPath: dir, debug: false });
@@ -50,7 +58,7 @@ describe('compileAll', () => {
         expect(github).not.toHaveProperty('functions');
 
         const functionsJson = JSON.parse(await fs.promises.readFile(path.join(dir, '.nango', 'functions.json'), 'utf8'));
-        expect(functionsJson).toHaveLength(1);
+        expect(functionsJson).toHaveLength(2);
         expect(functionsJson[0]).toMatchObject({
             name: 'fetchIssues',
             integrationId: 'github',
@@ -68,6 +76,12 @@ describe('compileAll', () => {
         });
         expect(functionsJson[0].json_schema.definitions).toHaveProperty('FunctionInput_github_fetchIssues');
         expect(functionsJson[0].json_schema.definitions).toHaveProperty('FunctionOutput_github_fetchIssues');
+        expect(functionsJson[1]).toMatchObject({
+            name: 'fetchIssues',
+            integrationId: 'github.js',
+            filePath: './github.js/functions/fetchIssues.ts'
+        });
+        expect(fs.existsSync(path.join(dir, 'build', 'github.js_functions_fetchIssues.cjs'))).toBe(true);
     });
 });
 
@@ -168,8 +182,18 @@ describe('getIntegrationId', () => {
         expect(getIntegrationId('./github/actions/createIssue.js').unwrap()).toBe('github');
     });
 
+    it('uses the integration from the normalized path', () => {
+        expect(getIntegrationId('./github/../slack/functions/fetchIssues.js').unwrap()).toBe('slack');
+        expect(getIntegrationId('.\\github\\nested\\..\\functions\\fetchIssues.js').unwrap()).toBe('github');
+    });
+
     it('rejects files outside an integration folder', () => {
         const result = getIntegrationId('./fetchIssues.js');
+        expect(result.isErr()).toBe(true);
+    });
+
+    it.each(['./../outside/fetchIssues.js', './github/../../outside/fetchIssues.js'])('rejects paths outside the project folder: %s', (filePath) => {
+        const result = getIntegrationId(filePath);
         expect(result.isErr()).toBe(true);
     });
 });

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -48,7 +48,7 @@ interface FunctionDefinition {
     data?: { models?: Record<string, ZodModel>; metadata?: ZodMetadata; checkpoint?: ZodCheckpoint } | undefined;
 }
 
-export type FunctionConfig = Omit<FunctionDeploymentArtifact, 'fileBody'>;
+export type FunctionConfig = Omit<FunctionDeploymentArtifact, 'fileBody'> & { filePath: string };
 
 export interface ParsedIntegrationDefinitions extends NangoYamlParsed {
     functions: FunctionConfig[];
@@ -93,8 +93,11 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
         const basename = path.basename(filePath, '.js');
         const realPath = filePath.replace('.js', '.ts');
         const basenameClean = basename.replaceAll(/[^a-zA-Z0-9]/g, '');
-        const split = filePath.split('/');
-        const integrationId = split[split.length - 3]!;
+        const integrationIdRes = getIntegrationId(filePath);
+        if (integrationIdRes.isErr()) {
+            return Err(integrationIdRes.error);
+        }
+        const integrationId = integrationIdRes.value;
         const integrationIdClean = integrationId.replaceAll(/[^a-zA-Z0-9]/g, '_');
 
         let integration: NangoYamlParsedIntegration | undefined = parsed.integrations.find((v) => v.providerConfigKey === integrationId);
@@ -141,7 +144,10 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
                         new Error(`Function '${integrationId}/functions/${basename}.ts' is already defined. Function names must be unique per integration.`)
                     );
                 }
-                parsed.functions.push(parseFunction({ params: script, integrationId, integrationIdClean, basename, basenameClean }));
+                parsed.functions.push({
+                    ...parseFunction({ params: script, integrationId, integrationIdClean, basename, basenameClean }),
+                    filePath: realPath
+                });
                 break;
             }
         }
@@ -159,6 +165,15 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
     printDebug('Correctly parsed', debug);
 
     return Ok(parsed);
+}
+
+export function getIntegrationId(filePath: string): Result<string> {
+    const segments = filePath.replaceAll('\\', '/').replace(/^\.\//, '').split('/');
+    const integrationId = segments[0];
+    if (!integrationId || segments.length < 2) {
+        return Err(new Error(`Script '${filePath.replace('.js', '.ts')}' must be inside an integration folder.`));
+    }
+    return Ok(integrationId);
 }
 
 const regexModelName = /^[A-Z][a-zA-Z0-9_]+$/;
@@ -324,7 +339,7 @@ export function parseFunction({
     integrationIdClean: string;
     basename: string;
     basenameClean: string;
-}): FunctionConfig {
+}): Omit<FunctionConfig, 'filePath'> {
     const inputName = params.input ? `FunctionInput_${integrationIdClean}_${basenameClean}` : null;
     const outputName = params.output ? `FunctionOutput_${integrationIdClean}_${basenameClean}` : null;
     const metadata = params.data?.metadata;

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -8,6 +8,7 @@ import { printDebug } from '../utils.js';
 import { Err, Ok } from '../utils/result.js';
 import { detectFeatures, getEntryPoints, readIndexContent, tsToJsPath } from './compile.js';
 import { buildJsonSchemaDefinitionsFromZodModels } from './json-schema.js';
+import { normalizeProjectRelativePath, resolveProjectPath } from './project-path.js';
 import {
     DuplicateEndpointDefinitionError,
     DuplicateModelDefinitionError,
@@ -71,11 +72,11 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
     for (const matchedFilePath of matched) {
         num += 1;
 
-        const filePathRes = normalizeIntegrationFilePath(matchedFilePath);
-        if (filePathRes.isErr()) {
-            return Err(filePathRes.error);
+        const sourcePath = resolveProjectPath({ projectRoot: fullPath, filePath: matchedFilePath });
+        if (!sourcePath) {
+            return Err(new Error(`Script '${matchedFilePath.replace(/\.js$/, '.ts')}' must be inside the project folder.`));
         }
-        const filePath = filePathRes.value;
+        const filePath = sourcePath.relative;
         const modulePath = path.join(fullPath, 'build', tsToJsPath(filePath));
         const moduleUrl = pathToFileURL(modulePath).href;
         const moduleContent = await import(moduleUrl);
@@ -173,24 +174,16 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
 }
 
 export function getIntegrationId(filePath: string): Result<string> {
-    const normalizedPathRes = normalizeIntegrationFilePath(filePath);
-    if (normalizedPathRes.isErr()) {
-        return Err(normalizedPathRes.error);
+    const relativePath = normalizeProjectRelativePath(filePath);
+    if (!relativePath) {
+        return Err(new Error(`Script '${filePath.replace(/\.js$/, '.ts')}' must be inside the project folder.`));
     }
-    const segments = normalizedPathRes.value.replace(/^\.\//, '').split('/');
+    const segments = relativePath.replace(/^\.\//, '').split('/');
     const integrationId = segments[0];
     if (!integrationId || segments.length < 2) {
         return Err(new Error(`Script '${filePath.replace(/\.js$/, '.ts')}' must be inside an integration folder.`));
     }
     return Ok(integrationId);
-}
-
-function normalizeIntegrationFilePath(filePath: string): Result<string> {
-    const normalizedPath = path.posix.normalize(filePath.replaceAll('\\', '/'));
-    if (path.posix.isAbsolute(normalizedPath) || normalizedPath === '..' || normalizedPath.startsWith('../')) {
-        return Err(new Error(`Script '${filePath.replace(/\.js$/, '.ts')}' must be inside the project folder.`));
-    }
-    return Ok(`./${normalizedPath.replace(/^\.\//, '')}`);
 }
 
 const regexModelName = /^[A-Z][a-zA-Z0-9_]+$/;

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -68,9 +68,14 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
     const matched = getEntryPoints(indexRes.value);
     let num = 0;
 
-    for (const filePath of matched) {
+    for (const matchedFilePath of matched) {
         num += 1;
 
+        const filePathRes = normalizeIntegrationFilePath(matchedFilePath);
+        if (filePathRes.isErr()) {
+            return Err(filePathRes.error);
+        }
+        const filePath = filePathRes.value;
         const modulePath = path.join(fullPath, 'build', tsToJsPath(filePath));
         const moduleUrl = pathToFileURL(modulePath).href;
         const moduleContent = await import(moduleUrl);
@@ -91,7 +96,7 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
             | CreateFunctionResponse;
 
         const basename = path.basename(filePath, '.js');
-        const realPath = filePath.replace('.js', '.ts');
+        const realPath = filePath.replace(/\.js$/, '.ts');
         const basenameClean = basename.replaceAll(/[^a-zA-Z0-9]/g, '');
         const integrationIdRes = getIntegrationId(filePath);
         if (integrationIdRes.isErr()) {
@@ -168,12 +173,24 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
 }
 
 export function getIntegrationId(filePath: string): Result<string> {
-    const segments = filePath.replaceAll('\\', '/').replace(/^\.\//, '').split('/');
+    const normalizedPathRes = normalizeIntegrationFilePath(filePath);
+    if (normalizedPathRes.isErr()) {
+        return Err(normalizedPathRes.error);
+    }
+    const segments = normalizedPathRes.value.replace(/^\.\//, '').split('/');
     const integrationId = segments[0];
     if (!integrationId || segments.length < 2) {
-        return Err(new Error(`Script '${filePath.replace('.js', '.ts')}' must be inside an integration folder.`));
+        return Err(new Error(`Script '${filePath.replace(/\.js$/, '.ts')}' must be inside an integration folder.`));
     }
     return Ok(integrationId);
+}
+
+function normalizeIntegrationFilePath(filePath: string): Result<string> {
+    const normalizedPath = path.posix.normalize(filePath.replaceAll('\\', '/'));
+    if (path.posix.isAbsolute(normalizedPath) || normalizedPath === '..' || normalizedPath.startsWith('../')) {
+        return Err(new Error(`Script '${filePath.replace(/\.js$/, '.ts')}' must be inside the project folder.`));
+    }
+    return Ok(`./${normalizedPath.replace(/^\.\//, '')}`);
 }
 
 const regexModelName = /^[A-Z][a-zA-Z0-9_]+$/;

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -34,6 +34,7 @@ type LegacyPackage = Pick<PostDeployConfirmation['Body'], 'flowConfigs' | 'onEve
 type FunctionsBundle = PostFunctionDeploymentBundle['Body'];
 type Deployment = { kind: 'legacy'; package: LegacyPackage } | { kind: 'functions'; bundle: FunctionsBundle };
 type DeploymentConfirmation = { kind: 'legacy'; value: ScriptDifferences } | { kind: 'functions'; value: PostFunctionDeploymentBundlePreview['Success'] };
+type ResolvedSourcePath = { absolute: string; relative: string };
 
 export async function deploy({
     fullPath,
@@ -261,12 +262,16 @@ async function createFunctionsBundle({
     const functions: FunctionsBundle['functions'] = [];
     for (const config of selectedConfigs) {
         const { filePath, ...artifact } = config;
+        const sourcePath = resolveFunctionSourcePath({ fullPath, filePath });
+        if (!sourcePath) {
+            return Err(new Error(`Function source path "${filePath}" must be within the project directory`));
+        }
         const fileBody = await loadScriptFiles({
             fullPath,
             scriptName: config.name,
             providerConfigKey: config.integrationId,
             type: 'functions',
-            sourcePath: filePath
+            sourcePath
         });
         if (!fileBody) {
             return Err(new Error(`No function files found for "${config.name}"`));
@@ -278,6 +283,22 @@ async function createFunctionsBundle({
         reconciliationScope: optionalIntegrationId ? { kind: 'integration', integrationId: optionalIntegrationId } : { kind: 'environment' },
         functions
     });
+}
+
+function resolveFunctionSourcePath({ fullPath, filePath }: { fullPath: string; filePath: string }): ResolvedSourcePath | null {
+    const normalizedPath = path.posix.normalize(filePath.replaceAll('\\', '/'));
+    if (path.posix.isAbsolute(normalizedPath) || normalizedPath === '..' || normalizedPath.startsWith('../')) {
+        return null;
+    }
+
+    const projectRoot = path.resolve(fullPath);
+    const absolute = path.resolve(projectRoot, normalizedPath);
+    const relative = path.relative(projectRoot, absolute);
+    if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+        return null;
+    }
+
+    return { absolute, relative: normalizedPath };
 }
 
 /**
@@ -441,14 +462,26 @@ async function loadScriptFiles({
     scriptName: string;
     providerConfigKey: string;
     type: ScriptFileType;
-    sourcePath?: string;
+    sourcePath?: ResolvedSourcePath;
 }): Promise<{ js: string; ts: string } | null> {
-    const js = await loadScriptJsFile({ fullPath, scriptName, providerConfigKey, type, ...(sourcePath ? { sourcePath } : {}) });
+    const js = await loadScriptJsFile({
+        fullPath,
+        scriptName,
+        providerConfigKey,
+        type,
+        ...(sourcePath ? { sourcePath: sourcePath.relative } : {})
+    });
     if (!js) {
         return null;
     }
 
-    const ts = await loadScriptTsFile({ fullPath, scriptName, providerConfigKey, type, ...(sourcePath ? { sourcePath } : {}) });
+    const ts = await loadScriptTsFile({
+        fullPath,
+        scriptName,
+        providerConfigKey,
+        type,
+        ...(sourcePath ? { sourceFilePath: sourcePath.absolute } : {})
+    });
     if (!ts) {
         return null;
     }
@@ -494,15 +527,15 @@ async function loadScriptTsFile({
     scriptName,
     providerConfigKey,
     type,
-    sourcePath
+    sourceFilePath
 }: {
     fullPath: string;
     scriptName: string;
     providerConfigKey: string;
     type: ScriptFileType;
-    sourcePath?: string;
+    sourceFilePath?: string;
 }): Promise<string | null> {
-    const filePath = sourcePath ? path.join(fullPath, sourcePath) : path.join(fullPath, providerConfigKey, type, `${scriptName}.ts`);
+    const filePath = sourceFilePath || path.join(fullPath, providerConfigKey, type, `${scriptName}.ts`);
 
     try {
         const content = await fs.promises.readFile(filePath, 'utf8');

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -9,6 +9,7 @@ import { getCliHeaders, isCI, parseSecretKey, printDebug, resolveHostport } from
 import { Err, Ok } from '../utils/result.js';
 import { Spinner } from '../utils/spinner.js';
 import { NANGO_VERSION } from '../version.js';
+import { tsToJsPath } from './compile.js';
 import { parseIntegrationDefinitions } from './definitions.js';
 import { ReadableError } from './utils.js';
 
@@ -259,16 +260,18 @@ async function createFunctionsBundle({
 
     const functions: FunctionsBundle['functions'] = [];
     for (const config of selectedConfigs) {
+        const { filePath, ...artifact } = config;
         const fileBody = await loadScriptFiles({
             fullPath,
             scriptName: config.name,
             providerConfigKey: config.integrationId,
-            type: 'functions'
+            type: 'functions',
+            sourcePath: filePath
         });
         if (!fileBody) {
             return Err(new Error(`No function files found for "${config.name}"`));
         }
-        functions.push({ ...config, fileBody });
+        functions.push({ ...artifact, fileBody });
     }
 
     return Ok({
@@ -431,19 +434,21 @@ async function loadScriptFiles({
     fullPath,
     scriptName,
     providerConfigKey,
-    type
+    type,
+    sourcePath
 }: {
     fullPath: string;
     scriptName: string;
     providerConfigKey: string;
     type: ScriptFileType;
+    sourcePath?: string;
 }): Promise<{ js: string; ts: string } | null> {
-    const js = await loadScriptJsFile({ fullPath, scriptName, providerConfigKey, type });
+    const js = await loadScriptJsFile({ fullPath, scriptName, providerConfigKey, type, ...(sourcePath ? { sourcePath } : {}) });
     if (!js) {
         return null;
     }
 
-    const ts = await loadScriptTsFile({ fullPath, scriptName, providerConfigKey, type });
+    const ts = await loadScriptTsFile({ fullPath, scriptName, providerConfigKey, type, ...(sourcePath ? { sourcePath } : {}) });
     if (!ts) {
         return null;
     }
@@ -458,14 +463,18 @@ async function loadScriptJsFile({
     scriptName,
     providerConfigKey,
     fullPath,
-    type
+    type,
+    sourcePath
 }: {
     scriptName: string;
     type: ScriptFileType;
     providerConfigKey: string;
     fullPath: string;
+    sourcePath?: string;
 }): Promise<string | null> {
-    const filePath = path.join(fullPath, 'build', `${providerConfigKey}_${type}_${scriptName}.cjs`);
+    const filePath = sourcePath
+        ? path.join(fullPath, 'build', tsToJsPath(sourcePath.replace(/\.ts$/, '.js')))
+        : path.join(fullPath, 'build', `${providerConfigKey}_${type}_${scriptName}.cjs`);
 
     try {
         const content = await fs.promises.readFile(filePath, 'utf8');
@@ -484,14 +493,16 @@ async function loadScriptTsFile({
     fullPath,
     scriptName,
     providerConfigKey,
-    type
+    type,
+    sourcePath
 }: {
     fullPath: string;
     scriptName: string;
     providerConfigKey: string;
     type: ScriptFileType;
+    sourcePath?: string;
 }): Promise<string | null> {
-    const filePath = path.join(fullPath, providerConfigKey, type, `${scriptName}.ts`);
+    const filePath = sourcePath ? path.join(fullPath, sourcePath) : path.join(fullPath, providerConfigKey, type, `${scriptName}.ts`);
 
     try {
         const content = await fs.promises.readFile(filePath, 'utf8');

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -11,10 +11,12 @@ import { Spinner } from '../utils/spinner.js';
 import { NANGO_VERSION } from '../version.js';
 import { tsToJsPath } from './compile.js';
 import { parseIntegrationDefinitions } from './definitions.js';
+import { resolveProjectPath } from './project-path.js';
 import { ReadableError } from './utils.js';
 
 import type { DeployOptions } from '../types.js';
 import type { FunctionConfig, ParsedIntegrationDefinitions } from './definitions.js';
+import type { ResolvedProjectPath } from './project-path.js';
 import type {
     CLIDeployFlowConfig,
     NangoConfigMetadata,
@@ -34,7 +36,6 @@ type LegacyPackage = Pick<PostDeployConfirmation['Body'], 'flowConfigs' | 'onEve
 type FunctionsBundle = PostFunctionDeploymentBundle['Body'];
 type Deployment = { kind: 'legacy'; package: LegacyPackage } | { kind: 'functions'; bundle: FunctionsBundle };
 type DeploymentConfirmation = { kind: 'legacy'; value: ScriptDifferences } | { kind: 'functions'; value: PostFunctionDeploymentBundlePreview['Success'] };
-type ResolvedSourcePath = { absolute: string; relative: string };
 
 export async function deploy({
     fullPath,
@@ -262,7 +263,7 @@ async function createFunctionsBundle({
     const functions: FunctionsBundle['functions'] = [];
     for (const config of selectedConfigs) {
         const { filePath, ...artifact } = config;
-        const sourcePath = resolveFunctionSourcePath({ fullPath, filePath });
+        const sourcePath = resolveProjectPath({ projectRoot: fullPath, filePath });
         if (!sourcePath) {
             return Err(new Error(`Function source path "${filePath}" must be within the project directory`));
         }
@@ -283,22 +284,6 @@ async function createFunctionsBundle({
         reconciliationScope: optionalIntegrationId ? { kind: 'integration', integrationId: optionalIntegrationId } : { kind: 'environment' },
         functions
     });
-}
-
-function resolveFunctionSourcePath({ fullPath, filePath }: { fullPath: string; filePath: string }): ResolvedSourcePath | null {
-    const normalizedPath = path.posix.normalize(filePath.replaceAll('\\', '/'));
-    if (path.posix.isAbsolute(normalizedPath) || normalizedPath === '..' || normalizedPath.startsWith('../')) {
-        return null;
-    }
-
-    const projectRoot = path.resolve(fullPath);
-    const absolute = path.resolve(projectRoot, normalizedPath);
-    const relative = path.relative(projectRoot, absolute);
-    if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
-        return null;
-    }
-
-    return { absolute, relative: normalizedPath };
 }
 
 /**
@@ -462,7 +447,7 @@ async function loadScriptFiles({
     scriptName: string;
     providerConfigKey: string;
     type: ScriptFileType;
-    sourcePath?: ResolvedSourcePath;
+    sourcePath?: ResolvedProjectPath;
 }): Promise<{ js: string; ts: string } | null> {
     const js = await loadScriptJsFile({
         fullPath,

--- a/packages/cli/lib/zeroYaml/deploy.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/deploy.unit.cli-test.ts
@@ -372,6 +372,7 @@ function functionConfig({ integrationId, name }: { integrationId: string; name: 
     return {
         name,
         integrationId,
+        filePath: `./${integrationId}/functions/${name}.ts`,
         description: 'Function',
         trigger: { kind: 'none' },
         requires: { connection: true, outbound: true, invoke: false },

--- a/packages/cli/lib/zeroYaml/deploy.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/deploy.unit.cli-test.ts
@@ -6,6 +6,7 @@ import promptly from 'promptly';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Ok } from '../utils/result.js';
+import { tsToJsPath } from './compile.js';
 import { parseIntegrationDefinitions } from './definitions.js';
 import { deploy } from './deploy.js';
 
@@ -265,6 +266,32 @@ describe('deploy', () => {
         expect(output).not.toContain('- slack → other');
     });
 
+    it('loads function files when the source path contains .js before the extension', async () => {
+        const config = functionConfig({ integrationId: 'github.js', name: 'fetch' });
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok({ ...functionsOnlyParsed, functions: [config] }));
+        await fs.mkdir(path.join(fullPath, 'github.js', 'functions'), { recursive: true });
+        await fs.writeFile(path.join(fullPath, '.nango', 'functions.json'), JSON.stringify([config]));
+        await fs.writeFile(path.join(fullPath, 'github.js', 'functions', 'fetch.ts'), 'source with dotted path');
+        await fs.writeFile(path.join(fullPath, 'build', 'github.js_functions_fetch.cjs'), 'compiled with dotted path');
+
+        const functionChanges = {
+            created: [{ integrationId: 'github.js', name: 'fetch' }],
+            updated: [],
+            unchanged: [],
+            deleted: []
+        } satisfies FunctionDeploymentBundleSuccess;
+        fetchMock.mockResolvedValueOnce(jsonResponse(functionChanges)).mockResolvedValueOnce(jsonResponse(functionChanges));
+
+        await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions() });
+
+        expect(logOutput(logSpy)).toContain('✓ Deployed');
+        const previewRequest = fetchMock.mock.calls[0]?.[1] as RequestInit;
+        const previewBody = JSON.parse(previewRequest.body as string) as {
+            functions: { fileBody: { js: string; ts: string } }[];
+        };
+        expect(previewBody.functions[0]?.fileBody).toEqual({ js: 'compiled with dotted path', ts: 'source with dotted path' });
+    });
+
     it.each([
         { state: 'malformed', write: async (artifactPath: string) => await fs.writeFile(artifactPath, '{'.repeat(2)) },
         { state: 'not an array', write: async (artifactPath: string) => await fs.writeFile(artifactPath, JSON.stringify({})) }
@@ -279,6 +306,27 @@ describe('deploy', () => {
         expect(output).toContain('functions artifact');
         expect(output).not.toContain('✓ Deployed');
         expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects function source paths outside the project directory', async () => {
+        vi.mocked(parseIntegrationDefinitions).mockResolvedValue(Ok(functionsOnlyParsed));
+        const externalDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-cli-external-'));
+
+        try {
+            const externalFilePath = path.join(externalDir, 'secret.ts');
+            const sourcePath = path.relative(fullPath, externalFilePath);
+            const maliciousConfig = { ...githubFunction, filePath: sourcePath };
+            await fs.writeFile(externalFilePath, 'sensitive contents');
+            await fs.writeFile(path.join(fullPath, '.nango', 'functions.json'), JSON.stringify([maliciousConfig]));
+            await fs.writeFile(path.join(fullPath, 'build', tsToJsPath(sourcePath.replace(/\.ts$/, '.js'))), 'compiled function');
+
+            await deploy({ fullPath, environmentName: 'test', interactive: false, options: deployOptions() });
+
+            expect(logOutput(logSpy)).toContain(`Function source path "${sourcePath}" must be within the project directory`);
+            expect(fetchMock).not.toHaveBeenCalled();
+        } finally {
+            await fs.rm(externalDir, { recursive: true, force: true });
+        }
     });
 
     it('prints only legacy summary rows when no functions bundle', async () => {

--- a/packages/cli/lib/zeroYaml/dev.ts
+++ b/packages/cli/lib/zeroYaml/dev.ts
@@ -92,7 +92,7 @@ function manualWatch({ fullPath, debug, interactive }: { fullPath: string; debug
                             watcher.emit('add', entry);
                         }
                         for (const entry of deletedEntries) {
-                            onDelete(entry.replace('.ts', '.js'));
+                            onDelete(entry.replace(/\.ts$/, '.js'));
                         }
                     });
                 }
@@ -116,7 +116,7 @@ function manualWatch({ fullPath, debug, interactive }: { fullPath: string; debug
 
             spinner = spinnerFactory.start(`Compiling ${filePath}`);
 
-            const res = await compileFunction({ entryPoint: path.join(fullPath, filePath).replace('.ts', '.js'), projectRootPath: fullPath });
+            const res = await compileFunction({ entryPoint: path.join(fullPath, filePath).replace(/\.ts$/, '.js'), projectRootPath: fullPath });
             if (res.isErr()) {
                 spinner.fail();
                 failingFiles.add(filePath);
@@ -187,7 +187,7 @@ function manualWatch({ fullPath, debug, interactive }: { fullPath: string; debug
             return;
         }
 
-        const jsFilePath = filePath.replace('.ts', '.js');
+        const jsFilePath = filePath.replace(/\.ts$/, '.js');
         if (entryPoints.includes(jsFilePath)) {
             console.warn(chalk.yellow(`You need to remove import ${filePath} from index.ts`));
         }
@@ -270,7 +270,7 @@ class DependencyGraph {
 
             let resolvedImp = imp;
             if (resolvedImp.endsWith('.js')) {
-                resolvedImp = resolvedImp.replace('.js', '.ts');
+                resolvedImp = resolvedImp.replace(/\.js$/, '.ts');
             } else if (!resolvedImp.endsWith('.ts')) {
                 resolvedImp += '.ts';
             }

--- a/packages/cli/lib/zeroYaml/project-path.ts
+++ b/packages/cli/lib/zeroYaml/project-path.ts
@@ -1,0 +1,31 @@
+import path from 'node:path';
+
+export interface ResolvedProjectPath {
+    absolute: string;
+    relative: string;
+}
+
+export function normalizeProjectRelativePath(filePath: string): string | null {
+    const normalizedPath = path.posix.normalize(filePath.replaceAll('\\', '/'));
+    if (path.posix.isAbsolute(normalizedPath) || normalizedPath === '..' || normalizedPath.startsWith('../')) {
+        return null;
+    }
+
+    return `./${normalizedPath.replace(/^\.\//, '')}`;
+}
+
+export function resolveProjectPath({ projectRoot, filePath }: { projectRoot: string; filePath: string }): ResolvedProjectPath | null {
+    const relative = normalizeProjectRelativePath(filePath);
+    if (!relative) {
+        return null;
+    }
+
+    const absoluteProjectRoot = path.resolve(projectRoot);
+    const absolute = path.resolve(absoluteProjectRoot, relative);
+    const relativeToProjectRoot = path.relative(absoluteProjectRoot, absolute);
+    if (relativeToProjectRoot === '..' || relativeToProjectRoot.startsWith(`..${path.sep}`) || path.isAbsolute(relativeToProjectRoot)) {
+        return null;
+    }
+
+    return { absolute, relative };
+}

--- a/packages/cli/lib/zeroYaml/project-path.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/project-path.unit.cli-test.ts
@@ -1,0 +1,24 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveProjectPath } from './project-path.js';
+
+describe('resolveProjectPath', () => {
+    const projectRoot = path.resolve('project');
+
+    it('returns canonical relative and absolute paths', () => {
+        expect(resolveProjectPath({ projectRoot, filePath: '.\\github\\nested\\..\\functions\\fetch.ts' })).toEqual({
+            absolute: path.join(projectRoot, 'github', 'functions', 'fetch.ts'),
+            relative: './github/functions/fetch.ts'
+        });
+    });
+
+    it.each(['../outside/secret.ts', './github/../../outside/secret.ts'])('rejects traversal outside the project: %s', (filePath) => {
+        expect(resolveProjectPath({ projectRoot, filePath })).toBeNull();
+    });
+
+    it('rejects absolute paths', () => {
+        expect(resolveProjectPath({ projectRoot, filePath: path.resolve(projectRoot, 'github/functions/fetch.ts') })).toBeNull();
+    });
+});


### PR DESCRIPTION
Legacy script were assumed to live at `<integrationId>/syncs/<name>.ts`,so `integrationId` was read from a fixed depth in the path.
Functions are allowed to be nested at the root or nested into subfolders.
With this commit, the compiler derives the integrationId from the first segment of the path and carry the path into functions.json for the deploy to point at the correct location


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

