### PR TITLE
fix(webapp): disallow crawling of app.nango.dev in robots.txt

### DIFF
--- a/packages/webapp/public/robots.txt
+++ b/packages/webapp/public/robots.txt
@@ -1,3 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
## Problem

`app.nango.dev`'s `robots.txt` allows crawling everything, and that same file is bundled into every ephemeral PR preview deployment (`pr-NNNN.app-development.nango.dev`). As a result these preview URLs (and the logged-in webapp itself) have been getting picked up and indexed by Google, showing up as crawl errors in Search Console.

## Solution

- Change `packages/webapp/public/robots.txt` to `Disallow: /`, blocking crawlers on both production `app.nango.dev` and every preview deployment

Fixes [NAN-6532](https://linear.app/nango/issue/NAN-6532)

Companion infra fix (CloudFront-level, needed because a bundled robots.txt disappears once a preview expires) is in a separate `nango-infra` PR.

## Testing

- Confirmed `robots.txt` is served as-is from `packages/webapp/public/` with no build step transforming it
