### PR TITLE
feat(feature-flags): NAN-6476 serve flags from env vars

### DIFF
--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -168,6 +168,17 @@ This serves `true` for the `audit-trail` flag on every account on the instance. 
 
 The variables apply to the whole process, so there is no per-account targeting or gradual rollout. Set them on every service that evaluates the flag, and note that each service reads them at startup.
 
+### Two-factor authentication
+
+Two-factor authentication is behind the `mfa` flag, which only the server evaluates. Set these on the server service to enable it:
+
+```bash
+NANGO_FLAG_PROVIDER=env
+NANGO_FEATURE_FLAG_MFA=true
+```
+
+Once the server restarts, users can turn it on from their profile settings by pairing an authenticator app and saving their backup codes. Nango then asks them for a code at login.
+
 ## Free self-hosting
 
 A limited free self-hosting option is available for hobby projects. It is intended for lightweight deployments that need Auth and Proxy, without the managed features and support included with Enterprise self-hosting or Nango Cloud.

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -153,6 +153,21 @@ The encryption key must be a base64-encoded 256-bit (32-byte) key. Key rotation 
 
 The default retention period for deleted connections is 31 days. You can configure this via the `CRON_DELETE_OLD_CONNECTIONS_MAX_DAYS` environment variable.
 
+## Feature flags
+
+Nango gates some behavior behind feature flags. Flags are served by the provider set in `NANGO_FLAG_PROVIDER`, which defaults to `noop`, so every flag uses its built-in default.
+
+To serve flags from environment variables instead, set `NANGO_FLAG_PROVIDER=env`, then set one variable per flag, named after the flag key uppercased with dashes replaced by underscores and prefixed with `NANGO_FEATURE_FLAG_`:
+
+```bash
+NANGO_FLAG_PROVIDER=env
+NANGO_FEATURE_FLAG_AUDIT_TRAIL=true
+```
+
+This serves `true` for the `audit-trail` flag on every account on the instance. Flags with no variable set keep their built-in default. Boolean flags accept `true` or `false`. A value that doesn't match the flag's type is ignored, and the flag keeps its default.
+
+The variables apply to the whole process, so there is no per-account targeting or gradual rollout. Set them on every service that evaluates the flag, and note that each service reads them at startup.
+
 ## Free self-hosting
 
 A limited free self-hosting option is available for hobby projects. It is intended for lightweight deployments that need Auth and Proxy, without the managed features and support included with Enterprise self-hosting or Nango Cloud.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6833,6 +6833,17 @@ This serves `true` for the `audit-trail` flag on every account on the instance. 
 
 The variables apply to the whole process, so there is no per-account targeting or gradual rollout. Set them on every service that evaluates the flag, and note that each service reads them at startup.
 
+### Two-factor authentication
+
+Two-factor authentication is behind the `mfa` flag, which only the server evaluates. Set these on the server service to enable it:
+
+```bash
+NANGO_FLAG_PROVIDER=env
+NANGO_FEATURE_FLAG_MFA=true
+```
+
+Once the server restarts, users can turn it on from their profile settings by pairing an authenticator app and saving their backup codes. Nango then asks them for a code at login.
+
 ## Free self-hosting
 
 A limited free self-hosting option is available for hobby projects. It is intended for lightweight deployments that need Auth and Proxy, without the managed features and support included with Enterprise self-hosting or Nango Cloud.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6818,6 +6818,21 @@ The encryption key must be a base64-encoded 256-bit (32-byte) key. Key rotation 
 
 The default retention period for deleted connections is 31 days. You can configure this via the `CRON_DELETE_OLD_CONNECTIONS_MAX_DAYS` environment variable.
 
