### PR TITLE
feat(environment): rotate webhook signing key (NAN-6550)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9222,6 +9222,12 @@ The **Default - Full access** key that comes with each environment already has a
 |-------|-------------|
 | `environment:variables:read` | Read environment variables |
 
+### Webhooks
+
+| Scope | Description |
+|-------|-------------|
+| `environment:webhook_signing_key:rotate` | Rotate the webhook signing key |
+
 ### MCP
 
 | Scope | Description |

--- a/docs/reference/backend/http-api/api-keys.mdx
+++ b/docs/reference/backend/http-api/api-keys.mdx
@@ -224,6 +224,12 @@ The **Default - Full access** key that comes with each environment already has a
 |-------|-------------|
 | `environment:variables:read` | Read environment variables |
 
+### Webhooks
+
+| Scope | Description |
+|-------|-------------|
+| `environment:webhook_signing_key:rotate` | Rotate the webhook signing key |
+
 ### MCP
 
 | Scope | Description |

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2835,6 +2835,8 @@ paths:
                                                 type: string
                                                 description: The new webhook signing key
                                                 example: '5f1c0d2e-6a1b-4f3c-9d8e-7b6a5c4d3e2f'
+                '400':
+                    $ref: '#/components/responses/BadRequest'
                 '401':
                     $ref: '#/components/responses/Unauthorized'
                 '403':

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2810,6 +2810,30 @@ paths:
                                             description: The value of the environment variable
                                             example: 'SK_373892NSHFNCOWFO...'
 
+    /environment/webhook-signing-key/rotate:
+        post:
+            summary: Rotate the webhook signing key
+            description: Replace the key Nango signs its webhooks with. The previous key stops being used within 5 minutes, so verify against both during that window.
+            responses:
+                '200':
+                    description: The new webhook signing key
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                properties:
+                                    data:
+                                        type: object
+                                        required:
+                                            - webhook_signing_key
+                                        properties:
+                                            webhook_signing_key:
+                                                type: string
+                                                description: The new webhook signing key, shown only in this response
+                                                example: '5f1c0d2e-6a1b-4f3c-9d8e-7b6a5c4d3e2f'
+
     /proxy/{anyPath}:
         get:
             summary: Proxy GET request

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2813,7 +2813,9 @@ paths:
     /environment/webhook-signing-key/rotate:
         post:
             summary: Rotate the webhook signing key
-            description: Replace the key Nango signs its webhooks with. The previous key stops being used within 5 minutes, so verify against both during that window.
+            description: |
+                Replace the key Nango signs its webhooks with. The previous key stops being used within 5 minutes,
+                so verify against both during that window. Requires the `environment:webhook_signing_key:rotate` scope.
             responses:
                 '200':
                     description: The new webhook signing key
@@ -2831,8 +2833,22 @@ paths:
                                         properties:
                                             webhook_signing_key:
                                                 type: string
-                                                description: The new webhook signing key, shown only in this response
+                                                description: The new webhook signing key
                                                 example: '5f1c0d2e-6a1b-4f3c-9d8e-7b6a5c4d3e2f'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+                '409':
+                    description: The environment has more than one webhook signing key and cannot be rotated automatically.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/StdError'
+                '500':
+                    $ref: '#/components/responses/ServerError'
 
     /proxy/{anyPath}:
         get:

--- a/packages/audit/lib/event.ts
+++ b/packages/audit/lib/event.ts
@@ -146,6 +146,7 @@ export type AuditResourceAction =
     | { resource: 'environment'; action: 'webhook_urls_changed'; metadata?: EnvironmentWebhookMetadata }
     | { resource: 'environment'; action: 'updated'; metadata?: EnvironmentUpdatedMetadata }
     | { resource: 'environment'; action: 'variables_changed'; metadata?: EnvironmentVariablesChangedMetadata }
+    | { resource: 'environment'; action: 'webhook_signing_key_rotated' }
     | { resource: 'billing'; action: 'trial_extended' | 'details_changed' | 'payment_method_added' }
     | { resource: 'billing'; action: 'plan_changed'; metadata?: BillingPlanChangedMetadata }
     | { resource: 'billing'; action: 'payment_method_removed'; metadata?: BillingPaymentMethodRemovedMetadata }

--- a/packages/server/lib/controllers/environment/postPublicRotateWebhookSigningKey.ts
+++ b/packages/server/lib/controllers/environment/postPublicRotateWebhookSigningKey.ts
@@ -1,0 +1,16 @@
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { handleRotateWebhookSigningKey } from '../shared/environment/rotateWebhookSigningKey.js';
+
+import type { PostPublicRotateWebhookSigningKey } from '@nangohq/types';
+
+export const postPublicRotateWebhookSigningKey = asyncWrapperWithEnvironment<PostPublicRotateWebhookSigningKey>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    await handleRotateWebhookSigningKey({ res, environmentId: res.locals.environment.id });
+});

