### PR TITLE
fix: keep auth tokens out of PostHog and Sentry

### DIFF
--- a/packages/connect-ui/index.html
+++ b/packages/connect-ui/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <!-- The session token rides in the query string, so never send this url as a referrer.
+             Must stay above any request-initiating tag. -->
+        <meta name="referrer" content="strict-origin" />
         <script>
             // Assets are relative to the document URL, so a slashless base URL ("…/nango/connect")
             // breaks them. Wired to `onerror` on the entry script: retry with a trailing slash.

--- a/packages/server/lib/middleware/security.ts
+++ b/packages/server/lib/middleware/security.ts
@@ -20,6 +20,10 @@ export function securityMiddlewares(): RequestHandler[] {
         helmet.ieNoOpen(),
         helmet.frameguard({ action: 'sameorigin' }),
         helmet.dnsPrefetchControl(),
+        // Auth urls carry tokens in the path, so never send one as a referrer — not even
+        // same-origin, where it would land in our own access logs. Cross-origin behaviour is
+        // unchanged from the browser default, keeping third-party referrer allowlists working.
+        helmet.referrerPolicy({ policy: 'strict-origin' }),
         helmet.hsts({
             maxAge: 5184000
         }),

--- a/packages/server/lib/routes.integration.test.ts
+++ b/packages/server/lib/routes.integration.test.ts
@@ -43,6 +43,25 @@ describe('route', () => {
         });
     });
 
