### PR TITLE
feat(webapp): add a billing & usage summary strip

### DIFF
--- a/packages/design-system/stories/SummaryStrip.stories.tsx
+++ b/packages/design-system/stories/SummaryStrip.stories.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Plus } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 
 import { SummaryStrip } from '@/pages/Team/Billing/components/SummaryStrip';
 import { IconButton } from '../src';
@@ -25,11 +25,6 @@ const editCard = (
         <Pencil className="size-3" />
     </IconButton>
 );
-const addCard = (
-    <IconButton variant="ghost" size="2xs" label="Add payment method">
-        <Plus className="size-3" />
-    </IconButton>
-);
 
 /** Starter and Growth: the billing period renews, and the card is editable inline. */
 export const Paid: Story = {
@@ -40,12 +35,15 @@ export const Paid: Story = {
     }
 };
 
-/** A customer paying by invoice or wire — no card to show, but the slot stays so one can be added. */
+/**
+ * No card on file — typically a customer paying by invoice or wire. The payment slot is dropped
+ * rather than dashed; a card gets added from the billing information section below. A viewer
+ * without the billing permission sees this same shape.
+ */
 export const PaidWithoutCard: Story = {
     args: {
         planTitle: 'Starter',
-        date: { label: 'RENEWS ON', value: 'September 1, 2026' },
-        payment: { card: null, action: addCard }
+        date: { label: 'RENEWS ON', value: 'September 1, 2026' }
     }
 };
 
@@ -63,7 +61,7 @@ export const Downgrading: Story = {
         planTitle: 'Growth',
         date: { label: 'CHANGES ON', value: 'September 1, 2026' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
-        change: { toPlanTitle: 'Free', at: 'September 1, 2026' }
+        change: { toPlanTitle: 'Free', at: 'September 1, 2026', detail: 'no further charges after this period.' }
     }
 };
 
@@ -73,7 +71,11 @@ export const DealConverting: Story = {
         planTitle: 'Startup deal',
         date: { label: 'CHANGES ON', value: 'September 25, 2026' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
-        change: { toPlanTitle: 'Growth', at: 'September 25, 2026' }
+        change: {
+            toPlanTitle: 'Growth',
+            at: 'September 25, 2026',
+            detail: "your startup deal ends and you'll be charged at standard Growth pricing."
+        }
     }
 };
 
@@ -85,18 +87,9 @@ export const DealWithoutDate: Story = {
     }
 };
 
-/** Viewers without the billing permission get plan and date only. */
-export const WithoutBillingPermission: Story = {
-    args: {
-        planTitle: 'Growth',
-        date: { label: 'RENEWS ON', value: 'September 1, 2026' }
-    }
-};
-
 /** While the plan resolves, nothing else can — the plan decides which slots exist. */
 export const Loading: Story = {
     args: {
-        planTitle: null,
-        payment: { card: null, isLoading: true }
+        planTitle: null
     }
 };

--- a/packages/design-system/stories/SummaryStrip.stories.tsx
+++ b/packages/design-system/stories/SummaryStrip.stories.tsx
@@ -55,13 +55,23 @@ export const Free: Story = {
     }
 };
 
