### PR TITLE
feat(environment): rotate webhook signing key (NAN-6550)

### DIFF
--- a/packages/server/lib/controllers/environment/postRotateWebhookSigningKey.integration.test.ts
+++ b/packages/server/lib/controllers/environment/postRotateWebhookSigningKey.integration.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { customerKeyService, seeders } from '@nangohq/shared';
+
+import { envs } from '../../env.js';
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
+
+const route = '/internal/environments/:environmentId/webhook-signing-key/rotate';
+let api: Awaited<ReturnType<typeof runServer>>;
+const internalKey = 'test-internal-api-key';
+let previousInternalKey: string | undefined;
+
+describe(`POST ${route}`, () => {
+    beforeAll(async () => {
+        previousInternalKey = envs.NANGO_INTERNAL_API_KEY;
+        envs.NANGO_INTERNAL_API_KEY = internalKey;
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        envs.NANGO_INTERNAL_API_KEY = previousInternalKey;
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, { method: 'POST', params: { environmentId: 1 } });
+
+        shouldBeProtected(res);
+    });
+
+    it('should reject a wrong internal key', async () => {
+        const { res, json } = await api.fetch(route, { method: 'POST', params: { environmentId: 1 }, token: 'nope' });
+
+        isError(json);
+        // The code is not registered in NangoError, so it comes back prefixed. Same for every /internal route.
+        expect(json.error.code).toContain('invalid_internal_private_key');
+        expect(res.status).toBe(500);
+    });
+
+    it('should 404 when the environment has no signing key', async () => {
+        const { res, json } = await api.fetch(route, { method: 'POST', params: { environmentId: 99999999 }, token: internalKey });
+
+        isError(json);
+        expect(json.error.code).toBe('not_found');
+        expect(res.status).toBe(404);
+    });
+
+    it('should rotate the key and serve the new one', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const before = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, env.id);
+        if (before.isErr()) {
+            throw before.error;
+        }
+
+        const { res, json } = await api.fetch(route, { method: 'POST', params: { environmentId: env.id }, token: internalKey });
+
+        isSuccess(json);
+        expect(res.status).toBe(200);
+        expect(json.data.webhook_signing_key).not.toBe(before.value);
+
+        const after = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, env.id);
+        if (after.isErr()) {
+            throw after.error;
+        }
+        expect(after.value).toBe(json.data.webhook_signing_key);
+    });
+
+    it('should keep the stored key decryptable', async () => {
+        const { env } = await seeders.seedAccountEnvAndUser();
+
+        const { json } = await api.fetch(route, { method: 'POST', params: { environmentId: env.id }, token: internalKey });
+        isSuccess(json);
+
+        const row = await db
+            .knex('customer_keys')
+            .select('customer_keys.secret', 'customer_keys.iv', 'customer_keys.tag', 'customer_keys.hashed')
+            .join('customer_keys_relations', 'customer_keys_relations.customer_key_id', 'customer_keys.id')
+            .where('customer_keys.key_type', 'webhook_signing')
+            .where('customer_keys_relations.entity_id', env.id)
+            .first();
+
+        expect(row.secret).not.toBe(json.data.webhook_signing_key);
+        expect(row.iv).not.toBe('');
+        expect(row.tag).not.toBe('');
+        expect(row.hashed).not.toBe('');
+    });
+});

--- a/packages/server/lib/controllers/environment/postRotateWebhookSigningKey.ts
+++ b/packages/server/lib/controllers/environment/postRotateWebhookSigningKey.ts
@@ -1,0 +1,51 @@
+import * as z from 'zod';
+
+import db from '@nangohq/database';
+import { CustomerKeyError, customerKeyService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+
+import type { PostRotateWebhookSigningKey } from '@nangohq/types';
+
+const paramsValidation = z
+    .object({
+        environmentId: z.coerce.number().positive()
+    })
+    .strict();
+
+export const postRotateWebhookSigningKey = asyncWrapper<PostRotateWebhookSigningKey>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const params = paramsValidation.safeParse(req.params);
+    if (!params.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(params.error) } });
+        return;
+    }
+
+    const rotated = await customerKeyService.rotateWebhookSigningKey(db.knex, params.data.environmentId);
+    if (rotated.isErr()) {
+        const err = rotated.error;
+        if (err instanceof CustomerKeyError && err.code === 'no_webhook_signing_key') {
+            res.status(404).send({ error: { code: 'not_found', message: `No webhook signing key for environment ${params.data.environmentId}` } });
+            return;
+        }
+        if (err instanceof CustomerKeyError && err.code === 'multiple_webhook_signing_keys') {
+            res.status(409).send({
+                error: {
+                    code: 'multiple_webhook_signing_keys',
+                    message: `Environment ${params.data.environmentId} has more than one webhook signing key, resolve manually`
+                }
+            });
+            return;
+        }
+        res.status(500).send({ error: { code: 'rotation_failed', message: err.message } });
+        return;
+    }
+
+    res.status(200).send({ data: { webhook_signing_key: rotated.value } });
+});