+## Feature flags
+
+Nango gates some behavior behind feature flags. Flags are served by the provider set in `NANGO_FLAG_PROVIDER`, which defaults to `noop`, so every flag uses its built-in default.
+
+To serve flags from environment variables instead, set `NANGO_FLAG_PROVIDER=env`, then set one variable per flag, named after the flag key uppercased with dashes replaced by underscores and prefixed with `NANGO_FEATURE_FLAG_`:
+
+```bash
+NANGO_FLAG_PROVIDER=env
+NANGO_FEATURE_FLAG_AUDIT_TRAIL=true
+```
+
+This serves `true` for the `audit-trail` flag on every account on the instance. Flags with no variable set keep their built-in default. Boolean flags accept `true` or `false`. A value that doesn't match the flag's type is ignored, and the flag keeps its default.
+
+The variables apply to the whole process, so there is no per-account targeting or gradual rollout. Set them on every service that evaluates the flag, and note that each service reads them at startup.
+
 ## Free self-hosting
 
 A limited free self-hosting option is available for hobby projects. It is intended for lightweight deployments that need Auth and Proxy, without the managed features and support included with Enterprise self-hosting or Nango Cloud.

--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -7,6 +7,9 @@ import type { FeatureFlagsClient } from './client.js';
  *
  * Add a method here when you add a flag, the method owns the context mapping
  * (targeting key, properties) and the default so it can't drift across call sites.