--- a/packages/server/lib/controllers/shared/environment/rotateWebhookSigningKey.ts
+++ b/packages/server/lib/controllers/shared/environment/rotateWebhookSigningKey.ts
@@ -1,0 +1,35 @@
+import db from '@nangohq/database';
+import { CustomerKeyError, customerKeyService } from '@nangohq/shared';
+import { report } from '@nangohq/utils';
+
+import type { RequestLocalsWithEnvironment } from '../../../utils/express.js';
+import type { PostPublicRotateWebhookSigningKey, PostRotateWebhookSigningKey } from '@nangohq/types';
+import type { Response } from 'express';
+
+export async function handleRotateWebhookSigningKey({
+    res,
+    environmentId
+}: {
+    res: Response<PostRotateWebhookSigningKey['Reply'] | PostPublicRotateWebhookSigningKey['Reply'], RequestLocalsWithEnvironment>;
+    environmentId: number;
+}): Promise<void> {
+    const rotated = await customerKeyService.rotateWebhookSigningKey(db.knex, environmentId);
+    if (rotated.isErr()) {
+        const err = rotated.error;
+        if (err instanceof CustomerKeyError && err.code === 'no_webhook_signing_key') {
+            res.status(404).send({ error: { code: 'not_found', message: 'This environment has no webhook signing key' } });
+            return;
+        }
+        if (err instanceof CustomerKeyError && err.code === 'multiple_webhook_signing_keys') {
+            res.status(409).send({
+                error: { code: 'multiple_webhook_signing_keys', message: 'This environment has more than one webhook signing key, contact support' }
+            });
+            return;
+        }
+        report(err, { environmentId });
+        res.status(500).send({ error: { code: 'rotation_failed', message: 'Failed to rotate the webhook signing key' } });
+        return;
+    }
+
+    res.status(200).send({ data: { webhook_signing_key: rotated.value } });
+}

--- a/packages/server/lib/controllers/v1/environment/postRotateWebhookSigningKey.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/postRotateWebhookSigningKey.integration.test.ts
@@ -105,10 +105,7 @@ describe(`POST ${route}`, () => {
         const otherEnv = await seeders.createEnvironmentSeed(account.id, 'other');
         const session = await authenticateUser(api, user);
 
-        const otherBefore = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, otherEnv.id);
-        if (otherBefore.isErr()) {
-            throw otherBefore.error;
-        }
+        const otherBefore = getEncryptionManager().decryptAPISecret(await signingKeyRow(otherEnv.id)).secret;
 
         const { json } = await api.fetch(route, {
             method: 'POST',
@@ -118,10 +115,7 @@ describe(`POST ${route}`, () => {
         });
         isSuccess(json);
 
-        const otherAfter = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, otherEnv.id);
-        if (otherAfter.isErr()) {
-            throw otherAfter.error;
-        }
-        expect(otherAfter.value).toBe(otherBefore.value);
+        expect(getEncryptionManager().decryptAPISecret(await signingKeyRow(env.id)).secret).toBe(json.data.webhook_signing_key);
+        expect(getEncryptionManager().decryptAPISecret(await signingKeyRow(otherEnv.id)).secret).toBe(otherBefore);
     });
 });

--- a/packages/server/lib/controllers/v1/environment/postRotateWebhookSigningKey.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/postRotateWebhookSigningKey.integration.test.ts
@@ -8,6 +8,16 @@ import { authenticateUser, isSuccess, runServer, shouldBeProtected } from '../..
 const route = '/api/v1/environment/webhook-signing-key/rotate';
 let api: Awaited<ReturnType<typeof runServer>>;
 