--- a/packages/server/lib/routes.internal.ts
+++ b/packages/server/lib/routes.internal.ts
@@ -1,6 +1,7 @@
 import bodyParser from 'body-parser';
 import express from 'express';
 
+import { postRotateWebhookSigningKey } from './controllers/environment/postRotateWebhookSigningKey.js';
 import { postRollout } from './controllers/fleet/postRollout.js';
 import { getSharedCredentialsProviders } from './controllers/sharedCredentials/getListSharedCredentials.js';
 import { getSharedCredentialsProvider } from './controllers/sharedCredentials/id/getSharedCredential.js';
@@ -28,3 +29,5 @@ internalApi.route('/shared-credentials').post(interalApiAuth, postSharedCredenti
 internalApi.route('/shared-credentials/:id').patch(interalApiAuth, patchSharedCredentialsProvider);
 
 internalApi.route('/users').get(interalApiAuth, getUsersProvider);
+
+internalApi.route('/environments/:environmentId/webhook-signing-key/rotate').post(interalApiAuth, postRotateWebhookSigningKey);

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -12,14 +12,16 @@ import type { Knex } from 'knex';
 
 const CUSTOMER_KEYS_TABLE = 'customer_keys';
 const CUSTOMER_KEYS_RELATIONS_TABLE = 'customer_keys_relations';
-// Cache decrypted webhook signing key per environment. No eviction needed since rotation is not supported yet.
-const webhookSigningKeyCache = new Map<number, string>();
+// Cache decrypted webhook signing key per environment. Entries expire so a rotation propagates to every
+// process on its own, without a cross-process invalidation channel.
+const webhookSigningKeyCache = new Map<number, { key: string; expiresAt: number }>();
+const WEBHOOK_SIGNING_KEY_CACHE_TTL_MS = 60_000;
 // Internal safety limits — not product constraints, just protection against unbounded key creation.
 // Can be raised without migration if needed.
 export const MAX_API_KEYS_PER_ENV = 50;
 export const MAX_API_KEYS_PER_ACCOUNT = 50;
 
-export type CustomerKeyErrorCode = 'duplicate_api_key' | 'resource_capped' | 'no_such_api_secret';
+export type CustomerKeyErrorCode = 'duplicate_api_key' | 'resource_capped' | 'no_such_api_secret' | 'no_webhook_signing_key' | 'multiple_webhook_signing_keys';
 
 export class CustomerKeyError extends Error {
     constructor(
@@ -318,29 +320,75 @@ class CustomerKeyService {
         }
     }
 
+    private webhookSigningKeyForEnv(trx: Knex, envId: number) {
+        return trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+            .select(`${CUSTOMER_KEYS_TABLE}.*`)
+            .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
+            .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'webhook_signing')
+            .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
+            .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
+            .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`);
+    }
+
     public async getWebhookSigningKeyForEnv(trx: Knex, envId: number): Promise<Result<string>> {
         const cached = webhookSigningKeyCache.get(envId);
-        if (cached) {
-            return Ok(cached);
+        if (cached && cached.expiresAt > Date.now()) {
+            return Ok(cached.key);
         }
 
         try {
-            const row = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
-                .select(`${CUSTOMER_KEYS_TABLE}.*`)
-                .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
-                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'webhook_signing')
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
-                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
-                .first();
+            const row = await this.webhookSigningKeyForEnv(trx, envId).first();
 
             if (!row) {
                 throw new NangoError('no_webhook_signing_key', { environment_id: envId });
             }
 
             const decrypted = getEncryptionManager().decryptAPISecret(row as Parameters<EncryptionManager['decryptAPISecret']>[0]) as DBCustomerKey;
-            webhookSigningKeyCache.set(envId, decrypted.secret);
+            webhookSigningKeyCache.set(envId, { key: decrypted.secret, expiresAt: Date.now() + WEBHOOK_SIGNING_KEY_CACHE_TTL_MS });
             return Ok(decrypted.secret);
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    /**
+     * Replaces the environment's webhook signing key with a fresh one and returns it in plain text.
+     * Callers in other processes keep signing with the previous key until their cache entry expires.
+     */
+    public async rotateWebhookSigningKey(trx: Knex, envId: number): Promise<Result<string>> {
+        try {
+            const plainText = uuid.v4();
+
+            const hashed = await this.hashSecret(plainText);
+            if (hashed.isErr()) {
+                throw hashed.error;
+            }
+
+            const encrypted = getEncryptionManager().encryptAPISecret({ secret: plainText, iv: '', tag: '' } as Parameters<
+                EncryptionManager['encryptAPISecret']
+            >[0]);
+
+            const existing = await this.webhookSigningKeyForEnv(trx, envId).forUpdate(CUSTOMER_KEYS_TABLE);
+            const current = existing[0];
+            if (!current) {
+                throw new CustomerKeyError('no_webhook_signing_key', { environmentId: envId });
+            }
+            // An environment has exactly one signing key. More than one means reads already pick an
+            // arbitrary row, so rotating would leave the customer with an unpredictable key.
+            if (existing.length > 1) {
+                throw new CustomerKeyError('multiple_webhook_signing_keys', { environmentId: envId });
+            }
+
+            await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE).where({ id: current.id }).update({
+                secret: encrypted.secret,
+                iv: encrypted.iv,
+                tag: encrypted.tag,
+                hashed: hashed.value,
+                updated_at: new Date()
+            });
+
+            webhookSigningKeyCache.set(envId, { key: plainText, expiresAt: Date.now() + WEBHOOK_SIGNING_KEY_CACHE_TTL_MS });
+            return Ok(plainText);
         } catch (err) {
             return Err(err);
         }

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -68,7 +68,8 @@ import type {
     ListApiKeys,
     PatchApiKey,
     PatchEnvironment,
-    PostEnvironment
+    PostEnvironment,
+    PostRotateWebhookSigningKey
 } from './environment/api/index.js';
 import type { PatchWebhook } from './environment/api/webhook.js';
 import type { PostEnvironmentVariables } from './environment/variable/api.js';
@@ -265,6 +266,7 @@ export type PrivateApiEndpoints =
     | DeleteEnvironment
     | GetEnvironments
     | GetEnvironment
+    | PostRotateWebhookSigningKey
     | ListApiKeys
     | CreateApiKey
     | DeleteApiKey

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -1,5 +1,5 @@
 import type { ApiKeyScope } from '../../api-keys/scopes.js';
-import type { ApiEndpoint, ApiError, ApiTimestamps } from '../../api.js';
+import type { ApiEndpoint, ApiError, ApiTimestamps, Endpoint } from '../../api.js';
 import type { AuditPolicy } from '../../audit-trail/event.js';
 import type { ApiPlan } from '../../plans/http.api.js';
 import type { DBEnvironment, DBExternalWebhook } from '../db.js';
@@ -75,6 +75,16 @@ export type DeleteEnvironment = ApiEndpoint<{
     Path: '/api/v1/environments';
     Success: never;
     Error: ApiError<'cannot_delete_prod_environment'>;
+}>;
+
+export type PostRotateWebhookSigningKey = Endpoint<{
+    Method: 'POST';
+    Path: '/internal/environments/:environmentId/webhook-signing-key/rotate';
+    Params: { environmentId: number };
+    Success: {
+        data: { webhook_signing_key: string };
+    };
+    Error: ApiError<'not_found'> | ApiError<'multiple_webhook_signing_keys'> | ApiError<'rotation_failed'>;
 }>;
 
 export type GetPublicEnvironmentVariables = ApiEndpoint<{


### PR DESCRIPTION
NAN-6550

Nango had no way to rotate the key it signs outgoing webhooks with.

## What this adds

`POST /internal/environments/:environmentId/webhook-signing-key/rotate`

## Cache

The decrypted key was cached per process with no invalidation, so a DB rotation only took effect once every server and jobs process restarted. Entries now expire after a minute, which propagates a rotation on its own.

The tradeoff is one extra DB read per environment per minute on the signing path, and a window of up to a minute where old and new keys are both in use, so the customer has to accept both during that window.

## Notes

Rotation aborts if the environment has more than one active signing key rather than picking one, since reads already pick an arbitrary row and the customer would end up with an unpredictable key.

No audit event: internal routes carry no user or account to attribute one to, and the audit vocabulary has no action for this yet.

Ops only for now, dashboard self serve is a separate ticket.

## Test plan

- [x] Integration tests for auth, unknown environment, rotation, and that the stored row stays encrypted and decryptable
- [ ] Test in dev

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