+ *
+ * Separate words in flag keys with dashes, never underscores: the env provider can't
+ * tell the two apart.
  */
 export function buildFlags(client: FeatureFlagsClient) {
     return {

--- a/packages/feature-flags/lib/index.ts
+++ b/packages/feature-flags/lib/index.ts
@@ -3,6 +3,7 @@ import { getLogger, metrics } from '@nangohq/utils';
 import { buildFeatureFlagsClient } from './client.js';
 import { envs } from './env.js';
 import { buildFlags } from './flags.js';
+import { EnvProvider } from './providers/env.js';
 import { NoopProvider } from './providers/noop.js';
 import { UnleashProvider } from './providers/unleash.js';
 
@@ -68,6 +69,13 @@ async function createClient(): Promise<FeatureFlagsClient> {
 }
 
 async function buildProvider(): Promise<Provider> {
+    if (envs.NANGO_FLAG_PROVIDER === 'env') {
+        if (envs.NANGO_CLOUD) {
+            logger.warning('NANGO_FLAG_PROVIDER=env is not supported on cloud; using noop provider');
+            return new NoopProvider();
+        }
+        return new EnvProvider();
+    }
     if (envs.NANGO_FLAG_PROVIDER === 'unleash') {
         if (!envs.NANGO_UNLEASH_URL) {
             logger.warning('NANGO_FLAG_PROVIDER=unleash but NANGO_UNLEASH_URL is unset; using noop provider');

--- a/packages/feature-flags/lib/index.unit.test.ts
+++ b/packages/feature-flags/lib/index.unit.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockEnvs = {
-    NANGO_FLAG_PROVIDER: 'noop' as 'noop' | 'unleash',
+    NANGO_FLAG_PROVIDER: 'noop' as 'noop' | 'unleash' | 'env',
+    NANGO_CLOUD: false,
     NANGO_UNLEASH_URL: undefined as string | undefined,
     NANGO_UNLEASH_API_TOKEN: undefined as string | undefined,
     NANGO_UNLEASH_APP_NAME: 'nango',
@@ -81,6 +82,7 @@ describe('getFeatureFlagsClient', () => {
         vi.useRealTimers();
         vi.clearAllMocks();
         mockEnvs.NANGO_FLAG_PROVIDER = 'noop';
+        mockEnvs.NANGO_CLOUD = false;
         mockEnvs.NANGO_UNLEASH_URL = undefined;
         mockEnvs.NANGO_UNLEASH_API_TOKEN = undefined;
         mockEnvs.NANGO_UNLEASH_REFRESH_INTERVAL_MS = 30_000;
@@ -94,6 +96,7 @@ describe('getFeatureFlagsClient', () => {
     afterEach(async () => {
         const { destroy } = await import('./index.js');
         await destroy();
+        vi.unstubAllEnvs();
         vi.resetModules();
         vi.restoreAllMocks();
         vi.useRealTimers();
@@ -105,6 +108,26 @@ describe('getFeatureFlagsClient', () => {
         const client = await getFeatureFlagsClient();
         await expect(client.isEnabled('any-flag', { 'account.uuid': 'abc' }, true)).resolves.toBe(true);
         await expect(client.isEnabled('any-flag', { 'account.uuid': 'abc' }, false)).resolves.toBe(false);
+    });
+
+    it('serves flags from env vars when the env provider is selected', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'env';
+        vi.stubEnv('NANGO_FEATURE_FLAG_ANY_FLAG', 'true');
+        vi.resetModules();
+        const { getFeatureFlagsClient } = await import('./index.js');
+        const client = await getFeatureFlagsClient();
+        await expect(client.isEnabled('any-flag', {}, false)).resolves.toBe(true);
+        await expect(client.isEnabled('other-flag', {}, false)).resolves.toBe(false);
+    });
+
+    it('falls back to noop when the env provider is selected on cloud', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'env';
+        mockEnvs.NANGO_CLOUD = true;
+        vi.stubEnv('NANGO_FEATURE_FLAG_ANY_FLAG', 'true');
+        vi.resetModules();
+        const { getFeatureFlagsClient } = await import('./index.js');
+        const client = await getFeatureFlagsClient();
+        await expect(client.isEnabled('any-flag', {}, false)).resolves.toBe(false);
     });
 
     it('falls back to noop when unleash is selected but url is missing', async () => {

--- a/packages/feature-flags/lib/providers/env.ts
+++ b/packages/feature-flags/lib/providers/env.ts
@@ -1,0 +1,121 @@
+import { ErrorCode } from '@openfeature/server-sdk';
+
+import { getLogger } from '@nangohq/utils';
+
+import type { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from '@openfeature/server-sdk';
+
+const logger = getLogger('FeatureFlags.Env');
+
+/**
+ * One env var per flag, named after the flag key uppercased with dashes as underscores:
+ * `NANGO_FEATURE_FLAG_AUDIT_TRAIL=true` serves `true` for the `audit-trail` flag.
+ */
+const FLAG_PREFIX = 'NANGO_FEATURE_FLAG_';
+
+/**
+ * Serves flags from environment variables, for local development and self-hosted
+ * deployments that have no flag service to point at. Flags with no variable set
+ * resolve to the default the call site declares.
+ *
+ * Evaluation context is ignored: a variable applies to the whole process, so there is
+ * no per-account targeting or gradual rollout. Use Unleash for those.
+ */
+export class EnvProvider implements Provider {
+    readonly metadata = { name: 'env' };
+    readonly runsOn = 'server' as const;
+
+    private readonly flags = new Map<string, string>();
+
+    constructor() {
+        for (const [name, value] of Object.entries(process.env)) {
+            if (value === undefined || !name.startsWith(FLAG_PREFIX) || name === FLAG_PREFIX) {
+                continue;
+            }
+            this.flags.set(flagKey(name), value);
+        }
+
+        if (this.flags.size > 0) {
+            logger.info(`Serving feature flags from env vars: ${[...this.flags.keys()].join(', ')}`);
+        } else {
+            logger.warning(`No ${FLAG_PREFIX}* variable is set; every flag will use its default`);
+        }
+    }
+
+    resolveBooleanEvaluation(flagKey: string, defaultValue: boolean, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<boolean>> {
+        return Promise.resolve(
+            this.resolve(flagKey, defaultValue, 'boolean', (raw) => {
+                const normalized = raw.trim().toLowerCase();
+                if (normalized === 'true') return true;
+                if (normalized === 'false') return false;
+                return undefined;
+            })
+        );
+    }
+
+    resolveStringEvaluation(flagKey: string, defaultValue: string, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<string>> {
+        return Promise.resolve(this.resolve(flagKey, defaultValue, 'string', (raw) => raw));
+    }
+
+    resolveNumberEvaluation(flagKey: string, defaultValue: number, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<number>> {
+        return Promise.resolve(
+            this.resolve(flagKey, defaultValue, 'number', (raw) => {
+                const trimmed = raw.trim();
+                if (trimmed === '') return undefined;
+                const parsed = Number(trimmed);
+                return Number.isFinite(parsed) ? parsed : undefined;
+            })
+        );
+    }
+
+    resolveObjectEvaluation<T extends JsonValue>(
+        flagKey: string,
+        defaultValue: T,
+        _context: EvaluationContext,
+        _logger: Logger
+    ): Promise<ResolutionDetails<T>> {
+        return Promise.resolve(
+            this.resolve(flagKey, defaultValue, 'object', (raw) => {
+                let parsed: JsonValue;
+                try {
+                    parsed = JSON.parse(raw) as JsonValue;
+                } catch {
+                    return undefined;
+                }
+                // Parsing succeeding doesn't make the value the right shape: JSON also gives us
+                // null, arrays and primitives, and handing one back as T lies to the caller.
+                return jsonKind(parsed) === jsonKind(defaultValue) ? (parsed as T) : undefined;
+            })
+        );
+    }
+
+    private resolve<T>(flagKey: string, defaultValue: T, type: string, parse: (raw: string) => T | undefined): ResolutionDetails<T> {
+        const raw = this.flags.get(flagKey);
+        if (raw === undefined) {
+            return { value: defaultValue, reason: 'DEFAULT' };
+        }
+
+        const value = parse(raw);
+        if (value === undefined) {
+            logger.warning('Ignoring feature flag value, it does not match the flag type', { flag: flagKey, type, value: raw });
+            const envVar = `${FLAG_PREFIX}${flagKey.toUpperCase().replaceAll('-', '_')}`;
+            return {
+                value: defaultValue,
+                reason: 'ERROR',
+                errorCode: ErrorCode.TYPE_MISMATCH,
+                errorMessage: `${envVar} is not a valid ${type}`
+            };
+        }
+
+        return { value, reason: 'STATIC' };
+    }
+}
+
+function jsonKind(value: JsonValue): string {
+    if (value === null) return 'null';
+    if (Array.isArray(value)) return 'array';
+    return typeof value;
+}
+
+function flagKey(envVar: string): string {
+    return envVar.slice(FLAG_PREFIX.length).toLowerCase().replaceAll('_', '-');
+}

--- a/packages/feature-flags/lib/providers/env.unit.test.ts
+++ b/packages/feature-flags/lib/providers/env.unit.test.ts
@@ -1,0 +1,152 @@
+import { ErrorCode } from '@openfeature/server-sdk';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EnvProvider } from './env.js';
+
+import type { Logger } from '@openfeature/server-sdk';
+
+const mockLogger = vi.hoisted(() => ({
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+}));
+
+vi.mock('@nangohq/utils', () => ({
+    getLogger: vi.fn(() => mockLogger)
+}));
+
+const noopLogger = {} as Logger;
+
+describe('EnvProvider', () => {
+    const realEnv = process.env;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env = {};
+    });
+
+    afterEach(() => {
+        process.env = realEnv;
+    });
+
+    it('serves a boolean from its env var', async () => {
+        process.env['NANGO_FEATURE_FLAG_AUDIT_TRAIL'] = 'true';
+        const provider = new EnvProvider();
+        await expect(provider.resolveBooleanEvaluation('audit-trail', false, {}, noopLogger)).resolves.toEqual({ value: true, reason: 'STATIC' });
+    });
+
+    it('returns the default when no var is set', async () => {
+        const provider = new EnvProvider();
+        await expect(provider.resolveBooleanEvaluation('audit-trail', true, {}, noopLogger)).resolves.toEqual({ value: true, reason: 'DEFAULT' });
+    });
+
+    it.each([
+        ['true', true],
+        ['TRUE', true],
+        [' true ', true],
+        ['false', false],
+        ['False', false]
+    ])('reads %s as the boolean %s', async (raw, expected) => {
+        process.env['NANGO_FEATURE_FLAG_AUDIT_TRAIL'] = raw;
+        const provider = new EnvProvider();
+        await expect(provider.resolveBooleanEvaluation('audit-trail', !expected, {}, noopLogger)).resolves.toEqual({ value: expected, reason: 'STATIC' });
+    });
+
+    it.each(['1', '0', 'yes', 'no', 'on', 'off', 'maybe', ''])('returns the default and a type mismatch for the boolean %s', async (raw) => {
+        process.env['NANGO_FEATURE_FLAG_AUDIT_TRAIL'] = raw;
+        const provider = new EnvProvider();
+        await expect(provider.resolveBooleanEvaluation('audit-trail', false, {}, noopLogger)).resolves.toEqual({
+            value: false,
+            reason: 'ERROR',
+            errorCode: ErrorCode.TYPE_MISMATCH,
+            errorMessage: 'NANGO_FEATURE_FLAG_AUDIT_TRAIL is not a valid boolean'
+        });
+        expect(mockLogger.warning).toHaveBeenCalledWith('Ignoring feature flag value, it does not match the flag type', {
+            flag: 'audit-trail',
+            type: 'boolean',
+            value: raw
+        });
+    });
+
+    it('serves strings verbatim', async () => {
+        process.env['NANGO_FEATURE_FLAG_UI_VARIANT'] = ' new ui ';
+        const provider = new EnvProvider();
+        await expect(provider.resolveStringEvaluation('ui-variant', 'old-ui', {}, noopLogger)).resolves.toEqual({ value: ' new ui ', reason: 'STATIC' });
+    });
+
+    it('serves numbers', async () => {
+        process.env['NANGO_FEATURE_FLAG_RATE_LIMIT'] = ' 42 ';
+        const provider = new EnvProvider();
+        await expect(provider.resolveNumberEvaluation('rate-limit', 10, {}, noopLogger)).resolves.toEqual({ value: 42, reason: 'STATIC' });
+    });
+
+    it.each(['', 'abc', 'Infinity'])('returns the default for the number %s', async (raw) => {
+        process.env['NANGO_FEATURE_FLAG_RATE_LIMIT'] = raw;
+        const provider = new EnvProvider();
+        await expect(provider.resolveNumberEvaluation('rate-limit', 10, {}, noopLogger)).resolves.toMatchObject({ value: 10, reason: 'ERROR' });
+    });
+
+    it('serves objects as JSON', async () => {
+        process.env['NANGO_FEATURE_FLAG_LIMITS'] = '{"max":3}';
+        const provider = new EnvProvider();
+        await expect(provider.resolveObjectEvaluation('limits', { max: 1 }, {}, noopLogger)).resolves.toEqual({ value: { max: 3 }, reason: 'STATIC' });
+    });
+
+    it('returns the default when the object is not valid JSON', async () => {
+        process.env['NANGO_FEATURE_FLAG_LIMITS'] = '{max:3}';
+        const provider = new EnvProvider();
+        await expect(provider.resolveObjectEvaluation('limits', { max: 1 }, {}, noopLogger)).resolves.toMatchObject({ value: { max: 1 }, reason: 'ERROR' });
+    });
+
+    it.each(['null', '[1,2]', '"str"', '42', 'true'])('returns the default when the object default is not shaped like %s', async (raw) => {
+        process.env['NANGO_FEATURE_FLAG_LIMITS'] = raw;
+        const provider = new EnvProvider();
+        await expect(provider.resolveObjectEvaluation('limits', { max: 1 }, {}, noopLogger)).resolves.toEqual({
+            value: { max: 1 },
+            reason: 'ERROR',
+            errorCode: ErrorCode.TYPE_MISMATCH,
+            errorMessage: 'NANGO_FEATURE_FLAG_LIMITS is not a valid object'
+        });
+    });
+
+    it('serves an array when the default is an array', async () => {
+        process.env['NANGO_FEATURE_FLAG_LIMITS'] = '[1,2]';
+        const provider = new EnvProvider();
+        await expect(provider.resolveObjectEvaluation('limits', [0], {}, noopLogger)).resolves.toEqual({ value: [1, 2], reason: 'STATIC' });
+    });
+
+    it('rejects an object when the default is an array', async () => {
+        process.env['NANGO_FEATURE_FLAG_LIMITS'] = '{"max":3}';
+        const provider = new EnvProvider();
+        await expect(provider.resolveObjectEvaluation('limits', [0], {}, noopLogger)).resolves.toMatchObject({ value: [0], reason: 'ERROR' });
+    });
+
+    it('ignores the evaluation context', async () => {
+        process.env['NANGO_FEATURE_FLAG_AUDIT_TRAIL'] = 'true';
+        const provider = new EnvProvider();
+        await expect(provider.resolveBooleanEvaluation('audit-trail', false, { targetingKey: 'uuid1' }, noopLogger)).resolves.toEqual({
+            value: true,
+            reason: 'STATIC'
+        });
+    });
+
+    it('ignores vars that are not flags', async () => {
+        process.env['NANGO_FLAG_PROVIDER'] = 'env';
+        process.env['AUDIT_TRAIL'] = 'true';
+        const provider = new EnvProvider();
+        await expect(provider.resolveBooleanEvaluation('audit-trail', false, {}, noopLogger)).resolves.toEqual({ value: false, reason: 'DEFAULT' });
+    });
+
+    it('logs the flags it serves', () => {
+        process.env['NANGO_FEATURE_FLAG_AUDIT_TRAIL'] = 'true';
+        process.env['NANGO_FEATURE_FLAG_MFA'] = 'false';
+        new EnvProvider();
+        expect(mockLogger.info).toHaveBeenCalledWith('Serving feature flags from env vars: audit-trail, mfa');
+    });
+
+    it('warns when it has no flag to serve', () => {
+        new EnvProvider();
+        expect(mockLogger.warning).toHaveBeenCalledWith('No NANGO_FEATURE_FLAG_* variable is set; every flag will use its default');
+    });
+});

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -778,7 +778,7 @@ const ENVS_SHAPE = z.object({
     NANGO_INTERNAL_TLS_KEY_PASSPHRASE: z.string().optional(),
 
     // Feature Flags
-    NANGO_FLAG_PROVIDER: z.enum(['noop', 'unleash']).optional().default('noop'),
+    NANGO_FLAG_PROVIDER: z.enum(['noop', 'unleash', 'env']).optional().default('noop'),
     NANGO_UNLEASH_URL: z.url().optional(),
     NANGO_UNLEASH_API_TOKEN: z.string().optional(),
     NANGO_UNLEASH_APP_NAME: z.string().optional().default('nango'),


### PR DESCRIPTION
Closes [NAN-6476](https://linear.app/nango/issue/NAN-6476/support-feature-flag-overrides-via-env-vars).

Set `NANGO_FLAG_PROVIDER=env` and one `NANGO_FEATURE_FLAG_<FLAG_KEY>` var per flag, so local dev and self-hosted instances can change a flag without running Unleash.

```bash
NANGO_FLAG_PROVIDER=env NANGO_FEATURE_FLAG_AUDIT_TRAIL=true npm run dev   # serves true for the `audit-trail` flag
```

Comes from [this thread](https://nangohq.slack.com/archives/C067NRBH1LL/p1784716526807259) with @pfreixes 

### Decisions

- **One env var per flag**, not a single var encoding all overrides. Easier to set ad hoc and to read in a deployment config.
- **Flag key mapping**: uppercase, dashes to underscores. `audit-trail` becomes `NANGO_FEATURE_FLAG_AUDIT_TRAIL`.
- **A provider, not an override layer** (thanks @TBonnin). It sits next to noop and unleash instead of intercepting inside our client, so it is exclusive with Unleash rather than layered on top.
- **Not available on cloud.** Flags there belong to the provider and roll out per account, so an env var must not pin a production value and bypass targeting. Selecting `env` on cloud falls back to noop and logs a warning.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
