### PR TITLE
fix(webapp): address post-merge Account API keys UI review

### DIFF
--- a/packages/design-system/stories/Alert.stories.tsx
+++ b/packages/design-system/stories/Alert.stories.tsx
@@ -21,11 +21,9 @@ export const Default: Story = {
                     <CircleCheck />
                     <AlertTitle className="capitalize">{variant}</AlertTitle>
                     <AlertDescription>Your integration is connected and syncing.</AlertDescription>
-                    {variant !== 'neutral' && (
-                        <AlertActions>
-                            <AlertButton variant={`${variant}-secondary`}>View logs</AlertButton>
-                        </AlertActions>
-                    )}
+                    <AlertActions>
+                        <AlertButton variant={`${variant}-secondary`}>View logs</AlertButton>
+                    </AlertActions>
                 </Alert>
             ))}
         </div>

--- a/packages/design-system/stories/DestructiveActionModal.stories.tsx
+++ b/packages/design-system/stories/DestructiveActionModal.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { DestructiveActionModal } from '@/components-v2/patterns/DestructiveActionModal';
+import { DestructiveActionModal } from '@/components/patterns/DestructiveActionModal';
 import { Button } from '../src/components/ui/button';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';

--- a/packages/webapp/components.json
+++ b/packages/webapp/components.json
@@ -12,9 +12,9 @@
     },
     "iconLibrary": "lucide",
     "aliases": {
-        "components": "@/components-v2",
+        "components": "@/components",
         "utils": "@/utils/utils.ts",
-        "ui": "@/components-v2/ui",
+        "ui": "@/components/ui",
         "lib": "@/utils",
         "hooks": "@/hooks"
     },