+    describe('Security headers', () => {
+        it('should set Referrer-Policy', async () => {
+            const res = await fetch(`${api.url}/health`);
+
+            expect(res.status).toBe(200);
+            expect(res.headers.get('referrer-policy')).toBe('strict-origin');
+        });
+
+        // Guards against the security middlewares being mounted after authentication.
+        it('should set Referrer-Policy on unauthenticated responses', async () => {
+            const res = await fetch(`${api.url}/providers`, {
+                headers: { Authorization: `Bearer 00000000-0000-4000-8000-000000000000` }
+            });
+
+            expect(res.status).toBe(401);
+            expect(res.headers.get('referrer-policy')).toBe('strict-origin');
+        });
+    });
+
     describe('GET /api/v1/environment/callback', () => {
         it('should handle invalid json', async () => {
             const { apiKey } = await seeders.seedAccountEnvAndUser();

--- a/packages/webapp/index.html
+++ b/packages/webapp/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
+        <!-- Auth urls carry tokens in the path. Cloud serves this from a CDN, so the server's
+             Referrer-Policy header doesn't apply. Must stay above any request-initiating tag. -->
+        <meta name="referrer" content="strict-origin" />
         <link rel="icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
@@ -18,7 +21,7 @@
                     var parsed = s ? JSON.parse(s) : null;
                     var state = parsed && parsed.state;
                     // Support new `theme` field and old boolean `darkMode`; default to dark to match the app default
-                    var theme = state && state.theme ? state.theme : (state && state.darkMode === false ? 'light' : 'dark');
+                    var theme = state && state.theme ? state.theme : state && state.darkMode === false ? 'light' : 'dark';
                     dark = theme === 'system' ? window.matchMedia('(prefers-color-scheme: dark)').matches : theme === 'dark';
                 } catch (e) {
                     dark = true;

--- a/packages/webapp/src/main.tsx
+++ b/packages/webapp/src/main.tsx
@@ -5,21 +5,46 @@ import ReactDOM from 'react-dom/client';
 import App from './app/App';
 import { Providers } from './app/providers';
 import { globalEnv } from './utils/env';
+import { redactSensitiveProperties, redactSensitiveText } from './utils/sensitive-url';
 
 if (globalEnv.publicPosthogKey) {
     posthog.init(globalEnv.publicPosthogKey, {
         api_host: globalEnv.publicPosthogHost,
         mask_personal_data_properties: true,
+        custom_personal_data_properties: ['session_token', 'token', 'next'],
         // The dashboard renders customer-supplied data that can contain PHI (NAN-6428):
         // mask all text by default, opt Nango-owned static chrome out with data-ph-unmask.
         mask_all_text: true,
         mask_all_element_attributes: true,
+        // Auth routes carry tokens in the URL path (NAN-6506), which no masking option covers.
+        before_send: (event) => {
+            if (!event) {
+                return event;
+            }
+            // Skipped for cost: $snapshot payloads are large and their urls go through maskNetworkRequestFn.
+            if (event.event === '$snapshot') {
+                return event;
+            }
+
+            redactSensitiveProperties(event.properties);
+            if (event.$set) {
+                redactSensitiveProperties(event.$set);
+            }
+            if (event.$set_once) {
+                redactSensitiveProperties(event.$set_once);
+            }
+
+            return event;
+        },
         session_recording: {
             maskAllInputs: true,
             // rrweb matches maskTextSelector against ancestors too, so a :not() opt-out can
             // never apply (body always matches). Mask everything, unmask via maskTextFn.
             maskTextSelector: '*',
-            maskTextFn: (text, element) => (element?.closest('[data-ph-unmask]') ? text : text.replace(/\S/g, '*'))
+            maskTextFn: (text, element) => (element?.closest('[data-ph-unmask]') ? text : text.replace(/\S/g, '*')),
+            // Masks the recording's own url. Deprecated, but the only key posthog-js 1.212 reads
+            // here; newer versions prefer maskCapturedNetworkRequestFn, whose payload is `name`.
+            maskNetworkRequestFn: (data) => ({ ...data, url: redactSensitiveText(data.url) })
         }
     });
 }

--- a/packages/webapp/src/utils/sensitive-url.ts
+++ b/packages/webapp/src/utils/sensitive-url.ts
@@ -1,0 +1,54 @@
+const REDACTED = '[redacted]';
+
+// Quotes and semicolons are excluded so a token inside an $elements_chain stops at its delimiter.
+const TOKEN_SEGMENT = String.raw`[^/?#\s"';]+`;
+
+// Specific prefixes first, so the bare /signup/ and /verify-email/ rules can't swallow them.
+const SENSITIVE_PATH_PATTERNS = [
+    new RegExp(String.raw`(/reset-password/)${TOKEN_SEGMENT}`, 'g'),
+    new RegExp(String.raw`(/signup/verification/)${TOKEN_SEGMENT}`, 'g'),
+    new RegExp(String.raw`(/verify-email/expired/)${TOKEN_SEGMENT}`, 'g'),
+    new RegExp(String.raw`(/verify-email/)(?!expired(?:/|$))${TOKEN_SEGMENT}`, 'g'),
+    new RegExp(String.raw`(/signup/)(?!verification(?:/|$))${TOKEN_SEGMENT}`, 'g')
+];
+
+// Signin carries the invite token in ?next=/signup/<token>, raw or percent-encoded.
+const NEXT_PARAM_PATTERN = /(next=(?:%2F|\/)signup(?:%2F|\/))[^&#\s"';]+/gi;
+
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/g;
+
+const HINTS = ['reset-password', 'verify-email', '/signup/', '%2Fsignup%2F', 'eyJ'];
+
+/**
+ * Removes auth tokens from URLs and URL-shaped strings before they reach PostHog or Sentry.
+ * Query params are handled separately by PostHog's `custom_personal_data_properties`.
+ */
+export function redactSensitiveText(value: string): string {
+    if (!value || !HINTS.some((hint) => value.includes(hint))) {
+        return value;
+    }
+
+    let redacted = value;
+    for (const pattern of SENSITIVE_PATH_PATTERNS) {
+        redacted = redacted.replace(pattern, `$1${REDACTED}`);
+    }
+    redacted = redacted.replace(NEXT_PARAM_PATTERN, `$1${REDACTED}`);
+
+    return redacted.replace(JWT_PATTERN, REDACTED);
+}
+
+/** Mutates in place: PostHog builds a fresh properties object per capture. */
+export function redactSensitiveProperties(properties: Record<string, unknown>): void {
+    for (const [key, value] of Object.entries(properties)) {
+        if (typeof value === 'string') {
+            properties[key] = redactSensitiveText(value);
+        } else if (key === '$elements' && Array.isArray(value)) {
+            // Autocapture puts anchor hrefs here; `mask_all_element_attributes` doesn't cover them.
+            for (const element of value) {
+                if (element && typeof element === 'object') {
+                    redactSensitiveProperties(element as Record<string, unknown>);
+                }
+            }
+        }
+    }
+}

--- a/packages/webapp/src/utils/sensitive-url.ts
+++ b/packages/webapp/src/utils/sensitive-url.ts
@@ -17,14 +17,22 @@ const NEXT_PARAM_PATTERN = /(next=(?:%2F|\/)signup(?:%2F|\/))[^&#\s"';]+/gi;
 
 const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/g;
 
-const HINTS = ['reset-password', 'verify-email', '/signup/', '%2Fsignup%2F', 'eyJ'];
+// Every string the patterns above can match contains one of these, so skipping on a miss can
+// never skip a redaction. Keep that true when adding a pattern: no delimiters, they vary by
+// encoding and case (`/signup/`, `%2Fsignup%2F`, `%2fsignup/`, …).
+const HINTS = ['reset-password', 'verify-email', 'signup', 'eyj'];
 
 /**
  * Removes auth tokens from URLs and URL-shaped strings before they reach PostHog or Sentry.
  * Query params are handled separately by PostHog's `custom_personal_data_properties`.
  */
 export function redactSensitiveText(value: string): string {
-    if (!value || !HINTS.some((hint) => value.includes(hint))) {
+    if (!value) {
+        return value;
+    }
+
+    const haystack = value.toLowerCase();
+    if (!HINTS.some((hint) => haystack.includes(hint))) {
         return value;
     }
 

--- a/packages/webapp/src/utils/sensitive-url.ts
+++ b/packages/webapp/src/utils/sensitive-url.ts
@@ -21,8 +21,9 @@ const SENSITIVE_PATH_PATTERNS = [
     new RegExp(String.raw`(/api/v1/account/email/)(?!expired-token(?:${BOUNDARY}|$))${TOKEN_SEGMENT}`, 'gi')
 ];
 
-// Signin carries the invite token in ?next=/signup/<token>, raw or percent-encoded.
-const NEXT_PARAM_PATTERN = /(next=(?:%2F|\/)signup(?:%2F|\/))[^&#\s"';]+/gi;
+// Signin carries tokens in ?next=/<token route>/<token>, raw or percent-encoded. The path
+// patterns above only see literal slashes, and a percent-encoded uuid has no jwt catch-all.
+const NEXT_PARAM_PATTERN = /(next=(?:%2F|\/)(?:signup|reset-password|verify-email)(?:%2F|\/))[^&#\s"';]+/gi;
 
 // No leading \b: a percent-encoded delimiter ends in a word char ('%2F'), which defeats it.
 const JWT_PATTERN = /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/g;

--- a/packages/webapp/src/utils/sensitive-url.ts
+++ b/packages/webapp/src/utils/sensitive-url.ts
@@ -1,26 +1,36 @@
 const REDACTED = '[redacted]';
 
-// Quotes and semicolons are excluded so a token inside an $elements_chain stops at its delimiter.
-const TOKEN_SEGMENT = String.raw`[^/?#\s"';]+`;
+// A token stops at URL delimiters ('?#&'), whitespace, quotes and semicolons (so a token inside
+// an $elements_chain stops at its delimiter), and ':' (so parameterized route names like
+// Sentry's /reset-password/:token transaction stay readable).
+const BOUNDARY = String.raw`[/?#&:\s"';]`;
+const TOKEN_SEGMENT = String.raw`[^/?#&:\s"';]+`;
 
-// Specific prefixes first, so the bare /signup/ and /verify-email/ rules can't swallow them.
+// The negative lookaheads keep the bare /verify-email/ and /signup/ rules from treating the
+// static `expired` and `verification` segments as tokens. Case-insensitive: react-router
+// matches routes case-insensitively, so /Signup/<token> serves the page too.
 const SENSITIVE_PATH_PATTERNS = [
-    new RegExp(String.raw`(/reset-password/)${TOKEN_SEGMENT}`, 'g'),
-    new RegExp(String.raw`(/signup/verification/)${TOKEN_SEGMENT}`, 'g'),
-    new RegExp(String.raw`(/verify-email/expired/)${TOKEN_SEGMENT}`, 'g'),
-    new RegExp(String.raw`(/verify-email/)(?!expired(?:/|$))${TOKEN_SEGMENT}`, 'g'),
-    new RegExp(String.raw`(/signup/)(?!verification(?:/|$))${TOKEN_SEGMENT}`, 'g')
+    new RegExp(String.raw`(/reset-password/)${TOKEN_SEGMENT}`, 'gi'),
+    new RegExp(String.raw`(/signup/verification/)${TOKEN_SEGMENT}`, 'gi'),
+    new RegExp(String.raw`(/verify-email/expired/)${TOKEN_SEGMENT}`, 'gi'),
+    new RegExp(String.raw`(/verify-email/)(?!expired(?:${BOUNDARY}|$))${TOKEN_SEGMENT}`, 'gi'),
+    new RegExp(String.raw`(/signup/)(?!verification(?:${BOUNDARY}|$))${TOKEN_SEGMENT}`, 'gi'),
+    // The API calls those pages make carry the same tokens in the path.
+    new RegExp(String.raw`(/api/v1/invite/)${TOKEN_SEGMENT}`, 'gi'),
+    new RegExp(String.raw`(/api/v1/account/email/expired-token/)${TOKEN_SEGMENT}`, 'gi'),
+    new RegExp(String.raw`(/api/v1/account/email/)(?!expired-token(?:${BOUNDARY}|$))${TOKEN_SEGMENT}`, 'gi')
 ];
 
 // Signin carries the invite token in ?next=/signup/<token>, raw or percent-encoded.
 const NEXT_PARAM_PATTERN = /(next=(?:%2F|\/)signup(?:%2F|\/))[^&#\s"';]+/gi;
 
-const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/g;
+// No leading \b: a percent-encoded delimiter ends in a word char ('%2F'), which defeats it.
+const JWT_PATTERN = /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/g;
 
 // Every string the patterns above can match contains one of these, so skipping on a miss can
 // never skip a redaction. Keep that true when adding a pattern: no delimiters, they vary by
 // encoding and case (`/signup/`, `%2Fsignup%2F`, `%2fsignup/`, …).
-const HINTS = ['reset-password', 'verify-email', 'signup', 'eyj'];
+const HINTS = ['reset-password', 'email', 'signup', 'invite', 'eyj'];
 
 /**
  * Removes auth tokens from URLs and URL-shaped strings before they reach PostHog or Sentry.
@@ -45,8 +55,12 @@ export function redactSensitiveText(value: string): string {
     return redacted.replace(JWT_PATTERN, REDACTED);
 }
 
-/** Mutates in place: PostHog builds a fresh properties object per capture. */
-export function redactSensitiveProperties(properties: Record<string, unknown>): void {
+/** Mutates in place: callers (PostHog capture hooks, Sentry before-send) own the object. */
+export function redactSensitiveProperties(properties: Record<string, unknown> | undefined): void {
+    if (!properties) {
+        return;
+    }
+
     for (const [key, value] of Object.entries(properties)) {
         if (typeof value === 'string') {
             properties[key] = redactSensitiveText(value);

--- a/packages/webapp/src/utils/sensitive-url.unit.test.ts
+++ b/packages/webapp/src/utils/sensitive-url.unit.test.ts
@@ -42,6 +42,16 @@ describe('redactSensitiveText', () => {
         expect(redactSensitiveText('/signin?next=%2Fsignup%2Finvite-token')).toBe('/signin?next=%2Fsignup%2F[redacted]');
     });
 
+    // Invite tokens are uuids, so the jwt catch-all can't rescue a missed ?next= variant.
+    it('redacts the invite token whatever the encoding or case of the delimiters', () => {
+        const uuid = '8f14e45f-ceea-467a-9b0d-1e0a1b2c3d4e';
+
+        expect(redactSensitiveText(`/signin?next=%2fsignup%2f${uuid}`)).toBe('/signin?next=%2fsignup%2f[redacted]');
+        expect(redactSensitiveText(`/signin?next=%2Fsignup/${uuid}`)).toBe('/signin?next=%2Fsignup/[redacted]');
+        expect(redactSensitiveText(`/signin?next=/signup%2F${uuid}`)).toBe('/signin?next=/signup%2F[redacted]');
+        expect(redactSensitiveText(`/signin?NEXT=%2FSignup%2F${uuid}`)).toBe('/signin?NEXT=%2FSignup%2F[redacted]');
+    });
+
     it('redacts a jwt anywhere, whatever the surrounding shape', () => {
         expect(redactSensitiveText(`a:link:href="/x/${JWT}";div:nth-child="1"`)).toBe('a:link:href="/x/[redacted]";div:nth-child="1"');
     });

--- a/packages/webapp/src/utils/sensitive-url.unit.test.ts
+++ b/packages/webapp/src/utils/sensitive-url.unit.test.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 
 import { redactSensitiveProperties, redactSensitiveText } from './sensitive-url.js';
 
 const JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoibWF0ZWpAbmFuZ28uZGV2IiwiaWF0IjoxNzAwMDAwMDAwfQ.abc123DEF-_456';
+const UUID = '8f14e45f-ceea-467a-9b0d-1e0a1b2c3d4e';
 
 describe('redactSensitiveText', () => {
     it('redacts the reset password token from a full url', () => {
@@ -23,7 +26,32 @@ describe('redactSensitiveText', () => {
         expect(redactSensitiveText('/signup/invite-token')).toBe('/signup/[redacted]');
         expect(redactSensitiveText('/signup/verification/verify-token')).toBe('/signup/verification/[redacted]');
         expect(redactSensitiveText('/verify-email/expired/expired-token')).toBe('/verify-email/expired/[redacted]');
-        expect(redactSensitiveText('/verify-email/8f14e45f-ceea-467a-9b0d-1e0a1b2c3d4e')).toBe('/verify-email/[redacted]');
+        expect(redactSensitiveText(`/verify-email/${UUID}`)).toBe('/verify-email/[redacted]');
+    });
+
+    // Guards the pattern list against new token routes added to the router.
+    it('covers every token-bearing route in the router', () => {
+        const routerSource = readFileSync(new URL('../app/router.tsx', import.meta.url), 'utf8');
+        const tokenRoutes = [...routerSource.matchAll(/path: '([^']*\/:(?:token|uuid))'/g)].map((match) => match[1]);
+
+        expect(tokenRoutes.length).toBeGreaterThan(0);
+        for (const route of tokenRoutes) {
+            expect(redactSensitiveText(route.replace(/:(?:token|uuid)$/, UUID))).toBe(route.replace(/:(?:token|uuid)$/, '[redacted]'));
+        }
+    });
+
+    // React-router matches routes case-insensitively, so these urls serve the token pages too.
+    it('redacts tokens whatever the path casing', () => {
+        expect(redactSensitiveText(`/Signup/${UUID}`)).toBe('/Signup/[redacted]');
+        expect(redactSensitiveText(`/Verify-Email/${UUID}`)).toBe('/Verify-Email/[redacted]');
+        expect(redactSensitiveText(`/RESET-PASSWORD/${JWT}`)).toBe('/RESET-PASSWORD/[redacted]');
+    });
+
+    it('redacts tokens from the api urls the auth pages call', () => {
+        expect(redactSensitiveText(`https://api.nango.dev/api/v1/invite/${UUID}`)).toBe('https://api.nango.dev/api/v1/invite/[redacted]');
+        expect(redactSensitiveText('/api/v1/account/email/expired-token/tok')).toBe('/api/v1/account/email/expired-token/[redacted]');
+        expect(redactSensitiveText(`/api/v1/account/email/${UUID}`)).toBe('/api/v1/account/email/[redacted]');
+        expect(redactSensitiveText('/api/v1/invite?env=dev')).toBe('/api/v1/invite?env=dev');
     });
 
     it('does not let the broader rules swallow the more specific routes', () => {
@@ -35,25 +63,36 @@ describe('redactSensitiveText', () => {
         expect(redactSensitiveText('/signup')).toBe('/signup');
         expect(redactSensitiveText('/forgot-password')).toBe('/forgot-password');
         expect(redactSensitiveText('/signup/verification')).toBe('/signup/verification');
+        expect(redactSensitiveText('/signup/verification?utm_source=email')).toBe('/signup/verification?utm_source=email');
+        expect(redactSensitiveText('/verify-email/expired#top')).toBe('/verify-email/expired#top');
+        expect(redactSensitiveText('a:href="/signup/verification"')).toBe('a:href="/signup/verification"');
+    });
+
+    // Sentry names transactions by the parameterized route pattern, never a real token.
+    it('leaves parameterized route names alone', () => {
+        expect(redactSensitiveText('/reset-password/:token')).toBe('/reset-password/:token');
+        expect(redactSensitiveText('/signup/:token')).toBe('/signup/:token');
+        expect(redactSensitiveText('/verify-email/:uuid')).toBe('/verify-email/:uuid');
+        expect(redactSensitiveText('/signup/verification/:token')).toBe('/signup/verification/:token');
     });
 
     it('redacts the invite token from the ?next= param', () => {
         expect(redactSensitiveText('/signin?next=/signup/invite-token')).toBe('/signin?next=/signup/[redacted]');
         expect(redactSensitiveText('/signin?next=%2Fsignup%2Finvite-token')).toBe('/signin?next=%2Fsignup%2F[redacted]');
+        expect(redactSensitiveText('/signin?next=/signup/invite-token&utm_source=x')).toBe('/signin?next=/signup/[redacted]&utm_source=x');
     });
 
     // Invite tokens are uuids, so the jwt catch-all can't rescue a missed ?next= variant.
     it('redacts the invite token whatever the encoding or case of the delimiters', () => {
-        const uuid = '8f14e45f-ceea-467a-9b0d-1e0a1b2c3d4e';
-
-        expect(redactSensitiveText(`/signin?next=%2fsignup%2f${uuid}`)).toBe('/signin?next=%2fsignup%2f[redacted]');
-        expect(redactSensitiveText(`/signin?next=%2Fsignup/${uuid}`)).toBe('/signin?next=%2Fsignup/[redacted]');
-        expect(redactSensitiveText(`/signin?next=/signup%2F${uuid}`)).toBe('/signin?next=/signup%2F[redacted]');
-        expect(redactSensitiveText(`/signin?NEXT=%2FSignup%2F${uuid}`)).toBe('/signin?NEXT=%2FSignup%2F[redacted]');
+        expect(redactSensitiveText(`/signin?next=%2fsignup%2f${UUID}`)).toBe('/signin?next=%2fsignup%2f[redacted]');
+        expect(redactSensitiveText(`/signin?next=%2Fsignup/${UUID}`)).toBe('/signin?next=%2Fsignup/[redacted]');
+        expect(redactSensitiveText(`/signin?next=/signup%2F${UUID}`)).toBe('/signin?next=/signup%2F[redacted]');
+        expect(redactSensitiveText(`/signin?NEXT=%2FSignup%2F${UUID}`)).toBe('/signin?NEXT=%2FSignup%2F[redacted]');
     });
 
     it('redacts a jwt anywhere, whatever the surrounding shape', () => {
         expect(redactSensitiveText(`a:link:href="/x/${JWT}";div:nth-child="1"`)).toBe('a:link:href="/x/[redacted]";div:nth-child="1"');
+        expect(redactSensitiveText(`/signin?next=%2Freset-password%2F${JWT}`)).toBe('/signin?next=%2Freset-password%2F[redacted]');
     });
 
     it('is idempotent', () => {

--- a/packages/webapp/src/utils/sensitive-url.unit.test.ts
+++ b/packages/webapp/src/utils/sensitive-url.unit.test.ts
@@ -90,6 +90,12 @@ describe('redactSensitiveText', () => {
         expect(redactSensitiveText(`/signin?NEXT=%2FSignup%2F${UUID}`)).toBe('/signin?NEXT=%2FSignup%2F[redacted]');
     });
 
+    // Same story for the other token routes: percent-encoded, so the path patterns can't see them.
+    it('redacts non-jwt tokens from an encoded ?next= for every token route', () => {
+        expect(redactSensitiveText(`/signin?next=%2Freset-password%2F${UUID}`)).toBe('/signin?next=%2Freset-password%2F[redacted]');
+        expect(redactSensitiveText(`/signin?next=%2Fverify-email%2F${UUID}`)).toBe('/signin?next=%2Fverify-email%2F[redacted]');
+    });
+
     it('redacts a jwt anywhere, whatever the surrounding shape', () => {
         expect(redactSensitiveText(`a:link:href="/x/${JWT}";div:nth-child="1"`)).toBe('a:link:href="/x/[redacted]";div:nth-child="1"');
         expect(redactSensitiveText(`/signin?next=%2Freset-password%2F${JWT}`)).toBe('/signin?next=%2Freset-password%2F[redacted]');

--- a/packages/webapp/src/utils/sensitive-url.unit.test.ts
+++ b/packages/webapp/src/utils/sensitive-url.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { redactSensitiveProperties, redactSensitiveText } from './sensitive-url.js';
+
+const JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoibWF0ZWpAbmFuZ28uZGV2IiwiaWF0IjoxNzAwMDAwMDAwfQ.abc123DEF-_456';
+
+describe('redactSensitiveText', () => {
+    it('redacts the reset password token from a full url', () => {
+        expect(redactSensitiveText(`https://app.nango.dev/reset-password/${JWT}`)).toBe('https://app.nango.dev/reset-password/[redacted]');
+    });
+
+    it('redacts the reset password token from a bare pathname', () => {
+        expect(redactSensitiveText(`/reset-password/${JWT}`)).toBe('/reset-password/[redacted]');
+    });
+
+    it('keeps the query string and hash', () => {
+        expect(redactSensitiveText(`https://app.nango.dev/reset-password/${JWT}?foo=bar#top`)).toBe(
+            'https://app.nango.dev/reset-password/[redacted]?foo=bar#top'
+        );
+    });
+
+    it('redacts every token-bearing route', () => {
+        expect(redactSensitiveText('/signup/invite-token')).toBe('/signup/[redacted]');
+        expect(redactSensitiveText('/signup/verification/verify-token')).toBe('/signup/verification/[redacted]');
+        expect(redactSensitiveText('/verify-email/expired/expired-token')).toBe('/verify-email/expired/[redacted]');
+        expect(redactSensitiveText('/verify-email/8f14e45f-ceea-467a-9b0d-1e0a1b2c3d4e')).toBe('/verify-email/[redacted]');
+    });
+
+    it('does not let the broader rules swallow the more specific routes', () => {
+        expect(redactSensitiveText('/signup/verification/tok')).not.toContain('/signup/[redacted]');
+        expect(redactSensitiveText('/verify-email/expired/tok')).not.toContain('/verify-email/[redacted]/');
+    });
+
+    it('leaves token-free auth routes alone', () => {
+        expect(redactSensitiveText('/signup')).toBe('/signup');
+        expect(redactSensitiveText('/forgot-password')).toBe('/forgot-password');
+        expect(redactSensitiveText('/signup/verification')).toBe('/signup/verification');
+    });
+
+    it('redacts the invite token from the ?next= param', () => {
+        expect(redactSensitiveText('/signin?next=/signup/invite-token')).toBe('/signin?next=/signup/[redacted]');
+        expect(redactSensitiveText('/signin?next=%2Fsignup%2Finvite-token')).toBe('/signin?next=%2Fsignup%2F[redacted]');
+    });
+
+    it('redacts a jwt anywhere, whatever the surrounding shape', () => {
+        expect(redactSensitiveText(`a:link:href="/x/${JWT}";div:nth-child="1"`)).toBe('a:link:href="/x/[redacted]";div:nth-child="1"');
+    });
+
+    it('is idempotent', () => {
+        const once = redactSensitiveText(`/reset-password/${JWT}`);
+
+        expect(redactSensitiveText(once)).toBe(once);
+    });
+
+    it('returns unrelated strings untouched', () => {
+        expect(redactSensitiveText('')).toBe('');
+        expect(redactSensitiveText('https://app.nango.dev/integrations/github')).toBe('https://app.nango.dev/integrations/github');
+    });
+});
+
+describe('redactSensitiveProperties', () => {
+    it('redacts url properties and autocapture element hrefs', () => {
+        const properties: Record<string, unknown> = {
+            $current_url: `https://app.nango.dev/reset-password/${JWT}`,
+            $pathname: `/reset-password/${JWT}`,
+            $referrer: '/signin?next=/signup/invite-token',
+            $elements_chain: `a:href="/reset-password/${JWT}"`,
+            $elements: [{ tag_name: 'a', attr__href: `/reset-password/${JWT}` }],
+            $screen_height: 1080
+        };
+
+        redactSensitiveProperties(properties);
+
+        expect(properties).toStrictEqual({
+            $current_url: 'https://app.nango.dev/reset-password/[redacted]',
+            $pathname: '/reset-password/[redacted]',
+            $referrer: '/signin?next=/signup/[redacted]',
+            $elements_chain: 'a:href="/reset-password/[redacted]"',
+            $elements: [{ tag_name: 'a', attr__href: '/reset-password/[redacted]' }],
+            $screen_height: 1080
+        });
+    });
+
+    it('does not walk arrays other than $elements', () => {
+        const snapshotData = [{ data: { href: `/reset-password/${JWT}` } }];
+        const properties: Record<string, unknown> = { $snapshot_data: snapshotData };
+
+        redactSensitiveProperties(properties);
+
+        expect(properties.$snapshot_data).toStrictEqual(snapshotData);
+    });
+});

--- a/packages/webapp/src/utils/sentry.tsx
+++ b/packages/webapp/src/utils/sentry.tsx
@@ -23,6 +23,12 @@ function redactSensitiveEvent<TEvent extends Sentry.Event>(event: TEvent): TEven
     if (typeof event.message === 'string') {
         event.message = redactSensitiveText(event.message);
     }
+    // A captured Error's text lands here rather than in `event.message`.
+    for (const exception of event.exception?.values ?? []) {
+        if (typeof exception.value === 'string') {
+            exception.value = redactSensitiveText(exception.value);
+        }
+    }
 
     for (const breadcrumb of event.breadcrumbs ?? []) {
         // Navigation breadcrumbs keep the token in `from`/`to`, fetch ones in `url`.

--- a/packages/webapp/src/utils/sentry.tsx
+++ b/packages/webapp/src/utils/sentry.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { createBrowserRouter, createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router-dom';
 
 import { globalEnv } from './env';
-import { redactSensitiveText } from './sensitive-url';
+import { redactSensitiveProperties, redactSensitiveText } from './sensitive-url';
 
 /**
  * Auth routes carry tokens in the URL path (NAN-6506). `sendDefaultPii: false` does not cover
@@ -32,31 +32,19 @@ function redactSensitiveEvent<TEvent extends Sentry.Event>(event: TEvent): TEven
 
     for (const breadcrumb of event.breadcrumbs ?? []) {
         // Navigation breadcrumbs keep the token in `from`/`to`, fetch ones in `url`.
-        redactSensitiveValues(breadcrumb.data);
+        redactSensitiveProperties(breadcrumb.data);
     }
 
-    redactSensitiveValues(event.contexts?.trace?.data);
+    redactSensitiveProperties(event.contexts?.trace?.data);
 
     for (const span of event.spans ?? []) {
         if (span.description) {
             span.description = redactSensitiveText(span.description);
         }
-        redactSensitiveValues(span.data);
+        redactSensitiveProperties(span.data);
     }
 
     return event;
-}
-
-function redactSensitiveValues(data: Record<string, unknown> | undefined): void {
-    if (!data) {
-        return;
-    }
-
-    for (const [key, value] of Object.entries<unknown>(data)) {
-        if (typeof value === 'string') {
-            data[key] = redactSensitiveText(value);
-        }
-    }
 }
 
 // The dashboard renders customer-supplied data that can contain PHI (NAN-6428): no session

--- a/packages/webapp/src/utils/sentry.tsx
+++ b/packages/webapp/src/utils/sentry.tsx
@@ -3,6 +3,55 @@ import { useEffect } from 'react';
 import { createBrowserRouter, createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router-dom';
 
 import { globalEnv } from './env';
+import { redactSensitiveText } from './sensitive-url';
+
+/**
+ * Auth routes carry tokens in the URL path (NAN-6506). `sendDefaultPii: false` does not cover
+ * urls, and `httpContextIntegration` attaches `request.url` to errors and transactions alike.
+ * Stack frame filenames are left alone: those are script urls, not the document url.
+ */
+function redactSensitiveEvent<TEvent extends Sentry.Event>(event: TEvent): TEvent {
+    if (event.request?.url) {
+        event.request.url = redactSensitiveText(event.request.url);
+    }
+    if (event.request?.headers?.['Referer']) {
+        event.request.headers['Referer'] = redactSensitiveText(event.request.headers['Referer']);
+    }
+    if (event.transaction) {
+        event.transaction = redactSensitiveText(event.transaction);
+    }
+    if (typeof event.message === 'string') {
+        event.message = redactSensitiveText(event.message);
+    }
+
+    for (const breadcrumb of event.breadcrumbs ?? []) {
+        // Navigation breadcrumbs keep the token in `from`/`to`, fetch ones in `url`.
+        redactSensitiveValues(breadcrumb.data);
+    }
+
+    redactSensitiveValues(event.contexts?.trace?.data);
+
+    for (const span of event.spans ?? []) {
+        if (span.description) {
+            span.description = redactSensitiveText(span.description);
+        }
+        redactSensitiveValues(span.data);
+    }
+
+    return event;
+}
+
+function redactSensitiveValues(data: Record<string, unknown> | undefined): void {
+    if (!data) {
+        return;
+    }
+
+    for (const [key, value] of Object.entries<unknown>(data)) {
+        if (typeof value === 'string') {
+            data[key] = redactSensitiveText(value);
+        }
+    }
+}
 
 // The dashboard renders customer-supplied data that can contain PHI (NAN-6428): no session
 // replays, no console breadcrumbs, no serialized non-Error throw payloads.
@@ -25,7 +74,10 @@ Sentry.init({
         if (event.extra) {
             delete event.extra['__serialized__'];
         }
-        return event;
+        return redactSensitiveEvent(event);
+    },
+    beforeSendTransaction(event) {
+        return redactSensitiveEvent(event);
     },
     beforeBreadcrumb(breadcrumb) {
         if (breadcrumb.category === 'console') {


### PR DESCRIPTION
## Problem

The password reset link puts a live JWT in the URL path, and the reset page renders inside the normal app shell — so PostHog autocapture sent `$current_url` and `$pathname` with the token to a third party, and Sentry did the same via `request.url`, navigation breadcrumbs and transactions. The token's payload also exposes the user's email. Reported externally; assessed Medium (needs access to PostHog/Sentry data, token is single-use with a 10-minute TTL).

The same shape applies to the other token routes: `/signup/:token`, `/verify-email/expired/:token`, `/signup/verification/:token`, and `?next=/signup/<token>` on `/signin`.

## Solution

- Add `redactSensitiveText` / `redactSensitiveProperties` (`packages/webapp/src/utils/sensitive-url.ts`) covering all token-bearing paths, `?next=`, and bare JWTs anywhere.
- Wire them into PostHog's `before_send` and `session_recording.maskNetworkRequestFn`, plus `custom_personal_data_properties` for token query params.
- Wire them into Sentry's `beforeSend` and a new `beforeSendTransaction` — covering `request.url`, `Referer`, transaction name, breadcrumbs, trace context and spans.
- Set `Referrer-Policy: strict-origin` via helmet, plus matching `<meta name="referrer">` in the webapp and Connect UI entrypoints (Cloud serves those from a CDN, where the server header doesn't apply).

Scrubbing at the analytics boundary rather than stripping the URL, because the invite token is deliberately re-embedded into links and into `?next=` and so can't be removed from the URL anyway. Existing masking options don't help: `mask_all_text` and `mask_personal_data_properties` leave URL paths alone, and `mask_all_element_attributes` is an autocapture option that doesn't suppress anchor `href` capture.

Fixes [NAN-6506](https://linear.app/nango/issue/NAN-6506)

## Testing

- 12 unit tests for the redaction helpers; 2 integration tests asserting `Referrer-Policy` on both a 200 and a 401 (a regression that mounted the security middlewares after auth would fail the second).
- Verified in a browser on `/reset-password/<probe JWT>`: took the property set PostHog's own `_calculate_event_properties` builds from the real `window.location`, ran it through the `before_send` in `posthog.config`, and confirmed `$current_url`, `$pathname` and `$initial_current_url` come out as `/reset-password/[redacted]` with the token absent from the serialized event. Same check against the live Sentry client on the dev API for every field listed above.
- Reset form still renders and submits normally.

## Notes for the reviewer

- `publicPosthogKey` is empty in dev and staging env.js — PostHog only initializes in **production**, so the PostHog half can't be validated on the dev deploy. I verified it against a local sink using the real `posthog-js` bundle rather than firing test events at the production project.
- `NANGO_ADMIN_KEY` (ticket item 4) is confirmed set in all three cloud environments — 32 chars, not the `'nango'` fallback — so `resetPasswordSecret()` and the session cookie secret never hit that fallback in Cloud.
- Accepted and deliberately out of scope: the token stays in `window.location`, so it remains in browser history and CDN access logs — the `GET /reset-password/<jwt>` happens regardless of any client-side fix. Tracked in NAN-6557 below.

## Follow-ups

- [NAN-6557](https://linear.app/nango/issue/NAN-6557/keep-auth-tokens-out-of-urls-entirely) — Keep auth tokens out of URLs entirely. The real fix: this PR stops the URL reaching analytics, but the token still sits in browser history, CDN access logs and the address bar.
- [NAN-6558](https://linear.app/nango/issue/NAN-6558/upgrade-posthog-js) — Upgrade posthog-js. We're on a January 2025 build, ~600 releases behind, and the replay-URL scrubbing here sits on `maskNetworkRequestFn`, the deprecated key our version reads exclusively.
- [NAN-6559](https://linear.app/nango/issue/NAN-6559/upgrade-sentryreact) — Upgrade @sentry/react, two majors behind.
- [NAN-6560](https://linear.app/nango/issue/NAN-6560/stop-putting-the-connect-ui-session-token-in-the-preview-iframe-url) — Stop putting the Connect UI session token in the preview iframe `src`, where it reaches CDN access logs, the DOM and replay snapshots.
- [NAN-6561](https://linear.app/nango/issue/NAN-6561/set-referrer-policy-at-the-cdn) — Set `Referrer-Policy` at the CDN, so the app-ui and connect-ui distributions don't depend on the meta tags alone.
