### PR TITLE
fix(webapp): align env settings panel border

### DIFF
--- a/packages/webapp/src/pages/Environment/Settings/components/SettingsContent.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/SettingsContent.tsx
@@ -1,6 +1,6 @@
 const SettingsContent: React.FC<{ title: string; action?: React.ReactNode; children: React.ReactNode }> = ({ title, action, children }) => {
     return (
-        <div className="text-text-strong flex flex-col rounded-sm border-2 border-border-disabled h-full">
+        <div className="text-text-strong flex flex-col rounded border border-border-muted h-full">
             <div className="text-body-large-semi bg-surface-panel h-10 flex items-center justify-between p-6">
                 <h2>{title}</h2>
                 {action}

--- a/packages/webapp/src/pages/Environment/Settings/components/SettingsContent.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/SettingsContent.tsx
@@ -1,6 +1,6 @@
 const SettingsContent: React.FC<{ title: string; action?: React.ReactNode; children: React.ReactNode }> = ({ title, action, children }) => {
     return (
-        <div className="text-text-strong flex flex-col rounded border border-border-muted h-full">
+        <div className="text-text-strong flex flex-col rounded border border-border-muted overflow-hidden h-full">
             <div className="text-body-large-semi bg-surface-panel h-10 flex items-center justify-between p-6">
                 <h2>{title}</h2>
                 {action}


### PR DESCRIPTION
## Problem

The Environment settings panel was the only container in the app using a 2px `border-border-disabled` border. It reads noticeably heavier than every other bordered surface — the connections table, the billing metrics table, and every other list view. The panel header's opaque background also protruded past the rounded corners.

## Solution

- Swap `border-2 border-border-disabled` for `border border-border-muted` on the settings panel wrapper, matching `components/ui/Table.tsx`.
- Change `rounded-sm` to `rounded` for the same reason.
- Add `overflow-hidden` so the header's opaque background is clipped to the radius instead of protruding past the rounded corner.

`border-border-muted` is the dominant border token in the webapp (45 files vs 20 for `border-border-default`). The old combination appeared exactly once in the codebase.

## Testing

Checked `/dev/environment-settings` against `REMOTE_API=dev` in dark and light mode, side by side with `/dev/connections` — the panel border now matches the table, and the header corner is clipped cleanly.

Verified `overflow-hidden` doesn't clip overlays anchored inside the panel: `Select` and `Tooltip` both render through `Portal`, the Connect UI theme dropdown opens over the field below it, and the API key create/delete dialogs are unaffected.

Before
<img width="1360" height="496" alt="image" src="https://github.com/user-attachments/assets/a8944c5a-6008-4ed9-8bd2-cfb48c6fced1" />


After
<img width="1354" height="477" alt="image" src="https://github.com/user-attachments/assets/2f6e2bd1-290c-4f53-8bad-452f4aa57564" />