+function signingKeyRow(envId: number) {
+    return db
+        .knex('customer_keys')
+        .select('customer_keys.secret', 'customer_keys.iv', 'customer_keys.tag', 'customer_keys.hashed')
+        .join('customer_keys_relations', 'customer_keys_relations.customer_key_id', 'customer_keys.id')
+        .where('customer_keys.key_type', 'webhook_signing')
+        .where('customer_keys_relations.entity_id', envId)
+        .first();
+}
+
 describe(`POST ${route}`, () => {
     beforeAll(async () => {
         api = await runServer();
@@ -49,6 +59,9 @@ describe(`POST ${route}`, () => {
             throw after.error;
         }
         expect(after.value).toBe(json.data.webhook_signing_key);
+
+        // getWebhookSigningKeyForEnv is served from the cache the rotation just filled, so check the row too.
+        expect(getEncryptionManager().decryptAPISecret(await signingKeyRow(env.id)).secret).toBe(json.data.webhook_signing_key);
     });
 
     it('should store the key encrypted and decryptable', async () => {
@@ -63,13 +76,7 @@ describe(`POST ${route}`, () => {
         });
         isSuccess(json);
 
-        const row = await db
-            .knex('customer_keys')
-            .select('customer_keys.secret', 'customer_keys.iv', 'customer_keys.tag', 'customer_keys.hashed')
-            .join('customer_keys_relations', 'customer_keys_relations.customer_key_id', 'customer_keys.id')
-            .where('customer_keys.key_type', 'webhook_signing')
-            .where('customer_keys_relations.entity_id', env.id)
-            .first();
+        const row = await signingKeyRow(env.id);
 
         expect(row.secret).not.toBe(json.data.webhook_signing_key);
         expect(row.iv).not.toBe('');

--- a/packages/server/lib/controllers/v1/environment/postRotateWebhookSigningKey.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/postRotateWebhookSigningKey.integration.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { customerKeyService, getEncryptionManager, seeders } from '@nangohq/shared';
+
+import { authenticateUser, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+const route = '/api/v1/environment/webhook-signing-key/rotate';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe(`POST ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        // @ts-expect-error query params are required
+        const res = await api.fetch(route, { method: 'POST', query: { env: 'dev' } });
+
+        shouldBeProtected(res);
+    });
+
+    it('should rotate the key and serve the new one', async () => {
+        const { env, user } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        const before = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, env.id);
+        if (before.isErr()) {
+            throw before.error;
+        }
+
+        const { res, json } = await api.fetch(route, {
+            method: 'POST',
+            // @ts-expect-error query params are required
+            query: { env: env.name },
+            session
+        });
+
+        isSuccess(json);
+        expect(res.status).toBe(200);
+        expect(json.data.webhook_signing_key).not.toBe(before.value);
+
+        const after = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, env.id);
+        if (after.isErr()) {
+            throw after.error;
+        }
+        expect(after.value).toBe(json.data.webhook_signing_key);
+    });
+
+    it('should store the key encrypted and decryptable', async () => {
+        const { env, user } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        const { json } = await api.fetch(route, {
+            method: 'POST',
+            // @ts-expect-error query params are required
+            query: { env: env.name },
+            session
+        });
+        isSuccess(json);
+
+        const row = await db
+            .knex('customer_keys')
+            .select('customer_keys.secret', 'customer_keys.iv', 'customer_keys.tag', 'customer_keys.hashed')
+            .join('customer_keys_relations', 'customer_keys_relations.customer_key_id', 'customer_keys.id')
+            .where('customer_keys.key_type', 'webhook_signing')
+            .where('customer_keys_relations.entity_id', env.id)
+            .first();
+
+        expect(row.secret).not.toBe(json.data.webhook_signing_key);
+        expect(row.iv).not.toBe('');
+        expect(row.tag).not.toBe('');
+        expect(row.hashed).not.toBe('');
+        expect(getEncryptionManager().decryptAPISecret(row).secret).toBe(json.data.webhook_signing_key);
+    });
+
+    it('should rotate through the public api with a secret key', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const before = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, env.id);
+        if (before.isErr()) {
+            throw before.error;
+        }
+
+        const { res, json } = await api.fetch('/environment/webhook-signing-key/rotate', { method: 'POST', token: apiKey.secret });
+
+        isSuccess(json);
+        expect(res.status).toBe(200);
+        expect(json.data.webhook_signing_key).not.toBe(before.value);
+    });
+
+    it('should rotate only the requested environment', async () => {
+        const { env, account, user } = await seeders.seedAccountEnvAndUser();
+        const otherEnv = await seeders.createEnvironmentSeed(account.id, 'other');
+        const session = await authenticateUser(api, user);
+
+        const otherBefore = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, otherEnv.id);
+        if (otherBefore.isErr()) {
+            throw otherBefore.error;
+        }
+
+        const { json } = await api.fetch(route, {
+            method: 'POST',
+            // @ts-expect-error query params are required
+            query: { env: env.name },
+            session
+        });
+        isSuccess(json);
+
+        const otherAfter = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, otherEnv.id);
+        if (otherAfter.isErr()) {
+            throw otherAfter.error;
+        }
+        expect(otherAfter.value).toBe(otherBefore.value);
+    });
+});

--- a/packages/server/lib/controllers/v1/environment/postRotateWebhookSigningKey.ts
+++ b/packages/server/lib/controllers/v1/environment/postRotateWebhookSigningKey.ts
@@ -1,0 +1,16 @@
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
+import { handleRotateWebhookSigningKey } from '../../shared/environment/rotateWebhookSigningKey.js';
+
+import type { PostRotateWebhookSigningKey } from '@nangohq/types';
+
+export const postRotateWebhookSigningKey = asyncWrapperWithEnvironment<PostRotateWebhookSigningKey>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    await handleRotateWebhookSigningKey({ res, environmentId: res.locals.environment.id });
+});

--- a/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
@@ -403,6 +403,20 @@ describe('Scope enforcement on public API routes', () => {
         });
     });
 
+    describe('POST /environment/webhook-signing-key/rotate', () => {
+        it('should allow with webhook_signing_key:rotate scope', async () => {
+            const token = await createKeyWithScopes(['environment:webhook_signing_key:rotate']);
+            const res = await api.fetch('/environment/webhook-signing-key/rotate' as any, { method: 'POST', token } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without webhook_signing_key:rotate scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/environment/webhook-signing-key/rotate' as any, { method: 'POST', token } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
     describe('GET /scripts/config', () => {
         it('should allow with integrations:list_functions scope', async () => {
             const token = await createKeyWithScopes(['environment:integrations:list_functions']);

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -62,8 +62,10 @@ import type {
     PostPublicConnection,
     PostPublicIntegration,
     PostPublicQuickstartIntegration,
+    PostPublicRotateWebhookSigningKey,
     PostPublicSyncPause,
     PostPublicSyncStart,
+    PostRotateWebhookSigningKey,
     PostStripeCollectPayment,
     PostSyncVariant,
     PutBillingInvoicingDetails,
@@ -592,6 +594,14 @@ export const auditEnvironmentVariablesChanged = auditable<PostEnvironmentVariabl
             .filter((n): n is string => typeof n === 'string');
         return omitUndefined({ variableCount: variables.length, variableNames: variableNames.length > 0 ? variableNames : undefined });
     }
+});
+export const auditWebhookSigningKeyRotated = auditable<PostRotateWebhookSigningKey>({
+    policy: Audit.auditable({ resource: 'environment', action: 'webhook_signing_key_rotated', scope: 'environment' }),
+    target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name)
+});
+export const auditPublicWebhookSigningKeyRotated = auditable<PostPublicRotateWebhookSigningKey>({
+    policy: Audit.auditable({ resource: 'environment', action: 'webhook_signing_key_rotated', scope: 'environment' }),
+    target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name)
 });
 export const auditEnvironmentWebhookUrlsChanged = auditable<PatchWebhook>({
     policy: Audit.auditable({ resource: 'environment', action: 'webhook_urls_changed', scope: 'environment' }),

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -67,6 +67,7 @@ import { listApiKeys } from './controllers/v1/environment/listApiKeys.js';
 import { patchApiKey } from './controllers/v1/environment/patchApiKey.js';
 import { patchEnvironment } from './controllers/v1/environment/patchEnvironment.js';
 import { postEnvironment } from './controllers/v1/environment/postEnvironment.js';
+import { postRotateWebhookSigningKey } from './controllers/v1/environment/postRotateWebhookSigningKey.js';
 import { postEnvironmentVariables } from './controllers/v1/environment/variables/postVariables.js';
 import { patchWebhook } from './controllers/v1/environment/webhook/patchWebhook.js';
 import { getFlowDownload } from './controllers/v1/flow/getDownload.js';
@@ -167,7 +168,8 @@ import {
     auditSyncEnabled,
     auditSyncFrequencyChanged,
     auditTeamUpdated,
-    auditUserUpdated
+    auditUserUpdated,
+    auditWebhookSigningKeyRotated
 } from './middleware/audit.middleware.js';
 import {
     auditAuthLogin,
@@ -322,6 +324,13 @@ web.route('/environment/api-keys/:keyId').delete(
     auditApiKeyDeleted,
     can({ action: 'update', resource: 'environment_key', scopedBy: envScope }),
     deleteApiKey
+);
+
+web.route('/environment/webhook-signing-key/rotate').post(
+    webAuth,
+    auditWebhookSigningKeyRotated,
+    can({ action: 'update', resource: 'environment_key', scopedBy: envScope }),
+    postRotateWebhookSigningKey
 );
 
 web.route('/environment/hmac').get(webAuth, environmentController.getHmacDigest.bind(environmentController));

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -36,6 +36,7 @@ import { patchPublicConnection } from './controllers/connection/connectionId/pat
 import { getPublicConnections } from './controllers/connection/getConnections.js';
 import { postPublicConnection } from './controllers/connection/postConnection.js';
 import { getPublicEnvironmentVariables } from './controllers/environment/getVariables.js';
+import { postPublicRotateWebhookSigningKey } from './controllers/environment/postPublicRotateWebhookSigningKey.js';
 import { postFunctionCompile } from './controllers/functions/compile/postCompile.js';
 import { postFunctionDeploymentBundle } from './controllers/functions/deployments/bundle/postBundle.js';
 import { postFunctionDeploymentBundlePreview } from './controllers/functions/deployments/bundle/postPreview.js';
@@ -93,6 +94,7 @@ import {
     auditPublicIntegrationUpdated,
     auditPublicQuickstartIntegrationCreated,
     auditPublicSyncFrequencyChanged,
+    auditPublicWebhookSigningKeyRotated,
     auditSyncPaused,
     auditSyncStarted,
     auditSyncVariantCreated,
@@ -300,6 +302,11 @@ publicAPI
 // Config
 publicAPI.use('/environment-variables', jsonContentTypeMiddleware);
 publicAPI.route('/environment-variables').get(apiAuth, withScope('environment:variables:read'), getPublicEnvironmentVariables);
+
+publicAPI.use('/environment', jsonContentTypeMiddleware);
+publicAPI
+    .route('/environment/webhook-signing-key/rotate')
+    .post(apiAuth, auditPublicWebhookSigningKeyRotated, withScope('environment:webhook_signing_key:rotate'), postPublicRotateWebhookSigningKey);
 
 // Deploy
 publicAPI.use('/sync', jsonContentTypeMiddleware);

--- a/packages/shared/lib/services/customerKey.rotation.integration.test.ts
+++ b/packages/shared/lib/services/customerKey.rotation.integration.test.ts
@@ -1,0 +1,72 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import db, { multipleMigrations } from '@nangohq/database';
+
+import { seedAccountEnvAndUser } from '../seeders/global.seeder.js';
+import { getEncryptionManager } from '../utils/encryption.manager.js';
+import customerKeyService from './customerKey.service.js';
+
+async function storedKey(envId: number): Promise<string> {
+    const row = await db
+        .knex('customer_keys')
+        .select('customer_keys.secret', 'customer_keys.iv', 'customer_keys.tag')
+        .join('customer_keys_relations', 'customer_keys_relations.customer_key_id', 'customer_keys.id')
+        .where('customer_keys.key_type', 'webhook_signing')
+        .where('customer_keys_relations.entity_id', envId)
+        .first();
+    return getEncryptionManager().decryptAPISecret(row).secret;
+}
+
+describe('rotateWebhookSigningKey cache', () => {
+    beforeAll(async () => {
+        await multipleMigrations();
+    });
+
+    it('serves the last committed key when rotations overlap', async () => {
+        const { env } = await seedAccountEnvAndUser();
+
+        const [first, second] = await Promise.all([
+            customerKeyService.rotateWebhookSigningKey(db.knex, env.id),
+            customerKeyService.rotateWebhookSigningKey(db.knex, env.id)
+        ]);
+        if (first.isErr()) {
+            throw first.error;
+        }
+        if (second.isErr()) {
+            throw second.error;
+        }
+
+        expect(first.value).not.toBe(second.value);
+        const stored = await storedKey(env.id);
+        expect([first.value, second.value]).toContain(stored);
+
+        const served = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, env.id);
+        if (served.isErr()) {
+            throw served.error;
+        }
+        expect(served.value).toBe(stored);
+    });
+
+    it('does not let a read that started before a rotation repopulate the old key', async () => {
+        const { env } = await seedAccountEnvAndUser();
+
+        const before = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, env.id);
+        if (before.isErr()) {
+            throw before.error;
+        }
+
+        const inFlight = customerKeyService.getWebhookSigningKeyForEnv(db.knex, env.id);
+        const rotated = await customerKeyService.rotateWebhookSigningKey(db.knex, env.id);
+        if (rotated.isErr()) {
+            throw rotated.error;
+        }
+        await inFlight;
+
+        const served = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, env.id);
+        if (served.isErr()) {
+            throw served.error;
+        }
+        expect(served.value).toBe(rotated.value);
+        expect(served.value).not.toBe(before.value);
+    });
+});

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -12,14 +12,16 @@ import type { Knex } from 'knex';
 
 const CUSTOMER_KEYS_TABLE = 'customer_keys';
 const CUSTOMER_KEYS_RELATIONS_TABLE = 'customer_keys_relations';
-// Cache decrypted webhook signing key per environment. No eviction needed since rotation is not supported yet.
-const webhookSigningKeyCache = new Map<number, string>();
+// Cache decrypted webhook signing key per environment. Entries expire so a rotation propagates to every
+// process on its own, without a cross-process invalidation channel.
+const webhookSigningKeyCache = new Map<number, { key: string; expiresAt: number }>();
+const WEBHOOK_SIGNING_KEY_CACHE_TTL_MS = 300_000;
 // Internal safety limits — not product constraints, just protection against unbounded key creation.
 // Can be raised without migration if needed.
 export const MAX_API_KEYS_PER_ENV = 50;
 export const MAX_API_KEYS_PER_ACCOUNT = 50;
 
-export type CustomerKeyErrorCode = 'duplicate_api_key' | 'resource_capped' | 'no_such_api_secret';
+export type CustomerKeyErrorCode = 'duplicate_api_key' | 'resource_capped' | 'no_such_api_secret' | 'no_webhook_signing_key' | 'multiple_webhook_signing_keys';
 
 export class CustomerKeyError extends Error {
     constructor(
@@ -318,29 +320,85 @@ class CustomerKeyService {
         }
     }
 
+    private webhookSigningKeyForEnv(trx: Knex, envId: number) {
+        return trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+            .select(`${CUSTOMER_KEYS_TABLE}.*`)
+            .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
+            .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'webhook_signing')
+            .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
+            .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
+            .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`);
+    }
+
     public async getWebhookSigningKeyForEnv(trx: Knex, envId: number): Promise<Result<string>> {
         const cached = webhookSigningKeyCache.get(envId);
-        if (cached) {
-            return Ok(cached);
+        if (cached && cached.expiresAt > Date.now()) {
+            return Ok(cached.key);
         }
 
         try {
-            const row = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
-                .select(`${CUSTOMER_KEYS_TABLE}.*`)
-                .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
-                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'webhook_signing')
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
-                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
-                .first();
+            const row = await this.webhookSigningKeyForEnv(trx, envId).first();
 
             if (!row) {
                 throw new NangoError('no_webhook_signing_key', { environment_id: envId });
             }
 
             const decrypted = getEncryptionManager().decryptAPISecret(row as Parameters<EncryptionManager['decryptAPISecret']>[0]) as DBCustomerKey;
-            webhookSigningKeyCache.set(envId, decrypted.secret);
+            webhookSigningKeyCache.set(envId, { key: decrypted.secret, expiresAt: Date.now() + WEBHOOK_SIGNING_KEY_CACHE_TTL_MS });
             return Ok(decrypted.secret);
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    /**
+     * Replaces the environment's webhook signing key with a fresh one and returns it in plain text.
+     * Callers in other processes keep signing with the previous key until their cache entry expires.
+     */
+    public async rotateWebhookSigningKey(trx: Knex, envId: number): Promise<Result<string>> {
+        try {
+            const plainText = uuid.v4();
+
+            const hashed = await this.hashSecret(plainText);
+            if (hashed.isErr()) {
+                throw hashed.error;
+            }
+
+            const encrypted = getEncryptionManager().encryptAPISecret({ secret: plainText, iv: '', tag: '' } as Parameters<
+                EncryptionManager['encryptAPISecret']
+            >[0]);
+
+            // The row lock only holds for the length of a transaction, so the guard below and the update
+            // have to share one, otherwise two concurrent rotations both pass it and one key is lost.
+            await trx.transaction(async (innerTrx) => {
+                const existing = await this.webhookSigningKeyForEnv(innerTrx, envId).forUpdate(CUSTOMER_KEYS_TABLE);
+                const current = existing[0];
+                if (!current) {
+                    throw new CustomerKeyError('no_webhook_signing_key', { environmentId: envId });
+                }
+                // An environment has exactly one signing key. More than one means reads already pick an
+                // arbitrary row, so rotating would leave the customer with an unpredictable key.
+                if (existing.length > 1) {
+                    throw new CustomerKeyError('multiple_webhook_signing_keys', { environmentId: envId });
+                }
+
+                const updated = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE).where({ id: current.id }).update({
+                    secret: encrypted.secret,
+                    iv: encrypted.iv,
+                    tag: encrypted.tag,
+                    hashed: hashed.value,
+                    updated_at: new Date()
+                });
+
+                // Never report success on a key we did not persist: the caller would hand it to a customer
+                // and we would keep signing with the old one.
+                if (updated !== 1) {
+                    throw new CustomerKeyError('no_webhook_signing_key', { environmentId: envId });
+                }
+            });
+
+            webhookSigningKeyCache.set(envId, { key: plainText, expiresAt: Date.now() + WEBHOOK_SIGNING_KEY_CACHE_TTL_MS });
+            return Ok(plainText);
         } catch (err) {
             return Err(err);
         }

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -12,7 +12,7 @@ import type { Knex } from 'knex';
 
 const CUSTOMER_KEYS_TABLE = 'customer_keys';
 const CUSTOMER_KEYS_RELATIONS_TABLE = 'customer_keys_relations';
-const webhookSigningKeyCache = new Map<number, { key: string; expiresAt: number }>();
+const webhookSigningKeyCache = new Map<number, { key: string; committedAt: number; expiresAt: number }>();
 const WEBHOOK_SIGNING_KEY_CACHE_TTL_MS = 300_000;
 // Internal safety limits — not product constraints, just protection against unbounded key creation.
 // Can be raised without migration if needed.
@@ -328,6 +328,17 @@ class CustomerKeyService {
             .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`);
     }
 
+    private cacheWebhookSigningKey(envId: number, key: string, updatedAt: Date): string {
+        const existing = webhookSigningKeyCache.get(envId);
+        const committedAt = updatedAt.getTime();
+        if (existing && existing.expiresAt > Date.now() && existing.committedAt > committedAt) {
+            return existing.key;
+        }
+
+        webhookSigningKeyCache.set(envId, { key, committedAt, expiresAt: Date.now() + WEBHOOK_SIGNING_KEY_CACHE_TTL_MS });
+        return key;
+    }
+
     public async getWebhookSigningKeyForEnv(trx: Knex, envId: number): Promise<Result<string>> {
         const cached = webhookSigningKeyCache.get(envId);
         if (cached && cached.expiresAt > Date.now()) {
@@ -342,14 +353,7 @@ class CustomerKeyService {
             }
 
             const decrypted = getEncryptionManager().decryptAPISecret(row as Parameters<EncryptionManager['decryptAPISecret']>[0]) as DBCustomerKey;
-            // A rotation can land while this read is in flight, so prefer a fresher entry over what we read.
-            const cachedSinceRead = webhookSigningKeyCache.get(envId);
-            if (cachedSinceRead && cachedSinceRead.expiresAt > Date.now()) {
-                return Ok(cachedSinceRead.key);
-            }
-
-            webhookSigningKeyCache.set(envId, { key: decrypted.secret, expiresAt: Date.now() + WEBHOOK_SIGNING_KEY_CACHE_TTL_MS });
-            return Ok(decrypted.secret);
+            return Ok(this.cacheWebhookSigningKey(envId, decrypted.secret, row.updated_at));
         } catch (err) {
             return Err(err);
         }
@@ -372,7 +376,7 @@ class CustomerKeyService {
                 EncryptionManager['encryptAPISecret']
             >[0]);
 
-            await trx.transaction(async (innerTrx) => {
+            const committedAt = await trx.transaction(async (innerTrx) => {
                 const existing = await this.webhookSigningKeyForEnv(innerTrx, envId).forUpdate(CUSTOMER_KEYS_TABLE);
                 const current = existing[0];
                 if (!current) {
@@ -382,20 +386,25 @@ class CustomerKeyService {
                     throw new CustomerKeyError('multiple_webhook_signing_keys', { environmentId: envId });
                 }
 
-                const updated = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE).where({ id: current.id }).update({
-                    secret: encrypted.secret,
-                    iv: encrypted.iv,
-                    tag: encrypted.tag,
-                    hashed: hashed.value,
-                    updated_at: new Date()
-                });
+                const updated = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                    .where({ id: current.id })
+                    .update({
+                        secret: encrypted.secret,
+                        iv: encrypted.iv,
+                        tag: encrypted.tag,
+                        hashed: hashed.value,
+                        updated_at: innerTrx.raw('clock_timestamp()') as unknown as Date
+                    })
+                    .returning('updated_at');
 
-                if (updated !== 1) {
+                const row = updated[0];
+                if (updated.length !== 1 || !row) {
                     throw new CustomerKeyError('no_webhook_signing_key', { environmentId: envId });
                 }
+                return row.updated_at;
             });
 
-            webhookSigningKeyCache.set(envId, { key: plainText, expiresAt: Date.now() + WEBHOOK_SIGNING_KEY_CACHE_TTL_MS });
+            this.cacheWebhookSigningKey(envId, plainText, committedAt);
             return Ok(plainText);
         } catch (err) {
             return Err(err);

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -12,8 +12,6 @@ import type { Knex } from 'knex';
 
 const CUSTOMER_KEYS_TABLE = 'customer_keys';
 const CUSTOMER_KEYS_RELATIONS_TABLE = 'customer_keys_relations';
-// Cache decrypted webhook signing key per environment. Entries expire so a rotation propagates to every
-// process on its own, without a cross-process invalidation channel.
 const webhookSigningKeyCache = new Map<number, { key: string; expiresAt: number }>();
 const WEBHOOK_SIGNING_KEY_CACHE_TTL_MS = 300_000;
 // Internal safety limits — not product constraints, just protection against unbounded key creation.
@@ -368,16 +366,12 @@ class CustomerKeyService {
                 EncryptionManager['encryptAPISecret']
             >[0]);
 
-            // The row lock only holds for the length of a transaction, so the guard below and the update
-            // have to share one, otherwise two concurrent rotations both pass it and one key is lost.
             await trx.transaction(async (innerTrx) => {
                 const existing = await this.webhookSigningKeyForEnv(innerTrx, envId).forUpdate(CUSTOMER_KEYS_TABLE);
                 const current = existing[0];
                 if (!current) {
                     throw new CustomerKeyError('no_webhook_signing_key', { environmentId: envId });
                 }
-                // An environment has exactly one signing key. More than one means reads already pick an
-                // arbitrary row, so rotating would leave the customer with an unpredictable key.
                 if (existing.length > 1) {
                     throw new CustomerKeyError('multiple_webhook_signing_keys', { environmentId: envId });
                 }
@@ -390,8 +384,6 @@ class CustomerKeyService {
                     updated_at: new Date()
                 });
 
-                // Never report success on a key we did not persist: the caller would hand it to a customer
-                // and we would keep signing with the old one.
                 if (updated !== 1) {
                     throw new CustomerKeyError('no_webhook_signing_key', { environmentId: envId });
                 }

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -342,6 +342,12 @@ class CustomerKeyService {
             }
 
             const decrypted = getEncryptionManager().decryptAPISecret(row as Parameters<EncryptionManager['decryptAPISecret']>[0]) as DBCustomerKey;
+            // A rotation can land while this read is in flight, so prefer a fresher entry over what we read.
+            const cachedSinceRead = webhookSigningKeyCache.get(envId);
+            if (cachedSinceRead && cachedSinceRead.expiresAt > Date.now()) {
+                return Ok(cachedSinceRead.key);
+            }
+
             webhookSigningKeyCache.set(envId, { key: decrypted.secret, expiresAt: Date.now() + WEBHOOK_SIGNING_KEY_CACHE_TTL_MS });
             return Ok(decrypted.secret);
         } catch (err) {

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -50,6 +50,8 @@ export const API_KEY_SCOPES = [
     'environment:proxy',
     // Variables
     'environment:variables:read',
+    // Webhooks
+    'environment:webhook_signing_key:rotate',
     // MCP
     'environment:mcp'
 ] as const;

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -68,7 +68,9 @@ import type {
     ListApiKeys,
     PatchApiKey,
     PatchEnvironment,
-    PostEnvironment
+    PostEnvironment,
+    PostPublicRotateWebhookSigningKey,
+    PostRotateWebhookSigningKey
 } from './environment/api/index.js';
 import type { PatchWebhook } from './environment/api/webhook.js';
 import type { PostEnvironmentVariables } from './environment/variable/api.js';
@@ -193,6 +195,7 @@ export type PublicApiEndpoints =
     | GetPublicIntegrationFunction
     | DeletePublicIntegrationFunction
     | GetPublicProviderTemplates
+    | PostPublicRotateWebhookSigningKey
     | AllPublicProxy;
 
 export type PrivateApiEndpoints =
@@ -265,6 +268,7 @@ export type PrivateApiEndpoints =
     | DeleteEnvironment
     | GetEnvironments
     | GetEnvironment
+    | PostRotateWebhookSigningKey
     | ListApiKeys
     | CreateApiKey
     | DeleteApiKey

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -14,7 +14,7 @@ interface AuditEventTable {
     member: 'invited' | 'invite_accepted' | 'invite_declined' | 'invite_revoked' | 'role_changed' | 'removed';
     team: 'updated';
     user: 'updated';
-    environment: 'created' | 'updated' | 'variables_changed' | 'webhook_urls_changed' | 'deleted';
+    environment: 'created' | 'updated' | 'variables_changed' | 'webhook_urls_changed' | 'webhook_signing_key_rotated' | 'deleted';
     app_auth: 'login' | 'logout' | 'signup' | 'password_changed' | 'password_reset';
     mfa: 'enrolled' | 'enabled' | 'disabled' | 'verified' | 'recovery_regenerated';
     billing: 'plan_changed' | 'trial_extended' | 'details_changed' | 'payment_method_added' | 'payment_method_removed';

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -77,6 +77,26 @@ export type DeleteEnvironment = ApiEndpoint<{
     Error: ApiError<'cannot_delete_prod_environment'>;
 }>;
 
+export type PostRotateWebhookSigningKey = ApiEndpoint<{
+    Audit: AuditPolicy<'environment', 'webhook_signing_key_rotated', 'environment'>;
+    Method: 'POST';
+    Path: '/api/v1/environment/webhook-signing-key/rotate';
+    Success: {
+        data: { webhook_signing_key: string };
+    };
+    Error: ApiError<'not_found'> | ApiError<'multiple_webhook_signing_keys'> | ApiError<'rotation_failed'>;
+}>;
+
+export type PostPublicRotateWebhookSigningKey = ApiEndpoint<{
+    Audit: AuditPolicy<'environment', 'webhook_signing_key_rotated', 'environment'>;
+    Method: 'POST';
+    Path: '/environment/webhook-signing-key/rotate';
+    Success: {
+        data: { webhook_signing_key: string };
+    };
+    Error: ApiError<'not_found'> | ApiError<'multiple_webhook_signing_keys'> | ApiError<'rotation_failed'>;
+}>;
+
 export type GetPublicEnvironmentVariables = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';

--- a/packages/utils/lib/api-key-scopes.ts
+++ b/packages/utils/lib/api-key-scopes.ts
@@ -52,6 +52,8 @@ export const apiKeyScopes = [
     'environment:proxy',
     // Variables
     'environment:variables:read',
+    // Webhooks
+    'environment:webhook_signing_key:rotate',
     // MCP
     'environment:mcp'
 ] as const satisfies readonly ApiKeyScope[];

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -16,7 +16,7 @@ const actionsByResource = {
     member: ['invited', 'invite_accepted', 'invite_declined', 'invite_revoked', 'role_changed', 'removed'],
     team: ['updated'],
     user: ['updated'],
-    environment: ['created', 'updated', 'variables_changed', 'webhook_urls_changed', 'deleted'],
+    environment: ['created', 'updated', 'variables_changed', 'webhook_urls_changed', 'webhook_signing_key_rotated', 'deleted'],
     app_auth: ['login', 'logout', 'signup', 'password_changed', 'password_reset'],
     mfa: ['enrolled', 'enabled', 'disabled', 'verified', 'recovery_regenerated'],
     billing: ['plan_changed', 'trial_extended', 'details_changed', 'payment_method_added', 'payment_method_removed']


### PR DESCRIPTION
NAN-6550

Nango had no way to rotate the key it signs outgoing webhooks with.

## What this adds

The same rotation on both APIs, sharing one handler:

| | |
|---|---|
| `POST /api/v1/environment/webhook-signing-key/rotate` | dashboard session, `environment_key` update permission |
| `POST /environment/webhook-signing-key/rotate` | secret key with the new `environment:webhook_signing_key:rotate` scope |

```bash
curl -X POST -H "Authorization: Bearer $NANGO_SECRET_KEY" \
  https://api.nango.dev/environment/webhook-signing-key/rotate
```

Returns the new key once. It also stays readable in the dashboard, already exposed as `webhook_signing_key` on the environment endpoint.

Both record an `environment.webhook_signing_key_rotated` audit event.

## Cache

The decrypted key was cached per process with no invalidation, so a DB rotation only took effect once every server and jobs process restarted. Entries now expire after 5 minutes, which propagates a rotation on its own. Pubsub was not an option, delivery is competing consumer per group and the server does not subscribe at all.

The tradeoff is one extra DB read per environment per 5 minutes on the signing path, and a window of up to 5 minutes where old and new keys are both in use, so the customer has to accept both during that window. The OpenAPI description says so.

## Test plan

- [x] Integration tests: session auth, public secret key, rotation, cross environment isolation, and that the stored row is encrypted and decrypts to the returned key
- [x] Scope enforcement test for the public route, allowed with the scope and 403 without
- [ ] Rotate on staging and confirm a delivered webhook verifies against the new key within 5 minutes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