--- a/packages/webapp/src/components/patterns/DestructiveActionModal.tsx
+++ b/packages/webapp/src/components/patterns/DestructiveActionModal.tsx
@@ -18,7 +18,7 @@ import {
 
 interface DestructiveActionModalProps {
     title: string;
-    description: string;
+    description: React.ReactNode;
     inputLabel: string;
     confirmationKeyword: string;
     confirmButtonText: string;

--- a/packages/webapp/src/components/ui/Alert.tsx
+++ b/packages/webapp/src/components/ui/Alert.tsx
@@ -99,7 +99,11 @@ const alertButtonVariants = cva(
                 warning:
                     'border border-transparent bg-status-warning-icon text-status-warning-bg hover:bg-status-warning-bg-hover/30 hover:text-status-warning-text hover:border-status-warning-icon active:bg-status-warning-bg active:text-status-warning-text',
                 'warning-secondary':
-                    'border border-status-warning-icon bg-transparent text-status-warning-text hover:bg-status-warning-bg-hover/30 active:border-transparent active:text-status-warning-bg active:bg-status-warning-icon'
+                    'border border-status-warning-icon bg-transparent text-status-warning-text hover:bg-status-warning-bg-hover/30 active:border-transparent active:text-status-warning-bg active:bg-status-warning-icon',
+                neutral:
+                    'border border-transparent bg-icon-secondary text-surface-panel hover:bg-state-hover hover:text-text-strong hover:border-border-muted active:bg-icon-secondary active:text-surface-panel',
+                'neutral-secondary':
+                    'border border-border-muted bg-transparent text-text-secondary hover:bg-state-hover hover:text-text-strong active:border-transparent active:bg-icon-secondary active:text-surface-panel'
             }
         },
         defaultVariants: {

--- a/packages/webapp/src/pages/ApiKeys/Show.tsx
+++ b/packages/webapp/src/pages/ApiKeys/Show.tsx
@@ -1,4 +1,4 @@
-import { KeyRound, Trash2 } from 'lucide-react';
+import { CircleX, KeyRound, Trash2 } from 'lucide-react';
 import { useId, useState } from 'react';
 import { Helmet } from 'react-helmet';
 
@@ -19,9 +19,11 @@ import {
     Input
 } from '@nangohq/design-system';
 
-import { DestructiveActionModal } from '@/components-v2/patterns/DestructiveActionModal';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/Alert';
+import { DestructiveActionModal } from '@/components/patterns/DestructiveActionModal';
+import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle } from '@/components/ui/Alert';
 import { CopyButton } from '@/components/ui/CopyButton';
+import { EmptyCard } from '@/components/ui/EmptyCard';
+import { Skeleton } from '@/components/ui/Skeleton';
 import { StyledLink } from '@/components/ui/StyledLink';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/Table';
 import { useAccountApiKeys, useCreateAccountApiKey, useDeleteAccountApiKey } from '@/hooks/useAccountApiKeys';
@@ -146,7 +148,12 @@ const DeleteAccountApiKeyButton: React.FC<{
     return (
         <DestructiveActionModal
             title="Delete Account API key"
-            description={`This action is irreversible. Any services using "${apiKey.display_name}" will lose account access immediately.`}
+            description={
+                <>
+                    This action is irreversible. Any services using <strong className="text-text-strong">{apiKey.display_name}</strong> will lose account access
+                    immediately.
+                </>
+            }
             inputLabel="To confirm, type the Account API key name below:"
             confirmationKeyword={apiKey.display_name}
             confirmButtonText="Delete Account API key"
@@ -158,6 +165,7 @@ const DeleteAccountApiKeyButton: React.FC<{
             onConfirm={() => {
                 void onDelete(apiKey)
                     .then(() => setOpen(false))
+                    // Error already toasted in handleDelete; swallowed so the modal stays open without an unhandled rejection.
                     .catch(() => undefined);
             }}
             open={open}
@@ -191,7 +199,11 @@ export const AccountApiKeysShow: React.FC = () => {
                 <Helmet>
                     <title>Account API keys - Nango</title>
                 </Helmet>
-                <p className="text-body-small-regular text-text-muted">Loading Account API keys…</p>
+                <div className="mx-auto flex max-w-377 flex-col gap-4">
+                    <Skeleton className="h-16 w-full" />
+                    <Skeleton className="h-10 w-40 self-end" />
+                    <Skeleton className="h-48 w-full" />
+                </div>
             </DashboardLayout>
         );
     }
@@ -242,19 +254,23 @@ export const AccountApiKeysShow: React.FC = () => {
                 </div>
 
                 {isLoading ? (
-                    <p className="text-body-small-regular text-text-muted">Loading Account API keys…</p>
+                    <Skeleton className="h-48 w-full" />
                 ) : isError ? (
-                    <div className="flex items-center justify-between gap-4">
-                        <p className="text-body-small-regular text-text-muted">Failed to load Account API keys.</p>
-                        <Button variant="outline" size="sm" onClick={() => void refetch()}>
-                            Try again
-                        </Button>
-                    </div>
+                    <Alert variant="error">
+                        <CircleX />
+                        <AlertTitle>Failed to load Account API keys</AlertTitle>
+                        <AlertDescription>Something went wrong while loading your Account API keys.</AlertDescription>
+                        <AlertActions>
+                            <AlertButton variant="error-secondary" onClick={() => void refetch()}>
+                                Try again
+                            </AlertButton>
+                        </AlertActions>
+                    </Alert>
                 ) : apiKeys.length === 0 ? (
-                    <div className="flex flex-col gap-1 py-4">
-                        <p className="text-body-small-semi text-text-strong">No Account API keys</p>
-                        <p className="text-body-small-regular text-text-muted">Create an Account API key for account-level automation.</p>
-                    </div>
+                    <EmptyCard>
+                        <span className="text-text-strong text-title-body">No Account API keys</span>
+                        <span className="text-text-secondary text-body-medium-regular">Create an Account API key for account-level automation.</span>
+                    </EmptyCard>
                 ) : (
                     <Table>
                         <TableHeader>

--- a/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { permissions } from '@nangohq/authz';
 import { Button, Dialog, DialogBody, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger, IconButton, Input } from '@nangohq/design-system';
 
-import { DestructiveActionModal } from '@/components-v2/patterns/DestructiveActionModal';
+import { DestructiveActionModal } from '@/components/patterns/DestructiveActionModal';
 import { PermissionGate } from '@/components/patterns/PermissionGate';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
@@ -417,7 +417,12 @@ const DeleteApiKeyButton: React.FC<{ displayName: string; onDelete: () => void }
     return (
         <DestructiveActionModal
             title="Delete API Key"
-            description={`This action is irreversible. Any services using the key "${displayName}" will lose access immediately.`}
+            description={
+                <>
+                    This action is irreversible. Any services using the key <strong className="text-text-strong">{displayName}</strong> will lose access
+                    immediately.
+                </>
+            }
             inputLabel="To confirm, type the key name below:"
             confirmationKeyword={displayName}
             confirmButtonText="Delete API Key"

--- a/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
@@ -3,8 +3,8 @@ import { Trash2 } from 'lucide-react';
 import { permissions } from '@nangohq/authz';
 import { Button } from '@nangohq/design-system';
 
-import { DestructiveActionModal } from '@/components-v2/patterns/DestructiveActionModal';
 import { ConditionalTooltip } from '@/components/patterns/ConditionalTooltip';
+import { DestructiveActionModal } from '@/components/patterns/DestructiveActionModal';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { usePermissions } from '@/hooks/usePermissions';
 


### PR DESCRIPTION
## Summary
- Follow-up to [#7025](https://github.com/NangoHQ/nango/pull/7025) for late UI review feedback
- Bold API key names in destructive confirm copy (`DestructiveActionModal` description now accepts `ReactNode`)
- Align Account API keys loading / error / empty states with existing `Skeleton`, `Alert` + `AlertButton`, and `EmptyCard` patterns
- Show Alert actions for all story variants (adds `neutral` / `neutral-secondary` `AlertButton` variants)
- Move `DestructiveActionModal` out of `components-v2` into `components/patterns` (same cleanup as [#7089](https://github.com/NangoHQ/nango/pull/7089))

Noted without code change: dual destructive-confirm paths → tracked in [NAN-6572](https://linear.app/nango/issue/NAN-6572).

## Test plan
- [ ] Open Account API keys page: loading skeleton, empty state, and error + Try again
- [ ] Delete an Account API key: name is bold in the confirm dialog; failed delete keeps modal open and shows toast
- [ ] Delete an Environment API key: name is bold in the confirm dialog
- [ ] Storybook Alert Default story shows action button on every variant including neutral
- [ ] Storybook DestructiveActionModal still loads from the new import path


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

