### PR TITLE
fix(design-system): sync danger-family tokens from design/tokens

### DIFF
--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -29,7 +29,7 @@ const inputGroupVariants = cva(
         'has-[[data-slot=input-group-control]:disabled]:border-border-input has-[[data-slot=input-group-control]:disabled]:bg-state-selected-muted',
 
         // Error state.
-        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!border-[var(--focus-ring-danger)] has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]'
+        'has-[[data-slot][aria-invalid=true]]:!border-border-input-danger has-[[data-slot][aria-invalid=true]:hover]:!border-border-input-danger-hover has-[[data-slot][aria-invalid=true]:focus-visible]:!border-[var(--focus-ring-danger)] has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]'
     ],
     {
         variants: {

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -18,7 +18,7 @@ export const inputVariants = cva(
         'hover:border-border-input-hover',
         'focus:border-[var(--focus-ring-default)] focus:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]',
         // Invalid
-        'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]',
+        'aria-invalid:border-border-input-danger aria-invalid:hover:border-border-input-danger-hover aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]',
         // Disabled — keep the interactive border (Figma), only the bg + text switch to the disabled tokens; no opacity
         'disabled:cursor-not-allowed disabled:border-border-input disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
         // File-input affordance

--- a/packages/design-system/src/components/ui/textarea.tsx
+++ b/packages/design-system/src/components/ui/textarea.tsx
@@ -21,7 +21,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
                 'hover:border-border-input-hover',
                 'focus:border-[var(--focus-ring-default)] focus:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]',
                 // Invalid
-                'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]',
+                'aria-invalid:border-border-input-danger aria-invalid:hover:border-border-input-danger-hover aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]',
                 // Disabled — keep the interactive border, only the bg + text switch to the disabled tokens; no opacity
                 'disabled:cursor-not-allowed disabled:border-border-input disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
                 className

--- a/packages/design-system/tokens/tokens.generated.css
+++ b/packages/design-system/tokens/tokens.generated.css
@@ -302,7 +302,8 @@
     --border-input-hover: #505155;
     --border-selected: #009cc8;
     --border-danger: #ee4242;
-    --border-danger-hover: #eb2d2d;
+    --border-input-danger: #ee4242;
+    --border-input-danger-hover: #f27474;
     --border-disabled: #c4c4c8;
     --border-inverse: #ffffff33;
     --interactive-primary: #007ca0;
@@ -428,7 +429,8 @@
     --border-input-hover: #ffffffa3;
     --border-selected: #00b2e3;
     --border-danger: #eb2d2d;
-    --border-danger-hover: #f27474;
+    --border-input-danger: #ee4242;
+    --border-input-danger-hover: #f27474;
     --border-disabled: #ffffff1f;
     --border-inverse: #00000033;
     --interactive-primary: #007ca0;
@@ -558,7 +560,8 @@
     --color-border-input-hover: var(--border-input-hover);
     --color-border-selected: var(--border-selected);
     --color-border-danger: var(--border-danger);
-    --color-border-danger-hover: var(--border-danger-hover);
+    --color-border-input-danger: var(--border-input-danger);
+    --color-border-input-danger-hover: var(--border-input-danger-hover);
     --color-border-disabled: var(--border-disabled);
     --color-border-inverse: var(--border-inverse);
     --color-interactive-primary: var(--interactive-primary);

--- a/packages/design-system/tokens/tokens.generated.css
+++ b/packages/design-system/tokens/tokens.generated.css
@@ -289,7 +289,7 @@
     --text-link: #0089b0;
     --text-link-hover: #02485d;
     --text-link-active: #013747;
-    --text-danger: #e81818;
+    --text-danger: #ee4242;
     --text-success: #1a6b2c;
     --text-warning: #7a5e0a;
     --border-muted: #0000001a;
@@ -301,7 +301,7 @@
     --border-input: #8b8c8f;
     --border-input-hover: #505155;
     --border-selected: #009cc8;
-    --border-danger: #f27474;
+    --border-danger: #ee4242;
     --border-danger-hover: #eb2d2d;
     --border-disabled: #c4c4c8;
     --border-inverse: #ffffff33;
@@ -477,7 +477,7 @@
     --status-warning-bg-hover: #5c4a0b;
     --status-warning-border-hover: #f7c752;
     --status-danger-bg: #3f0a0a;
-    --status-danger-border: #a11313;
+    --status-danger-border: #ee4242;
     --status-danger-icon: #f27474;
     --status-danger-text: #f27474;
     --status-danger-strong: #f7a6a6;

--- a/packages/design-system/tokens/tokens.generated.css
+++ b/packages/design-system/tokens/tokens.generated.css
@@ -289,7 +289,7 @@
     --text-link: #0089b0;
     --text-link-hover: #02485d;
     --text-link-active: #013747;
-    --text-danger: #a11313;
+    --text-danger: #e81818;
     --text-success: #1a6b2c;
     --text-warning: #7a5e0a;
     --border-muted: #0000001a;
@@ -354,7 +354,7 @@
     --status-danger-border: #fac9c9;
     --status-danger-icon: #e81818;
     --status-danger-text: #e81818;
-    --status-danger-strong: #5a0f0f;
+    --status-danger-strong: #e81818;
     --status-danger-bg-hover: #fac9c9;
     --status-danger-border-hover: #f7a6a6;
     --focus-ring-default: #0089b0;
@@ -477,7 +477,7 @@
     --status-warning-bg-hover: #5c4a0b;
     --status-warning-border-hover: #f7c752;
     --status-danger-bg: #3f0a0a;
-    --status-danger-border: #e81818;
+    --status-danger-border: #a11313;
     --status-danger-icon: #f27474;
     --status-danger-text: #f27474;
     --status-danger-strong: #f7a6a6;

--- a/packages/design-system/tokens/tokens.json
+++ b/packages/design-system/tokens/tokens.json
@@ -613,8 +613,8 @@
                 "bg": { "$type": "color", "$value": "{color.danger.950}" },
                 "border": {
                     "$type": "color",
-                    "$value": "{color.danger.800}",
-                    "$description": "TONED DOWN (2026-07-22): started at .700 (#E81818, the ramp's most saturated stop — reported as too strong). Tried .750 (#D31616, 3.09:1 against fill) as a compliant middle ground, still reported as too strong. .750 turned out to be close to the practical floor for staying ≥3:1 against either the alert's own fill (danger.950) or the true page background — .800 (#A11313) clears neither (2.08:1 vs fill, 2.33–2.62:1 vs page/panel/canvas). Moved to .800 anyway: this border is decorative reinforcement, not the sole means of conveying status — the tinted fill, icon, and colored title/text already carry that redundantly, so strict 1.4.11 non-text-contrast enforcement on the border itself is a defensible relaxation here. Flagged as a known accessibility trade-off, not an oversight."
+                    "$value": "{color.danger.500}",
+                    "$description": "CHANGED (2026-08-12): was danger.800, set per design request in an earlier sync. Design has since moved dark specifically to danger.500 — vs status.danger.bg (danger.950): 4.36:1, still well clear of the 3:1 non-text minimum. Light's status.danger.border is a separate, unrelated value not touched by this sync — the two modes are intentionally independent here."
                 },
                 "icon": { "$type": "color", "$value": "{color.danger.400}" },
                 "text": { "$type": "color", "$value": "{color.danger.400}" },
@@ -736,8 +736,8 @@
             "linkActive": { "$type": "color", "$value": "{color.info.950}" },
             "danger": {
                 "$type": "color",
-                "$value": "{color.danger.700}",
-                "$description": "MOVED (2026-07-22): was danger.800. Alert Title reads from this token (not status.danger.strong), so it needed to match status.danger.icon (.700) to stop the icon/title mismatch in light mode. Caveat: .700 on surface.page/panel = ~4.0:1, under the 4.5:1 AA threshold for regular body text. Fine for bold headings (Alert Title) which only need 3:1 as large text — but if text.danger is used elsewhere for smaller regular-weight text (e.g. inline form error messages), that usage may now fail AA and should be checked."
+                "$value": "{border.danger}",
+                "$description": "SWAPPED (2026-08-12): was danger.700 (4.59:1 on surface.input). Now aliased to border.danger (danger.500) per design request, so Input error label/description and the error stroke render as the exact same red. KNOWN AA MISS: danger.500 on surface.input/white = 3.83:1, under the 4.5:1 AA minimum for regular-weight text — accepted deliberately, not an oversight. SIDE EFFECT: Alert Title also reads from this token — it now diverges from status.danger.icon (.700), reopening the icon/title mismatch the 2026-07-22 move to .700 was meant to fix. Re-check Alert Title/icon pairing if that still matters."
             },
             "success": { "$type": "color", "$value": "{color.success.800}" },
             "warning": { "$type": "color", "$value": "{color.warning.800}" }
@@ -765,7 +765,11 @@
                 "$description": "A11Y/VISIBILITY FIX (2026-08-12): was neutral.600 — only 1.79x the resting border's contrast against surface.input (3.36:1 → 6.01:1), reported as not enough visual separation between default and hover. Moved one stop further to .650 (7.93:1 on surface.input, 2.36x the default) for a hover state that reads as a clear, deliberate darken instead of a near-imperceptible shift. See border.input for the resting value."
             },
             "selected": { "$type": "color", "$value": "{color.info.600}" },
-            "danger": { "$type": "color", "$value": "{color.danger.400}" },
+            "danger": {
+                "$type": "color",
+                "$value": "{color.danger.500}",
+                "$description": "FIX (2026-08-12): was {color.danger.400} (#F27474) — 2.79:1 against surface.input (#FFFFFF), failed WCAG non-text contrast (3:1 min). danger.500 (#EE4242) = 3.83:1, passes. Prerequisite for text.danger's alias to this token to resolve at the intended contrast — see text.danger's description."
+            },
             "dangerHover": { "$type": "color", "$value": "{color.danger.600}" },
             "disabled": {
                 "$type": "color",

--- a/packages/design-system/tokens/tokens.json
+++ b/packages/design-system/tokens/tokens.json
@@ -491,7 +491,12 @@
             },
             "selected": { "$type": "color", "$value": "{color.info.500}" },
             "danger": { "$type": "color", "$value": "{color.danger.600}" },
-            "dangerHover": { "$type": "color", "$value": "{color.danger.400}" },
+            "inputDanger": {
+                "$type": "color",
+                "$value": "{color.danger.500}",
+                "$description": "RENAMED from border.dangerHover (2026-08-13): design/tokens split the old generic dangerHover into input-specific inputDanger/inputDangerHover, matching the Input component's Danger/Danger-Hover states in Figma (node 5:4471 / 1680:4212)."
+            },
+            "inputDangerHover": { "$type": "color", "$value": "{color.danger.400}" },
             "disabled": {
                 "$type": "color",
                 "$value": "{color.alpha.white.12}",
@@ -770,7 +775,12 @@
                 "$value": "{color.danger.500}",
                 "$description": "FIX (2026-08-12): was {color.danger.400} (#F27474) — 2.79:1 against surface.input (#FFFFFF), failed WCAG non-text contrast (3:1 min). danger.500 (#EE4242) = 3.83:1, passes. Prerequisite for text.danger's alias to this token to resolve at the intended contrast — see text.danger's description."
             },
-            "dangerHover": { "$type": "color", "$value": "{color.danger.600}" },
+            "inputDanger": {
+                "$type": "color",
+                "$value": "{color.danger.500}",
+                "$description": "RENAMED from border.dangerHover (2026-08-13): design/tokens split the old generic dangerHover into input-specific inputDanger/inputDangerHover, matching the Input component's Danger/Danger-Hover states in Figma (node 5:4471 / 1680:4212)."
+            },
+            "inputDangerHover": { "$type": "color", "$value": "{color.danger.400}" },
             "disabled": {
                 "$type": "color",
                 "$value": "{color.neutral.300}",
@@ -1321,7 +1331,8 @@
                 "border.inputHover": "dc913e1518547dd2d805f00d4a21b621b7e33e2a",
                 "border.selected": "bd541b171bf340a84ea3219553d5c9603652872c",
                 "border.danger": "db51208fffc08f5feea246bd22ef6aad6e4e26e2",
-                "border.dangerHover": "d70cc23005dcbc564b2db5f1ada8b60a2df6bf97",
+                "border.inputDanger": "f03894fb7b99be6831387db381434d8bf748edc3",
+                "border.inputDangerHover": "dee9ad307ff9d0093616586f79d8775f6c005ff8",
                 "border.disabled": "51c2ddaf0413d5e87d71ff45470f76e203a5ccf0",
                 "border.inverse": "99df0e9b340cd08be31048c16f5e9e3ef8402f5d",
                 "icon.default": "c5a6e63d6f39c53a0ab2470adcb7e0ce72343160",
@@ -1477,7 +1488,8 @@
                 "border.inputHover": "dc913e1518547dd2d805f00d4a21b621b7e33e2a",
                 "border.selected": "bd541b171bf340a84ea3219553d5c9603652872c",
                 "border.danger": "db51208fffc08f5feea246bd22ef6aad6e4e26e2",
-                "border.dangerHover": "d70cc23005dcbc564b2db5f1ada8b60a2df6bf97",
+                "border.inputDanger": "f03894fb7b99be6831387db381434d8bf748edc3",
+                "border.inputDangerHover": "dee9ad307ff9d0093616586f79d8775f6c005ff8",
                 "border.disabled": "51c2ddaf0413d5e87d71ff45470f76e203a5ccf0",
                 "border.inverse": "99df0e9b340cd08be31048c16f5e9e3ef8402f5d",
                 "icon.default": "c5a6e63d6f39c53a0ab2470adcb7e0ce72343160",

--- a/packages/design-system/tokens/tokens.json
+++ b/packages/design-system/tokens/tokens.json
@@ -611,7 +611,11 @@
             },
             "danger": {
                 "bg": { "$type": "color", "$value": "{color.danger.950}" },
-                "border": { "$type": "color", "$value": "{color.danger.700}" },
+                "border": {
+                    "$type": "color",
+                    "$value": "{color.danger.800}",
+                    "$description": "TONED DOWN (2026-07-22): started at .700 (#E81818, the ramp's most saturated stop — reported as too strong). Tried .750 (#D31616, 3.09:1 against fill) as a compliant middle ground, still reported as too strong. .750 turned out to be close to the practical floor for staying ≥3:1 against either the alert's own fill (danger.950) or the true page background — .800 (#A11313) clears neither (2.08:1 vs fill, 2.33–2.62:1 vs page/panel/canvas). Moved to .800 anyway: this border is decorative reinforcement, not the sole means of conveying status — the tinted fill, icon, and colored title/text already carry that redundantly, so strict 1.4.11 non-text-contrast enforcement on the border itself is a defensible relaxation here. Flagged as a known accessibility trade-off, not an oversight."
+                },
                 "icon": { "$type": "color", "$value": "{color.danger.400}" },
                 "text": { "$type": "color", "$value": "{color.danger.400}" },
                 "strong": { "$type": "color", "$value": "{color.danger.300}" },
@@ -730,7 +734,11 @@
             "link": { "$type": "color", "$value": "{color.info.700}" },
             "linkHover": { "$type": "color", "$value": "{color.info.900}" },
             "linkActive": { "$type": "color", "$value": "{color.info.950}" },
-            "danger": { "$type": "color", "$value": "{color.danger.800}" },
+            "danger": {
+                "$type": "color",
+                "$value": "{color.danger.700}",
+                "$description": "MOVED (2026-07-22): was danger.800. Alert Title reads from this token (not status.danger.strong), so it needed to match status.danger.icon (.700) to stop the icon/title mismatch in light mode. Caveat: .700 on surface.page/panel = ~4.0:1, under the 4.5:1 AA threshold for regular body text. Fine for bold headings (Alert Title) which only need 3:1 as large text — but if text.danger is used elsewhere for smaller regular-weight text (e.g. inline form error messages), that usage may now fail AA and should be checked."
+            },
             "success": { "$type": "color", "$value": "{color.success.800}" },
             "warning": { "$type": "color", "$value": "{color.warning.800}" }
         },
@@ -932,7 +940,11 @@
                     "$value": "{color.danger.700}",
                     "$description": "UNIFIED WITH ICON (2026-07-22): was danger.800 (#A11313) — the Badge/Alert danger icon and text were rendering as two visibly different reds. Moved text to .700 (#E81818) to match status.danger.icon. Caveat: .700 on the new .100 bg = 4.02:1, under 4.5:1 for regular body text — fine for bold/large text (3:1 threshold), but check AA if this token is ever used for small regular-weight copy."
                 },
-                "strong": { "$type": "color", "$value": "{color.danger.900}" },
+                "strong": {
+                    "$type": "color",
+                    "$value": "{color.danger.700}",
+                    "$description": "UNIFIED WITH ICON (2026-07-22): was danger.900 — moving icon to .900 earlier made it too dark, and leaving icon at .700 while strong stayed at .900 left icon and Alert Title visibly mismatched. Rather than dulling the icon again, brightened strong to meet it at .700. Caveat: .700 on the new .100 bg = 4.02:1, just under the 4.5:1 body-text threshold. This is fine if Alert Title renders bold at ≥14px (or ≥18px regular) — it then only needs 3:1 as 'large text' per WCAG, which .700 clears with room. Flag to design/eng: confirm Alert Title's actual type style meets that bar; if it's regular-weight and under 18px, this needs a different resolution."
+                },
                 "bgHover": {
                     "$type": "color",
                     "$value": "{color.danger.200}",


### PR DESCRIPTION
## Problem

Scoping the Button link-variant work (NAN-6420) surfaced 3 semantic-color values that had drifted between code and the `design/tokens` branch — already authored with contrast rationale in the tokens source, but never synced.

## Solution

- `Semantic/Light.status.danger.strong`: `danger.900` → `danger.700` — unifies the Alert title color with the icon (light mode). Currently unused in app code (0 consumers).
- `Semantic/Dark.status.danger.border`: `danger.700` → `danger.500` (updated again per review — see below).
- `Semantic/Light.text.danger`: now aliased to `border.danger` rather than a literal ramp value (updated again per review — see below).

Fixes [NAN-6556](https://linear.app/nango/issue/NAN-6556)

### Follow-up from review

`design/tokens` moved again on the exact same tokens after this PR opened:

- `status.danger.border` (dark) is now `danger.500` (was heading to `.800`).
- `text.danger` (light) is now aliased to `border.danger` (`danger.500`) instead of a literal `.700` — lower contrast than before, but design is deliberately accepting that trade-off, which resolves the accessibility open question this PR originally flagged.
- `status.danger.strong` — confirmed unaffected, no conflict.

Pulling in the alias correctly required bumping `border.danger` itself (light) from `.400` to `.500` — a token this PR hadn't touched before, now a hard dependency. Side effect: `border.danger` also feeds `PeriodSelector.tsx` and `Connection/CreateLegacy.tsx`'s error-state borders (both conditional, only shown on validation error) — nudges those slightly darker too.

Also noted for awareness, no action needed: design added `border.inputDanger`/`inputDangerHover` as future replacements for `status.danger.border` on Input/InputGroup/Textarea — nothing consumes them yet.

## Testing

- `tokens:check`, `ts-build`, and `format:check` all pass; diff to generated CSS is exactly the intended values.
- Verified in Storybook (dark mode): `Input` invalid state still reads clearly as an error with the updated `status.danger.border` red.

## Accessibility checklist — stories to check once the preview deploy comments in

- [ ] `Design System/Components/Field` → **States** — `FieldError` renders `text.danger` at 12px regular; check light-mode legibility against the current `#EE4242` (was `#A11313`)
- [ ] `Design System/Components/Input` → **States** — invalid state border uses `status.danger.border`; check dark mode against the current `#EE4242` (was `#E81818`)
- [ ] `Design System/Components/InputGroup` → **Addons** — same invalid-border token, dark mode
- [ ] `Design System/Components/Textarea` → **States** — same invalid-border token, dark mode
- [ ] `packages/webapp/src/layout/AppSidebar/UsageLimitAlert.tsx` — also consumes `status.danger.border` (dark) but has no Storybook story; check manually in the app
- [ ] `packages/webapp/src/components/patterns/PeriodSelector.tsx` and `packages/webapp/src/pages/Connection/CreateLegacy.tsx` — both consume `border.danger` (light) on a conditional error-state border; no story, check manually by triggering the validation error
- No story exercises `status.danger.strong` (light) — 0 consumers in app code today, nothing to visually check