-/** A scheduled downgrade: the plan isn't renewing, so the date is relabelled and explained. */
+/** A scheduled downgrade to Free: the plan isn't renewing, so the date is relabelled and explained. */
 export const Downgrading: Story = {
+    args: {
+        planTitle: 'Starter',
+        date: { label: 'CHANGES ON', value: 'September 1, 2026' },
+        payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
+        change: { toPlanTitle: 'Free', at: 'September 1, 2026', detail: 'no further charges after this period.' }
+    }
+};
+
+/** A downgrade between paid plans, which needs no gloss — billing continues at the new plan's rate. */
+export const DowngradingToSmallerPlan: Story = {
     args: {
         planTitle: 'Growth',
         date: { label: 'CHANGES ON', value: 'September 1, 2026' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
-        change: { toPlanTitle: 'Free', at: 'September 1, 2026', detail: 'no further charges after this period.' }
+        change: { toPlanTitle: 'Starter', at: 'September 1, 2026', detail: null }
     }
 };
 

--- a/packages/design-system/stories/SummaryStrip.stories.tsx
+++ b/packages/design-system/stories/SummaryStrip.stories.tsx
@@ -1,0 +1,102 @@
+import { Pencil, Plus } from 'lucide-react';
+
+import { SummaryStrip } from '@/pages/Team/Billing/components/SummaryStrip';
+import { IconButton } from '../src';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * The billing page's summary strip. Which slots appear is decided by `buildSummaryState` from the
+ * account's plan — these stories cover every state that decision can produce.
+ *
+ * Legacy, enterprise and free-uncapped accounts (30 today) render no strip at all, so they have no
+ * story: their terms are negotiated per customer or nothing is billable.
+ */
+const meta: Meta<typeof SummaryStrip> = {
+    component: SummaryStrip,
+    title: 'Features/Billing/SummaryStrip',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const editCard = (
+    <IconButton variant="ghost" size="2xs" label="Edit payment method">
+        <Pencil className="size-3" />
+    </IconButton>
+);
+const addCard = (
+    <IconButton variant="ghost" size="2xs" label="Add payment method">
+        <Plus className="size-3" />
+    </IconButton>
+);
+
+/** Starter and Growth: the billing period renews, and the card is editable inline. */
+export const Paid: Story = {
+    args: {
+        planTitle: 'Growth',
+        date: { label: 'RENEWS ON', value: 'September 1, 2026' },
+        payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
+    }
+};
+
+/** A customer paying by invoice or wire — no card to show, but the slot stays so one can be added. */
+export const PaidWithoutCard: Story = {
+    args: {
+        planTitle: 'Starter',
+        date: { label: 'RENEWS ON', value: 'September 1, 2026' },
+        payment: { card: null, action: addCard }
+    }
+};
+
+/** Free shows when its caps reset, and never a payment method — even when a card is on file. */
+export const Free: Story = {
+    args: {
+        planTitle: 'Free',
+        date: { label: 'LIMITS RESET', value: 'September 1, 2026' }
+    }
+};
+
+/** A scheduled downgrade: the plan isn't renewing, so the date is relabelled and explained. */
+export const Downgrading: Story = {
+    args: {
+        planTitle: 'Growth',
+        date: { label: 'CHANGES ON', value: 'September 1, 2026' },
+        payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
+        change: { toPlanTitle: 'Free', at: 'September 1, 2026' }
+    }
+};
+
+/** A YC startup deal converting to Growth — same treatment, opposite direction. */
+export const DealConverting: Story = {
+    args: {
+        planTitle: 'Startup deal',
+        date: { label: 'CHANGES ON', value: 'September 25, 2026' },
+        payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
+        change: { toPlanTitle: 'Growth', at: 'September 25, 2026' }
+    }
+};
+
+/** A deal with no conversion date stored yet — no date rather than a false renewal (NAN-6640). */
+export const DealWithoutDate: Story = {
+    args: {
+        planTitle: 'Startup deal',
+        payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
+    }
+};
+
+/** Viewers without the billing permission get plan and date only. */
+export const WithoutBillingPermission: Story = {
+    args: {
+        planTitle: 'Growth',
+        date: { label: 'RENEWS ON', value: 'September 1, 2026' }
+    }
+};
+
+/** While the plan resolves, nothing else can — the plan decides which slots exist. */
+export const Loading: Story = {
+    args: {
+        planTitle: null,
+        payment: { card: null, isLoading: true }
+    }
+};

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -6,15 +6,17 @@ import { permissions } from '@nangohq/authz';
 
 import { Separator } from '@/components/ui/Separator';
 import { usePermissions } from '@/hooks/usePermissions';
-import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
+import { useApiGetPlans, useApiGetUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
+import { getAggregateUsageState } from '@/utils/usage';
 import DashboardLayout from '../../../layout/DashboardLayout';
 import { BillingHeaderAction } from './components/BillingHeaderAction';
 import { Payment } from './components/Payment';
 import { Plans } from './components/Plans';
 import { Summary } from './components/Summary';
 import { Usage } from './components/Usage';
+import { UsageLimitBanner } from './components/UsageLimitBanner';
 import { showsSummaryStrip } from './planVisibility';
 
 export const TeamBilling: React.FC = () => {
@@ -30,6 +32,10 @@ export const TeamBilling: React.FC = () => {
     // so a failed load hides the section rather than leaking them or holding a skeleton forever.
     const { isError: didPlanListFail } = useApiGetPlans(env);
     const showSummary = !didPlanListFail && (isPlanPending || showsSummaryStrip(environmentData?.plan));
+
+    // The cap warning belongs with the plan, not the usage table, so it sits above the divider.
+    // Free is the only capped plan, and the sidebar alert already runs this query app-wide.
+    const { data: caps } = useApiGetUsage(env);
 
     useEffect(() => {
         track('web:usage:viewed', {});
@@ -61,6 +67,7 @@ export const TeamBilling: React.FC = () => {
                         <div id="summary">
                             <Summary />
                         </div>
+                        <UsageLimitBanner state={getAggregateUsageState(caps?.data ?? {})} />
                         <Separator />
                     </>
                 )}

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -6,6 +6,8 @@ import { permissions } from '@nangohq/authz';
 
 import { Separator } from '@/components/ui/Separator';
 import { usePermissions } from '@/hooks/usePermissions';
+import { useCurrentPlan } from '@/hooks/usePlan';
+import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
 import DashboardLayout from '../../../layout/DashboardLayout';
 import { BillingHeaderAction } from './components/BillingHeaderAction';
@@ -13,10 +15,18 @@ import { Payment } from './components/Payment';
 import { Plans } from './components/Plans';
 import { Summary } from './components/Summary';
 import { Usage } from './components/Usage';
+import { showsSummaryStrip } from './summaryState';
 
 export const TeamBilling: React.FC = () => {
     const { can } = usePermissions();
     const canManageBilling = can(permissions.canManageBilling);
+
+    // Hidden for legacy, enterprise and free-uncapped accounts. Checked here as well as inside
+    // `Summary` so the section's separator goes with it. Shown while the plan is still loading.
+    const env = useStore((state) => state.env);
+    const { data: environmentData } = useCurrentPlan(env);
+    const plan = environmentData?.plan;
+    const showSummary = !plan || showsSummaryStrip(plan);
 
     useEffect(() => {
         track('web:usage:viewed', {});
@@ -43,10 +53,14 @@ export const TeamBilling: React.FC = () => {
                 <title>Billing & usage - Nango</title>
             </Helmet>
             <div className="flex flex-col gap-8">
-                <div id="summary">
-                    <Summary />
-                </div>
-                <Separator />
+                {showSummary && (
+                    <>
+                        <div id="summary">
+                            <Summary />
+                        </div>
+                        <Separator />
+                    </>
+                )}
                 <div id="usage">
                     <Usage />
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -22,11 +22,11 @@ export const TeamBilling: React.FC = () => {
     const canManageBilling = can(permissions.canManageBilling);
 
     // Hidden for legacy, enterprise and free-uncapped accounts. Checked here as well as inside
-    // `Summary` so the section's separator goes with it. Shown while the plan is still loading.
+    // `Summary` so the section's separator goes with it. Shown while the plan is still loading, but
+    // not once the query has settled without one — otherwise a failed load leaves a stuck skeleton.
     const env = useStore((state) => state.env);
-    const { data: environmentData } = useCurrentPlan(env);
-    const plan = environmentData?.plan;
-    const showSummary = !plan || showsSummaryStrip(plan);
+    const { data: environmentData, isPending: isPlanPending } = useCurrentPlan(env);
+    const showSummary = isPlanPending || showsSummaryStrip(environmentData?.plan);
 
     useEffect(() => {
         track('web:usage:viewed', {});

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -6,7 +6,7 @@ import { permissions } from '@nangohq/authz';
 
 import { Separator } from '@/components/ui/Separator';
 import { usePermissions } from '@/hooks/usePermissions';
-import { useCurrentPlan } from '@/hooks/usePlan';
+import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
 import DashboardLayout from '../../../layout/DashboardLayout';
@@ -15,7 +15,7 @@ import { Payment } from './components/Payment';
 import { Plans } from './components/Plans';
 import { Summary } from './components/Summary';
 import { Usage } from './components/Usage';
-import { showsSummaryStrip } from './summaryState';
+import { showsSummaryStrip } from './planVisibility';
 
 export const TeamBilling: React.FC = () => {
     const { can } = usePermissions();
@@ -26,7 +26,10 @@ export const TeamBilling: React.FC = () => {
     // not once the query has settled without one — otherwise a failed load leaves a stuck skeleton.
     const env = useStore((state) => state.env);
     const { data: environmentData, isPending: isPlanPending } = useCurrentPlan(env);
-    const showSummary = isPlanPending || showsSummaryStrip(environmentData?.plan);
+    // Plan titles come from `/api/v1/plans`; with no titles the strip can only show raw Orb codes,
+    // so a failed load hides the section rather than leaking them or holding a skeleton forever.
+    const { isError: didPlanListFail } = useApiGetPlans(env);
+    const showSummary = !didPlanListFail && (isPlanPending || showsSummaryStrip(environmentData?.plan));
 
     useEffect(() => {
         track('web:usage:viewed', {});

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -11,6 +11,7 @@ import DashboardLayout from '../../../layout/DashboardLayout';
 import { BillingHeaderAction } from './components/BillingHeaderAction';
 import { Payment } from './components/Payment';
 import { Plans } from './components/Plans';
+import { Summary } from './components/Summary';
 import { Usage } from './components/Usage';
 
 export const TeamBilling: React.FC = () => {
@@ -42,6 +43,10 @@ export const TeamBilling: React.FC = () => {
                 <title>Billing & usage - Nango</title>
             </Helmet>
             <div className="flex flex-col gap-8">
+                <div id="summary">
+                    <Summary />
+                </div>
+                <Separator />
                 <div id="usage">
                     <Usage />
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/billingPeriod.ts
+++ b/packages/webapp/src/pages/Team/Billing/billingPeriod.ts
@@ -1,0 +1,16 @@
+/**
+ * When the Free plan's usage caps reset: midnight UTC on the 1st. The caps are measured over the UTC
+ * calendar month for every account regardless of signup date — see `getCurrentMonthBillingMetrics`
+ * in `packages/usage/lib/clickhouse/clickhouse.ts`, which windows on `Date.UTC(y, m, 1)`.
+ *
+ * Paid plans have no caps; their period comes from Orb (`/plans/subscription`) and is anchored to the
+ * subscription's start date, so it usually isn't the 1st.
+ */
+export function nextUsageResetDate(now: Date): Date {
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+}
+
+/** Formatted in UTC: billing period boundaries are UTC instants, so a local-time formatter can show the wrong day. */
+export function formatBillingDate(date: Date): string {
+    return date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
+}

--- a/packages/webapp/src/pages/Team/Billing/billingPeriod.ts
+++ b/packages/webapp/src/pages/Team/Billing/billingPeriod.ts
@@ -1,10 +1,13 @@
 /**
- * When the Free plan's usage caps reset: midnight UTC on the 1st. The caps are measured over the UTC
- * calendar month for every account regardless of signup date — see `getCurrentMonthBillingMetrics`
- * in `packages/usage/lib/clickhouse/clickhouse.ts`, which windows on `Date.UTC(y, m, 1)`.
+ * Midnight UTC on the 1st of the next month, which is the boundary behind both dates the summary
+ * strip shows.
  *
- * Paid plans have no caps; their period comes from Orb (`/plans/subscription`) and is anchored to the
- * subscription's start date, so it usually isn't the 1st.
+ * Free's caps are measured over the UTC calendar month regardless of signup date —
+ * `getCurrentMonthBillingMetrics` in `packages/usage/lib/clickhouse/clickhouse.ts` windows on
+ * `Date.UTC(y, m, 1)`. Paid renewals land on the same day: the billing cycle is anchored by the Orb
+ * *plan*, not the subscription, so it doesn't follow the signup date. Verified against the Orb API
+ * across all 667 non-free accounts — 660 end on the 1st, and every exception is a legacy contract or
+ * an expiring deal, none of which reach the "renews on" branch.
  */
 export function nextUsageResetDate(now: Date): Date {
     return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));

--- a/packages/webapp/src/pages/Team/Billing/billingPeriod.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/billingPeriod.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatBillingDate, nextUsageResetDate } from './billingPeriod.js';
+
+describe('nextUsageResetDate', () => {
+    it('returns the 1st of the next month', () => {
+        expect(nextUsageResetDate(new Date('2026-08-12T15:00:00Z')).toISOString()).toBe('2026-09-01T00:00:00.000Z');
+    });
+
+    it('handles the last day of the month', () => {
+        expect(nextUsageResetDate(new Date('2026-08-31T23:59:59Z')).toISOString()).toBe('2026-09-01T00:00:00.000Z');
+    });
+
+    it('rolls over the year in December', () => {
+        expect(nextUsageResetDate(new Date('2026-12-25T10:00:00Z')).toISOString()).toBe('2027-01-01T00:00:00.000Z');
+    });
+
+    it('uses the UTC month, not the local one', () => {
+        // 01:30 on Sep 1st in UTC+2 is still August 31st in UTC, so the reset is Sep 1st — not Oct 1st.
+        expect(nextUsageResetDate(new Date('2026-08-31T23:30:00Z')).toISOString()).toBe('2026-09-01T00:00:00.000Z');
+    });
+});
+
+describe('formatBillingDate', () => {
+    it('formats as month day, year', () => {
+        expect(formatBillingDate(new Date('2026-09-14T00:00:00Z'))).toBe('September 14, 2026');
+    });
+
+    it('formats in UTC regardless of the local timezone', () => {
+        // Midnight UTC is the previous evening west of Greenwich; the date must not shift back a day.
+        expect(formatBillingDate(new Date('2027-01-01T00:00:00Z'))).toBe('January 1, 2027');
+    });
+});

--- a/packages/webapp/src/pages/Team/Billing/components/FreeUsage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/FreeUsage.tsx
@@ -4,11 +4,9 @@ import { useMemo } from 'react';
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { useApiGetBillingUsage, useApiGetUsage } from '@/hooks/usePlan';
 import { useStore } from '@/store';
-import { getAggregateUsageState } from '@/utils/usage';
 import { useSelectedMonth } from '../useSelectedMonth';
 import { toggleExpandedMetric } from './expandedMetrics';
 import { MonthSelector } from './MonthSelector';
-import { UsageLimitBanner } from './UsageLimitBanner';
 import { USAGE_METRIC_LABELS, USAGE_METRICS } from './usageMetrics';
 import { UsageTable } from './UsageTable';
 
@@ -67,7 +65,6 @@ export const FreeUsage: React.FC = () => {
 
     return (
         <div className="w-full flex flex-col gap-4">
-            <UsageLimitBanner state={getAggregateUsageState(caps?.data ?? {})} />
             <div className="flex justify-between items-center">
                 <span className="text-text-strong text-body-medium-medium">Usage</span>
                 <MonthSelector />

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -2,30 +2,17 @@ import { Pencil, Plus } from 'lucide-react';
 import { useMemo } from 'react';
 
 import { permissions } from '@nangohq/authz';
-import { Card, IconButton } from '@nangohq/design-system';
+import { IconButton } from '@nangohq/design-system';
 
-import { Skeleton } from '@/components/ui/Skeleton';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
 import { useStripePaymentMethods } from '@/hooks/useStripe';
 import { useStore } from '@/store';
-import { formatBillingDate, nextUsageResetDate } from '../billingPeriod';
-import { isLegacyPlan } from '../legacyPlans';
+import { buildSummaryState, showsSummaryStrip } from '../summaryState';
 import { PaymentMethodDialog } from './PaymentMethodDialog';
+import { SummaryStrip } from './SummaryStrip';
 
-const SummaryItem: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
-    <div className="flex flex-col gap-1">
-        <span className="type-text-regular-xs text-text-disabled">{label}</span>
-        <div className="flex items-center gap-1.5 h-5 type-text-regular-sm text-text-default">{children}</div>
-    </div>
-);
-
-/**
- * At-a-glance billing summary: current plan, when usage resets, and the card on file. On paid plans
- * the design leads with a current-period spend figure and demotes the plan into the right-hand group —
- * that figure needs an Orb spend read our backend doesn't have yet, so it lands with NAN-6246 and
- * takes over this headline slot then.
- */
+/** Data for the summary strip. The rules live in `buildSummaryState`, the layout in `SummaryStrip`. */
 export const Summary: React.FC = () => {
     const env = useStore((state) => state.env);
     const { can } = usePermissions();
@@ -33,81 +20,44 @@ export const Summary: React.FC = () => {
 
     const { data: environmentData } = useCurrentPlan(env);
     const plan = environmentData?.plan;
-    const { data: plansList, isError: plansListError } = useApiGetPlans(env);
+    const { data: plansList } = useApiGetPlans(env);
+    const { data: paymentMethods, isLoading: isPaymentMethodsLoading } = useStripePaymentMethods(env);
+    const paymentMethod = paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
 
-    // Hidden/legacy codes are in the list too (`getPlans` doesn't filter), so they resolve to a real
-    // title. Falling back to the raw code keeps the strip filled if the list fails to load.
-    const planTitle = useMemo(() => {
+    const state = useMemo(() => {
         if (!plan) {
             return null;
         }
-        if (!plansList) {
-            return plansListError ? plan.name : null;
-        }
-        return plansList.data.find((p) => p.code === plan.name)?.title ?? plan.name;
-    }, [plan, plansList, plansListError]);
+        return buildSummaryState({ plan, plans: plansList?.data, paymentMethod, canManageBilling, now: new Date() });
+    }, [plan, plansList, paymentMethod, canManageBilling]);
 
-    // Usage is metered over the UTC calendar month on every current plan — Free's caps and the paid
-    // plans' monthly tiered pricing alike (`getCurrentMonthBillingMetrics`), so the reset is the 1st.
-    // Legacy plans are excluded: their terms are negotiated per customer (several are annual), so no
-    // single date here would be true for them.
-    const isLegacy = isLegacyPlan(plan);
-    const resetsAt = useMemo(() => nextUsageResetDate(new Date()), []);
-
-    const { data: paymentMethods, isLoading: isPaymentMethodsLoading, error: paymentMethodsError } = useStripePaymentMethods(env);
-    const paymentMethod = paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
+    // Legacy, enterprise and free-uncapped accounts get no strip at all — their terms are negotiated
+    // per customer or nothing is billable, so every field would be empty or untrue.
+    if (plan && !showsSummaryStrip(plan)) {
+        return null;
+    }
 
     return (
         <div className="flex flex-col gap-4">
             <h3 className="text-text-strong text-body-medium-medium">Summary</h3>
-            <Card>
-                <div className="p-4 flex items-start justify-between gap-8">
-                    <div className="flex flex-col gap-1">
-                        <span className="type-text-regular-xs text-text-disabled">CURRENT PLAN</span>
-                        <span className="type-heading-lg text-text-strong">{planTitle ?? <Skeleton className="w-24 h-7" />}</span>
-                    </div>
-                    {/* 62px is the gap between the items in the design, off the spacing scale. */}
-                    <div className="flex items-start justify-end gap-[62px]">
-                        {/* Skeleton until the plan resolves — whether this item renders at all depends on it. */}
-                        {!plan ? (
-                            <SummaryItem label="RESETS">
-                                <Skeleton className="w-24" />
-                            </SummaryItem>
-                        ) : (
-                            !isLegacy && <SummaryItem label="RESETS">{formatBillingDate(resetsAt)}</SummaryItem>
-                        )}
-                        {canManageBilling && (
-                            <SummaryItem label="PAYMENT METHOD">
-                                {isPaymentMethodsLoading ? (
-                                    <Skeleton className="w-24" />
-                                ) : paymentMethodsError ? (
-                                    <span>—</span>
-                                ) : paymentMethod ? (
-                                    <>
-                                        <span className="capitalize">
-                                            {paymentMethod.brand ?? 'Card'}···{paymentMethod.last4}
-                                        </span>
-                                        <PaymentMethodDialog replace>
-                                            <IconButton variant="ghost" size="2xs" label="Edit payment method">
-                                                <Pencil className="size-3" />
-                                            </IconButton>
-                                        </PaymentMethodDialog>
-                                    </>
-                                ) : (
-                                    <>
-                                        <span>—</span>
-                                        <PaymentMethodDialog>
-                                            <IconButton variant="ghost" size="2xs" label="Add payment method">
-                                                <Plus className="size-3" />
-                                            </IconButton>
-                                        </PaymentMethodDialog>
-                                    </>
-                                )}
-                            </SummaryItem>
-                        )}
-                    </div>
-                </div>
-            </Card>
+            <SummaryStrip
+                planTitle={state?.planTitle ?? null}
+                date={state?.date}
+                payment={
+                    state?.payment && {
+                        card: state.payment.card,
+                        isLoading: isPaymentMethodsLoading,
+                        action: (
+                            <PaymentMethodDialog replace={Boolean(state.payment.card)}>
+                                <IconButton variant="ghost" size="2xs" label={state.payment.card ? 'Edit payment method' : 'Add payment method'}>
+                                    {state.payment.card ? <Pencil className="size-3" /> : <Plus className="size-3" />}
+                                </IconButton>
+                            </PaymentMethodDialog>
+                        )
+                    }
+                }
+                change={state?.change}
+            />
         </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -20,16 +20,18 @@ export const Summary: React.FC = () => {
 
     const { data: environmentData } = useCurrentPlan(env);
     const plan = environmentData?.plan;
-    const { data: plansList } = useApiGetPlans(env);
+    // Wait for the plan list to settle before building state: until it does, titles fall back to raw
+    // plan codes, and "changes to growth-v2" is not a sentence to show a customer.
+    const { data: plansList, isPending: arePlansPending } = useApiGetPlans(env);
     const { data: paymentMethods } = useStripePaymentMethods(env);
     const paymentMethod = paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
 
     const state = useMemo(() => {
-        if (!plan) {
+        if (!plan || arePlansPending) {
             return null;
         }
         return buildSummaryState({ plan, plans: plansList?.data, paymentMethod, canManageBilling, now: new Date() });
-    }, [plan, plansList, paymentMethod, canManageBilling]);
+    }, [plan, plansList, arePlansPending, paymentMethod, canManageBilling]);
 
     // Legacy, enterprise and free-uncapped accounts get no strip at all — their terms are negotiated
     // per customer or nothing is billable, so every field would be empty or untrue.

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Plus } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 import { useMemo } from 'react';
 
 import { permissions } from '@nangohq/authz';
@@ -21,7 +21,7 @@ export const Summary: React.FC = () => {
     const { data: environmentData } = useCurrentPlan(env);
     const plan = environmentData?.plan;
     const { data: plansList } = useApiGetPlans(env);
-    const { data: paymentMethods, isLoading: isPaymentMethodsLoading } = useStripePaymentMethods(env);
+    const { data: paymentMethods } = useStripePaymentMethods(env);
     const paymentMethod = paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
 
     const state = useMemo(() => {
@@ -46,11 +46,10 @@ export const Summary: React.FC = () => {
                 payment={
                     state?.payment && {
                         card: state.payment.card,
-                        isLoading: isPaymentMethodsLoading,
                         action: (
-                            <PaymentMethodDialog replace={Boolean(state.payment.card)}>
-                                <IconButton variant="ghost" size="2xs" label={state.payment.card ? 'Edit payment method' : 'Add payment method'}>
-                                    {state.payment.card ? <Pencil className="size-3" /> : <Plus className="size-3" />}
+                            <PaymentMethodDialog replace>
+                                <IconButton variant="ghost" size="2xs" label="Edit payment method">
+                                    <Pencil className="size-3" />
                                 </IconButton>
                             </PaymentMethodDialog>
                         )

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -1,0 +1,113 @@
+import { Pencil, Plus } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { permissions } from '@nangohq/authz';
+import { Card, IconButton } from '@nangohq/design-system';
+
+import { Skeleton } from '@/components/ui/Skeleton';
+import { usePermissions } from '@/hooks/usePermissions';
+import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
+import { useStripePaymentMethods } from '@/hooks/useStripe';
+import { useStore } from '@/store';
+import { formatBillingDate, nextUsageResetDate } from '../billingPeriod';
+import { isLegacyPlan } from '../legacyPlans';
+import { PaymentMethodDialog } from './PaymentMethodDialog';
+
+const SummaryItem: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+    <div className="flex flex-col gap-1">
+        <span className="type-text-regular-xs text-text-disabled">{label}</span>
+        <div className="flex items-center gap-1.5 h-5 type-text-regular-sm text-text-default">{children}</div>
+    </div>
+);
+
+/**
+ * At-a-glance billing summary: current plan, when usage resets, and the card on file. On paid plans
+ * the design leads with a current-period spend figure and demotes the plan into the right-hand group —
+ * that figure needs an Orb spend read our backend doesn't have yet, so it lands with NAN-6246 and
+ * takes over this headline slot then.
+ */
+export const Summary: React.FC = () => {
+    const env = useStore((state) => state.env);
+    const { can } = usePermissions();
+    const canManageBilling = can(permissions.canManageBilling);
+
+    const { data: environmentData } = useCurrentPlan(env);
+    const plan = environmentData?.plan;
+    const { data: plansList, isError: plansListError } = useApiGetPlans(env);
+
+    // Hidden/legacy codes are in the list too (`getPlans` doesn't filter), so they resolve to a real
+    // title. Falling back to the raw code keeps the strip filled if the list fails to load.
+    const planTitle = useMemo(() => {
+        if (!plan) {
+            return null;
+        }
+        if (!plansList) {
+            return plansListError ? plan.name : null;
+        }
+        return plansList.data.find((p) => p.code === plan.name)?.title ?? plan.name;
+    }, [plan, plansList, plansListError]);
+
+    // Usage is metered over the UTC calendar month on every current plan — Free's caps and the paid
+    // plans' monthly tiered pricing alike (`getCurrentMonthBillingMetrics`), so the reset is the 1st.
+    // Legacy plans are excluded: their terms are negotiated per customer (several are annual), so no
+    // single date here would be true for them.
+    const isLegacy = isLegacyPlan(plan);
+    const resetsAt = useMemo(() => nextUsageResetDate(new Date()), []);
+
+    const { data: paymentMethods, isLoading: isPaymentMethodsLoading, error: paymentMethodsError } = useStripePaymentMethods(env);
+    const paymentMethod = paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
+
+    return (
+        <div className="flex flex-col gap-4">
+            <h3 className="text-text-strong text-body-medium-medium">Summary</h3>
+            <Card>
+                <div className="p-4 flex items-start justify-between gap-8">
+                    <div className="flex flex-col gap-1">
+                        <span className="type-text-regular-xs text-text-disabled">CURRENT PLAN</span>
+                        <span className="type-heading-lg text-text-strong">{planTitle ?? <Skeleton className="w-24 h-7" />}</span>
+                    </div>
+                    {/* 62px is the gap between the items in the design, off the spacing scale. */}
+                    <div className="flex items-start justify-end gap-[62px]">
+                        {/* Skeleton until the plan resolves — whether this item renders at all depends on it. */}
+                        {!plan ? (
+                            <SummaryItem label="RESETS">
+                                <Skeleton className="w-24" />
+                            </SummaryItem>
+                        ) : (
+                            !isLegacy && <SummaryItem label="RESETS">{formatBillingDate(resetsAt)}</SummaryItem>
+                        )}
+                        {canManageBilling && (
+                            <SummaryItem label="PAYMENT METHOD">
+                                {isPaymentMethodsLoading ? (
+                                    <Skeleton className="w-24" />
+                                ) : paymentMethodsError ? (
+                                    <span>—</span>
+                                ) : paymentMethod ? (
+                                    <>
+                                        <span className="capitalize">
+                                            {paymentMethod.brand ?? 'Card'}···{paymentMethod.last4}
+                                        </span>
+                                        <PaymentMethodDialog replace>
+                                            <IconButton variant="ghost" size="2xs" label="Edit payment method">
+                                                <Pencil className="size-3" />
+                                            </IconButton>
+                                        </PaymentMethodDialog>
+                                    </>
+                                ) : (
+                                    <>
+                                        <span>—</span>
+                                        <PaymentMethodDialog>
+                                            <IconButton variant="ghost" size="2xs" label="Add payment method">
+                                                <Plus className="size-3" />
+                                            </IconButton>
+                                        </PaymentMethodDialog>
+                                    </>
+                                )}
+                            </SummaryItem>
+                        )}
+                    </div>
+                </div>
+            </Card>
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -8,7 +8,8 @@ import { usePermissions } from '@/hooks/usePermissions';
 import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
 import { useStripePaymentMethods } from '@/hooks/useStripe';
 import { useStore } from '@/store';
-import { buildSummaryState, showsSummaryStrip } from '../summaryState';
+import { showsSummaryStrip } from '../planVisibility';
+import { buildSummaryState } from '../summaryState';
 import { PaymentMethodDialog } from './PaymentMethodDialog';
 import { SummaryStrip } from './SummaryStrip';
 

--- a/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
@@ -1,0 +1,64 @@
+import { Card } from '@nangohq/design-system';
+
+import { Skeleton } from '@/components/ui/Skeleton';
+
+export interface SummaryStripProps {
+    /** Null renders a skeleton — the plan decides which other slots appear, so nothing else can resolve first. */
+    planTitle: string | null;
+    date?: { label: string; value: string } | null;
+    /** `card` null means no card on file. Omit the prop entirely to hide the slot. */
+    payment?: { card: { brand?: string | null; last4: string } | null; isLoading?: boolean; action?: React.ReactNode } | null;
+    /** Footer sentence for a scheduled plan change. */
+    change?: { toPlanTitle: string; at: string } | null;
+}
+
+const SummaryItem: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+    <div className="flex flex-col gap-1">
+        <span className="type-text-regular-xs text-text-disabled">{label}</span>
+        <div className="flex items-center gap-1.5 h-5 type-text-regular-sm text-text-default">{children}</div>
+    </div>
+);
+
+/**
+ * Presentational billing summary strip: current plan, a date whose meaning depends on the plan, and
+ * the card on file. Pure — every decision about which slots appear is made by `buildSummaryState`.
+ *
+ * The design leads paid plans with a current-period spend figure instead of the plan name; that
+ * figure needs an Orb spend read our backend doesn't have yet (NAN-6246), so the plan holds the
+ * headline until then.
+ */
+export const SummaryStrip: React.FC<SummaryStripProps> = ({ planTitle, date, payment, change }) => (
+    <Card>
+        <div className="p-4 flex items-start justify-between gap-8">
+            <div className="flex flex-col gap-1">
+                <span className="type-text-regular-xs text-text-disabled">CURRENT PLAN</span>
+                <span className="type-heading-lg text-text-strong">{planTitle ?? <Skeleton className="w-24 h-7" />}</span>
+            </div>
+            {/* 62px is the gap between the items in the design, off the spacing scale. */}
+            <div className="flex items-start justify-end gap-[62px]">
+                {date && <SummaryItem label={date.label}>{date.value}</SummaryItem>}
+                {payment && (
+                    <SummaryItem label="PAYMENT METHOD">
+                        {payment.isLoading ? (
+                            <Skeleton className="w-24" />
+                        ) : (
+                            <>
+                                <span className="capitalize">{payment.card ? `${payment.card.brand ?? 'Card'}···${payment.card.last4}` : '—'}</span>
+                                {payment.action}
+                            </>
+                        )}
+                    </SummaryItem>
+                )}
+            </div>
+        </div>
+        {change && (
+            <>
+                {/* Inset separator, matching the design's divider between the card row and the notice. */}
+                <div className="mx-4 border-t border-border-muted" />
+                <div className="px-4 py-3 type-text-regular-sm text-text-default">
+                    Your plan changes to <span className="font-ds-bold">{change.toPlanTitle}</span> on {change.at}.
+                </div>
+            </>
+        )}
+    </Card>
+);

--- a/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
@@ -6,10 +6,10 @@ export interface SummaryStripProps {
     /** Null renders a skeleton — the plan decides which other slots appear, so nothing else can resolve first. */
     planTitle: string | null;
     date?: { label: string; value: string } | null;
-    /** `card` null means no card on file. Omit the prop entirely to hide the slot. */
-    payment?: { card: { brand?: string | null; last4: string } | null; isLoading?: boolean; action?: React.ReactNode } | null;
+    /** Omitted whenever there's no card to show — Free, no card on file, or no billing permission. */
+    payment?: { card: { brand?: string | null; last4: string }; action?: React.ReactNode } | null;
     /** Footer sentence for a scheduled plan change. */
-    change?: { toPlanTitle: string; at: string } | null;
+    change?: { toPlanTitle: string; at: string; detail: string } | null;
 }
 
 const SummaryItem: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
@@ -39,14 +39,10 @@ export const SummaryStrip: React.FC<SummaryStripProps> = ({ planTitle, date, pay
                 {date && <SummaryItem label={date.label}>{date.value}</SummaryItem>}
                 {payment && (
                     <SummaryItem label="PAYMENT METHOD">
-                        {payment.isLoading ? (
-                            <Skeleton className="w-24" />
-                        ) : (
-                            <>
-                                <span className="capitalize">{payment.card ? `${payment.card.brand ?? 'Card'}···${payment.card.last4}` : '—'}</span>
-                                {payment.action}
-                            </>
-                        )}
+                        <span className="capitalize">
+                            {payment.card.brand ?? 'Card'}···{payment.card.last4}
+                        </span>
+                        {payment.action}
                     </SummaryItem>
                 )}
             </div>
@@ -55,8 +51,8 @@ export const SummaryStrip: React.FC<SummaryStripProps> = ({ planTitle, date, pay
             <>
                 {/* Inset separator, matching the design's divider between the card row and the notice. */}
                 <div className="mx-4 border-t border-border-muted" />
-                <div className="px-4 py-3 type-text-regular-sm text-text-default">
-                    Your plan changes to <span className="font-ds-bold">{change.toPlanTitle}</span> on {change.at}.
+                <div className="px-4 py-3 type-text-regular-sm text-text-muted">
+                    Your plan changes to <span className="font-ds-bold">{change.toPlanTitle}</span> on {change.at} — {change.detail}
                 </div>
             </>
         )}

--- a/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
@@ -9,7 +9,7 @@ export interface SummaryStripProps {
     /** Omitted whenever there's no card to show — Free, no card on file, or no billing permission. */
     payment?: { card: { brand?: string | null; last4: string }; action?: React.ReactNode } | null;
     /** Footer sentence for a scheduled plan change. */
-    change?: { toPlanTitle: string; at: string; detail: string } | null;
+    change?: { toPlanTitle: string; at: string; detail: string | null } | null;
 }
 
 const SummaryItem: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
@@ -52,7 +52,8 @@ export const SummaryStrip: React.FC<SummaryStripProps> = ({ planTitle, date, pay
                 {/* Inset separator, matching the design's divider between the card row and the notice. */}
                 <div className="mx-4 border-t border-border-muted" />
                 <div className="px-4 py-3 type-text-regular-sm text-text-muted">
-                    Your plan changes to <span className="font-ds-bold">{change.toPlanTitle}</span> on {change.at} — {change.detail}
+                    Your plan changes to <span className="font-ds-bold">{change.toPlanTitle}</span> on {change.at}
+                    {change.detail ? ` — ${change.detail}` : '.'}
                 </div>
             </>
         )}

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -7,7 +7,7 @@ import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
-import { isLegacyPlan } from '../legacyPlans';
+import { isLegacyPlan } from '../planVisibility';
 import { useSelectedMonth } from '../useSelectedMonth';
 import { FreeUsage } from './FreeUsage';
 import { MonthSelector } from './MonthSelector';

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -7,17 +7,12 @@ import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
+import { isLegacyPlan } from '../legacyPlans';
 import { useSelectedMonth } from '../useSelectedMonth';
 import { FreeUsage } from './FreeUsage';
 import { MonthSelector } from './MonthSelector';
 import { USAGE_METRIC_LABELS, USAGE_METRICS } from './usageMetrics';
 import { UsageTable } from './UsageTable';
-
-import type { DBPlan } from '@nangohq/types';
-
-// Plans on the current usage model. Any plan not listed here is treated as a legacy plan (different usage metrics).
-// Typed against `DBPlan['name']` so a renamed or removed plan fails to compile instead of silently drifting.
-const CURRENT_PLAN_NAMES: readonly DBPlan['name'][] = ['free', 'free-uncapped', 'startup-deal', 'enterprise-cloud-hosted', 'starter-v2', 'growth-v2'];
 
 export const Usage: React.FC = () => {
     const env = useStore((state) => state.env);
@@ -54,7 +49,7 @@ export const Usage: React.FC = () => {
         return <FreeUsage />;
     }
 
-    const isLegacyPlan = plan && !CURRENT_PLAN_NAMES.includes(plan.name);
+    const isLegacy = isLegacyPlan(plan);
     // Paid/legacy plans are uncapped (only `freePlan` sets real limits in `plans/definitions.ts`),
     // so every row shows just its usage total — `UsageRow` already renders that gracefully for a
     // `null` limit (no bar, "—" instead of a percent).
@@ -69,7 +64,7 @@ export const Usage: React.FC = () => {
 
     return (
         <div className="w-full flex flex-col gap-4">
-            {isLegacyPlan && (
+            {isLegacy && (
                 <Alert variant="info">
                     <Info />
                     <AlertTitle>You&apos;re on a legacy plan</AlertTitle>

--- a/packages/webapp/src/pages/Team/Billing/legacyPlans.ts
+++ b/packages/webapp/src/pages/Team/Billing/legacyPlans.ts
@@ -1,14 +1,29 @@
 import type { ApiPlan, DBPlan } from '@nangohq/types';
 
-// Plans on the current usage model. Any plan not listed here is treated as a legacy plan: different
-// usage metrics, and billing terms negotiated per customer (several are annual, so there's no monthly
+// Which plans are on the current usage model. Anything else is a legacy plan: different usage
+// metrics, and billing terms negotiated per customer (several are annual, so there's no monthly
 // reset to show).
-// Typed against `DBPlan['name']` so a renamed or removed plan fails to compile instead of silently drifting.
-const CURRENT_PLAN_NAMES: readonly DBPlan['name'][] = ['free', 'free-uncapped', 'startup-deal', 'enterprise-cloud-hosted', 'starter-v2', 'growth-v2'];
+// Exhaustive over `DBPlan['name']` rather than an allowlist, so adding a plan to the DB type fails
+// to compile until it's classified here — otherwise a new current plan would silently be treated as
+// legacy and lose its reset date.
+const PLAN_IS_CURRENT: Record<DBPlan['name'], boolean> = {
+    free: true,
+    'free-uncapped': true,
+    'startup-deal': true,
+    'enterprise-cloud-hosted': true,
+    'starter-v2': true,
+    'growth-v2': true,
+    enterprise: false,
+    starter: false,
+    growth: false,
+    'starter-legacy': false,
+    'scale-legacy': false,
+    'growth-legacy': false
+};
 
 export function isLegacyPlan(plan: ApiPlan | null | undefined): boolean {
     if (!plan) {
         return false;
     }
-    return !CURRENT_PLAN_NAMES.includes(plan.name);
+    return !PLAN_IS_CURRENT[plan.name];
 }

--- a/packages/webapp/src/pages/Team/Billing/legacyPlans.ts
+++ b/packages/webapp/src/pages/Team/Billing/legacyPlans.ts
@@ -1,0 +1,14 @@
+import type { ApiPlan, DBPlan } from '@nangohq/types';
+
+// Plans on the current usage model. Any plan not listed here is treated as a legacy plan: different
+// usage metrics, and billing terms negotiated per customer (several are annual, so there's no monthly
+// reset to show).
+// Typed against `DBPlan['name']` so a renamed or removed plan fails to compile instead of silently drifting.
+const CURRENT_PLAN_NAMES: readonly DBPlan['name'][] = ['free', 'free-uncapped', 'startup-deal', 'enterprise-cloud-hosted', 'starter-v2', 'growth-v2'];
+
+export function isLegacyPlan(plan: ApiPlan | null | undefined): boolean {
+    if (!plan) {
+        return false;
+    }
+    return !CURRENT_PLAN_NAMES.includes(plan.name);
+}

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -21,6 +21,32 @@ const PLAN_IS_CURRENT: Record<DBPlan['name'], boolean> = {
     'growth-legacy': false
 };
 
+// Plans the summary strip renders for. A deliberately different question from `isLegacyPlan` above:
+// `free-uncapped` and `enterprise-cloud-hosted` are current plans that still get no strip, because
+// nothing is billable or the contract is custom. Both maps are exhaustive over `DBPlan['name']`, so
+// a new plan fails to compile until it is classified for both.
+const SHOWS_SUMMARY_STRIP: Record<DBPlan['name'], boolean> = {
+    free: true,
+    'starter-v2': true,
+    'growth-v2': true,
+    'startup-deal': true,
+    'free-uncapped': false,
+    enterprise: false,
+    'enterprise-cloud-hosted': false,
+    starter: false,
+    growth: false,
+    'starter-legacy': false,
+    'scale-legacy': false,
+    'growth-legacy': false
+};
+
+export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {
+    if (!plan) {
+        return false;
+    }
+    return SHOWS_SUMMARY_STRIP[plan.name];
+}
+
 export function isLegacyPlan(plan: ApiPlan | null | undefined): boolean {
     if (!plan) {
         return false;

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -31,14 +31,25 @@ export interface SummaryStripState {
     planTitle: string;
     /** Omitted when no date can be stated truthfully — e.g. a deal whose conversion date we don't hold. */
     date: { label: string; value: string } | null;
-    /** Null hides the slot entirely (Free, or a viewer who can't manage billing). */
-    payment: { card: StripePaymentMethod | null } | null;
+    /** Null hides the slot entirely — Free, no card on file, or a viewer who can't manage billing. */
+    payment: { card: StripePaymentMethod } | null;
     /** Renders the footer sentence; set only when a plan change is actually pending. */
-    change: { toPlanTitle: string; at: string } | null;
+    change: { toPlanTitle: string; at: string; detail: string } | null;
 }
 
 function planTitleOf(code: string, plans: PlanDefinition[] | undefined): string {
     return plans?.find((p) => p.code === code)?.title ?? code;
+}
+
+/** The clause after the date, which depends on what the change actually means for the bill. */
+function changeDetail({ from, toCode, toTitle }: { from: string; toCode: string; toTitle: string }): string {
+    if (toCode === 'free') {
+        return 'no further charges after this period.';
+    }
+    if (from === 'startup-deal') {
+        return `your startup deal ends and you'll be charged at standard ${toTitle} pricing.`;
+    }
+    return `you'll be charged at standard ${toTitle} pricing.`;
 }
 
 /**
@@ -71,7 +82,11 @@ export function buildSummaryState({
     const changeTo = plan.orb_future_plan;
     const change =
         changeTo && changeTo !== plan.name && changeAt && changeAt.getTime() > now.getTime()
-            ? { toPlanTitle: planTitleOf(changeTo, plans), at: formatBillingDate(changeAt) }
+            ? {
+                  toPlanTitle: planTitleOf(changeTo, plans),
+                  at: formatBillingDate(changeAt),
+                  detail: changeDetail({ from: plan.name, toCode: changeTo, toTitle: planTitleOf(changeTo, plans) })
+              }
             : null;
 
     let date: SummaryStripState['date'] = null;
@@ -88,8 +103,10 @@ export function buildSummaryState({
     return {
         planTitle,
         date,
-        // Free never shows a payment method, even when a card is on file.
-        payment: isFree || !canManageBilling ? null : { card: paymentMethod },
+        // Free never shows a payment method, even when a card is on file. Nor does an account with
+        // no card — the slot is dropped rather than dashed, and the billing section below is where
+        // a card gets added.
+        payment: isFree || !canManageBilling || !paymentMethod ? null : { card: paymentMethod },
         change
     };
 }

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -2,31 +2,6 @@ import { formatBillingDate, nextUsageResetDate } from './billingPeriod';
 
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
-// Plans the strip renders for. Everything else — legacy, enterprise, free-uncapped — hides it
-// entirely: terms are negotiated per customer or nothing is billable, so no field would be true.
-// Typed against `ApiPlan['name']` so a new plan fails to compile until it's classified here.
-const STRIP_PLANS: Record<ApiPlan['name'], boolean> = {
-    free: true,
-    'starter-v2': true,
-    'growth-v2': true,
-    'startup-deal': true,
-    'free-uncapped': false,
-    enterprise: false,
-    'enterprise-cloud-hosted': false,
-    starter: false,
-    growth: false,
-    'starter-legacy': false,
-    'scale-legacy': false,
-    'growth-legacy': false
-};
-
-export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {
-    if (!plan) {
-        return false;
-    }
-    return STRIP_PLANS[plan.name];
-}
-
 export interface SummaryStripState {
     planTitle: string;
     /** Omitted when no date can be stated truthfully — e.g. a deal whose conversion date we don't hold. */

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -9,15 +9,15 @@ export interface SummaryStripState {
     /** Null hides the slot entirely — Free, no card on file, or a viewer who can't manage billing. */
     payment: { card: StripePaymentMethod } | null;
     /** Renders the footer sentence; set only when a plan change is actually pending. */
-    change: { toPlanTitle: string; at: string; detail: string } | null;
+    change: { toPlanTitle: string; at: string; detail: string | null } | null;
 }
 
 function planTitleOf(code: string, plans: PlanDefinition[] | undefined): string {
     return plans?.find((p) => p.code === code)?.title ?? code;
 }
 
-/** The clause after the date, which depends on what the change actually means for the bill. */
-function changeDetail({ from, toCode, toTitle }: { from: string; toCode: string; toTitle: string }): string {
+/** The clause after the date, for changes whose effect on the bill isn't obvious from the plan name. */
+function changeDetail({ from, toCode, toTitle }: { from: string; toCode: string; toTitle: string }): string | null {
     // Both free plans have a $0 base and no overage, so there is nothing left to charge.
     if (toCode === 'free' || toCode === 'free-uncapped') {
         return 'no further charges after this period.';
@@ -25,7 +25,8 @@ function changeDetail({ from, toCode, toTitle }: { from: string; toCode: string;
     if (from === 'startup-deal') {
         return `your startup deal ends and you'll be charged at standard ${toTitle} pricing.`;
     }
-    return `you'll be charged at standard ${toTitle} pricing.`;
+    // Moving between paid plans needs no gloss — the new plan's own pricing says it.
+    return null;
 }
 
 /**

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -1,0 +1,95 @@
+import { formatBillingDate, nextUsageResetDate } from './billingPeriod';
+
+import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
+
+// Plans the strip renders for. Everything else — legacy, enterprise, free-uncapped — hides it
+// entirely: terms are negotiated per customer or nothing is billable, so no field would be true.
+// Typed against `ApiPlan['name']` so a new plan fails to compile until it's classified here.
+const STRIP_PLANS: Record<ApiPlan['name'], boolean> = {
+    free: true,
+    'starter-v2': true,
+    'growth-v2': true,
+    'startup-deal': true,
+    'free-uncapped': false,
+    enterprise: false,
+    'enterprise-cloud-hosted': false,
+    starter: false,
+    growth: false,
+    'starter-legacy': false,
+    'scale-legacy': false,
+    'growth-legacy': false
+};
+
+export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {
+    if (!plan) {
+        return false;
+    }
+    return STRIP_PLANS[plan.name];
+}
+
+export interface SummaryStripState {
+    planTitle: string;
+    /** Omitted when no date can be stated truthfully — e.g. a deal whose conversion date we don't hold. */
+    date: { label: string; value: string } | null;
+    /** Null hides the slot entirely (Free, or a viewer who can't manage billing). */
+    payment: { card: StripePaymentMethod | null } | null;
+    /** Renders the footer sentence; set only when a plan change is actually pending. */
+    change: { toPlanTitle: string; at: string } | null;
+}
+
+function planTitleOf(code: string, plans: PlanDefinition[] | undefined): string {
+    return plans?.find((p) => p.code === code)?.title ?? code;
+}
+
+/**
+ * Everything the strip shows, derived in one place so the rules are testable without React.
+ *
+ * The date slot carries three different meanings, which is why it isn't a single "reset" value:
+ * Free's caps reset on the UTC calendar month, paid plans renew on their billing period, and an
+ * account with a scheduled change isn't doing either — it's changing plan.
+ */
+export function buildSummaryState({
+    plan,
+    plans,
+    paymentMethod,
+    canManageBilling,
+    now
+}: {
+    plan: ApiPlan;
+    plans: PlanDefinition[] | undefined;
+    paymentMethod: StripePaymentMethod | null;
+    canManageBilling: boolean;
+    now: Date;
+}): SummaryStripState {
+    const planTitle = planTitleOf(plan.name, plans);
+    const isFree = plan.name === 'free';
+
+    // A change only counts while it's still ahead of us and actually moves the customer somewhere
+    // else. Same-plan rows are Orb-side repricings, and past-dated ones are stale mirrors that
+    // nothing clears — neither is a plan change from the customer's point of view.
+    const changeAt = plan.orb_future_plan_at ? new Date(plan.orb_future_plan_at) : null;
+    const changeTo = plan.orb_future_plan;
+    const change =
+        changeTo && changeTo !== plan.name && changeAt && changeAt.getTime() > now.getTime()
+            ? { toPlanTitle: planTitleOf(changeTo, plans), at: formatBillingDate(changeAt) }
+            : null;
+
+    let date: SummaryStripState['date'] = null;
+    if (change) {
+        date = { label: 'CHANGES ON', value: change.at };
+    } else if (isFree) {
+        date = { label: 'LIMITS RESET', value: formatBillingDate(nextUsageResetDate(now)) };
+    } else if (plan.name !== 'startup-deal') {
+        // The deal never renews — it always converts — so with no change date we say nothing rather
+        // than claim a renewal. The missing dates are a data gap (NAN-6640), not a display state.
+        date = { label: 'RENEWS ON', value: formatBillingDate(nextUsageResetDate(now)) };
+    }
+
+    return {
+        planTitle,
+        date,
+        // Free never shows a payment method, even when a card is on file.
+        payment: isFree || !canManageBilling ? null : { card: paymentMethod },
+        change
+    };
+}

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -43,7 +43,8 @@ function planTitleOf(code: string, plans: PlanDefinition[] | undefined): string 
 
 /** The clause after the date, which depends on what the change actually means for the bill. */
 function changeDetail({ from, toCode, toTitle }: { from: string; toCode: string; toTitle: string }): string {
-    if (toCode === 'free') {
+    // Both free plans have a $0 base and no overage, so there is nothing left to charge.
+    if (toCode === 'free' || toCode === 'free-uncapped') {
         return 'no further charges after this period.';
     }
     if (from === 'startup-deal') {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildSummaryState, showsSummaryStrip } from './summaryState.js';
+import { showsSummaryStrip } from './planVisibility.js';
+import { buildSummaryState } from './summaryState.js';
 
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -73,8 +73,8 @@ describe('buildSummaryState', () => {
         expect(build(planOf('growth-v2'), { paymentMethod: card, canManageBilling: false }).payment).toBeNull();
     });
 
-    it('keeps the payment slot when there is no card, so it can be added', () => {
-        expect(build(planOf('starter-v2')).payment).toEqual({ card: null });
+    it('hides the payment slot entirely when there is no card', () => {
+        expect(build(planOf('starter-v2')).payment).toBeNull();
     });
 
     it('says nothing about dates for a deal whose conversion date is missing', () => {
@@ -85,13 +85,17 @@ describe('buildSummaryState', () => {
     it('announces a scheduled change instead of a renewal', () => {
         const state = build(planOf('startup-deal', { orb_future_plan: 'growth-v2', orb_future_plan_at: '2026-09-25T00:00:00.000Z' }));
         expect(state.date).toEqual({ label: 'CHANGES ON', value: 'September 25, 2026' });
-        expect(state.change).toEqual({ toPlanTitle: 'Growth', at: 'September 25, 2026' });
+        expect(state.change).toEqual({
+            toPlanTitle: 'Growth',
+            at: 'September 25, 2026',
+            detail: "your startup deal ends and you'll be charged at standard Growth pricing."
+        });
     });
 
     it('announces a downgrade the same way', () => {
         const state = build(planOf('growth-v2', { orb_future_plan: 'free', orb_future_plan_at: '2026-09-01T00:00:00.000Z' }));
         expect(state.date?.label).toBe('CHANGES ON');
-        expect(state.change).toEqual({ toPlanTitle: 'Free', at: 'September 1, 2026' });
+        expect(state.change).toEqual({ toPlanTitle: 'Free', at: 'September 1, 2026', detail: 'no further charges after this period.' });
     });
 
     it('ignores a change to the same plan — those are Orb-side repricings', () => {
@@ -104,6 +108,11 @@ describe('buildSummaryState', () => {
         const state = build(planOf('growth-v2', { orb_future_plan: 'free', orb_future_plan_at: '2026-07-01T00:00:00.000Z' }));
         expect(state.date?.label).toBe('RENEWS ON');
         expect(state.change).toBeNull();
+    });
+
+    it('explains a paid-to-paid downgrade in terms of the new plan', () => {
+        const state = build(planOf('growth-v2', { orb_future_plan: 'starter-v2', orb_future_plan_at: '2026-09-01T00:00:00.000Z' }));
+        expect(state.change?.detail).toBe("you'll be charged at standard Starter pricing.");
     });
 
     it('falls back to the plan code when the plan list has not loaded', () => {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSummaryState, showsSummaryStrip } from './summaryState.js';
+
+import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
+
+const NOW = new Date('2026-08-17T10:00:00Z');
+
+const plans = [
+    { code: 'free', title: 'Free' },
+    { code: 'starter-v2', title: 'Starter' },
+    { code: 'growth-v2', title: 'Growth' },
+    { code: 'startup-deal', title: 'Startup deal' }
+] as PlanDefinition[];
+
+const card: StripePaymentMethod = { id: 'pm_1', brand: 'visa', last4: '4242', expMonth: 8, expYear: 2028 };
+
+function planOf(name: ApiPlan['name'], overrides: Partial<ApiPlan> = {}): ApiPlan {
+    return { name, orb_future_plan: null, orb_future_plan_at: null, ...overrides } as ApiPlan;
+}
+function build(plan: ApiPlan, opts: { paymentMethod?: StripePaymentMethod | null; canManageBilling?: boolean } = {}) {
+    return buildSummaryState({
+        plan,
+        plans,
+        paymentMethod: opts.paymentMethod ?? null,
+        canManageBilling: opts.canManageBilling ?? true,
+        now: NOW
+    });
+}
+
+describe('showsSummaryStrip', () => {
+    it('renders for the four current plans', () => {
+        for (const name of ['free', 'starter-v2', 'growth-v2', 'startup-deal'] as const) {
+            expect(showsSummaryStrip(planOf(name))).toBe(true);
+        }
+    });
+
+    it('hides for legacy, enterprise and free-uncapped', () => {
+        for (const name of [
+            'starter-legacy',
+            'scale-legacy',
+            'growth',
+            'starter',
+            'growth-legacy',
+            'enterprise',
+            'enterprise-cloud-hosted',
+            'free-uncapped'
+        ] as const) {
+            expect(showsSummaryStrip(planOf(name))).toBe(false);
+        }
+    });
+
+    it('hides when the plan is not loaded yet', () => {
+        expect(showsSummaryStrip(null)).toBe(false);
+    });
+});
+
+describe('buildSummaryState', () => {
+    it('shows Free the caps reset and never a payment method, even with a card', () => {
+        const state = build(planOf('free'), { paymentMethod: card });
+        expect(state.planTitle).toBe('Free');
+        expect(state.date).toEqual({ label: 'LIMITS RESET', value: 'September 1, 2026' });
+        expect(state.payment).toBeNull();
+    });
+
+    it('shows paid plans a renewal date and the card', () => {
+        const state = build(planOf('starter-v2'), { paymentMethod: card });
+        expect(state.date).toEqual({ label: 'RENEWS ON', value: 'September 1, 2026' });
+        expect(state.payment).toEqual({ card });
+    });
+
+    it('hides the payment slot from viewers who cannot manage billing', () => {
+        expect(build(planOf('growth-v2'), { paymentMethod: card, canManageBilling: false }).payment).toBeNull();
+    });
+
+    it('keeps the payment slot when there is no card, so it can be added', () => {
+        expect(build(planOf('starter-v2')).payment).toEqual({ card: null });
+    });
+
+    it('says nothing about dates for a deal whose conversion date is missing', () => {
+        // The deal never renews, so "Renews on" would be a lie — see NAN-6640 for the missing dates.
+        expect(build(planOf('startup-deal')).date).toBeNull();
+    });
+
+    it('announces a scheduled change instead of a renewal', () => {
+        const state = build(planOf('startup-deal', { orb_future_plan: 'growth-v2', orb_future_plan_at: '2026-09-25T00:00:00.000Z' }));
+        expect(state.date).toEqual({ label: 'CHANGES ON', value: 'September 25, 2026' });
+        expect(state.change).toEqual({ toPlanTitle: 'Growth', at: 'September 25, 2026' });
+    });
+
+    it('announces a downgrade the same way', () => {
+        const state = build(planOf('growth-v2', { orb_future_plan: 'free', orb_future_plan_at: '2026-09-01T00:00:00.000Z' }));
+        expect(state.date?.label).toBe('CHANGES ON');
+        expect(state.change).toEqual({ toPlanTitle: 'Free', at: 'September 1, 2026' });
+    });
+
+    it('ignores a change to the same plan — those are Orb-side repricings', () => {
+        const state = build(planOf('starter-v2', { orb_future_plan: 'starter-v2', orb_future_plan_at: '2026-10-01T00:00:00.000Z' }));
+        expect(state.date?.label).toBe('RENEWS ON');
+        expect(state.change).toBeNull();
+    });
+
+    it('ignores a change date that has already passed — stale mirror rows', () => {
+        const state = build(planOf('growth-v2', { orb_future_plan: 'free', orb_future_plan_at: '2026-07-01T00:00:00.000Z' }));
+        expect(state.date?.label).toBe('RENEWS ON');
+        expect(state.change).toBeNull();
+    });
+
+    it('falls back to the plan code when the plan list has not loaded', () => {
+        const state = buildSummaryState({ plan: planOf('growth-v2'), plans: undefined, paymentMethod: null, canManageBilling: true, now: NOW });
+        expect(state.planTitle).toBe('growth-v2');
+    });
+});

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -118,9 +118,9 @@ describe('buildSummaryState', () => {
         }
     });
 
-    it('explains a paid-to-paid downgrade in terms of the new plan', () => {
+    it('adds no gloss to a paid-to-paid downgrade — the new plan name says it', () => {
         const state = build(planOf('growth-v2', { orb_future_plan: 'starter-v2', orb_future_plan_at: '2026-09-01T00:00:00.000Z' }));
-        expect(state.change?.detail).toBe("you'll be charged at standard Starter pricing.");
+        expect(state.change).toEqual({ toPlanTitle: 'Starter', at: 'September 1, 2026', detail: null });
     });
 
     it('falls back to the plan code when the plan list has not loaded', () => {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -110,6 +110,13 @@ describe('buildSummaryState', () => {
         expect(state.change).toBeNull();
     });
 
+    it('promises no further charges when moving to either free plan', () => {
+        for (const target of ['free', 'free-uncapped'] as const) {
+            const state = build(planOf('growth-v2', { orb_future_plan: target, orb_future_plan_at: '2026-09-01T00:00:00.000Z' }));
+            expect(state.change?.detail).toBe('no further charges after this period.');
+        }
+    });
+
     it('explains a paid-to-paid downgrade in terms of the new plan', () => {
         const state = build(planOf('growth-v2', { orb_future_plan: 'starter-v2', orb_future_plan_at: '2026-09-01T00:00:00.000Z' }));
         expect(state.change?.detail).toBe("you'll be charged at standard Starter pricing.");


### PR DESCRIPTION
## Problem

The billing page opens straight into the usage table, with no answer to "where do I stand" — the current plan, when things reset or renew, and the card on file are either buried further down the page or absent.

## Solution

Adds a summary strip as the first section of the billing page, covering every account situation the design review settled:

- **Free** — current plan and when its caps reset (1st of the next UTC month, computed locally). Never shows a payment method, even when a card is on file.
- **Starter / Growth** — current plan, renewal date, and the card with inline edit. With no card on file the payment slot is dropped rather than dashed; a card is added from the billing information section below.
- **Plan change scheduled** — replaces the renewal with the change date and a sentence naming the new plan and what it means for the bill: charges ending, a startup deal ending, or a move to another paid plan's pricing.
- **No strip at all** for legacy, enterprise and `free-uncapped` accounts (30 today) — terms are negotiated per customer or nothing is billable, so every field would be empty or untrue.
- Suppresses two Orb quirks: a scheduled change to the plan the account is already on (an Orb-side repricing) and a change date already in the past (a stale mirror row nothing clears).
- Splits the strip into `buildSummaryState` (rules, testable without React) and `SummaryStrip` (markup, renderable from Storybook).

Fixes [NAN-6229](https://linear.app/nango/issue/NAN-6229)

## Testing

13 unit tests over `buildSummaryState` cover each state and both suppression rules. Verified in the app across plans via the plan-override dev tool: Growth renders the renewal date, a scheduled change renders the notice, and a legacy plan renders no section at all.

## Storybook

New `Features/Billing/SummaryStrip` group — `Paid`, `PaidWithoutCard`, `Free`, `Downgrading`, `DealConverting`, `DealWithoutDate`, `Loading`. `Features` is a new top level alongside `Components`, since the strip is a page composition rather than a reusable primitive.

<!-- Suggest adding: the Free and Downgrading stories side by side, in light and dark -->

## Follow-ups

- Current-period spend takes the headline slot on paid plans — needs an Orb spend read the backend doesn't have: [NAN-6246](https://linear.app/nango/issue/NAN-6246).
- Six startup-deal accounts have no stored conversion date, so they show no date until that data is repaired: [NAN-6640](https://linear.app/nango/issue/NAN-6640).
- The designed "Keep &lt;plan&gt;" action for a scheduled downgrade is deferred — there's no endpoint to unschedule a plan change today.
