### PR TITLE
feat: add POST /functions/invocations

### DIFF
--- a/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
@@ -91,7 +91,7 @@ describe(`POST ${endpoint}`, () => {
                 connection_id: 'test',
                 name: 'test',
                 input: {},
-                invocation_type: 'Async'
+                invocation_type: 'no_wait'
             }
         });
 
@@ -110,7 +110,7 @@ describe(`POST ${endpoint}`, () => {
                 connection_id: 'test',
                 name: 'test',
                 input: {},
-                invocation_type: 'Async'
+                invocation_type: 'no_wait'
             }
         });
 
@@ -133,7 +133,7 @@ describe(`POST ${endpoint}`, () => {
                 integration_id: '',
                 connection_id: '',
                 name: '',
-                invocation_type: 'Async'
+                invocation_type: 'no_wait'
             }
         });
 
@@ -160,7 +160,7 @@ describe(`POST ${endpoint}`, () => {
                 integration_id: 'github',
                 connection_id: 'missing-connection',
                 name: 'test-function',
-                invocation_type: 'Async'
+                invocation_type: 'no_wait'
             }
         });
 
@@ -185,7 +185,7 @@ describe(`POST ${endpoint}`, () => {
                 integration_id: integration.unique_key,
                 connection_id: connection.connection_id,
                 name: 'missing-function',
-                invocation_type: 'Async'
+                invocation_type: 'no_wait'
             }
         });
 
@@ -209,7 +209,7 @@ describe(`POST ${endpoint}`, () => {
                 connection_id: connection.connection_id,
                 name: 'test-function',
                 input: { value: 42 },
-                invocation_type: 'Async'
+                invocation_type: 'no_wait'
             }
         });
 
@@ -240,7 +240,7 @@ describe(`POST ${endpoint}`, () => {
                 connection_id: connection.connection_id,
                 name: 'test-function',
                 input: { value: 'test' },
-                invocation_type: 'Async'
+                invocation_type: 'no_wait'
             }
         });
 

