### PR TITLE
feat(mfa): require a second factor to change or reset a password (NAN-6586)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35990,6 +35990,7 @@
                 "he": "1.2.0",
                 "helmet": "7.1.0",
                 "jsonwebtoken": "9.0.3",
+                "knex": "3.1.0",
                 "lodash-es": "4.18.1",
                 "multer": "2.2.0",
                 "node-cron": "4.6.0",

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -7,6 +7,7 @@ import { markMfaVerified } from './elevation.js';
 
 import type { DBUser, PostMFALoginVerification } from '@nangohq/types';
 import type { Request } from 'express';
+import type { Knex } from 'knex';
 
 const MFA_LOGIN_TTL_MS = 10 * 60 * 1000;
 
@@ -67,8 +68,8 @@ async function loadEligibleUser(userId: number): Promise<DBUser | null> {
     return user;
 }
 
-export async function isMFAEnabled(user: DBUser): Promise<boolean> {
-    const account = await accountService.getAccountById(db.knex, user.account_id);
+export async function isMFAEnabled(user: DBUser, trx: Knex = db.knex): Promise<boolean> {
+    const account = await accountService.getAccountById(trx, user.account_id);
     return Boolean(account && (await getFlags().isMFAEnabled(account.uuid)));
 }
 

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -67,7 +67,7 @@ async function loadEligibleUser(userId: number): Promise<DBUser | null> {
     return user;
 }
 
-async function isMFAEnabled(user: DBUser): Promise<boolean> {
+export async function isMFAEnabled(user: DBUser): Promise<boolean> {
     const account = await accountService.getAccountById(db.knex, user.account_id);
     return Boolean(account && (await getFlags().isMFAEnabled(account.uuid)));
 }

--- a/packages/server/lib/controllers/v1/account/mfa/mfa.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/mfa.ts
@@ -7,6 +7,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { userToAPI } from '../../../../formatters/user.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { verifyPendingMfaLogin } from './login.js';
+import { mfaCredentialSchema } from './stepUp.js';
 
 import type { RequestLocals } from '../../../../utils/express.js';
 import type { DeleteMFA, GetMFAStatus, PostMFAActivation, PostMFAEnrollment, PostMFALoginVerification, PostMFARecoveryCodes } from '@nangohq/types';
@@ -18,20 +19,7 @@ const codeValidation = z
     })
     .strict();
 
