### PR TITLE
fix(mfa): tolerate authenticator clock drift (NAN-6568)

### DIFF
--- a/packages/database/lib/migrations/20260812150000_add_clock_offset_to_user_mfa_factors.cjs
+++ b/packages/database/lib/migrations/20260812150000_add_clock_offset_to_user_mfa_factors.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "user_mfa_factors" ADD COLUMN IF NOT EXISTS "clock_offset_steps" INTEGER NOT NULL DEFAULT 0`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/shared/lib/services/mfa.service.integration.test.ts
+++ b/packages/shared/lib/services/mfa.service.integration.test.ts
@@ -8,6 +8,8 @@ import { seedUser } from '../seeders/user.seeder.js';
 import * as encryptionManager from '../utils/encryption.manager.js';
 import mfaService from './mfa.service.js';
 
+const STEP_MS = 30 * 1000;
+
 describe('MFA service', () => {
     beforeAll(async () => {
         await multipleMigrations();
@@ -59,6 +61,65 @@ describe('MFA service', () => {
 
         (await mfaService.disable(user.id)).unwrap();
         expect(await mfaService.hasActiveFactor(user.id)).toBe(false);
+    });
+
+    it('tracks the clock offset of a device that runs ahead', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-12T12:00:00Z'));
+
+        const account = await createAccount();
+        const user = await seedUser(account.id);
+        const enrollment = (await mfaService.startEnrollment(user.id, user.email)).unwrap();
+        const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
+        (await mfaService.activateEnrollment(user.id, totp.generate())).unwrap();
+        expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(0);
+
+        // Marcin's case: the authenticator is 2 steps (60s) ahead of us
+        const twoStepsAhead = totp.generate({ timestamp: Date.now() + 2 * STEP_MS });
+        expect((await mfaService.verifyTotp(user.id, twoStepsAhead)).unwrap()).toBe(true);
+        expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(2);
+
+        // now that we know the offset, a code 3 steps out is within the window centered on it
+        const threeStepsAhead = totp.generate({ timestamp: Date.now() + 3 * STEP_MS });
+        expect((await mfaService.verifyTotp(user.id, threeStepsAhead)).unwrap()).toBe(true);
+        expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(3);
+
+        // and a fixed clock still works, rather than being locked out by the stale offset
+        vi.setSystemTime(new Date('2026-08-12T12:02:00Z'));
+        expect((await mfaService.verifyTotp(user.id, totp.generate())).unwrap()).toBe(true);
+        expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(0);
+    });
+
+    it('rejects a login code beyond the window when no offset is known', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-12T12:00:00Z'));
+
+        const account = await createAccount();
+        const user = await seedUser(account.id);
+        const enrollment = (await mfaService.startEnrollment(user.id, user.email)).unwrap();
+        const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
+        (await mfaService.activateEnrollment(user.id, totp.generate())).unwrap();
+
+        const fiveStepsAhead = totp.generate({ timestamp: Date.now() + 5 * STEP_MS });
+        expect((await mfaService.verifyTotp(user.id, fiveStepsAhead)).unwrap()).toBe(false);
+        expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(0);
+    });
+
+    it('seeds the offset at activation so a badly unsynced device can still enroll', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-12T12:00:00Z'));
+
+        const account = await createAccount();
+        const user = await seedUser(account.id);
+        const enrollment = (await mfaService.startEnrollment(user.id, user.email)).unwrap();
+        const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
+
+        // 5 steps out would be refused at login, but activation is lenient enough to learn it
+        (await mfaService.activateEnrollment(user.id, totp.generate({ timestamp: Date.now() + 5 * STEP_MS }))).unwrap();
+        expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(5);
+
+        const sixStepsAhead = totp.generate({ timestamp: Date.now() + 6 * STEP_MS });
+        expect((await mfaService.verifyTotp(user.id, sixStepsAhead)).unwrap()).toBe(true);
     });
 
     it('returns only the user ids with an active factor', async () => {

--- a/packages/shared/lib/services/mfa.service.integration.test.ts
+++ b/packages/shared/lib/services/mfa.service.integration.test.ts
@@ -79,12 +79,42 @@ describe('MFA service', () => {
         expect((await mfaService.verifyTotp(user.id, twoStepsAhead)).unwrap()).toBe(true);
         expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(2);
 
-        // now that we know the offset, a code 3 steps out is within the window centered on it
+        // the window now sits on the offset, so a code 4 steps out is reachable where it was not before
+        const fourStepsAhead = totp.generate({ timestamp: Date.now() + 4 * STEP_MS });
+        expect((await mfaService.verifyTotp(user.id, fourStepsAhead)).unwrap()).toBe(true);
+        expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(4);
+
+        // a fixed clock is accepted on the real time center rather than being locked out by the
+        // stale offset. Advance well past the recorded offset so the replay guard below is not
+        // what this assertion ends up measuring.
+        vi.setSystemTime(new Date('2026-08-12T12:04:00Z'));
+        expect((await mfaService.verifyTotp(user.id, totp.generate())).unwrap()).toBe(true);
+        expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(0);
+    });
+
+    it('makes a corrected clock wait out the recorded offset', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-12T12:00:00Z'));
+
+        const account = await createAccount();
+        const user = await seedUser(account.id);
+        const enrollment = (await mfaService.startEnrollment(user.id, user.email)).unwrap();
+        const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
+        (await mfaService.activateEnrollment(user.id, totp.generate())).unwrap();
+
+        const twoStepsAhead = totp.generate({ timestamp: Date.now() + 2 * STEP_MS });
+        expect((await mfaService.verifyTotp(user.id, twoStepsAhead)).unwrap()).toBe(true);
         const threeStepsAhead = totp.generate({ timestamp: Date.now() + 3 * STEP_MS });
         expect((await mfaService.verifyTotp(user.id, threeStepsAhead)).unwrap()).toBe(true);
+
+        // Accepted behaviour, not a fix we are chasing. The replay guard stores the step of the
+        // code we accepted, which was 3 ahead of us, so a device that gets corrected has to catch
+        // up to it before its codes are new enough. The wait is bounded by the recorded offset,
+        // so at most MAX_CLOCK_OFFSET_STEPS steps, and nothing is written while it is failing.
+        vi.setSystemTime(new Date('2026-08-12T12:01:00Z'));
+        expect((await mfaService.verifyTotp(user.id, totp.generate())).unwrap()).toBe(false);
         expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(3);
 
-        // and a fixed clock still works, rather than being locked out by the stale offset
         vi.setSystemTime(new Date('2026-08-12T12:02:00Z'));
         expect((await mfaService.verifyTotp(user.id, totp.generate())).unwrap()).toBe(true);
         expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(0);

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -14,7 +14,12 @@ const FACTORS_TABLE = 'user_mfa_factors';
 const RECOVERY_CODES_TABLE = 'user_mfa_recovery_codes';
 const RECOVERY_CODE_COUNT = 10;
 const TOTP_ISSUER = 'Nango';
-const TOTP_WINDOW = 1;
+const TOTP_PERIOD_SECONDS = 30;
+const TOTP_WINDOW = 2;
+// The user is already authenticated when they activate, so we can be lenient enough to
+// learn the offset of a badly unsynced device instead of failing setup with no way out.
+const TOTP_ENROLLMENT_WINDOW = 10;
+const MAX_CLOCK_OFFSET_STEPS = 20;
 
 export type MFAErrorCode = 'encryption_unavailable' | 'already_enabled' | 'enrollment_not_found' | 'invalid_code' | 'not_enabled';
 
@@ -52,6 +57,7 @@ class MFAService {
                             iv,
                             auth_tag: authTag,
                             last_accepted_counter: null,
+                            clock_offset_steps: 0,
                             updated_at: trx.fn.now() as unknown as Date
                         });
                     return;
@@ -64,7 +70,8 @@ class MFAService {
                     iv,
                     auth_tag: authTag,
                     enabled_at: null,
-                    last_accepted_counter: null
+                    last_accepted_counter: null,
+                    clock_offset_steps: 0
                 });
             });
             return Ok({ otpauthUri: totp.toString() });
@@ -81,8 +88,8 @@ class MFAService {
                     throw new MFAError('enrollment_not_found');
                 }
 
-                const counter = this.getVerifiedCounter(factor, token);
-                if (counter === null) {
+                const verified = this.verifyToken(factor, token, TOTP_ENROLLMENT_WINDOW);
+                if (verified === null) {
                     throw new MFAError('invalid_code');
                 }
 
@@ -91,7 +98,8 @@ class MFAService {
                     .where({ id: factor.id })
                     .update({
                         enabled_at: trx.fn.now() as unknown as Date,
-                        last_accepted_counter: counter.toString(),
+                        last_accepted_counter: verified.counter.toString(),
+                        clock_offset_steps: verified.offsetSteps,
                         updated_at: trx.fn.now() as unknown as Date
                     });
                 await this.replaceRecoveryCodes(trx, userId, recoveryCodes);
@@ -130,8 +138,8 @@ class MFAService {
                     return false;
                 }
 
-                const counter = this.getVerifiedCounter(factor, token);
-                if (counter === null || (factor.last_accepted_counter !== null && counter <= BigInt(factor.last_accepted_counter))) {
+                const verified = this.verifyToken(factor, token, TOTP_WINDOW);
+                if (verified === null || (factor.last_accepted_counter !== null && verified.counter <= BigInt(factor.last_accepted_counter))) {
                     return false;
                 }
 
@@ -144,7 +152,11 @@ class MFAService {
                             queryBuilder.where('last_accepted_counter', factor.last_accepted_counter);
                         }
                     })
-                    .update({ last_accepted_counter: counter.toString(), updated_at: trx.fn.now() as unknown as Date });
+                    .update({
+                        last_accepted_counter: verified.counter.toString(),
+                        clock_offset_steps: verified.offsetSteps,
+                        updated_at: trx.fn.now() as unknown as Date
+                    });
 
                 return updated === 1;
             });
@@ -213,12 +225,12 @@ class MFAService {
             label: 'email' in input ? input.email : '',
             algorithm: 'SHA1',
             digits: 6,
-            period: 30,
+            period: TOTP_PERIOD_SECONDS,
             secret: 'secret' in input ? input.secret : new OTPAuth.Secret({ size: 20 })
         });
     }
 
-    private getVerifiedCounter(factor: DBMFAFactor, token: string): bigint | null {
+    private verifyToken(factor: DBMFAFactor, token: string, window: number): { counter: bigint; offsetSteps: number } | null {
         if (!/^\d{6}$/.test(token)) {
             return null;
         }
@@ -231,8 +243,25 @@ class MFAService {
         const secret = encryptionManager.decryptSync(factor.encrypted_secret, factor.iv, factor.auth_tag);
         const totp = this.createTotp({ secret: OTPAuth.Secret.fromBase32(secret) });
         const timestamp = Date.now();
-        const delta = totp.validate({ token, timestamp, window: TOTP_WINDOW });
-        return delta === null ? null : BigInt(totp.counter({ timestamp }) + delta);
+
+        // Check around our own clock as well as around the offset we last saw on this device.
+        // Recentering alone would lock a user out the moment they fix their clock, because the
+        // stored offset would then be pointing at where the device used to be.
+        const centers = new Set([0, factor.clock_offset_steps]);
+        for (const center of centers) {
+            const delta = totp.validate({ token, timestamp: timestamp + center * TOTP_PERIOD_SECONDS * 1000, window });
+            if (delta === null) {
+                continue;
+            }
+
+            const offsetSteps = center + delta;
+            return {
+                counter: BigInt(totp.counter({ timestamp }) + offsetSteps),
+                offsetSteps: Math.max(-MAX_CLOCK_OFFSET_STEPS, Math.min(MAX_CLOCK_OFFSET_STEPS, offsetSteps))
+            };
+        }
+
+        return null;
     }
 
     private createRecoveryCodes(): string[] {

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -18,8 +18,8 @@ const TOTP_PERIOD_SECONDS = 30;
 const TOTP_WINDOW = 2;
 // The user is already authenticated when they activate, so we can be lenient enough to
 // learn the offset of a badly unsynced device instead of failing setup with no way out.
-const TOTP_ENROLLMENT_WINDOW = 10;
-const MAX_CLOCK_OFFSET_STEPS = 20;
+const TOTP_ENROLLMENT_WINDOW = 5; // 2.5 minutes either side
+const MAX_CLOCK_OFFSET_STEPS = 10; // 5 minutes either side
 
 export type MFAErrorCode = 'encryption_unavailable' | 'already_enabled' | 'enrollment_not_found' | 'invalid_code' | 'not_enabled';
 

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -16,10 +16,8 @@ const RECOVERY_CODE_COUNT = 10;
 const TOTP_ISSUER = 'Nango';
 const TOTP_PERIOD_SECONDS = 30;
 const TOTP_WINDOW = 2;
-// The user is already authenticated when they activate, so we can be lenient enough to
-// learn the offset of a badly unsynced device instead of failing setup with no way out.
-const TOTP_ENROLLMENT_WINDOW = 5; // 2.5 minutes either side
-const MAX_CLOCK_OFFSET_STEPS = 10; // 5 minutes either side
+const TOTP_ENROLLMENT_WINDOW = 5;
+const MAX_CLOCK_OFFSET_STEPS = 10;
 
 export type MFAErrorCode = 'encryption_unavailable' | 'already_enabled' | 'enrollment_not_found' | 'invalid_code' | 'not_enabled';
 
@@ -245,8 +243,6 @@ class MFAService {
         const timestamp = Date.now();
 
         // Check around our own clock as well as around the offset we last saw on this device.
-        // Recentering alone would lock a user out the moment they fix their clock, because the
-        // stored offset would then be pointing at where the device used to be.
         const centers = new Set([0, factor.clock_offset_steps]);
         for (const center of centers) {
             const delta = totp.validate({ token, timestamp: timestamp + center * TOTP_PERIOD_SECONDS * 1000, window });

--- a/packages/types/lib/mfa/db.ts
+++ b/packages/types/lib/mfa/db.ts
@@ -11,6 +11,7 @@ export interface DBMFAFactor extends Timestamps {
     auth_tag: string;
     enabled_at: Date | null;
     last_accepted_counter: string | null;
+    clock_offset_steps: number;
 }
 
 export interface DBMFARecoveryCode {


### PR DESCRIPTION
NAN-6568

`TOTP_WINDOW` was 1, so we accepted T-1, T and T+1 and nothing else. A device running a minute fast has its valid codes rejected every time.

Two changes:
1. The login window goes to 2
2. We now record the offset we observe on each successful verification and check around it as well as around our own clock.

Activation gets a wider window of 5 steps. The user is already authenticated at that point so leniency costs nothing, and it is the only place we can learn the offset of a device that is already badly out. With a narrow window there the first code is rejected and the offset never gets seeded at all.

Checking both centers, rather than only the stored offset, is deliberate. Pure recentering would lock a user out the moment they fixed their clock, because the stored offset would still be pointing at where the device used to be.

[RFC 6238, Section 6 (Resynchronization)](https://www.rfc-editor.org/rfc/rfc6238#section-6)

## Test plan

- [x] `npm run ts-build`
- [x] `npm run test:integration -- packages/shared/lib/services/mfa.service.integration.test.ts` (9 passed)
- [x] `npm run test:integration -- packages/server/lib/controllers/v1/account/mfa/ packages/server/lib/controllers/v1/account/signin.integration.test.ts` (18 passed)
- [ ] Marcin confirms he can log in on staging without syncing his phone