--- a/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { customerKeyService, functionConfigService, seeders } from '@nangohq/shared';
+
+import { runServer, shouldBeProtected } from '../../utils/tests.js';
+
+import type { ApiKeyScope, DBFunctionConfigVersion } from '@nangohq/types';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/functions/invocations';
+
+function functionVersion(): Omit<DBFunctionConfigVersion, 'id' | 'function_config_id' | 'created_at' | 'updated_at' | 'deleted_at'> {
+    return {
+        description: 'Test function',
+        file_location: 'functions/github/test-function',
+        version: 'test-version',
+        source: 'repo',
+        trigger: { kind: 'http' },
+        requires: { connection: true, outbound: false, invoke: false },
+        capabilities: { usesRecords: false, usesOutbound: false, usesCheckpoints: false, usesMetadata: false, usesInvoke: false },
+        limits: { concurrency: { perConnection: 'max' } },
+        input_schema_ref: '#/definitions/Input',
+        output_schema_ref: null,
+        model_schema_refs: [],
+        metadata_schema_ref: null,
+        checkpoint_schema_ref: null,
+        json_schema: {
+            definitions: {
+                Input: {
+                    type: 'object',
+                    properties: { value: { type: 'string' } },
+                    required: ['value'],
+                    additionalProperties: false
+                }
+            }
+        }
+    };
+}
+
+async function seedAccount(scopes?: ApiKeyScope[]) {
+    const seed = await seeders.seedAccountEnvAndUser();
+    if (scopes) {
+        await db.knex('customer_keys').where('id', seed.apiKey.id).update({ scopes });
+    }
+    return seed;
+}
+
+async function createApiKeyWithScopes(seed: Awaited<ReturnType<typeof seedAccount>>, scopes: string[]) {
+    const key = await customerKeyService.createApiKey(db.knex, {
+        accountId: seed.account.id,
+        environmentId: seed.env.id,
+        displayName: `test-${randomUUID()}`,
+        scopes
+    });
+
+    return key.unwrap();
+}
+
+async function seedFunction() {
+    const { apiKey, env } = await seedAccount(['environment:functions:invocations']);
+    const integration = await seeders.createConfigSeed(env, 'github', 'github');
+    const connection = await seeders.createConnectionSeed({ env, provider: integration.unique_key, connectionId: 'test-connection' });
+    await functionConfigService.upsert(db.knex, {
+        environmentId: env.id,
+        integrationId: integration.unique_key,
+        name: 'test-function',
+        version: functionVersion()
+    });
+
+    return { apiKey, connection, integration };
+}
+
+describe(`POST ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            body: {
+                integration_id: 'test',
+                connection_id: 'test',
+                name: 'test',
+                input: {},
+                invocation_type: 'Async'
+            }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should reject requests without the invocations scope', async () => {
+        const seed = await seedAccount();
+        const apiKey = await createApiKeyWithScopes(seed, ['environment:functions:dryrun']);
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: 'test',
+                connection_id: 'test',
+                name: 'test',
+                input: {},
+                invocation_type: 'Async'
+            }
+        });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: environment:functions:invocations'
+            }
+        });
+    });
+
+    it('should reject empty invocation identifiers', async () => {
+        const { apiKey } = await seedAccount(['environment:functions:invocations']);
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: '',
+                connection_id: '',
+                name: '',
+                invocation_type: 'Async'
+            }
+        });
+
+        expect(res.res.status).toBe(400);
+        expect(res.json).toEqual({
+            error: {
+                code: 'invalid_body',
+                errors: expect.arrayContaining([
+                    expect.objectContaining({ path: ['integration_id'] }),
+                    expect.objectContaining({ path: ['connection_id'] }),
+                    expect.objectContaining({ path: ['name'] })
+                ])
+            }
+        });
+    });
+
+    it('should error when the connection is not found', async () => {
+        const { apiKey } = await seedAccount(['environment:functions:invocations']);
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: 'github',
+                connection_id: 'missing-connection',
+                name: 'test-function',
+                invocation_type: 'Async'
+            }
+        });
+
+        expect(res.res.status).toBe(404);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'connection_not_found',
+                message: "Connection 'missing-connection' was not found for integration 'github'"
+            }
+        });
+    });
+
+    it('should return an error when the function is not found', async () => {
+        const { apiKey, env } = await seedAccount(['environment:functions:invocations']);
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: integration.unique_key, connectionId: 'test-connection' });
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'missing-function',
+                invocation_type: 'Async'
+            }
+        });
+
+        expect(res.res.status).toBe(404);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'unknown_function',
+                message: "Function 'missing-function' was not found"
+            }
+        });
+    });
+
+    it('should return validation errors for invalid function input', async () => {
+        const { apiKey, connection, integration } = await seedFunction();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 42 },
+                invocation_type: 'Async'
+            }
+        });
+
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'validation_error',
+                message: 'invalid_function_input',
+                errors: [
+                    {
+                        code: 'type',
+                        message: 'must be string',
+                        path: ['value']
+                    }
+                ]
+            }
+        });
+    });
+
+    it('should return not implemented', async () => {
+        const { apiKey, connection, integration } = await seedFunction();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'Async'
+            }
+        });
+
+        expect(res.res.status).toBe(501);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'not_implemented',
+                message: 'Function invocation is not implemented yet'
+            }
+        });
+    });
+});

--- a/packages/server/lib/controllers/functions/postInvocation.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+
+import db from '@nangohq/database';
+import { connectionService, functionConfigService, validateFunctionInput } from '@nangohq/shared';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { connectionIdSchema, providerConfigKeySchema, scriptNameSchema } from '../../helpers/validation.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+
+import type { DBFunctionConfigVersion, FunctionInvocationType, PostFunctionInvocation } from '@nangohq/types';
+
+const bodyValidation = z
+    .object({
+        connection_id: connectionIdSchema,
+        integration_id: providerConfigKeySchema,
+        name: scriptNameSchema,
+        input: z.unknown().optional(),
+        invocation_type: z.enum(['RequestResponse', 'Async'] satisfies FunctionInvocationType[]),
+        // TODO: Validate options based on function config
+        // Ex: scheduled functions can have variant, functions with models can have clear cache, etc...
+        // For now we just accept any options without using them yet.
+        options: z.record(z.string(), z.any()).optional()
+    })
+    .strict();
+
+export const postFunctionInvocation = asyncWrapperWithEnvironment<PostFunctionInvocation>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const bodyValidationResult = bodyValidation.safeParse(req.body);
+    if (!bodyValidationResult.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(bodyValidationResult.error) } });
+        return;
+    }
+
+    const body: PostFunctionInvocation['Body'] = bodyValidationResult.data;
+
+    const connectionRes = await connectionService.getConnection(body.connection_id, body.integration_id, res.locals.environment.id);
+
+    if (!connectionRes.success) {
+        res.status(404).send({
+            error: {
+                code: 'connection_not_found',
+                message: `Connection '${body.connection_id}' was not found for integration '${body.integration_id}'`
+            }
+        });
+        return;
+    }
+
+    const functionRes = await functionConfigService.search(db.knex, {
+        environmentId: res.locals.environment.id,
+        filter: { integrationKey: body.integration_id, name: body.name }
+    });
+
+    if (functionRes.isErr()) {
+        report(functionRes.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to find function' } });
+        return;
+    }
+
+    if (functionRes.value.length !== 1) {
+        res.status(404).send({ error: { code: 'unknown_function', message: `Function '${body.name}' was not found` } });
+        return;
+    }
+
+    if (!functionRes.value[0]?.config.enabled) {
+        res.status(403).send({ error: { code: 'function_disabled', message: 'Function is disabled' } });
+        return;
+    }
+
+    const { currentVersion } = functionRes.value[0];
+
+    if (!supportInvocation(currentVersion, body.invocation_type)) {
+        res.status(400).send({ error: { code: 'invalid_invocation', message: `Function '${body.name}' is not invokable with ${body.invocation_type}` } });
+        return;
+    }
+
+    const validation = validateFunctionInput(currentVersion, body.input);
+
+    if (validation.isErr()) {
+        res.status(400).send({ error: { code: 'validation_error', message: validation.error.message, errors: validation.error.validationErrors } });
+        return;
+    }
+
+    res.status(501).send({ error: { code: 'not_implemented', message: 'Function invocation is not implemented yet' } });
+});
+
+function supportInvocation(version: DBFunctionConfigVersion, invocationType: FunctionInvocationType): boolean {
+    const supported: Record<DBFunctionConfigVersion['trigger']['kind'], FunctionInvocationType[]> = {
+        http: ['RequestResponse', 'Async'],
+        schedule: ['Async'],
+        event: ['Async'],
+        none: []
+    };
+    return supported[version.trigger.kind]?.includes(invocationType) ?? false;
+}

--- a/packages/server/lib/controllers/functions/postInvocation.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.ts
@@ -15,7 +15,7 @@ const bodyValidation = z
         integration_id: providerConfigKeySchema,
         name: scriptNameSchema,
         input: z.unknown().optional(),
-        invocation_type: z.enum(['RequestResponse', 'Async'] satisfies FunctionInvocationType[]),
+        invocation_type: z.enum(['wait', 'no_wait'] satisfies FunctionInvocationType[]),
         // TODO: Validate options based on function config
         // Ex: scheduled functions can have variant, functions with models can have clear cache, etc...
         // For now we just accept any options without using them yet.
@@ -90,9 +90,9 @@ export const postFunctionInvocation = asyncWrapperWithEnvironment<PostFunctionIn
 
 function supportInvocation(version: DBFunctionConfigVersion, invocationType: FunctionInvocationType): boolean {
     const supported: Record<DBFunctionConfigVersion['trigger']['kind'], FunctionInvocationType[]> = {
-        http: ['RequestResponse', 'Async'],
-        schedule: ['Async'],
-        event: ['Async'],
+        http: ['wait', 'no_wait'],
+        schedule: ['no_wait'],
+        event: ['no_wait'],
         none: []
     };
     return supported[version.trigger.kind]?.includes(invocationType) ?? false;

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -46,6 +46,7 @@ import { postFunctionDeploymentResult } from './controllers/functions/deployment
 import { getFunctionDryrun } from './controllers/functions/dryrun/getDryrun.js';
 import { postFunctionDryrun } from './controllers/functions/dryrun/postDryrun.js';
 import { postFunctionDryrunResult } from './controllers/functions/dryrun/postDryrunResult.js';
+import { postFunctionInvocation } from './controllers/functions/postInvocation.js';
 import { getPublicListIntegrations } from './controllers/integrations/getListIntegrations.js';
 import { postPublicIntegration, postPublicQuickstartIntegration } from './controllers/integrations/postIntegration.js';
 import { deletePublicIntegration } from './controllers/integrations/uniqueKey/deleteIntegration.js';
@@ -348,6 +349,7 @@ publicAPI.route('/scripts/config').get(apiAuth, withScope('environment:integrati
 
 // Functions
 publicAPI.use('/functions', jsonContentTypeMiddleware);
+
 publicAPI.route('/functions/compile').post(functionCompileAuth, postFunctionCompile);
 publicAPI.route('/functions/dryruns').post(functionDryrunAuth, postFunctionDryrun);
 publicAPI.route('/functions/dryruns/:id').get(functionDryrunAuth, getFunctionDryrun);
@@ -358,6 +360,8 @@ publicAPI.route('/functions/deployments/:id/result').post(functionDeploymentResu
 
 publicAPI.route('/functions/deployments/bundle/preview').post(apiAuth, withScope('environment:deploy'), postFunctionDeploymentBundlePreview);
 publicAPI.route('/functions/deployments/bundle').post(apiAuth, auditFunctionDeploymentBundle, withScope('environment:deploy'), postFunctionDeploymentBundle);
+
+publicAPI.route('/functions/invocations').post(apiAuth, withScope('environment:functions:invocations'), postFunctionInvocation);
 
 // Actions
 publicAPI.use('/action', jsonContentTypeMiddleware);

--- a/packages/shared/lib/services/functions/deploy.ts
+++ b/packages/shared/lib/services/functions/deploy.ts
@@ -61,7 +61,7 @@ export async function prepareDeploymentBundle({
 
         const deployed = await functionConfigService.search(db.knex, {
             environmentId,
-            integrationKey: reconciliationScope.kind === 'integration' ? reconciliationScope.integrationId : undefined
+            filter: reconciliationScope.kind === 'integration' ? { integrationKey: reconciliationScope.integrationId } : undefined
         });
         if (deployed.isErr()) {
             return Err(functionsDeploymentError(deployed.error));

--- a/packages/shared/lib/services/functions/index.ts
+++ b/packages/shared/lib/services/functions/index.ts
@@ -5,3 +5,4 @@ export * as functionConfigService from './models/functions.js';
 export { reconcile } from './reconcile.js';
 export type { DeploymentBundleReconciliation } from './reconcile.js';
 export { functionVersionHash } from './version.js';
+export { validateFunctionInput } from './models/validate.js';

--- a/packages/shared/lib/services/functions/models/functions.integration.test.ts
+++ b/packages/shared/lib/services/functions/models/functions.integration.test.ts
@@ -52,7 +52,12 @@ describe(search, () => {
             version: functionVersion('second-version')
         });
 
-        const functions = (await search(db.knex, { environmentId: environment.id, integrationKey: firstIntegration.unique_key })).unwrap();
+        const functions = (
+            await search(db.knex, {
+                environmentId: environment.id,
+                filter: { integrationKey: firstIntegration.unique_key }
+            })
+        ).unwrap();
 
         expect(functions).toHaveLength(1);
         expect(functions[0]).toMatchObject({
@@ -65,16 +70,80 @@ describe(search, () => {
     it('returns no functions for an unknown integration unique key', async () => {
         const account = await createAccount();
         const environment = await createEnvironmentSeed(account.id);
-        const integration = await createConfigSeed(environment, 'github', 'github');
+        const github = await createConfigSeed(environment, 'github', 'github');
         await upsert(db.knex, {
             environmentId: environment.id,
-            integrationId: integration.unique_key,
+            integrationId: github.unique_key,
             name: 'function',
             version: functionVersion('version')
         });
 
-        const functions = (await search(db.knex, { environmentId: environment.id, integrationKey: 'unknown' })).unwrap();
+        const functions = (await search(db.knex, { environmentId: environment.id, filter: { integrationKey: 'unknown' } })).unwrap();
 
         expect(functions).toStrictEqual([]);
+    });
+
+    it('filters functions by name', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const github = await createConfigSeed(environment, 'github', 'github');
+
+        const config = {
+            environmentId: environment.id,
+            integrationId: github.unique_key,
+            name: 'firstFunction',
+            version: functionVersion('123')
+        };
+
+        await upsert(db.knex, config);
+        await upsert(db.knex, { ...config, name: 'secondFunction', version: functionVersion('456') });
+
+        const functions = (
+            await search(db.knex, {
+                environmentId: environment.id,
+                filter: { integrationKey: github.unique_key, name: config.name }
+            })
+        ).unwrap();
+
+        expect(functions).toHaveLength(1);
+        expect(functions[0]).toMatchObject({
+            integration: { id: github.id, unique_key: github.unique_key },
+            config: { nango_config_id: github.id, name: config.name },
+            currentVersion: { version: config.version.version }
+        });
+    });
+
+    it('returns no functions for an unknown name', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const github = await createConfigSeed(environment, 'github', 'github');
+        await upsert(db.knex, {
+            environmentId: environment.id,
+            integrationId: github.unique_key,
+            name: 'function',
+            version: functionVersion('version')
+        });
+
+        const functions = (await search(db.knex, { environmentId: environment.id, filter: { integrationKey: github.unique_key, name: 'unknown' } })).unwrap();
+
+        expect(functions).toStrictEqual([]);
+    });
+
+    it('does not ignore empty filter values', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const github = await createConfigSeed(environment, 'github', 'github');
+        await upsert(db.knex, {
+            environmentId: environment.id,
+            integrationId: github.unique_key,
+            name: 'function',
+            version: functionVersion('version')
+        });
+
+        const emptyIntegrationKey = (await search(db.knex, { environmentId: environment.id, filter: { integrationKey: '' } })).unwrap();
+        const emptyName = (await search(db.knex, { environmentId: environment.id, filter: { integrationKey: github.unique_key, name: '' } })).unwrap();
+
+        expect(emptyIntegrationKey).toStrictEqual([]);
+        expect(emptyName).toStrictEqual([]);
     });
 });

--- a/packages/shared/lib/services/functions/models/functions.ts
+++ b/packages/shared/lib/services/functions/models/functions.ts
@@ -84,7 +84,13 @@ type JoinedFunctionConfigRow = Prefixed<DBFunctionConfig, typeof CONFIG_PREFIX> 
 
 export async function search(
     trx: Knex,
-    { environmentId, integrationKey }: { environmentId: number; integrationKey?: string | undefined }
+    {
+        environmentId,
+        filter
+    }: {
+        environmentId: number;
+        filter?: { integrationKey: string; name?: string | undefined } | undefined;
+    }
 ): Promise<Result<CurrentFunctionConfig[]>> {
     try {
         const query = trx
@@ -103,8 +109,11 @@ export async function search(
             .whereNull('config.deleted_at')
             .whereNull('version.deleted_at');
 
-        if (integrationKey) {
-            query.where('integration.unique_key', integrationKey);
+        if (filter) {
+            query.where('integration.unique_key', filter.integrationKey);
+        }
+        if (filter?.name !== undefined) {
+            query.where('config.name', filter.name);
         }
 
         const rows = await query;

--- a/packages/shared/lib/services/functions/models/validate.ts
+++ b/packages/shared/lib/services/functions/models/validate.ts
@@ -1,0 +1,159 @@
+import { Ajv } from 'ajv';
+import addFormats from 'ajv-formats';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import type { DBFunctionConfigVersion, ValidationError } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+import type { AnySchema, ErrorObject, ValidateFunction } from 'ajv';
+
+export const MAX_VALIDATOR_CACHE_SIZE = 1000;
+
+const ajv = new Ajv({
+    // We avoid collecting all errors for performance reasons
+    // as well as preventing huge malicious inputs from causing OOM errors
+    // Important: Only the first validation error will be returned,
+    // making the error reporting less comprehensive for the users
+    // but it is a trade-off for performance and security.
+    allErrors: false,
+    strict: true
+});
+// @ts-expect-error ajv-formats CommonJS default export is callable at runtime but mis-typed under NodeNext
+addFormats(ajv);
+
+// ajv owns the schema cache,
+// but we maintain a LRU cache of version id to validator status
+// to avoid re-compiling schemas unnecessarily and evict the oldest entries.
+const validatorCache = new Map<number, 'valid' | 'invalid'>();
+
+export function clearFunctionInputValidatorCache(): void {
+    for (const [versionId, status] of validatorCache) {
+        if (status === 'valid') {
+            ajv.removeSchema(validatorSchemaId(versionId));
+        }
+    }
+    validatorCache.clear();
+}
+
+class FunctionInputValidationError extends Error {
+    public validationErrors: ValidationError[];
+
+    constructor(message: string, errors: ValidationError[] = []) {
+        super(message);
+        this.name = 'function_input_validation_error';
+        this.validationErrors = errors;
+    }
+}
+
+export function validateFunctionInput(version: DBFunctionConfigVersion, input: unknown): Result<unknown, FunctionInputValidationError> {
+    if (!version.input_schema_ref) {
+        return input === undefined ? Ok(input) : Err(new FunctionInputValidationError('unexpected_function_input'));
+    }
+
+    try {
+        const validate = getValidator(version);
+        if (!validate) {
+            return Err(new FunctionInputValidationError('invalid_function_input_schema'));
+        }
+
+        const valid = validate(input);
+        if (!valid) {
+            return Err(new FunctionInputValidationError('invalid_function_input', toValidationErrors(validate.errors || [])));
+        }
+        return Ok(input);
+    } catch (_err) {
+        return Err(new FunctionInputValidationError('invalid_function_input_schema'));
+    }
+}
+
+function getValidator(version: DBFunctionConfigVersion): ValidateFunction | null {
+    const cached = validatorCache.get(version.id);
+    if (cached) {
+        // Re-insert the cached validator to mark it as recently used
+        validatorCache.delete(version.id);
+        validatorCache.set(version.id, cached);
+
+        // If the cached validator is marked as invalid,
+        // return null to indicate that validation cannot proceed
+        if (cached === 'invalid') {
+            return null;
+        }
+
+        // If the cached validator is marked as valid,
+        // retrieve it from Ajv and return it
+        const validate = ajv.getSchema(validatorSchemaId(version.id));
+        if (validate) {
+            return validate;
+        }
+
+        // If the cached validator is marked as valid but not found in Ajv,
+        // remove it from the cache and proceed to recompile it
+        validatorCache.delete(version.id);
+    }
+
+    const schemaId = validatorSchemaId(version.id);
+    try {
+        ajv.addSchema({ ...version.json_schema, $id: schemaId, $ref: version.input_schema_ref } as AnySchema);
+        const validate = ajv.getSchema(schemaId);
+        if (!validate) {
+            throw new Error('failed_to_compile_function_input_schema');
+        }
+
+        validatorCache.set(version.id, 'valid');
+        return validate;
+    } catch {
+        ajv.removeSchema(schemaId);
+        validatorCache.set(version.id, 'invalid');
+        return null;
+    } finally {
+        tryEvictValidator();
+    }
+}
+
+function validatorSchemaId(versionId: number): string {
+    return `nango:function:input:${versionId}`;
+}
+
+function tryEvictValidator(): void {
+    if (validatorCache.size <= MAX_VALIDATOR_CACHE_SIZE) {
+        return;
+    }
+
+    const oldest = validatorCache.entries().next().value;
+    if (!oldest) {
+        return;
+    }
+
+    const [versionId, status] = oldest;
+    validatorCache.delete(versionId);
+    if (status === 'valid') {
+        ajv.removeSchema(validatorSchemaId(versionId));
+    }
+}
+
+function toValidationErrors(errors: ErrorObject[]): ValidationError[] {
+    return errors.map((error) => {
+        const path = error.instancePath
+            ? error.instancePath
+                  .slice(1)
+                  .split('/')
+                  .map((part) => part.replace(/~1/g, '/').replace(/~0/g, '~'))
+            : [];
+
+        const property: unknown =
+            error.keyword === 'required'
+                ? error.params['missingProperty']
+                : error.keyword === 'additionalProperties'
+                  ? error.params['additionalProperty']
+                  : undefined;
+        if (typeof property === 'string') {
+            path.push(property);
+        }
+
+        return {
+            code: error.keyword,
+            message: error.message || 'Invalid input',
+            path
+        };
+    });
+}

--- a/packages/shared/lib/services/functions/models/validate.unit.test.ts
+++ b/packages/shared/lib/services/functions/models/validate.unit.test.ts
@@ -1,0 +1,187 @@
+import { Ajv } from 'ajv';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearFunctionInputValidatorCache, MAX_VALIDATOR_CACHE_SIZE, validateFunctionInput } from './validate.js';
+
+import type { DBFunctionConfigVersion } from '@nangohq/types';
+
+const now = new Date('2026-01-01T00:00:00.000Z');
+
+const version = {
+    id: 1,
+    function_config_id: 1,
+    description: 'Test function',
+    file_location: 'functions/github/test',
+    version: '1',
+    source: 'repo',
+    trigger: { kind: 'none' },
+    requires: { connection: true, outbound: false, invoke: false },
+    capabilities: { usesRecords: false, usesOutbound: false, usesCheckpoints: false, usesMetadata: false, usesInvoke: false },
+    limits: { concurrency: { perConnection: 'max' } },
+    input_schema_ref: '#/definitions/Input',
+    output_schema_ref: null,
+    model_schema_refs: [],
+    metadata_schema_ref: null,
+    checkpoint_schema_ref: null,
+    json_schema: {
+        definitions: {
+            Input: {
+                type: 'object',
+                properties: { user: { $ref: '#/definitions/User' } },
+                required: ['user'],
+                additionalProperties: false
+            },
+            User: {
+                type: 'object',
+                properties: { id: { type: 'string' } },
+                required: ['id'],
+                additionalProperties: false
+            }
+        }
+    },
+    created_at: now,
+    updated_at: now,
+    deleted_at: null
+} satisfies DBFunctionConfigVersion;
+
+describe('validateFunctionInput', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        clearFunctionInputValidatorCache();
+    });
+
+    it('validates input against the referenced definition', () => {
+        const input = { user: { id: 'user-1' } };
+
+        const result = validateFunctionInput(version, input);
+
+        expect(result.unwrap()).toBe(input);
+    });
+
+    it('returns the first JSON schema validation error', () => {
+        const result = validateFunctionInput(version, { user: { id: 1, unexpected: true }, unexpected: true });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) return;
+        expect(result.error.message).toBe('invalid_function_input');
+        expect(result.error.validationErrors).toStrictEqual([
+            { code: 'additionalProperties', message: 'must NOT have additional properties', path: ['unexpected'] }
+        ]);
+    });
+
+    it('validates JSON schema formats', () => {
+        const formattedVersion: DBFunctionConfigVersion = {
+            ...version,
+            id: 2,
+            json_schema: {
+                definitions: {
+                    Input: {
+                        type: 'object',
+                        properties: { url: { type: 'string', format: 'uri' } },
+                        required: ['url'],
+                        additionalProperties: false
+                    }
+                }
+            }
+        };
+
+        const valid = validateFunctionInput(formattedVersion, { url: 'https://example.com' });
+        expect(valid.unwrap()).toStrictEqual({ url: 'https://example.com' });
+
+        const invalid = validateFunctionInput(formattedVersion, { url: 'not-a-url' });
+        expect(invalid.isErr()).toBe(true);
+        if (invalid.isOk()) return;
+        expect(invalid.error.validationErrors).toContainEqual({ code: 'format', message: 'must match format "uri"', path: ['url'] });
+    });
+
+    it('accepts omitted input when the function has no input schema', () => {
+        const result = validateFunctionInput({ ...version, input_schema_ref: null }, undefined);
+
+        expect(result.unwrap()).toBeUndefined();
+    });
+
+    it.each([{}, null, false])('rejects provided input when the function has no input schema: %j', (input) => {
+        const result = validateFunctionInput({ ...version, input_schema_ref: null }, input);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) return;
+        expect(result.error.message).toBe('unexpected_function_input');
+        expect(result.error.validationErrors).toStrictEqual([]);
+    });
+
+    it('returns an error when the input schema reference cannot be compiled', () => {
+        const result = validateFunctionInput({ ...version, id: 3, input_schema_ref: '#/definitions/Missing' }, {});
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) return;
+        expect(result.error.name).toBe('function_input_validation_error');
+        expect(result.error.message).toBe('invalid_function_input_schema');
+        expect(result.error.validationErrors).toStrictEqual([]);
+    });
+
+    it('validates omitted input against the input schema', () => {
+        const result = validateFunctionInput(version, undefined);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) return;
+        expect(result.error.message).toBe('invalid_function_input');
+        expect(result.error.validationErrors).toContainEqual({ code: 'type', message: 'must be object', path: [] });
+    });
+
+    it('validates falsy input values', () => {
+        const booleanVersion: DBFunctionConfigVersion = {
+            ...version,
+            id: 4,
+            json_schema: { definitions: { Input: { type: 'boolean' } } }
+        };
+
+        const result = validateFunctionInput(booleanVersion, false);
+
+        expect(result.unwrap()).toBe(false);
+    });
+
+    it('reuses the compiled validator for a function version', () => {
+        const addSchema = vi.spyOn(Ajv.prototype, 'addSchema');
+
+        expect(validateFunctionInput(version, { user: { id: 'user-1' } }).isOk()).toBe(true);
+        expect(validateFunctionInput(version, { user: { id: 'user-2' } }).isOk()).toBe(true);
+
+        expect(addSchema).toHaveBeenCalledOnce();
+    });
+
+    it('caches schema compilation failures', () => {
+        const addSchema = vi.spyOn(Ajv.prototype, 'addSchema');
+        const invalidVersion = { ...version, id: 5, input_schema_ref: '#/definitions/Missing' };
+
+        expect(validateFunctionInput(invalidVersion, {}).isErr()).toBe(true);
+        expect(validateFunctionInput(invalidVersion, {}).isErr()).toBe(true);
+
+        expect(addSchema).toHaveBeenCalledOnce();
+    });
+
+    it('evicts the least recently used validator', () => {
+        // Spy on Ajv.addSchema to count how many times a schema is compiled
+        const addSchema = vi.spyOn(Ajv.prototype, 'addSchema');
+
+        // Compile and cache 1000 validators
+        for (let id = 0; id < MAX_VALIDATOR_CACHE_SIZE; id++) {
+            expect(validateFunctionInput({ ...version, id }, { user: { id: 'user-1' } }).isOk()).toBe(true);
+        }
+        expect(addSchema).toHaveBeenCalledTimes(MAX_VALIDATOR_CACHE_SIZE);
+
+        // Re-calling version 0 should use the cached validator,
+        // not trigger a new schema compilation,
+        // and mark version 0 as recently used.
+        expect(validateFunctionInput({ ...version, id: 0 }, { user: { id: 'user-1' } }).isOk()).toBe(true);
+        expect(addSchema).toHaveBeenCalledTimes(MAX_VALIDATOR_CACHE_SIZE);
+
+        // Overflow the cache with a new version
+        // This should evict version 1, which was the least recently used.
+        expect(validateFunctionInput({ ...version, id: 123456 }, { user: { id: 'user-1' } }).isOk()).toBe(true);
+        expect(addSchema).toHaveBeenCalledTimes(MAX_VALIDATOR_CACHE_SIZE + 1);
+
+        // Version 1 was least recently used, so re-calling it registers it again.
+        expect(validateFunctionInput({ ...version, id: 1 }, { user: { id: 'user-1' } }).isOk()).toBe(true);
+        expect(addSchema).toHaveBeenCalledTimes(MAX_VALIDATOR_CACHE_SIZE + 2);
+    });
+});

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -34,6 +34,7 @@ export const API_KEY_SCOPES = [
     'environment:functions:delete',
     'environment:functions:compile',
     'environment:functions:dryrun',
+    'environment:functions:invocations',
     'environment:functions:*',
     // Deploy
     'environment:deploy',

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -93,7 +93,8 @@ import type {
     PostFunctionDeploymentBundlePreview,
     PostFunctionDeploymentResult,
     PostFunctionDryrun,
-    PostFunctionDryrunResult
+    PostFunctionDryrunResult,
+    PostFunctionInvocation
 } from './functions/api.js';
 import type { GetGettingStarted, PatchGettingStarted } from './gettingStarted/api.js';
 import type {
@@ -188,6 +189,7 @@ export type PublicApiEndpoints =
     | PostFunctionDeployment
     | GetFunctionDeployment
     | PostFunctionDeploymentResult
+    | PostFunctionInvocation
     | PostFunctionDeploymentBundle
     | PostFunctionDeploymentBundlePreview
     | GetPublicFunctionCode

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -233,7 +233,7 @@ export type PostFunctionDeploymentResult = ApiEndpoint<{
     Success: { ok: true };
 }>;
 
-export type FunctionInvocationType = 'RequestResponse' | 'Async';
+export type FunctionInvocationType = 'wait' | 'no_wait';
 
 export type PostFunctionInvocation = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -233,6 +233,24 @@ export type PostFunctionDeploymentResult = ApiEndpoint<{
     Success: { ok: true };
 }>;
 
+export type FunctionInvocationType = 'RequestResponse' | 'Async';
+
+export type PostFunctionInvocation = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
+    Method: 'POST';
+    Path: '/functions/invocations';
+    Body: {
+        connection_id: string;
+        integration_id: string;
+        name: string;
+        input?: unknown | undefined;
+        invocation_type: FunctionInvocationType;
+        options?: Record<string, unknown> | undefined;
+    };
+    Error: ApiError<'not_implemented' | 'connection_not_found' | 'unknown_function' | 'function_disabled' | 'validation_error' | 'invalid_invocation'>;
+    Success: Record<string, unknown>;
+}>;
+
 // Shared between the private and public function-management endpoints. The two surfaces differ only in auth,
 // path, param names, and the `env` querystring (private) — the payloads and filters below are identical.
 export interface FunctionListFilters {

--- a/packages/utils/lib/api-key-scopes.ts
+++ b/packages/utils/lib/api-key-scopes.ts
@@ -36,6 +36,7 @@ export const apiKeyScopes = [
     'environment:functions:delete',
     'environment:functions:compile',
     'environment:functions:dryrun',
+    'environment:functions:invocations',
     'environment:functions:*',
     // Deploy
     'environment:deploy',

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
@@ -51,7 +51,8 @@ export const SCOPE_GROUPS: ScopeGroup[] = [
             { value: 'environment:functions:read', label: 'read' },
             { value: 'environment:functions:delete', label: 'delete' },
             { value: 'environment:functions:compile', label: 'compile' },
-            { value: 'environment:functions:dryrun', label: 'dryrun' }
+            { value: 'environment:functions:dryrun', label: 'dryrun' },
+            { value: 'environment:functions:invocations', label: 'invocations' }
         ]
     },
     { group: 'Deploy', items: [{ value: 'environment:deploy', label: 'deploy' }] },


### PR DESCRIPTION
Adding `POST /functions/invocations` validating body and input 
Still returns 501 Not Implemented for now, until we build functions execution into Nango.

```

export type PostFunctionInvocation = ApiEndpoint<{
    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
    Method: 'POST';
    Path: '/functions/invocations';
    Body: {
        connection_id: string;
        integration_id: string;
        name: string;
        input?: unknown | undefined;
        invocation_type: 'RequestResponse' | 'Async';
        options?: Record<string, unknown> | undefined; // not used yet
    };
    Error: ApiError<'not_implemented' | 'connection_not_found' | 'unknown_function' | 'function_disabled' | 'validation_error' | 'invalid_invocation'>;
    Success: Record<string, unknown>;
}>;
```

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