-const loginValidation = z.discriminatedUnion('type', [
-    z
-        .object({
-            type: z.literal('code'),
-            code: z.string().regex(/^\d{6}$/)
-        })
-        .strict(),
-    z
-        .object({
-            type: z.literal('recoveryCode'),
-            recoveryCode: z.string().min(1).max(255)
-        })
-        .strict()
-]);
+const loginValidation = mfaCredentialSchema;
 
 function validateQuery(req: Request, res: Response): boolean {
     const emptyQuery = requireEmptyQuery(req, { withEnv: false });

--- a/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
@@ -22,7 +22,12 @@ export const mfaCredentialSchema = z.discriminatedUnion('type', [
         .strict()
 ]);
 
-export type StepUpOutcome = 'not_required' | 'verified' | 'required' | 'invalid';
+export type StepUpOutcome = 'not_required' | 'recently_verified' | 'verified' | 'required' | 'invalid';
+
+/** Outcomes that mean the caller must stop and tell the client what is missing. */
+export function isStepUpRefused(outcome: StepUpOutcome): outcome is 'required' | 'invalid' {
+    return outcome === 'required' || outcome === 'invalid';
+}
 
 /**
  * Whether this user owes a second factor. Consumes nothing and needs no transaction, so callers can
@@ -38,8 +43,16 @@ export async function isStepUpRequired(user: DBUser): Promise<boolean> {
  *
  * Call this inside the transaction that performs the action and pass `trx`. A one-time credential is
  * spent here, so it has to roll back with the action rather than outlive a failed one.
+ *
+ * `recentlyVerified` lets a factor this session already presented stand in for a fresh one. A
+ * credential that is sent is always the one that decides, so a wrong code is never waved through.
  */
-export async function verifyStepUpMfa(user: DBUser, credential: MFACredential | undefined, trx: Knex): Promise<StepUpOutcome> {
+export async function verifyStepUpMfa(
+    user: DBUser,
+    credential: MFACredential | undefined,
+    trx: Knex,
+    { recentlyVerified = false }: { recentlyVerified?: boolean } = {}
+): Promise<StepUpOutcome> {
     // Re-checked here rather than trusted from an earlier isStepUpRequired call, so enrolling a
     // factor mid-request cannot slip a write past the gate.
     if (!(await isStepUpRequired(user))) {
@@ -47,7 +60,7 @@ export async function verifyStepUpMfa(user: DBUser, credential: MFACredential | 
     }
 
     if (!credential) {
-        return 'required';
+        return recentlyVerified ? 'recently_verified' : 'required';
     }
 
     const verified = (

--- a/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
@@ -25,6 +25,14 @@ export const mfaCredentialSchema = z.discriminatedUnion('type', [
 export type StepUpOutcome = 'not_required' | 'verified' | 'required' | 'invalid';
 
 /**
+ * Whether this user owes a second factor. Consumes nothing and needs no transaction, so callers can
+ * turn away a request with no credential before spending anything expensive on it.
+ */
+export async function isStepUpRequired(user: DBUser): Promise<boolean> {
+    return (await isMFAEnabled(user)) && (await mfaService.hasActiveFactor(user.id));
+}
+
+/**
  * Second factor for a sensitive action the user is already part way through, rather than for a login.
  * Returns 'not_required' when the user has nothing enrolled, so callers stay usable for everyone else.
  *
@@ -32,7 +40,9 @@ export type StepUpOutcome = 'not_required' | 'verified' | 'required' | 'invalid'
  * spent here, so it has to roll back with the action rather than outlive a failed one.
  */
 export async function verifyStepUpMfa(user: DBUser, credential: MFACredential | undefined, trx: Knex): Promise<StepUpOutcome> {
-    if (!(await isMFAEnabled(user)) || !(await mfaService.hasActiveFactor(user.id))) {
+    // Re-checked here rather than trusted from an earlier isStepUpRequired call, so enrolling a
+    // factor mid-request cannot slip a write past the gate.
+    if (!(await isStepUpRequired(user))) {
         return 'not_required';
     }
 

--- a/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
@@ -5,6 +5,7 @@ import { mfaService } from '@nangohq/shared';
 import { isMFAEnabled } from './login.js';
 
 import type { DBUser, MFACredential } from '@nangohq/types';
+import type { Knex } from 'knex';
 
 export const mfaCredentialSchema = z.discriminatedUnion('type', [
     z
@@ -26,8 +27,11 @@ export type StepUpOutcome = 'not_required' | 'verified' | 'required' | 'invalid'
 /**
  * Second factor for a sensitive action the user is already part way through, rather than for a login.
  * Returns 'not_required' when the user has nothing enrolled, so callers stay usable for everyone else.
+ *
+ * Call this inside the transaction that performs the action and pass `trx`. A one-time credential is
+ * spent here, so it has to roll back with the action rather than outlive a failed one.
  */
-export async function verifyStepUpMfa(user: DBUser, credential: MFACredential | undefined): Promise<StepUpOutcome> {
+export async function verifyStepUpMfa(user: DBUser, credential: MFACredential | undefined, trx: Knex): Promise<StepUpOutcome> {
     if (!(await isMFAEnabled(user)) || !(await mfaService.hasActiveFactor(user.id))) {
         return 'not_required';
     }
@@ -38,8 +42,8 @@ export async function verifyStepUpMfa(user: DBUser, credential: MFACredential | 
 
     const verified = (
         credential.type === 'recoveryCode'
-            ? await mfaService.consumeRecoveryCode(user.id, credential.recoveryCode)
-            : await mfaService.verifyTotp(user.id, credential.code)
+            ? await mfaService.consumeRecoveryCode(user.id, credential.recoveryCode, trx)
+            : await mfaService.verifyTotp(user.id, credential.code, trx)
     ).unwrap();
 
     return verified ? 'verified' : 'invalid';

--- a/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
@@ -1,0 +1,46 @@
+import * as z from 'zod';
+
+import { mfaService } from '@nangohq/shared';
+
+import { isMFAEnabled } from './login.js';
+
+import type { DBUser, MFACredential } from '@nangohq/types';
+
+export const mfaCredentialSchema = z.discriminatedUnion('type', [
+    z
+        .object({
+            type: z.literal('code'),
+            code: z.string().regex(/^\d{6}$/)
+        })
+        .strict(),
+    z
+        .object({
+            type: z.literal('recoveryCode'),
+            recoveryCode: z.string().min(1).max(255)
+        })
+        .strict()
+]);
+
+export type StepUpOutcome = 'not_required' | 'verified' | 'required' | 'invalid';
+
+/**
+ * Second factor for a sensitive action the user is already part way through, rather than for a login.
+ * Returns 'not_required' when the user has nothing enrolled, so callers stay usable for everyone else.
+ */
+export async function verifyStepUpMfa(user: DBUser, credential: MFACredential | undefined): Promise<StepUpOutcome> {
+    if (!(await isMFAEnabled(user)) || !(await mfaService.hasActiveFactor(user.id))) {
+        return 'not_required';
+    }
+
+    if (!credential) {
+        return 'required';
+    }
+
+    const verified = (
+        credential.type === 'recoveryCode'
+            ? await mfaService.consumeRecoveryCode(user.id, credential.recoveryCode)
+            : await mfaService.verifyTotp(user.id, credential.code)
+    ).unwrap();
+
+    return verified ? 'verified' : 'invalid';
+}

--- a/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
@@ -33,8 +33,8 @@ export function isStepUpRefused(outcome: StepUpOutcome): outcome is 'required' |
  * Whether this user owes a second factor. Consumes nothing and needs no transaction, so callers can
  * turn away a request with no credential before spending anything expensive on it.
  */
-export async function isStepUpRequired(user: DBUser): Promise<boolean> {
-    return (await isMFAEnabled(user)) && (await mfaService.hasActiveFactor(user.id));
+export async function isStepUpRequired(user: DBUser, trx?: Knex): Promise<boolean> {
+    return (await isMFAEnabled(user, trx)) && (await mfaService.hasActiveFactor(user.id, trx));
 }
 
 /**
@@ -55,7 +55,7 @@ export async function verifyStepUpMfa(
 ): Promise<StepUpOutcome> {
     // Re-checked here rather than trusted from an earlier isStepUpRequired call, so enrolling a
     // factor mid-request cannot slip a write past the gate.
-    if (!(await isStepUpRequired(user))) {
+    if (!(await isStepUpRequired(user, trx))) {
         return 'not_required';
     }
 

--- a/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
@@ -169,6 +169,33 @@ describe(`PUT ${resetPasswordRoute}`, () => {
         expect(json).toStrictEqual({ error: { code: 'user_not_found' } });
     });
 
+    it('should not spend a recovery code when the reset itself fails', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const session = await signin(email, password);
+        const { recoveryCodes } = await enrollMfa(session);
+
+        // issue the token before spying, issueResetToken writes through editUserPassword too
+        const token = await issueResetToken(email);
+
+        vi.spyOn(userService, 'editUserPassword').mockRejectedValueOnce(new Error('write failed'));
+        const failed = await api.fetch(resetPasswordRoute, {
+            method: 'PUT',
+            body: { token, password: 'aZ1-newpass!?', mfa: { type: 'recoveryCode', recoveryCode: recoveryCodes[0]! } }
+        });
+        expect(failed.res.status).toBe(500);
+
+        // the password never changed
+        await signin(email, password);
+
+        // and the rollback left both the recovery code and the reset token spendable
+        const retry = await api.fetch(resetPasswordRoute, {
+            method: 'PUT',
+            body: { token, password: 'aZ1-newpass!?', mfa: { type: 'recoveryCode', recoveryCode: recoveryCodes[0]! } }
+        });
+        expect(retry.res.status).toBe(200);
+        isSuccess(retry.json);
+    });
+
     it('should skip the second factor when the feature is off for the account', async () => {
         const { email, password } = await signupVerifiedUser();
         const session = await signin(email, password);

--- a/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
@@ -1,19 +1,25 @@
 import jwt from 'jsonwebtoken';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as OTPAuth from 'otpauth';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
+import * as featureFlags from '@nangohq/feature-flags';
 import { userService } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
-import { isSuccess, runServer } from '../../../utils/tests.js';
+import { isError, isSuccess, runServer } from '../../../utils/tests.js';
 import { resetPasswordSecret } from '../../../utils/utils.js';
+
+import type { MockInstance } from 'vitest';
 
 const signupRoute = '/api/v1/account/signup';
 const signinRoute = '/api/v1/account/signin';
 const resetPasswordRoute = '/api/v1/account/reset-password';
 const userRoute = '/api/v1/user';
 const accountDiscoveryRoute = '/api/v1/account/onboarding/account-discovery';
+const mfaRoute = '/api/v1/account/mfa';
 
 let api: Awaited<ReturnType<typeof runServer>>;
+let mfaFlagSpy: MockInstance<ReturnType<typeof featureFlags.getFlags>['isMFAEnabled']>;
 
 async function signupVerifiedUser(): Promise<{ email: string; password: string }> {
     const email = `${nanoid()}@example.com`;
@@ -39,13 +45,35 @@ async function signin(email: string, password: string): Promise<string> {
     return cookie!.split(';')[0]!;
 }
 
+async function enrollMfa(session: string): Promise<{ totp: OTPAuth.TOTP; recoveryCodes: string[] }> {
+    const enrollment = await api.fetch(`${mfaRoute}/enroll`, { method: 'POST', session });
+    expect(enrollment.res.status).toBe(200);
+    isSuccess(enrollment.json);
+    const totp = OTPAuth.URI.parse(enrollment.json.data.otpauthUri) as OTPAuth.TOTP;
+
+    const activation = await api.fetch(`${mfaRoute}/activate`, { method: 'POST', session, body: { code: totp.generate() } });
+    expect(activation.res.status).toBe(200);
+    isSuccess(activation.json);
+
+    return { totp, recoveryCodes: activation.json.data.recoveryCodes };
+}
+
+async function issueResetToken(email: string): Promise<string> {
+    const dbUser = await userService.getUserByEmail(email);
+    const token = jwt.sign({ user: email }, resetPasswordSecret(), { expiresIn: '10m' });
+    await userService.editUserPassword({ id: dbUser!.id, reset_password_token: token, hashed_password: dbUser!.hashed_password });
+    return token;
+}
+
 describe(`PUT ${resetPasswordRoute}`, () => {
     beforeAll(async () => {
         api = await runServer();
+        mfaFlagSpy = vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
     });
 
     afterAll(() => {
         api.server.close();
+        vi.restoreAllMocks();
     });
 
     it('should invalidate all sessions after a password reset', async () => {
@@ -75,5 +103,81 @@ describe(`PUT ${resetPasswordRoute}`, () => {
         const recoveredSession = await signin(email, 'aZ1-newpass!?');
         // password recovery must not make an existing user eligible for new-user account discovery.
         expect((await api.fetch(accountDiscoveryRoute, { method: 'GET', session: recoveredSession })).res.status).toBe(404);
+    });
+
+    it('should require a second factor when the user has one enrolled', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const session = await signin(email, password);
+        await enrollMfa(session);
+
+        const token = await issueResetToken(email);
+
+        // a mailbox alone must not be enough to take the account over
+        const missing = await api.fetch(resetPasswordRoute, { method: 'PUT', body: { token, password: 'aZ1-newpass!?' } });
+        expect(missing.res.status).toBe(400);
+        isError(missing.json);
+        expect(missing.json).toStrictEqual({ error: { code: 'mfa_code_required' } });
+
+        const wrongCode = await api.fetch(resetPasswordRoute, {
+            method: 'PUT',
+            body: { token, password: 'aZ1-newpass!?', mfa: { type: 'code', code: '000000' } }
+        });
+        expect(wrongCode.res.status).toBe(400);
+        isError(wrongCode.json);
+        expect(wrongCode.json).toStrictEqual({ error: { code: 'invalid_mfa_code' } });
+
+        // the old password still works, so nothing was changed by the rejected attempts
+        await signin(email, password);
+    });
+
+    it('should reset the password with a valid code, and with a recovery code', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const session = await signin(email, password);
+        const { totp, recoveryCodes } = await enrollMfa(session);
+
+        const withCode = await api.fetch(resetPasswordRoute, {
+            method: 'PUT',
+            body: {
+                token: await issueResetToken(email),
+                password: 'aZ1-newpass!?',
+                mfa: { type: 'code', code: totp.generate({ timestamp: Date.now() + 30_000 }) }
+            }
+        });
+        expect(withCode.res.status).toBe(200);
+        isSuccess(withCode.json);
+
+        const withRecoveryCode = await api.fetch(resetPasswordRoute, {
+            method: 'PUT',
+            body: { token: await issueResetToken(email), password: 'aZ1-thirdpass!?', mfa: { type: 'recoveryCode', recoveryCode: recoveryCodes[0]! } }
+        });
+        expect(withRecoveryCode.res.status).toBe(200);
+        isSuccess(withRecoveryCode.json);
+    });
+
+    it('should reject an invalid token before asking for a second factor', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const session = await signin(email, password);
+        await enrollMfa(session);
+
+        await issueResetToken(email);
+        const { res, json } = await api.fetch(resetPasswordRoute, {
+            method: 'PUT',
+            body: { token: jwt.sign({ user: email }, 'not-the-reset-secret', { expiresIn: '10m' }), password: 'aZ1-newpass!?' }
+        });
+        expect(res.status).toBe(400);
+        isError(json);
+        expect(json).toStrictEqual({ error: { code: 'user_not_found' } });
+    });
+
+    it('should skip the second factor when the feature is off for the account', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const session = await signin(email, password);
+        await enrollMfa(session);
+
+        const token = await issueResetToken(email);
+        mfaFlagSpy.mockResolvedValueOnce(false);
+        const { res, json } = await api.fetch(resetPasswordRoute, { method: 'PUT', body: { token, password: 'aZ1-newpass!?' } });
+        expect(res.status).toBe(200);
+        isSuccess(json);
     });
 });

--- a/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
@@ -202,8 +202,10 @@ describe(`PUT ${resetPasswordRoute}`, () => {
         await enrollMfa(session);
 
         const token = await issueResetToken(email);
-        mfaFlagSpy.mockResolvedValueOnce(false);
+        mfaFlagSpy.mockResolvedValue(false);
         const { res, json } = await api.fetch(resetPasswordRoute, { method: 'PUT', body: { token, password: 'aZ1-newpass!?' } });
+        mfaFlagSpy.mockResolvedValue(true);
+
         expect(res.status).toBe(200);
         isSuccess(json);
     });

--- a/packages/server/lib/controllers/v1/account/putResetPassword.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.ts
@@ -55,8 +55,6 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
         return;
     }
 
-    // Turn away a request with no credential before paying for the hash. Anyone can reach this
-    // endpoint, so the work it does before rejecting is worth keeping small.
     if (!mfa && (await isStepUpRequired(user))) {
         res.status(400).send({ error: { code: 'mfa_code_required' } });
         return;
@@ -64,9 +62,6 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
 
     const hashedPassword = (await pbkdf2(password, user.salt, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
 
-    // Without the second factor the emailed token is the only thing standing between someone with
-    // mailbox access and the account, which is exactly what MFA is meant to prevent. Verified in the
-    // same transaction as the write so a failed reset does not spend a one-time code.
     const outcome = await db.knex.transaction(async (trx) => {
         const stepUp = await verifyStepUpMfa(user, mfa, trx);
         if (isStepUpRefused(stepUp)) {

--- a/packages/server/lib/controllers/v1/account/putResetPassword.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.ts
@@ -8,7 +8,7 @@ import { PBKDF2_ITERATIONS, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/u
 import { deleteUserSessions } from '../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { resetPasswordSecret } from '../../../utils/utils.js';
-import { mfaCredentialSchema, verifyStepUpMfa } from './mfa/stepUp.js';
+import { isStepUpRequired, mfaCredentialSchema, verifyStepUpMfa } from './mfa/stepUp.js';
 import { passwordSchema } from './signup.js';
 
 import type { PutResetPassword } from '@nangohq/types';
@@ -52,6 +52,13 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
         res.status(400).send({
             error: { code: 'invalid_token' }
         });
+        return;
+    }
+
+    // Turn away a request with no credential before paying for the hash. Anyone can reach this
+    // endpoint, so the work it does before rejecting is worth keeping small.
+    if (!mfa && (await isStepUpRequired(user))) {
+        res.status(400).send({ error: { code: 'mfa_code_required' } });
         return;
     }
 

--- a/packages/server/lib/controllers/v1/account/putResetPassword.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.ts
@@ -55,26 +55,32 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
         return;
     }
 
-    // Without this the emailed token is the only thing standing between someone with mailbox access
-    // and the account, which is exactly what the second factor is meant to prevent.
-    const stepUp = await verifyStepUpMfa(user, mfa);
-    if (stepUp === 'required') {
+    const hashedPassword = (await pbkdf2(password, user.salt, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
+
+    // Without the second factor the emailed token is the only thing standing between someone with
+    // mailbox access and the account, which is exactly what MFA is meant to prevent. Verified in the
+    // same transaction as the write so a failed reset does not spend a one-time code.
+    const outcome = await db.knex.transaction(async (trx) => {
+        const stepUp = await verifyStepUpMfa(user, mfa, trx);
+        if (stepUp !== 'verified' && stepUp !== 'not_required') {
+            return stepUp;
+        }
+
+        user.hashed_password = hashedPassword;
+        user.reset_password_token = null;
+        await userService.editUserPassword(user, trx);
+        await deleteUserSessions(user.id, { trx });
+        return 'reset' as const;
+    });
+
+    if (outcome === 'required') {
         res.status(400).send({ error: { code: 'mfa_code_required' } });
         return;
     }
-    if (stepUp === 'invalid') {
+    if (outcome === 'invalid') {
         res.status(400).send({ error: { code: 'invalid_mfa_code' } });
         return;
     }
-
-    const hashedPassword = (await pbkdf2(password, user.salt, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
-
-    user.hashed_password = hashedPassword;
-    user.reset_password_token = null;
-    await db.knex.transaction(async (trx) => {
-        await userService.editUserPassword(user, trx);
-        await deleteUserSessions(user.id, { trx });
-    });
 
     res.status(200).json({
         success: true

--- a/packages/server/lib/controllers/v1/account/putResetPassword.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.ts
@@ -8,6 +8,7 @@ import { PBKDF2_ITERATIONS, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/u
 import { deleteUserSessions } from '../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { resetPasswordSecret } from '../../../utils/utils.js';
+import { mfaCredentialSchema, verifyStepUpMfa } from './mfa/stepUp.js';
 import { passwordSchema } from './signup.js';
 
 import type { PutResetPassword } from '@nangohq/types';
@@ -15,7 +16,8 @@ import type { PutResetPassword } from '@nangohq/types';
 const validation = z
     .object({
         token: z.string(),
-        password: passwordSchema
+        password: passwordSchema,
+        mfa: mfaCredentialSchema.optional()
     })
     .strict();
 
@@ -34,7 +36,7 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
         return;
     }
 
-    const { password, token } = val.data;
+    const { password, token, mfa } = val.data;
 
     const user = await userService.getUserByResetPasswordToken(token);
     if (!user) {
@@ -50,6 +52,18 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
         res.status(400).send({
             error: { code: 'invalid_token' }
         });
+        return;
+    }
+
+    // Without this the emailed token is the only thing standing between someone with mailbox access
+    // and the account, which is exactly what the second factor is meant to prevent.
+    const stepUp = await verifyStepUpMfa(user, mfa);
+    if (stepUp === 'required') {
+        res.status(400).send({ error: { code: 'mfa_code_required' } });
+        return;
+    }
+    if (stepUp === 'invalid') {
+        res.status(400).send({ error: { code: 'invalid_mfa_code' } });
         return;
     }
 

--- a/packages/server/lib/controllers/v1/account/putResetPassword.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.ts
@@ -8,7 +8,7 @@ import { PBKDF2_ITERATIONS, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/u
 import { deleteUserSessions } from '../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { resetPasswordSecret } from '../../../utils/utils.js';
-import { isStepUpRequired, mfaCredentialSchema, verifyStepUpMfa } from './mfa/stepUp.js';
+import { isStepUpRefused, isStepUpRequired, mfaCredentialSchema, verifyStepUpMfa } from './mfa/stepUp.js';
 import { passwordSchema } from './signup.js';
 
 import type { PutResetPassword } from '@nangohq/types';
@@ -69,7 +69,7 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
     // same transaction as the write so a failed reset does not spend a one-time code.
     const outcome = await db.knex.transaction(async (trx) => {
         const stepUp = await verifyStepUpMfa(user, mfa, trx);
-        if (stepUp !== 'verified' && stepUp !== 'not_required') {
+        if (isStepUpRefused(stepUp)) {
             return stepUp;
         }
 

--- a/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
@@ -200,6 +200,29 @@ describe(`PUT ${passwordRoute}`, () => {
         isSuccess(retry.json);
     });
 
+    it('should not spend a recovery code when the change itself fails', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const session = await signin(email, password);
+        const { recoveryCodes } = await enrollMfa(session);
+
+        vi.spyOn(userService, 'update').mockRejectedValueOnce(new Error('write failed'));
+        const failed = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session,
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!?', mfa: { type: 'recoveryCode', recoveryCode: recoveryCodes[0]! } }
+        });
+        expect(failed.res.status).toBe(500);
+
+        // the password did not change, so the code it consumed has to be spendable again
+        const retry = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session,
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!?', mfa: { type: 'recoveryCode', recoveryCode: recoveryCodes[0]! } }
+        });
+        expect(retry.res.status).toBe(200);
+        isSuccess(retry.json);
+    });
+
     it('should skip the second factor when the feature is off for the account', async () => {
         const { email, password } = await signupVerifiedUser();
         const session = await signin(email, password);

--- a/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
@@ -1,16 +1,23 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as OTPAuth from 'otpauth';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
+import * as featureFlags from '@nangohq/feature-flags';
 import { userService } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
 import { isError, isSuccess, runServer } from '../../../../utils/tests.js';
 
+import type { MockInstance } from 'vitest';
+
 const signupRoute = '/api/v1/account/signup';
 const signinRoute = '/api/v1/account/signin';
 const passwordRoute = '/api/v1/user/password';
 const userRoute = '/api/v1/user';
+const mfaRoute = '/api/v1/account/mfa';
+const STEP_MS = 30 * 1000;
 
 let api: Awaited<ReturnType<typeof runServer>>;
+let mfaFlagSpy: MockInstance<ReturnType<typeof featureFlags.getFlags>['isMFAEnabled']>;
 
 async function signupVerifiedUser(): Promise<{ email: string; password: string }> {
     const email = `${nanoid()}@example.com`;
@@ -36,13 +43,28 @@ async function signin(email: string, password: string): Promise<string> {
     return cookie!.split(';')[0]!;
 }
 
+async function enrollMfa(session: string): Promise<{ totp: OTPAuth.TOTP; recoveryCodes: string[] }> {
+    const enrollment = await api.fetch(`${mfaRoute}/enroll`, { method: 'POST', session });
+    expect(enrollment.res.status).toBe(200);
+    isSuccess(enrollment.json);
+    const totp = OTPAuth.URI.parse(enrollment.json.data.otpauthUri) as OTPAuth.TOTP;
+
+    const activation = await api.fetch(`${mfaRoute}/activate`, { method: 'POST', session, body: { code: totp.generate() } });
+    expect(activation.res.status).toBe(200);
+    isSuccess(activation.json);
+
+    return { totp, recoveryCodes: activation.json.data.recoveryCodes };
+}
+
 describe(`PUT ${passwordRoute}`, () => {
     beforeAll(async () => {
         api = await runServer();
+        mfaFlagSpy = vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
     });
 
     afterAll(() => {
         api.server.close();
+        vi.restoreAllMocks();
     });
 
     it('should reject an incorrect current password', async () => {
@@ -92,5 +114,104 @@ describe(`PUT ${passwordRoute}`, () => {
 
         // the user who made the change stays authenticated via the rotated session
         expect((await api.fetch(userRoute, { method: 'GET', session: rotatedSession })).res.status).toBe(200);
+    });
+
+    it('should require a second factor once the user has one enrolled', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const session = await signin(email, password);
+        await enrollMfa(session);
+
+        const missing = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session,
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!?' }
+        });
+        expect(missing.res.status).toBe(400);
+        isError(missing.json);
+        expect(missing.json).toStrictEqual({ error: { code: 'mfa_code_required' } });
+
+        const wrongCode = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session,
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!?', mfa: { type: 'code', code: '000000' } }
+        });
+        expect(wrongCode.res.status).toBe(400);
+        isError(wrongCode.json);
+        expect(wrongCode.json).toStrictEqual({ error: { code: 'invalid_mfa_code' } });
+    });
+
+    it('should accept a valid code, and a recovery code, from a user with MFA enrolled', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const session = await signin(email, password);
+        const { totp, recoveryCodes } = await enrollMfa(session);
+
+        const withCode = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session,
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!?', mfa: { type: 'code', code: totp.generate({ timestamp: Date.now() + STEP_MS }) } }
+        });
+        expect(withCode.res.status).toBe(200);
+        isSuccess(withCode.json);
+
+        // the change killed every session, so sign in again with the new password. Use a recovery
+        // code to get past the login challenge, since consecutive TOTP steps would depend on the
+        // accepted window size.
+        const nextSession = await signin(email, 'aZ1-newpass!?');
+        const mfaLogin = await api.fetch(`${mfaRoute}/login/verify`, {
+            method: 'POST',
+            session: nextSession,
+            body: { type: 'recoveryCode', recoveryCode: recoveryCodes[1]! }
+        });
+        expect(mfaLogin.res.status).toBe(200);
+        const verifiedSession = mfaLogin.res.headers.getSetCookie()[0]!.split(';')[0]!;
+
+        const withRecoveryCode = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session: verifiedSession,
+            body: { oldPassword: 'aZ1-newpass!?', newPassword: 'aZ1-thirdpass!?', mfa: { type: 'recoveryCode', recoveryCode: recoveryCodes[0]! } }
+        });
+        expect(withRecoveryCode.res.status).toBe(200);
+        isSuccess(withRecoveryCode.json);
+    });
+
+    it('should not consume the code when the current password is wrong', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const session = await signin(email, password);
+        const { totp } = await enrollMfa(session);
+
+        const code = totp.generate({ timestamp: Date.now() + STEP_MS });
+
+        const wrongPassword = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session,
+            body: { oldPassword: 'aZ1-wrongpass!?', newPassword: 'aZ1-newpass!?', mfa: { type: 'code', code } }
+        });
+        expect(wrongPassword.res.status).toBe(400);
+        isError(wrongPassword.json);
+        expect(wrongPassword.json).toStrictEqual({ error: { code: 'incorrect_password' } });
+
+        // the same code still works, so the failed attempt did not burn it
+        const retry = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session,
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!?', mfa: { type: 'code', code } }
+        });
+        expect(retry.res.status).toBe(200);
+        isSuccess(retry.json);
+    });
+
+    it('should skip the second factor when the feature is off for the account', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const session = await signin(email, password);
+        await enrollMfa(session);
+
+        mfaFlagSpy.mockResolvedValueOnce(false);
+        const { res, json } = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session,
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!?' }
+        });
+        expect(res.status).toBe(200);
+        isSuccess(json);
     });
 });

--- a/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
@@ -223,6 +223,56 @@ describe(`PUT ${passwordRoute}`, () => {
         isSuccess(retry.json);
     });
 
+    it('should accept the factor presented at login when the change follows straight after', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const enrollSession = await signin(email, password);
+        const { recoveryCodes } = await enrollMfa(enrollSession);
+
+        // Sign in again now that a factor is enrolled, so this session goes through the MFA challenge
+        // and carries the verification. A recovery code avoids depending on the TOTP window here.
+        const pending = await signin(email, password);
+        const mfaLogin = await api.fetch(`${mfaRoute}/login/verify`, {
+            method: 'POST',
+            session: pending,
+            body: { type: 'recoveryCode', recoveryCode: recoveryCodes[0]! }
+        });
+        expect(mfaLogin.res.status).toBe(200);
+        const verifiedSession = mfaLogin.res.headers.getSetCookie()[0]!.split(';')[0]!;
+
+        const { res, json } = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session: verifiedSession,
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!?' }
+        });
+        expect(res.status).toBe(200);
+        isSuccess(json);
+    });
+
+    it('should still reject a wrong code inside the post-login window', async () => {
+        const { email, password } = await signupVerifiedUser();
+        const enrollSession = await signin(email, password);
+        const { recoveryCodes } = await enrollMfa(enrollSession);
+
+        const pending = await signin(email, password);
+        const mfaLogin = await api.fetch(`${mfaRoute}/login/verify`, {
+            method: 'POST',
+            session: pending,
+            body: { type: 'recoveryCode', recoveryCode: recoveryCodes[0]! }
+        });
+        expect(mfaLogin.res.status).toBe(200);
+        const verifiedSession = mfaLogin.res.headers.getSetCookie()[0]!.split(';')[0]!;
+
+        // The window only stands in for a credential that was not sent. One that is sent still decides.
+        const { res, json } = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session: verifiedSession,
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!?', mfa: { type: 'code', code: '000000' } }
+        });
+        expect(res.status).toBe(400);
+        isError(json);
+        expect(json).toStrictEqual({ error: { code: 'invalid_mfa_code' } });
+    });
+
     it('should skip the second factor when the feature is off for the account', async () => {
         const { email, password } = await signupVerifiedUser();
         const session = await signin(email, password);

--- a/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
@@ -228,12 +228,14 @@ describe(`PUT ${passwordRoute}`, () => {
         const session = await signin(email, password);
         await enrollMfa(session);
 
-        mfaFlagSpy.mockResolvedValueOnce(false);
+        mfaFlagSpy.mockResolvedValue(false);
         const { res, json } = await api.fetch(passwordRoute, {
             method: 'PUT',
             session,
             body: { oldPassword: password, newPassword: 'aZ1-newpass!?' }
         });
+        mfaFlagSpy.mockResolvedValue(true);
+
         expect(res.status).toBe(200);
         isSuccess(json);
     });

--- a/packages/server/lib/controllers/v1/user/password/putPassword.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.ts
@@ -8,7 +8,7 @@ import { PBKDF2_ITERATIONS, report, requireEmptyQuery, zodErrorToHTTP } from '@n
 
 import { deleteUserSessions } from '../../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
-import { mfaCredentialSchema, verifyStepUpMfa } from '../../account/mfa/stepUp.js';
+import { isStepUpRequired, mfaCredentialSchema, verifyStepUpMfa } from '../../account/mfa/stepUp.js';
 import { passwordSchema } from '../../account/signup.js';
 
 import type { DBUser, PutUserPassword } from '@nangohq/types';
@@ -42,6 +42,11 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
 
     if (oldHashedPassword.length !== actualHashedPassword.length || !crypto.timingSafeEqual(actualHashedPassword, oldHashedPassword)) {
         res.status(400).send({ error: { code: 'incorrect_password' } });
+        return;
+    }
+
+    if (!body.mfa && (await isStepUpRequired(user))) {
+        res.status(400).send({ error: { code: 'mfa_code_required' } });
         return;
     }
 

--- a/packages/server/lib/controllers/v1/user/password/putPassword.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.ts
@@ -45,24 +45,30 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
         return;
     }
 
-    // After the password check so a wrong password never consumes a code or a recovery code.
-    const stepUp = await verifyStepUpMfa(user, body.mfa);
-    if (stepUp === 'required') {
-        res.status(400).send({ error: { code: 'mfa_code_required' } });
-        return;
-    }
-    if (stepUp === 'invalid') {
-        res.status(400).send({ error: { code: 'invalid_mfa_code' } });
-        return;
-    }
-
     const salt = crypto.randomBytes(16).toString('base64');
     const hashedPassword = (await pbkdf2(body.newPassword, salt, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
 
-    await db.knex.transaction(async (trx) => {
+    // The factor is verified after the old password, so a wrong password never spends a code, and
+    // inside the same transaction as the write, so a failed write does not spend one either.
+    const outcome = await db.knex.transaction(async (trx) => {
+        const stepUp = await verifyStepUpMfa(user, body.mfa, trx);
+        if (stepUp !== 'verified' && stepUp !== 'not_required') {
+            return stepUp;
+        }
+
         await userService.update({ id: user.id, hashed_password: hashedPassword, salt }, trx);
         await deleteUserSessions(user.id, { trx });
+        return 'changed' as const;
     });
+
+    if (outcome === 'required') {
+        res.status(400).send({ error: { code: 'mfa_code_required' } });
+        return;
+    }
+    if (outcome === 'invalid') {
+        res.status(400).send({ error: { code: 'invalid_mfa_code' } });
+        return;
+    }
 
     // Re-issue a fresh session so the user who just changed their password stays logged in seamlessly.
     // req.logIn regenerates the session id internally (passport's fixation guard), rotating the current

--- a/packages/server/lib/controllers/v1/user/password/putPassword.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.ts
@@ -14,16 +14,7 @@ import { passwordSchema } from '../../account/signup.js';
 
 import type { DBUser, PutUserPassword } from '@nangohq/types';
 
-/**
- * One TOTP step. Signing in with a factor and changing the password straight after is the normal
- * path, and asking for a code inside this window would ask for the one just spent at login — the
- * counter check rejects it, and the user's app has no other code to show yet.
- *
- * Deliberately no longer than a step: this endpoint is worth re-proving. It is also cheap to allow,
- * because a stolen session alone gets nobody here — the current password is checked first.
- * `putResetPassword` gets no equivalent: it authenticates a mailbox, which is the thing MFA is
- * there to backstop.
- */
+/** One TOTP step: any shorter and the only code the user has is the one just spent at login. */
 const PASSWORD_MFA_MAX_AGE_MS = 30 * 1000;
 
 const validation = z
@@ -67,8 +58,6 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
     const salt = crypto.randomBytes(16).toString('base64');
     const hashedPassword = (await pbkdf2(body.newPassword, salt, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
 
-    // The factor is verified after the old password, so a wrong password never spends a code, and
-    // inside the same transaction as the write, so a failed write does not spend one either.
     const outcome = await db.knex.transaction(async (trx) => {
         const stepUp = await verifyStepUpMfa(user, body.mfa, trx, { recentlyVerified });
         if (isStepUpRefused(stepUp)) {

--- a/packages/server/lib/controllers/v1/user/password/putPassword.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.ts
@@ -8,10 +8,23 @@ import { PBKDF2_ITERATIONS, report, requireEmptyQuery, zodErrorToHTTP } from '@n
 
 import { deleteUserSessions } from '../../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
-import { isStepUpRequired, mfaCredentialSchema, verifyStepUpMfa } from '../../account/mfa/stepUp.js';
+import { hasRecentMfa } from '../../account/mfa/elevation.js';
+import { isStepUpRefused, isStepUpRequired, mfaCredentialSchema, verifyStepUpMfa } from '../../account/mfa/stepUp.js';
 import { passwordSchema } from '../../account/signup.js';
 
 import type { DBUser, PutUserPassword } from '@nangohq/types';
+
+/**
+ * One TOTP step. Signing in with a factor and changing the password straight after is the normal
+ * path, and asking for a code inside this window would ask for the one just spent at login — the
+ * counter check rejects it, and the user's app has no other code to show yet.
+ *
+ * Deliberately no longer than a step: this endpoint is worth re-proving. It is also cheap to allow,
+ * because a stolen session alone gets nobody here — the current password is checked first.
+ * `putResetPassword` gets no equivalent: it authenticates a mailbox, which is the thing MFA is
+ * there to backstop.
+ */
+const PASSWORD_MFA_MAX_AGE_MS = 30 * 1000;
 
 const validation = z
     .object({
@@ -45,7 +58,8 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
         return;
     }
 
-    if (!body.mfa && (await isStepUpRequired(user))) {
+    const recentlyVerified = hasRecentMfa(req, PASSWORD_MFA_MAX_AGE_MS);
+    if (!body.mfa && !recentlyVerified && (await isStepUpRequired(user))) {
         res.status(400).send({ error: { code: 'mfa_code_required' } });
         return;
     }
@@ -56,8 +70,8 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
     // The factor is verified after the old password, so a wrong password never spends a code, and
     // inside the same transaction as the write, so a failed write does not spend one either.
     const outcome = await db.knex.transaction(async (trx) => {
-        const stepUp = await verifyStepUpMfa(user, body.mfa, trx);
-        if (stepUp !== 'verified' && stepUp !== 'not_required') {
+        const stepUp = await verifyStepUpMfa(user, body.mfa, trx, { recentlyVerified });
+        if (isStepUpRefused(stepUp)) {
             return stepUp;
         }
 

--- a/packages/server/lib/controllers/v1/user/password/putPassword.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.ts
@@ -8,6 +8,7 @@ import { PBKDF2_ITERATIONS, report, requireEmptyQuery, zodErrorToHTTP } from '@n
 
 import { deleteUserSessions } from '../../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { mfaCredentialSchema, verifyStepUpMfa } from '../../account/mfa/stepUp.js';
 import { passwordSchema } from '../../account/signup.js';
 
 import type { DBUser, PutUserPassword } from '@nangohq/types';
@@ -15,7 +16,8 @@ import type { DBUser, PutUserPassword } from '@nangohq/types';
 const validation = z
     .object({
         oldPassword: z.string().min(1).max(64),
-        newPassword: passwordSchema
+        newPassword: passwordSchema,
+        mfa: mfaCredentialSchema.optional()
     })
     .strict();
 
@@ -40,6 +42,17 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
 
     if (oldHashedPassword.length !== actualHashedPassword.length || !crypto.timingSafeEqual(actualHashedPassword, oldHashedPassword)) {
         res.status(400).send({ error: { code: 'incorrect_password' } });
+        return;
+    }
+
+    // After the password check so a wrong password never consumes a code or a recovery code.
+    const stepUp = await verifyStepUpMfa(user, body.mfa);
+    if (stepUp === 'required') {
+        res.status(400).send({ error: { code: 'mfa_code_required' } });
+        return;
+    }
+    if (stepUp === 'invalid') {
+        res.status(400).send({ error: { code: 'invalid_mfa_code' } });
         return;
     }
 

--- a/packages/server/lib/middleware/audit.auth.private.integration.test.ts
+++ b/packages/server/lib/middleware/audit.auth.private.integration.test.ts
@@ -70,8 +70,6 @@ function authEvent(action: AuditAction) {
     return auditSpy.mock.calls.map((call) => call[0]).find((event) => event.action === action);
 }
 
-// The signup route emits its own audit event on finish; wait for it to flush so a subsequent mockClear
-// in the test is deterministic and doesn't leave the signup event racing into the next assertion.
 async function signupVerifiedUser(): Promise<{ email: string; password: string; user: DBUser }> {
     const email = `${nanoid()}@example.com`;
     const password = 'aZ1-foobar!?';
@@ -98,13 +96,12 @@ async function enrollMfaUser(): Promise<{ email: string; password: string; user:
     return { email, password, user, totp };
 }
 
-// Same finish-hook race as signup: flush the login event before returning so the caller's mockClear
-// leaves nothing in flight.
 async function signin(email: string, password: string): Promise<string> {
+    const before = auditSpy.mock.calls.length;
     const { res } = await api.fetch(signinRoute, { method: 'POST', body: { email, password } });
     expect(res.status).toBe(200);
     await vi.waitFor(() => {
-        expect(authEvent('login')).toBeDefined();
+        expect(auditSpy.mock.calls.slice(before).some((call) => call[0]?.action === 'login')).toBe(true);
     });
     const cookie = res.headers.getSetCookie()[0];
     return cookie!.split(';')[0]!;

--- a/packages/server/lib/middleware/audit.auth.private.integration.test.ts
+++ b/packages/server/lib/middleware/audit.auth.private.integration.test.ts
@@ -70,17 +70,21 @@ function authEvent(action: AuditAction) {
     return auditSpy.mock.calls.map((call) => call[0]).find((event) => event.action === action);
 }
 
+// The signup route emits its own audit event on finish; wait for it to flush so a subsequent mockClear
+// in the test is deterministic and doesn't leave the signup event racing into the next assertion.
 async function signupVerifiedUser(): Promise<{ email: string; password: string; user: DBUser }> {
     const email = `${nanoid()}@example.com`;
     const password = 'aZ1-foobar!?';
-
-    const signupRes = await api.fetch(signupRoute, {
+    const res = await api.fetch(signupRoute, {
         method: 'POST',
         body: { email, name: 'Foobar', password, foundUs: 'tests' } as any
     });
-    expect(signupRes.res.status).toBe(200);
+    expect(res.res.status).toBe(200);
 
     const user = await userService.getUserByEmail(email);
+    await vi.waitFor(() => {
+        expect(auditSpy.mock.calls.some((c) => c[0]?.action === 'signup' && c[0].actor.id === String(user!.id))).toBe(true);
+    });
     await userService.verifyUserEmail(user!.id);
 
     return { email, password, user: user! };
@@ -94,31 +98,16 @@ async function enrollMfaUser(): Promise<{ email: string; password: string; user:
     return { email, password, user, totp };
 }
 
+// Same finish-hook race as signup: flush the login event before returning so the caller's mockClear
+// leaves nothing in flight.
 async function signin(email: string, password: string): Promise<string> {
     const { res } = await api.fetch(signinRoute, { method: 'POST', body: { email, password } });
     expect(res.status).toBe(200);
+    await vi.waitFor(() => {
+        expect(authEvent('login')).toBeDefined();
+    });
     const cookie = res.headers.getSetCookie()[0];
     return cookie!.split(';')[0]!;
-}
-
-// The signup route emits its own audit event on finish; wait for it to flush so a subsequent mockClear
-// in the test is deterministic and doesn't leave the signup event racing into the next assertion.
-async function signupUser({ verified }: { verified: boolean }): Promise<DBUser> {
-    const email = `${nanoid()}@example.com`;
-    const password = 'aZ1-foobar!?';
-    const res = await api.fetch(signupRoute, {
-        method: 'POST',
-        body: { email, name: 'Foobar', password, foundUs: 'tests' } as any
-    });
-    expect(res.res.status).toBe(200);
-    const user = await userService.getUserByEmail(email);
-    await vi.waitFor(() => {
-        expect(auditSpy.mock.calls.some((c) => c[0]?.action === 'signup' && c[0].actor.id === String(user!.id))).toBe(true);
-    });
-    if (verified) {
-        await userService.verifyUserEmail(user!.id);
-    }
-    return user!;
 }
 
 describe('audit — auth flows', () => {
@@ -299,7 +288,7 @@ describe('audit — auth flows', () => {
 
     describe('managed / SSO', () => {
         it('records app_auth/login (method sso) when the SSO callback logs an existing user in', async () => {
-            const user = await signupUser({ verified: true });
+            const { user } = await signupVerifiedUser();
             auditSpy.mockClear();
 
             workosMocks.authenticateWithCode.mockResolvedValue({
@@ -374,11 +363,6 @@ describe('audit — auth flows', () => {
             // must not be recorded as a successful login for them — it never called req.login this request.
             const { email, password } = await signupVerifiedUser();
             const session = await signin(email, password);
-            // signin records its own login asynchronously; wait for it, then clear, so the assertion only
-            // sees events from the failed callback attempt below.
-            await vi.waitFor(() => {
-                expect(auditSpy.mock.calls.some((c) => c[0]?.action === 'login')).toBe(true);
-            });
             auditSpy.mockClear();
             workosMocks.authenticateWithCode.mockRejectedValue(Object.assign(new Error('invalid'), { error: 'invalid_grant' }));
 
@@ -392,7 +376,7 @@ describe('audit — auth flows', () => {
         });
 
         it('records app_auth/login (method managed) on a successful email-verification login', async () => {
-            const user = await signupUser({ verified: true });
+            const { user } = await signupVerifiedUser();
 
             // First hop: the SSO callback rejects with email_verification_required and stashes the pending
             // verification in the session. No session is established yet, so no audit event is emitted here.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -57,6 +57,7 @@
         "he": "1.2.0",
         "helmet": "7.1.0",
         "jsonwebtoken": "9.0.3",
+        "knex": "3.1.0",
         "lodash-es": "4.18.1",
         "multer": "2.2.0",
         "node-cron": "4.6.0",

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -110,13 +110,13 @@ class MFAService {
         }
     }
 
-    public async getActiveFactor(userId: number): Promise<DBMFAFactor | null> {
-        const factor = await db.knex<DBMFAFactor>(FACTORS_TABLE).where({ user_id: userId }).whereNotNull('enabled_at').first();
+    public async getActiveFactor(userId: number, trx: Knex = db.knex): Promise<DBMFAFactor | null> {
+        const factor = await trx<DBMFAFactor>(FACTORS_TABLE).where({ user_id: userId }).whereNotNull('enabled_at').first();
         return factor || null;
     }
 
-    public async hasActiveFactor(userId: number): Promise<boolean> {
-        return Boolean(await this.getActiveFactor(userId));
+    public async hasActiveFactor(userId: number, trx?: Knex): Promise<boolean> {
+        return Boolean(await this.getActiveFactor(userId, trx));
     }
 
     public async getEnabledUserIds(userIds: number[]): Promise<Set<number>> {

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -128,9 +128,13 @@ class MFAService {
         return new Set(rows.map((row) => row.user_id));
     }
 
-    public async verifyTotp(userId: number, token: string): Promise<Result<boolean>> {
+    /**
+     * Pass `parentTrx` to consume the factor in the caller's transaction, so rolling that back
+     * un-burns the code rather than leaving it spent on an action that never happened.
+     */
+    public async verifyTotp(userId: number, token: string, parentTrx?: Knex): Promise<Result<boolean>> {
         try {
-            const verified = await db.knex.transaction(async (trx) => {
+            const verified = await this.inTransaction(parentTrx, async (trx) => {
                 const factor = await trx<DBMFAFactor>(FACTORS_TABLE).where({ user_id: userId }).whereNotNull('enabled_at').forUpdate().first();
                 if (!factor) {
                     return false;
@@ -164,10 +168,11 @@ class MFAService {
         }
     }
 
-    public async consumeRecoveryCode(userId: number, code: string): Promise<Result<boolean>> {
+    /** See {@link verifyTotp} for `parentTrx`. */
+    public async consumeRecoveryCode(userId: number, code: string, parentTrx?: Knex): Promise<Result<boolean>> {
         try {
             const codeHash = this.hashRecoveryCode(code);
-            const consumed = await db.knex.transaction(async (trx) => {
+            const consumed = await this.inTransaction(parentTrx, async (trx) => {
                 const factor = await trx<DBMFAFactor>(FACTORS_TABLE).where({ user_id: userId }).whereNotNull('enabled_at').forUpdate().first();
                 if (!factor) {
                     return false;
@@ -276,6 +281,10 @@ class MFAService {
     private async replaceRecoveryCodes(trx: Knex, userId: number, recoveryCodes: string[]): Promise<void> {
         await trx<DBMFARecoveryCode>(RECOVERY_CODES_TABLE).where({ user_id: userId }).delete();
         await trx<DBMFARecoveryCode>(RECOVERY_CODES_TABLE).insert(recoveryCodes.map((code) => ({ user_id: userId, code_hash: this.hashRecoveryCode(code) })));
+    }
+
+    private async inTransaction<T>(parentTrx: Knex | undefined, handler: (trx: Knex) => Promise<T>): Promise<T> {
+        return parentTrx ? await handler(parentTrx) : await db.knex.transaction(handler);
     }
 
     private async acquireUserLock(trx: Knex, userId: number): Promise<void> {

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -1,6 +1,7 @@
 import type { AccountApiKeyScope } from '../api-keys/scopes.js';
 import type { ApiEndpoint, ApiError } from '../api.js';
 import type { AuditPolicy } from '../audit-trail/event.js';
+import type { MFACredential } from '../mfa/credential.js';
 import type { ApiUser } from '../user/api.js';
 
 export interface AccountApiKey {
@@ -164,8 +165,9 @@ export type PutResetPassword = ApiEndpoint<{
     Body: {
         token: string;
         password: string;
+        mfa?: MFACredential | undefined;
     };
-    Error: ApiError<'user_not_found'> | ApiError<'invalid_token'>;
+    Error: ApiError<'user_not_found'> | ApiError<'invalid_token'> | ApiError<'invalid_mfa_code'> | ApiError<'mfa_code_required'>;
     Success: {
         success: true;
     };

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -108,6 +108,7 @@ export type * from './checkpoint/db.js';
 
 export type * from './mcp/api.js';
 export type * from './mfa/api.js';
+export type * from './mfa/credential.js';
 export type * from './mfa/db.js';
 export type * from './function/config.js';
 export type * from './function/db.js';

--- a/packages/types/lib/mfa/api.ts
+++ b/packages/types/lib/mfa/api.ts
@@ -1,6 +1,7 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 import type { AuditPolicy } from '../audit-trail/event.js';
 import type { ApiUser } from '../user/api.js';
+import type { MFACredential } from './credential.js';
 
 type MFAError = ApiError<'invalid_mfa_code'> | ApiError<'mfa_already_enabled'> | ApiError<'mfa_enrollment_not_found'> | ApiError<'mfa_not_enabled'>;
 
@@ -52,7 +53,7 @@ export type PostMFALoginVerification = ApiEndpoint<{
     Audit: AuditPolicy<'mfa', 'verified', 'account'>;
     Method: 'POST';
     Path: '/api/v1/account/mfa/login/verify';
-    Body: { type: 'code'; code: string } | { type: 'recoveryCode'; recoveryCode: string };
+    Body: MFACredential;
     Error: ApiError<'invalid_mfa_code'> | ApiError<'mfa_login_expired'>;
     Success: { data: { user: ApiUser; url: string } };
 }>;

--- a/packages/types/lib/mfa/credential.ts
+++ b/packages/types/lib/mfa/credential.ts
@@ -1,0 +1,1 @@
+export type MFACredential = { type: 'code'; code: string } | { type: 'recoveryCode'; recoveryCode: string };

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -1,5 +1,6 @@
 import type { ApiEndpoint, ApiError, Endpoint } from '../api.js';
 import type { AuditPolicy } from '../audit-trail/event.js';
+import type { MFACredential } from '../mfa/credential.js';
 import type { Role } from './db.js';
 
 export type GetUser = ApiEndpoint<{
@@ -57,7 +58,7 @@ export type PutUserPassword = ApiEndpoint<{
     Audit: AuditPolicy<'app_auth', 'password_changed', 'account'>;
     Method: 'PUT';
     Path: `/api/v1/user/password`;
-    Body: { oldPassword: string; newPassword: string };
-    Error: ApiError<'incorrect_password'>;
+    Body: { oldPassword: string; newPassword: string; mfa?: MFACredential | undefined };
+    Error: ApiError<'incorrect_password'> | ApiError<'invalid_mfa_code'> | ApiError<'mfa_code_required'>;
     Success: { success: true };
 }>;

--- a/packages/webapp/src/components/patterns/MfaChallengeDialog.tsx
+++ b/packages/webapp/src/components/patterns/MfaChallengeDialog.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+
+import {
+    Button,
+    Dialog,
+    DialogBody,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    InputGroup,
+    InputGroupInput
+} from '@nangohq/design-system';
+
+import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/InputOTP';
+
+import type { MFACredential } from '@nangohq/types';
+
+interface MfaChallengeDialogProps {
+    open: boolean;
+    /** What the factor unlocks, as an infinitive: 'change your password'. Completes the prompt. */
+    purpose: string;
+    confirmText: string;
+    /** Message from the last rejected attempt. Shown until the user edits the input. */
+    error: string | null;
+    verifying: boolean;
+    onCancel: () => void;
+    onConfirm: (credential: MFACredential) => void;
+}
+
+/**
+ * Second factor for an action the user already started: the caller sends the request, and on
+ * `mfa_code_required` opens this to collect the factor and send the same request again with it.
+ */
+export const MfaChallengeDialog: React.FC<MfaChallengeDialogProps> = ({ open, purpose, confirmText, error, verifying, onCancel, onConfirm }) => {
+    const [value, setValue] = useState('');
+    const [useRecoveryCode, setUseRecoveryCode] = useState(false);
+    // A rejected attempt stops being news as soon as the user starts entering the next one.
+    const [showError, setShowError] = useState(false);
+
+    // Controlled `open` changes (the caller closing after a success) do not fire Radix onOpenChange,
+    // so reset from the prop rather than only from a user-driven close.
+    useEffect(() => {
+        if (!open) {
+            setValue('');
+            setUseRecoveryCode(false);
+        }
+    }, [open]);
+
+    useEffect(() => {
+        if (error) {
+            setValue('');
+            setShowError(true);
+        }
+    }, [error]);
+
+    const change = (next: string) => {
+        setValue(next);
+        setShowError(false);
+    };
+
+    const isValid = useRecoveryCode ? value.length > 0 : /^\d{6}$/.test(value);
+
+    const confirm = () => {
+        if (isValid) {
+            onConfirm(useRecoveryCode ? { type: 'recoveryCode', recoveryCode: value } : { type: 'code', code: value });
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(next) => !next && !verifying && onCancel()}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Confirm with two-factor authentication</DialogTitle>
+                    <DialogDescription>
+                        {useRecoveryCode ? `Enter one of your recovery codes to ${purpose}` : `Enter the code from your authenticator app to ${purpose}`}
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogBody>
+                    <form
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            confirm();
+                        }}
+                    >
+                        <div className="flex flex-col items-center gap-3">
+                            {useRecoveryCode ? (
+                                <InputGroup>
+                                    <InputGroupInput
+                                        value={value}
+                                        onChange={(event) => change(event.target.value)}
+                                        placeholder="Recovery code"
+                                        aria-label="Recovery code"
+                                        autoComplete="one-time-code"
+                                        disabled={verifying}
+                                        autoFocus
+                                    />
+                                </InputGroup>
+                            ) : (
+                                <>
+                                    <span className="text-body-small-medium text-text-strong">Enter your verification code:</span>
+                                    <InputOTP maxLength={6} value={value} onChange={change} disabled={verifying} aria-label="Authenticator code" autoFocus>
+                                        <InputOTPGroup>
+                                            {[0, 1, 2, 3, 4, 5].map((i) => (
+                                                <InputOTPSlot key={i} index={i} />
+                                            ))}
+                                        </InputOTPGroup>
+                                    </InputOTP>
+                                </>
+                            )}
+                            {showError && error && <p className="text-body-small-regular text-status-danger-text">{error}</p>}
+                            <button
+                                type="button"
+                                className="text-body-small-regular text-text-muted underline"
+                                onClick={() => {
+                                    setUseRecoveryCode((current) => !current);
+                                    change('');
+                                }}
+                                disabled={verifying}
+                            >
+                                {useRecoveryCode ? 'Use an authenticator code' : 'Use a recovery code'}
+                            </button>
+                        </div>
+                    </form>
+                </DialogBody>
+                <DialogFooter>
+                    <Button variant="outline" size="sm" onClick={onCancel} disabled={verifying}>
+                        Cancel
+                    </Button>
+                    <Button size="sm" onClick={confirm} loading={verifying} disabled={!isValid}>
+                        {confirmText}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/packages/webapp/src/components/patterns/MfaChallengeDialog.tsx
+++ b/packages/webapp/src/components/patterns/MfaChallengeDialog.tsx
@@ -22,7 +22,7 @@ interface MfaChallengeDialogProps {
     /** What the factor unlocks, as an infinitive: 'change your password'. Completes the prompt. */
     purpose: string;
     confirmText: string;
-    /** Message from the last rejected attempt. Shown until the user edits the input. */
+    /** Message from the last rejected attempt. Clear it when starting a new one. */
     error: string | null;
     verifying: boolean;
     onCancel: () => void;
@@ -36,8 +36,6 @@ interface MfaChallengeDialogProps {
 export const MfaChallengeDialog: React.FC<MfaChallengeDialogProps> = ({ open, purpose, confirmText, error, verifying, onCancel, onConfirm }) => {
     const [value, setValue] = useState('');
     const [useRecoveryCode, setUseRecoveryCode] = useState(false);
-    // A rejected attempt stops being news as soon as the user starts entering the next one.
-    const [showError, setShowError] = useState(false);
 
     // Controlled `open` changes (the caller closing after a success) do not fire Radix onOpenChange,
     // so reset from the prop rather than only from a user-driven close.
@@ -51,14 +49,8 @@ export const MfaChallengeDialog: React.FC<MfaChallengeDialogProps> = ({ open, pu
     useEffect(() => {
         if (error) {
             setValue('');
-            setShowError(true);
         }
     }, [error]);
-
-    const change = (next: string) => {
-        setValue(next);
-        setShowError(false);
-    };
 
     const isValid = useRecoveryCode ? value.length > 0 : /^\d{6}$/.test(value);
 
@@ -89,7 +81,7 @@ export const MfaChallengeDialog: React.FC<MfaChallengeDialogProps> = ({ open, pu
                                 <InputGroup>
                                     <InputGroupInput
                                         value={value}
-                                        onChange={(event) => change(event.target.value)}
+                                        onChange={(event) => setValue(event.target.value)}
                                         placeholder="Recovery code"
                                         aria-label="Recovery code"
                                         autoComplete="one-time-code"
@@ -100,7 +92,7 @@ export const MfaChallengeDialog: React.FC<MfaChallengeDialogProps> = ({ open, pu
                             ) : (
                                 <>
                                     <span className="text-body-small-medium text-text-strong">Enter your verification code:</span>
-                                    <InputOTP maxLength={6} value={value} onChange={change} disabled={verifying} aria-label="Authenticator code" autoFocus>
+                                    <InputOTP maxLength={6} value={value} onChange={setValue} disabled={verifying} aria-label="Authenticator code" autoFocus>
                                         <InputOTPGroup>
                                             {[0, 1, 2, 3, 4, 5].map((i) => (
                                                 <InputOTPSlot key={i} index={i} />
@@ -109,13 +101,17 @@ export const MfaChallengeDialog: React.FC<MfaChallengeDialogProps> = ({ open, pu
                                     </InputOTP>
                                 </>
                             )}
-                            {showError && error && <p className="text-body-small-regular text-status-danger-text">{error}</p>}
+                            {error && (
+                                <p role="alert" className="text-body-small-regular text-status-danger-text">
+                                    {error}
+                                </p>
+                            )}
                             <button
                                 type="button"
                                 className="text-body-small-regular text-text-muted underline"
                                 onClick={() => {
                                     setUseRecoveryCode((current) => !current);
-                                    change('');
+                                    setValue('');
                                 }}
                                 disabled={verifying}
                             >

--- a/packages/webapp/src/hooks/useAuth.tsx
+++ b/packages/webapp/src/hooks/useAuth.tsx
@@ -275,12 +275,12 @@ export function useResetPasswordAPI() {
               json: PutResetPassword['Errors'];
           },
         APIError,
-        { token: string; password: string }
+        PutResetPassword['Body']
     >({
-        mutationFn: async ({ token, password }) => {
+        mutationFn: async ({ token, password, mfa }) => {
             const res = await apiFetch('/api/v1/account/reset-password', {
                 method: 'PUT',
-                body: JSON.stringify({ token, password })
+                body: JSON.stringify({ token, password, mfa })
             });
 
             if (res.status === 200) {

--- a/packages/webapp/src/pages/Account/ResetPassword.tsx
+++ b/packages/webapp/src/pages/Account/ResetPassword.tsx
@@ -8,11 +8,15 @@ import z from 'zod';
 
 import { Alert, AlertDescription, Button } from '@nangohq/design-system';
 
+import { MfaChallengeDialog } from '@/components/patterns/MfaChallengeDialog';
 import { Form, FormField } from '@/components/ui/Form';
 import { useToast } from '@/hooks/useToast';
+import { mfaErrorMessage } from '@/utils/mfaErrors';
 import { useResetPasswordAPI } from '../../hooks/useAuth';
 import DefaultLayout from '../../layout/DefaultLayout';
 import { Password, passwordSchema } from './components/Password';
+
+import type { MFACredential } from '@nangohq/types';
 
 const resetPasswordSchema = z.object({
     password: passwordSchema
@@ -33,6 +37,8 @@ export default function ResetPassword() {
     const navigate = useNavigate();
     const { toast } = useToast();
     const [serverErrorMessage, setServerErrorMessage] = useState('');
+    const [challengeOpen, setChallengeOpen] = useState(false);
+    const [challengeError, setChallengeError] = useState<string | null>(null);
     const { token } = useParams();
 
     if (!token) {
@@ -40,19 +46,41 @@ export default function ResetPassword() {
         return null;
     }
 
-    const onSubmit = async (data: ResetPasswordFormData) => {
+    const closeChallenge = () => {
+        setChallengeOpen(false);
+        setChallengeError(null);
+    };
+
+    // A user with a second factor has to prove it here too, otherwise mailbox access alone would be
+    // enough to take the account over. The server asks for it, then the same request is sent again.
+    const attempt = async (mfa?: MFACredential) => {
         setServerErrorMessage('');
 
         try {
-            const result = await resetPassword({ token: token, password: data.password });
+            const result = await resetPassword({ token, password: form.getValues().password, mfa });
 
             if (result.status === 200) {
+                closeChallenge();
                 toast({ title: 'Password updated!', variant: 'success' });
                 navigate('/signin');
-            } else {
-                setServerErrorMessage('Your reset token is invalid or expired.');
+                return;
             }
+
+            const { code } = result.json.error;
+            if (code === 'mfa_code_required') {
+                setChallengeError(null);
+                setChallengeOpen(true);
+                return;
+            }
+            if (code === 'invalid_mfa_code') {
+                setChallengeError(mfaErrorMessage(code));
+                return;
+            }
+
+            closeChallenge();
+            setServerErrorMessage('Your reset token is invalid or expired.');
         } catch {
+            closeChallenge();
             setServerErrorMessage('Issue resetting password. Please try again.');
         }
     };
@@ -72,7 +100,7 @@ export default function ResetPassword() {
             )}
 
             <Form {...form}>
-                <form onSubmit={form.handleSubmit(onSubmit)} className="w-full flex flex-col gap-5">
+                <form onSubmit={form.handleSubmit(() => attempt())} className="w-full flex flex-col gap-5">
                     <FormField
                         control={form.control}
                         name="password"
@@ -84,6 +112,16 @@ export default function ResetPassword() {
                     </Button>
                 </form>
             </Form>
+
+            <MfaChallengeDialog
+                open={challengeOpen}
+                purpose="reset your password"
+                confirmText="Reset password"
+                error={challengeError}
+                verifying={isPending}
+                onCancel={closeChallenge}
+                onConfirm={(mfa) => void attempt(mfa)}
+            />
         </DefaultLayout>
     );
 }

--- a/packages/webapp/src/pages/Account/ResetPassword.tsx
+++ b/packages/webapp/src/pages/Account/ResetPassword.tsx
@@ -53,6 +53,7 @@ export default function ResetPassword() {
 
     const attempt = async (mfa?: MFACredential) => {
         setServerErrorMessage('');
+        setChallengeError(null);
 
         try {
             const result = await resetPassword({ token, password: form.getValues().password, mfa });
@@ -66,7 +67,6 @@ export default function ResetPassword() {
 
             const { code } = result.json.error;
             if (code === 'mfa_code_required') {
-                setChallengeError(null);
                 setChallengeOpen(true);
                 return;
             }

--- a/packages/webapp/src/pages/Account/ResetPassword.tsx
+++ b/packages/webapp/src/pages/Account/ResetPassword.tsx
@@ -51,8 +51,6 @@ export default function ResetPassword() {
         setChallengeError(null);
     };
 
-    // A user with a second factor has to prove it here too, otherwise mailbox access alone would be
-    // enough to take the account over. The server asks for it, then the same request is sent again.
     const attempt = async (mfa?: MFACredential) => {
         setServerErrorMessage('');
 

--- a/packages/webapp/src/pages/User/ChangePasswordDialog.tsx
+++ b/packages/webapp/src/pages/User/ChangePasswordDialog.tsx
@@ -66,6 +66,7 @@ export const ChangePasswordDialog: React.FC = () => {
 
     const attempt = async (mfa?: MFACredential) => {
         const { oldPassword, newPassword } = form.getValues();
+        setChallengeError(null);
 
         try {
             await changePassword({ oldPassword, newPassword, mfa });
@@ -78,7 +79,6 @@ export const ChangePasswordDialog: React.FC = () => {
             const apiErr = err instanceof APIError && err.json && typeof err.json === 'object' && 'error' in err.json ? err.json.error : null;
 
             if (apiErr?.code === 'mfa_code_required') {
-                setChallengeError(null);
                 setChallengeOpen(true);
                 return;
             }

--- a/packages/webapp/src/pages/User/ChangePasswordDialog.tsx
+++ b/packages/webapp/src/pages/User/ChangePasswordDialog.tsx
@@ -18,12 +18,16 @@ import {
     InputGroupInput
 } from '@nangohq/design-system';
 
+import { MfaChallengeDialog } from '@/components/patterns/MfaChallengeDialog';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
 import { useToast } from '@/hooks/useToast';
 import { usePutUserPassword } from '@/hooks/useUser';
 import { track } from '@/utils/analytics';
 import { APIError } from '@/utils/api';
+import { getMFAErrorMessage } from '@/utils/mfaErrors';
 import { Password, passwordSchema } from '../Account/components/Password';
+
+import type { MFACredential } from '@nangohq/types';
 
 const changePasswordSchema = z
     .object({
@@ -41,6 +45,8 @@ type ChangePasswordFormData = z.infer<typeof changePasswordSchema>;
 export const ChangePasswordDialog: React.FC = () => {
     const { toast } = useToast();
     const [isOpen, setIsOpen] = useState(false);
+    const [challengeOpen, setChallengeOpen] = useState(false);
+    const [challengeError, setChallengeError] = useState<string | null>(null);
     const { mutateAsync: changePassword, isPending } = usePutUserPassword();
 
     const form = useForm<ChangePasswordFormData>({
@@ -53,15 +59,38 @@ export const ChangePasswordDialog: React.FC = () => {
         mode: 'onTouched'
     });
 
-    const onSubmit = async ({ oldPassword, newPassword }: ChangePasswordFormData) => {
+    const closeChallenge = () => {
+        setChallengeOpen(false);
+        setChallengeError(null);
+    };
+
+    // The second factor is only asked for once the server says it is needed, so a user without one
+    // never sees the dialog. Everything else about the request is unchanged on the retry.
+    const attempt = async (mfa?: MFACredential) => {
+        const { oldPassword, newPassword } = form.getValues();
+
         try {
-            await changePassword({ oldPassword, newPassword });
+            await changePassword({ oldPassword, newPassword, mfa });
             track('web:password:changed', {});
             toast({ title: 'Password updated', variant: 'success' });
+            closeChallenge();
             setIsOpen(false);
             form.reset();
         } catch (err) {
             const apiErr = err instanceof APIError && err.json && typeof err.json === 'object' && 'error' in err.json ? err.json.error : null;
+
+            if (apiErr?.code === 'mfa_code_required') {
+                setChallengeError(null);
+                setChallengeOpen(true);
+                return;
+            }
+
+            if (apiErr?.code === 'invalid_mfa_code') {
+                setChallengeError(getMFAErrorMessage(err));
+                return;
+            }
+
+            closeChallenge();
 
             if (apiErr?.code === 'incorrect_password') {
                 form.setError('oldPassword', { message: 'Incorrect current password' });
@@ -77,7 +106,10 @@ export const ChangePasswordDialog: React.FC = () => {
             open={isOpen}
             onOpenChange={(open) => {
                 setIsOpen(open);
-                if (!open) form.reset();
+                if (!open) {
+                    closeChallenge();
+                    form.reset();
+                }
             }}
         >
             <DialogTrigger asChild>
@@ -85,7 +117,7 @@ export const ChangePasswordDialog: React.FC = () => {
             </DialogTrigger>
             <DialogContent>
                 <Form {...form}>
-                    <form id="change-password-form" onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col">
+                    <form id="change-password-form" onSubmit={form.handleSubmit(() => attempt())} className="flex flex-col">
                         <DialogHeader>
                             <DialogTitle>Change password</DialogTitle>
                             <DialogDescription>Enter your current password and choose a new one.</DialogDescription>
@@ -148,6 +180,16 @@ export const ChangePasswordDialog: React.FC = () => {
                     </form>
                 </Form>
             </DialogContent>
+
+            <MfaChallengeDialog
+                open={challengeOpen}
+                purpose="change your password"
+                confirmText="Update password"
+                error={challengeError}
+                verifying={isPending}
+                onCancel={closeChallenge}
+                onConfirm={(mfa) => void attempt(mfa)}
+            />
         </Dialog>
     );
 };

--- a/packages/webapp/src/pages/User/ChangePasswordDialog.tsx
+++ b/packages/webapp/src/pages/User/ChangePasswordDialog.tsx
@@ -64,8 +64,6 @@ export const ChangePasswordDialog: React.FC = () => {
         setChallengeError(null);
     };
 
-    // The second factor is only asked for once the server says it is needed, so a user without one
-    // never sees the dialog. Everything else about the request is unchanged on the retry.
     const attempt = async (mfa?: MFACredential) => {
         const { oldPassword, newPassword } = form.getValues();
 

--- a/packages/webapp/src/pages/User/Enable2FA.tsx
+++ b/packages/webapp/src/pages/User/Enable2FA.tsx
@@ -13,9 +13,9 @@ import { useMFA } from '@/hooks/useMFA';
 import { useToast } from '@/hooks/useToast';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { track } from '@/utils/analytics';
+import { getMFAErrorMessage } from '@/utils/mfaErrors';
 import { MfaStepper } from './components/MfaStepper';
 import { RecoveryCodes } from './components/RecoveryCodes';
-import { getMFAErrorMessage } from './mfaErrors';
 
 import type { MfaStep } from './components/MfaStepper';
 

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -22,6 +22,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useThemeStore } from '@/lib/theme';
 import { track } from '@/utils/analytics';
+import { getMFAErrorMessage } from '@/utils/mfaErrors';
 import { useMFA } from '../../hooks/useMFA';
 import { useToast } from '../../hooks/useToast';
 import { apiPatchUser, useUser } from '../../hooks/useUser';
@@ -29,7 +30,6 @@ import DashboardLayout from '../../layout/DashboardLayout';
 import { APIError } from '../../utils/api';
 import { ChangePasswordDialog } from './ChangePasswordDialog';
 import { RecoveryCodes } from './components/RecoveryCodes';
-import { getMFAErrorMessage } from './mfaErrors';
 
 import type { Theme } from '@/lib/theme';
 

--- a/packages/webapp/src/utils/mfaErrors.ts
+++ b/packages/webapp/src/utils/mfaErrors.ts
@@ -2,10 +2,16 @@ import { APIError } from '@/utils/api';
 
 const mfaErrorMessages: Record<string, string> = {
     invalid_mfa_code: 'Invalid verification code. Try again.',
+    mfa_code_required: 'Enter your two-factor code to continue.',
     mfa_already_enabled: 'Two-factor authentication is already enabled.',
     mfa_enrollment_not_found: 'Start setup again before confirming.',
     mfa_not_enabled: 'Two-factor authentication is not enabled.'
 };
+
+/** Message for a known MFA error code, or null when the code is not one of ours. */
+export function mfaErrorMessage(code: string | undefined): string | null {
+    return code && Object.prototype.hasOwnProperty.call(mfaErrorMessages, code) ? mfaErrorMessages[code]! : null;
+}
 
 export function getMFAErrorMessage(error: unknown): string {
     if (error instanceof APIError) {
@@ -14,8 +20,9 @@ export function getMFAErrorMessage(error: unknown): string {
             const apiError = (json as { error: unknown }).error;
             if (typeof apiError === 'object' && apiError !== null) {
                 const { code, message } = apiError as { code?: unknown; message?: unknown };
-                if (typeof code === 'string' && Object.prototype.hasOwnProperty.call(mfaErrorMessages, code)) {
-                    return mfaErrorMessages[code]!;
+                const known = mfaErrorMessage(typeof code === 'string' ? code : undefined);
+                if (known) {
+                    return known;
                 }
                 if (typeof message === 'string') {
                     return message;


### PR DESCRIPTION
NAN-6586

MFA gates every sign-in path but neither password flow asked for it. Kelvin caught this on Aug 7.

`putUserPassword` only checked the old password, so a stolen session could rotate it without the second factor coming up. `putResetPassword` was worse: it trusted the emailed token alone, so mailbox access was enough to take an account over, which is exactly what MFA is supposed to stop.

Both endpoints now accept an optional `mfa` credential and require it when the user has an active factor. A TOTP code or a recovery code works, same as the login challenge. Users with nothing enrolled see no change, and the account-level feature flag still short-circuits the whole thing.

Three details worth a look:

The factor is verified after the old password check, so a wrong password returns before we touch the code and cannot burn a TOTP step or a recovery code.

It is also verified inside the same transaction that writes the password. A one-time credential is spent there, so it has to roll back with the action rather than outlive a failed one. `verifyTotp` and `consumeRecoveryCode` take an optional parent transaction for this, and `verifyStepUpMfa` requires one so a future call site cannot quietly reintroduce the gap.

`verifyStepUpMfa` in `account/mfa/stepUp.ts` is the shared helper, and its credential schema replaces the duplicate that was inline in the MFA controller. It takes a `DBUser` rather than reading `res.locals`, because the reset flow has no session to read from.

I did not add `rateLimiterMiddleware` to `PUT /user/password`. It now accepts codes, but an attacker needs a valid session and the current password before the code matters, so it did not seem worth the behaviour change. Reset-password is already rate limited. Say the word if you want it anyway.

Out of scope: the webapp fields to collect the code. Worth filing once you are happy with this API shape.

## Test plan

- [x] `npm run ts-build`
- [x] `npm run test:integration -- packages/shared/lib/services/mfa.service.integration.test.ts packages/server/lib/controllers/v1/account/ packages/server/lib/controllers/v1/user/ packages/server/lib/middleware/` (17 files, 98 passed)
- [ ] Manual check once the webapp sends the field
