### PR TITLE
fix(mcp): add missing schema and hints to management mcp tools

### DIFF
--- a/packages/server/lib/controllers/mcp/integrations/create.ts
+++ b/packages/server/lib/controllers/mcp/integrations/create.ts
@@ -23,22 +23,50 @@ const createIntegrationBaseArguments = {
     forward_webhooks: integrationForwardWebhooksSchema
 };
 
-const createIntegrationArgumentsSchema = z.discriminatedUnion('credential_source', [
-    z
-        .object({
-            ...createIntegrationBaseArguments,
-            credential_source: z.literal('nango')
-        })
-        .strict(),
-    z
-        .object({
-            ...createIntegrationBaseArguments,
-            credential_source: z.literal('own'),
-            credentials: integrationCredentialsSchema.optional(),
-            integration_config: z.record(z.string(), z.string().max(8192)).optional()
-        })
-        .strict()
-]);
+// The MCP SDK only advertises top-level Zod object schemas; a discriminated union is emitted as an empty object schema.
+// Keep this as an object and use metadata to expose the conditional fields to clients while superRefine enforces them at runtime.
+const createIntegrationArgumentsSchema = z
+    .object({
+        ...createIntegrationBaseArguments,
+        credential_source: z.enum(['nango', 'own']).describe('Use nango for Nango-provided credentials or own for caller-supplied credentials.'),
+        credentials: integrationCredentialsSchema.optional().describe('Only applicable when credential_source is own.'),
+        integration_config: z.record(z.string(), z.string().max(8192)).optional().describe('Only applicable when credential_source is own.')
+    })
+    .strict()
+    .superRefine((args, ctx) => {
+        if (args.credential_source !== 'nango') {
+            return;
+        }
+
+        if (args.credentials !== undefined) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['credentials'],
+                message: 'credentials is only allowed when credential_source is own'
+            });
+        }
+
+        if (args.integration_config !== undefined) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['integration_config'],
+                message: 'integration_config is only allowed when credential_source is own'
+            });
+        }
+    })
+    .meta({
+        oneOf: [
+            {
+                properties: { credential_source: { const: 'nango' } },
+                not: {
+                    anyOf: [{ required: ['credentials'] }, { required: ['integration_config'] }]
+                }
+            },
+            {
+                properties: { credential_source: { const: 'own' } }
+            }
+        ]
+    });
 
 export const createIntegrationsTool = defineManagementMcpTool<typeof createIntegrationArgumentsSchema, CreateIntegrationsOutput>({
     name: 'integrations_create',

--- a/packages/server/lib/controllers/mcp/integrations/create.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/create.unit.test.ts
@@ -142,7 +142,9 @@ describe('createIntegrationsTool', () => {
         expect(result.isErr()).toBe(true);
         if (result.isErr()) {
             expect(result.error).toBeInstanceOf(PublicMcpError);
-            expect(result.error.message).toContain('Invalid integrations_create arguments: arguments:');
+            expect(result.error.message).toContain(
+                'Invalid integrations_create arguments: credentials: credentials is only allowed when credential_source is own'
+            );
         }
         expect(createSpy).not.toHaveBeenCalled();
     });

--- a/packages/server/lib/controllers/mcp/integrations/list.ts
+++ b/packages/server/lib/controllers/mcp/integrations/list.ts
@@ -14,6 +14,7 @@ export const listIntegrationsTool = defineManagementMcpTool<typeof listIntegrati
     description: 'List integrations configured in the authenticated Nango environment.',
     inputSchema: listIntegrationsArgumentsSchema,
     outputSchema: listIntegrationsOutputSchema,
+    annotations: { readOnlyHint: true },
     requiredScopes: { every: ['environment:integrations:list'] },
     audit: { kind: 'no-audit', reason: 'read-only' },
     async handler({ environment }) {

--- a/packages/server/lib/controllers/mcp/logs/getOperation.ts
+++ b/packages/server/lib/controllers/mcp/logs/getOperation.ts
@@ -43,6 +43,7 @@ export const getLogOperationTool = defineManagementMcpTool<typeof getOperationAr
     description: 'Get one Nango log operation and a page of its message rows for the authenticated environment. Messages are returned newest first.',
     inputSchema: getOperationArgumentsSchema,
     outputSchema: getOperationOutputSchema,
+    annotations: { readOnlyHint: true },
     requiredScopes: { every: [logsReadScope] },
     audit: { kind: 'no-audit', reason: 'read-only' },
     async handler({ args, account, environment }) {

--- a/packages/server/lib/controllers/mcp/logs/listOperations.ts
+++ b/packages/server/lib/controllers/mcp/logs/listOperations.ts
@@ -178,6 +178,7 @@ export const listLogOperationsTool = defineManagementMcpTool<typeof listOperatio
     ].join(' '),
     inputSchema: listOperationsArgumentsSchema,
     outputSchema: listOperationsOutputSchema,
+    annotations: { readOnlyHint: true },
     requiredScopes: { every: [logsReadScope] },
     audit: { kind: 'no-audit', reason: 'read-only' },
     async handler({ args, account, environment }) {

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -29,15 +29,24 @@ describe('createManagementMcpServer', () => {
         try {
             const result = await client.listTools();
 
-            expect(result.tools.map((tool) => tool.name)).toStrictEqual([
-                'integrations_list',
-                'integrations_get',
-                'integrations_create',
-                'integrations_update',
-                'integrations_delete',
-                'connections_list',
-                'logs_list_operations',
-                'logs_get_operation'
+            expect(result.tools.map(({ name, annotations }) => ({ name, annotations }))).toStrictEqual([
+                { name: 'integrations_list', annotations: { readOnlyHint: true } },
+                { name: 'integrations_get', annotations: { readOnlyHint: true } },
+                {
+                    name: 'integrations_create',
+                    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
+                },
+                {
+                    name: 'integrations_update',
+                    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
+                },
+                {
+                    name: 'integrations_delete',
+                    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false }
+                },
+                { name: 'connections_list', annotations: { readOnlyHint: true } },
+                { name: 'logs_list_operations', annotations: { readOnlyHint: true } },
+                { name: 'logs_get_operation', annotations: { readOnlyHint: true } }
             ]);
         } finally {
             await client.close();
@@ -84,6 +93,27 @@ describe('createManagementMcpServer', () => {
             expect(result.tools).toHaveLength(1);
             expect(result.tools[0]).toMatchObject({
                 name: 'integrations_create',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        provider: { type: 'string' },
+                        integration_id: { type: 'string' },
+                        credential_source: { type: 'string', enum: ['nango', 'own'] },
+                        credentials: { description: 'Only applicable when credential_source is own.' },
+                        integration_config: { description: 'Only applicable when credential_source is own.' }
+                    },
+                    required: ['provider', 'integration_id', 'credential_source'],
+                    additionalProperties: false,
+                    oneOf: [
+                        {
+                            properties: { credential_source: { const: 'nango' } },
+                            not: {
+                                anyOf: [{ required: ['credentials'] }, { required: ['integration_config'] }]
+                            }
+                        },
+                        { properties: { credential_source: { const: 'own' } } }
+                    ]
+                },
                 annotations: {
                     readOnlyHint: false,
                     destructiveHint: false,


### PR DESCRIPTION
- integrations_create tool didn't advertise a schema because MCP SDK doesn't support a zod discriminated union
- add more annotation hints where appropriate

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

