### PR TITLE
feat(team): prefill invite form from join request (NAN-6564)

### DIFF
--- a/packages/server/lib/helpers/email.ts
+++ b/packages/server/lib/helpers/email.ts
@@ -9,6 +9,12 @@ export function sanitizeEmailSubject(subject: string): string {
     return subject.replace(/[\r\n]+/g, ' ');
 }
 
+// Encoding matters: URLSearchParams.get() turns "+" into a space, so a plus-addressed email
+// would come back malformed and the dashboard would silently drop the prefill.
+export function buildInvitePrefillUrl(email: string): string {
+    return `${basePublicUrl}/team-settings?invite_email=${encodeURIComponent(email)}`;
+}
+
 export async function sendVerificationEmail(email: string, name: string, token: string) {
     const emailClient = EmailClient.getInstance();
     await emailClient.send(
@@ -90,6 +96,7 @@ export async function sendAccountInvitationRequestEmail({
     requester: Pick<DBUser, 'name' | 'email'>;
 }) {
     const emailClient = EmailClient.getInstance();
+    const inviteUrl = buildInvitePrefillUrl(requester.email);
     await emailClient.send(
         email,
         sanitizeEmailSubject(`${requester.name} wants to join "${account.name}" on Nango`),
@@ -97,7 +104,9 @@ export async function sendAccountInvitationRequestEmail({
 
 <p><strong>${he.encode(requester.name)}</strong> (${he.encode(requester.email)}) has requested to join <strong>${he.encode(account.name)}</strong> on Nango.</p>
 
-<p>Their email address has been verified. To invite them, go to <a href="${basePublicUrl}/team-settings">Team Settings</a>.</p>
+<p>Their email address has been verified.</p>
+
+<p><a href="${he.encode(inviteUrl)}">Invite them to your team</a></p>
 
 <p>Best,<br>
 Team Nango</p>

--- a/packages/server/lib/helpers/email.unit.test.ts
+++ b/packages/server/lib/helpers/email.unit.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import { sanitizeEmailSubject } from './email.js';
+import { buildInvitePrefillUrl, sanitizeEmailSubject } from './email.js';
 
 describe('sanitizeEmailSubject', () => {
     it('removes carriage returns and line feeds from email subject values', () => {
         expect(sanitizeEmailSubject('Requester\r\nBcc: attacker@example.com\nAccount')).toBe('Requester Bcc: attacker@example.com Account');
+    });
+});
+
+describe('buildInvitePrefillUrl', () => {
+    it('percent-encodes the email so plus addressing is not read back as a space', () => {
+        expect(buildInvitePrefillUrl('user+tag@example.com')).toContain('invite_email=user%2Btag%40example.com');
+    });
+
+    it.each(['user+tag@example.com', "o'brien@example.com", 'Firstname.Lastname@Example.com'])('round-trips %s', (email) => {
+        expect(new URL(buildInvitePrefillUrl(email)).searchParams.get('invite_email')).toBe(email);
     });
 });

--- a/packages/webapp/src/main.tsx
+++ b/packages/webapp/src/main.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 
 import App from './app/App';
 import { Providers } from './app/providers';
+import { INVITE_PREFILL_PARAM } from './pages/Team/components/inviteForm';
 import { globalEnv } from './utils/env';
 import { redactSensitiveProperties, redactSensitiveText } from './utils/sensitive-url';
 
@@ -11,7 +12,10 @@ if (globalEnv.publicPosthogKey) {
     posthog.init(globalEnv.publicPosthogKey, {
         api_host: globalEnv.publicPosthogHost,
         mask_personal_data_properties: true,
-        custom_personal_data_properties: ['session_token', 'token', 'next'],
+        // mask_personal_data_properties only covers ad/click params, so name the rest explicitly.
+        // invite_email carries a requester's address and the first $pageview fires here, before
+        // React can strip it from the URL.
+        custom_personal_data_properties: ['session_token', 'token', 'next', INVITE_PREFILL_PARAM],
         // The dashboard renders customer-supplied data that can contain PHI (NAN-6428):
         // mask all text by default, opt Nango-owned static chrome out with data-ph-unmask.
         mask_all_text: true,

--- a/packages/webapp/src/pages/Team/components/InviteTeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/InviteTeamMembers.tsx
@@ -1,7 +1,8 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ExternalLink, Plus, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
-import { z } from 'zod';
+import { useSearchParams } from 'react-router-dom';
 
 import { permissions } from '@nangohq/authz';
 import { Button, Card, CardContent, CardFooter, CardHeader, CardTitle, FieldLabel, IconButton, InputGroup, InputGroupInput } from '@nangohq/design-system';
@@ -13,32 +14,10 @@ import { usePermissions } from '@/hooks/usePermissions';
 import { planHasRbac, useApiGetCurrentPlan } from '@/hooks/usePlan';
 import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
+import { emptyRow, INVITE_PREFILL_PARAM, inviteSchema, parseInvitePrefillEmail } from './inviteForm';
 import { RoleSelect } from './RoleSelect';
 
-const inviteRowSchema = z.object({
-    email: z.string().email('Please enter a valid email address'),
-    role: z.enum(['administrator', 'production_support', 'development_full_access'] as const)
-});
-
-const inviteSchema = z.object({ invites: z.array(inviteRowSchema).min(1) }).superRefine(({ invites }, ctx) => {
-    // Reject duplicate emails (case-insensitive) so one address isn't invited twice / raced across role requests.
-    const seen = new Set<string>();
-    invites.forEach((row, index) => {
-        const email = row.email.trim().toLowerCase();
-        if (!email) {
-            return; // empty rows are handled by the per-row email() check
-        }
-        if (seen.has(email)) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'This email is already in the list', path: ['invites', index, 'email'] });
-        } else {
-            seen.add(email);
-        }
-    });
-});
-
-type InviteFormData = z.infer<typeof inviteSchema>;
-
-const emptyRow = (): InviteFormData['invites'][number] => ({ email: '', role: 'administrator' });
+import type { InviteFormData } from './inviteForm';
 
 export const InviteTeamMembers = () => {
     const env = useStore((state) => state.env);
@@ -50,12 +29,28 @@ export const InviteTeamMembers = () => {
 
     const { mutateAsync: inviteAsync } = usePostInvite(env);
 
+    const [searchParams, setSearchParams] = useSearchParams();
+    // Read once at mount: useForm captures defaultValues on the first render and the effect below
+    // strips the param right after, so this must not re-derive from the URL on later renders.
+    const [prefillEmail] = useState(() => parseInvitePrefillEmail(searchParams.get(INVITE_PREFILL_PARAM)));
+
     const form = useForm<InviteFormData>({
         resolver: zodResolver(inviteSchema),
-        defaultValues: { invites: [emptyRow()] },
+        defaultValues: { invites: [prefillEmail ? { ...emptyRow(), email: prefillEmail } : emptyRow()] },
         mode: 'onTouched'
     });
     const { fields, append, remove, replace } = useFieldArray({ control: form.control, name: 'invites' });
+
+    // Consume the param once, so a refresh or back navigation doesn't re-prefill a row that was
+    // already sent and the address doesn't linger in history or analytics URLs.
+    useEffect(() => {
+        if (!searchParams.has(INVITE_PREFILL_PARAM)) {
+            return;
+        }
+        const next = new URLSearchParams(searchParams);
+        next.delete(INVITE_PREFILL_PARAM);
+        setSearchParams(next, { replace: true });
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     const onSubmit = async ({ invites }: InviteFormData) => {
         // One request per row (not batched by role): the invite endpoint commits per email, so a batched
@@ -67,6 +62,7 @@ export const InviteTeamMembers = () => {
         if (remaining.length === 0) {
             toast({ title: invites.length === 1 ? `Invite sent to ${invites[0]?.email}` : `${invites.length} invites sent`, variant: 'success' });
             // replace() (not form.reset) keeps useFieldArray's internal state in sync — otherwise a later "Add more" resurrects the sent rows.
+            // It also avoids restoring defaultValues, which would bring back a prefilled email that was just invited.
             replace([emptyRow()]);
             form.clearErrors();
             return;

--- a/packages/webapp/src/pages/Team/components/InviteTeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/InviteTeamMembers.tsx
@@ -42,8 +42,7 @@ export const InviteTeamMembers = () => {
     const { fields, append, remove, replace } = useFieldArray({ control: form.control, name: 'invites' });
 
     // Consume the param once, so a refresh or back navigation doesn't re-prefill a row that was
-    // already sent and the address doesn't linger in browser history. This runs after PostHog's
-    // first $pageview, so keeping it out of analytics relies on the masking set up in main.tsx.
+    // already sent and the address doesn't linger in browser history.
     useEffect(() => {
         if (!searchParams.has(INVITE_PREFILL_PARAM)) {
             return;

--- a/packages/webapp/src/pages/Team/components/InviteTeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/InviteTeamMembers.tsx
@@ -42,7 +42,8 @@ export const InviteTeamMembers = () => {
     const { fields, append, remove, replace } = useFieldArray({ control: form.control, name: 'invites' });
 
     // Consume the param once, so a refresh or back navigation doesn't re-prefill a row that was
-    // already sent and the address doesn't linger in history or analytics URLs.
+    // already sent and the address doesn't linger in browser history. This runs after PostHog's
+    // first $pageview, so keeping it out of analytics relies on the masking set up in main.tsx.
     useEffect(() => {
         if (!searchParams.has(INVITE_PREFILL_PARAM)) {
             return;

--- a/packages/webapp/src/pages/Team/components/inviteForm.ts
+++ b/packages/webapp/src/pages/Team/components/inviteForm.ts
@@ -1,10 +1,18 @@
 import { z } from 'zod';
 
+import type { Role } from '@nangohq/types';
+
 export const INVITE_PREFILL_PARAM = 'invite_email';
 
+// `satisfies` anchors these to Role, so renaming or dropping one fails the build instead of
+// silently diverging from the API. Same pattern as `roles` in @nangohq/utils, which the
+// invite endpoint validates against.
+const roleValues = ['administrator', 'production_support', 'development_full_access'] as const satisfies readonly Role[];
+
 export const inviteRowSchema = z.object({
-    email: z.string().email('Please enter a valid email address'),
-    role: z.enum(['administrator', 'production_support', 'development_full_access'] as const)
+    // max(255) mirrors the invite endpoint, so an over-long address fails here instead of as a 400.
+    email: z.string().max(255).email('Please enter a valid email address'),
+    role: z.enum(roleValues)
 });
 
 export const inviteSchema = z.object({ invites: z.array(inviteRowSchema).min(1) }).superRefine(({ invites }, ctx) => {
@@ -29,11 +37,8 @@ export const emptyRow = (): InviteFormData['invites'][number] => ({ email: '', r
 
 // The email comes from a link in a notification email, so treat it as untrusted. The form uses
 // mode: 'onTouched', so an invalid value would sit there looking fine and only fail on submit.
-// 255 mirrors the server's cap in postInvite.
+// Validating against the row schema keeps the rules (format, length) in one place.
 export function parseInvitePrefillEmail(raw: string | null): string {
     const trimmed = raw?.trim() ?? '';
-    if (!trimmed || trimmed.length > 255) {
-        return '';
-    }
-    return inviteRowSchema.shape.email.safeParse(trimmed).success ? trimmed : '';
+    return trimmed && inviteRowSchema.shape.email.safeParse(trimmed).success ? trimmed : '';
 }

--- a/packages/webapp/src/pages/Team/components/inviteForm.ts
+++ b/packages/webapp/src/pages/Team/components/inviteForm.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+export const INVITE_PREFILL_PARAM = 'invite_email';
+
+export const inviteRowSchema = z.object({
+    email: z.string().email('Please enter a valid email address'),
+    role: z.enum(['administrator', 'production_support', 'development_full_access'] as const)
+});
+
+export const inviteSchema = z.object({ invites: z.array(inviteRowSchema).min(1) }).superRefine(({ invites }, ctx) => {
+    // Reject duplicate emails (case-insensitive) so one address isn't invited twice / raced across role requests.
+    const seen = new Set<string>();
+    invites.forEach((row, index) => {
+        const email = row.email.trim().toLowerCase();
+        if (!email) {
+            return; // empty rows are handled by the per-row email() check
+        }
+        if (seen.has(email)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'This email is already in the list', path: ['invites', index, 'email'] });
+        } else {
+            seen.add(email);
+        }
+    });
+});
+
+export type InviteFormData = z.infer<typeof inviteSchema>;
+
+export const emptyRow = (): InviteFormData['invites'][number] => ({ email: '', role: 'administrator' });
+
+// The email comes from a link in a notification email, so treat it as untrusted. The form uses
+// mode: 'onTouched', so an invalid value would sit there looking fine and only fail on submit.
+// 255 mirrors the server's cap in postInvite.
+export function parseInvitePrefillEmail(raw: string | null): string {
+    const trimmed = raw?.trim() ?? '';
+    if (!trimmed || trimmed.length > 255) {
+        return '';
+    }
+    return inviteRowSchema.shape.email.safeParse(trimmed).success ? trimmed : '';
+}

--- a/packages/webapp/src/pages/Team/components/inviteForm.ts
+++ b/packages/webapp/src/pages/Team/components/inviteForm.ts
@@ -4,9 +4,6 @@ import type { Role } from '@nangohq/types';
 
 export const INVITE_PREFILL_PARAM = 'invite_email';
 
-// `satisfies` anchors these to Role, so renaming or dropping one fails the build instead of
-// silently diverging from the API. Same pattern as `roles` in @nangohq/utils, which the
-// invite endpoint validates against.
 const roleValues = ['administrator', 'production_support', 'development_full_access'] as const satisfies readonly Role[];
 
 export const inviteRowSchema = z.object({

--- a/packages/webapp/src/pages/Team/components/inviteForm.unit.test.ts
+++ b/packages/webapp/src/pages/Team/components/inviteForm.unit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { inviteSchema, parseInvitePrefillEmail } from './inviteForm';
+
+describe('parseInvitePrefillEmail', () => {
+    it('keeps a valid address as-is, including plus addressing and casing', () => {
+        expect(parseInvitePrefillEmail('User+tag@Example.com')).toBe('User+tag@Example.com');
+    });
+
+    it('trims surrounding whitespace', () => {
+        expect(parseInvitePrefillEmail('  a@b.com  ')).toBe('a@b.com');
+    });
+
+    it.each([
+        ['null', null],
+        ['empty string', ''],
+        ['whitespace only', '   '],
+        ['not an email', 'not-an-email'],
+        ['markup', '<script>alert(1)</script>'],
+        ['a list of emails', 'a@b.com, c@d.com'],
+        ['an address over 255 chars', `${'a'.repeat(250)}@example.com`]
+    ])('rejects %s', (_label, input) => {
+        expect(parseInvitePrefillEmail(input)).toBe('');
+    });
+});
+
+describe('inviteSchema', () => {
+    it('accepts distinct emails', () => {
+        const res = inviteSchema.safeParse({
+            invites: [
+                { email: 'a@b.com', role: 'administrator' },
+                { email: 'c@d.com', role: 'production_support' }
+            ]
+        });
+        expect(res.success).toBe(true);
+    });
+
+    it('flags a case-insensitive duplicate on the later row', () => {
+        const res = inviteSchema.safeParse({
+            invites: [
+                { email: 'a@b.com', role: 'administrator' },
+                { email: 'A@B.com', role: 'administrator' }
+            ]
+        });
+        expect(res.success).toBe(false);
+        expect(res.error?.issues[0]?.path).toEqual(['invites', 1, 'email']);
+    });
+
+    it('rejects an empty invite list', () => {
+        expect(inviteSchema.safeParse({ invites: [] }).success).toBe(false);
+    });
+});


### PR DESCRIPTION
## Problem

When someone requests to join an existing team account via account discovery, the admin gets a notification email that links to a bare `/team-settings`. They then have to copy the requester's address out of the email body, paste it into the invite form, and confirm — the one manual step left in that flow.

## Solution

- The email CTA is now a deep link carrying the requester's address in an `invite_email` query param, which prefills the first row of the invite form.
- Prefill only — the admin still reviews and clicks **Invite**, so a bare link click or a mail client prefetch changes nothing. No new persisted state.
- The param is validated and length-capped before it reaches the form, then stripped from the URL so it doesn't linger in history or come back on refresh.
- `invite_email` is added to PostHog's `custom_personal_data_properties`, since the first `$pageview` fires before React can strip it and the requester's address shouldn't reach analytics or session replay.
- Invite form schema moved out of `InviteTeamMembers.tsx` into `inviteForm.ts` so the param parsing can reuse the email validator and both become unit-testable. The role list is anchored to `Role` from `@nangohq/types`, and the 255-char email cap now lives on the schema instead of being duplicated.

The requester's address stays in the email body as a fallback, so the flow is never worse than it is today.

Fixes [NAN-6564](https://linear.app/nango/issue/NAN-6564/let-admins-invite-a-requester-directly-from-the-join-request-email)

## Testing

17 unit tests added/extended: URL encoding round-trip including plus addressing, prefill param validation, and the invite schema. The form wiring is covered manually below.

### Quick check — no email needed

On the preview deploy, which runs against the dev API:

1. [Log in first](https://pr-7093.app-development.nango.dev/signin) as an admin. This matters — the deep link only works with a session, see Follow-ups.
2. Then open the prefilled link: **[/team-settings?invite_email=user+tag@example.com](https://pr-7093.app-development.nango.dev/team-settings?invite_email=user%2Btag%40example.com)**
3. The first invite row is prefilled with `user+tag@example.com` — the `+` survives, it isn't read back as a space.
4. The address bar drops to plain `/team-settings`, and Back doesn't restore the param.
5. Click **Invite** — success toast, row clears. "Add more" and a page refresh both stay empty, so the prefill doesn't come back after it's been sent.
6. Swap in [`?invite_email=notanemail`](https://pr-7093.app-development.nango.dev/team-settings?invite_email=notanemail) — the row stays empty and no validation error is shown.

### Full flow — end to end

1. Start the stack locally and sign up a new user whose email domain already has an account with a verified admin. Account discovery offers "Request to join".
2. Request to join. With no email provider configured locally the server logs the email instead of sending it, so grab the `Invite them to your team` link out of the server log.
3. Open that link as the admin: the invite form is prefilled with the requester's address. Click **Invite** to finish.

## Follow-ups

- A logged-out admin loses the deep link's destination and lands on `/` after logging in, so they fall back to copying the address from the email body — unchanged behavior, tracked in [NAN-6573](https://linear.app/nango/issue/NAN-6573/keep-the-intended-destination-when-a-logged-out-user-opens-a-dashboard).
- The prefill wiring itself has no automated coverage, since the webapp has no DOM test harness — adding one is its own decision.
