### PR TITLE
feat(webapp): add a primary action to the billing page header

### DIFF
--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -180,11 +180,11 @@ Key rules:
 
 ### Step 4: Add a Storybook story
 
-Add the story to the top-level `stories/` dir as `stories/<ComponentName>.stories.tsx` (not co-located with the component). Show every variant and state that needs to be *frozen* to be seen — default, hover, disabled. Skip a dedicated story for focus: it's driven by real browser focus behavior (click/tab), not a prop you can statically set in a way that renders meaningfully in Storybook's static preview — reviewers exercise it by clicking directly into the default/interactive story instead. Use Tailwind classes for layout in stories — Tailwind's default 4px scale matches our spacing tokens exactly (`gap-2` = 8px = `--ds-space-2`), so no `var(--ds-space-*)` needed.
+Co-locate the story with the component as `src/components/ui/<component-name>.stories.tsx`, titled `Design System/Components/<ComponentName>`. (The top-level `stories/` dir is for the webapp's own components — different package, different title prefix.) Show every variant and state that needs to be *frozen* to be seen — default, hover, disabled. Skip a dedicated story for focus: it's driven by real browser focus behavior (click/tab), not a prop you can statically set in a way that renders meaningfully in Storybook's static preview — reviewers exercise it by clicking directly into the default/interactive story instead. Use Tailwind classes for layout in stories — Tailwind's default 4px scale matches our spacing tokens exactly (`gap-2` = 8px = `--ds-space-2`), so no `var(--ds-space-*)` needed.
 
 ```tsx
 import type { Meta, StoryObj } from '@storybook/react';
-import { MyComponent } from '../src/components/ui/my-component';
+import { MyComponent } from './my-component';
 
 const meta: Meta<typeof MyComponent> = {
     title: 'Design System/Components/MyComponent',
@@ -218,14 +218,14 @@ src/
   components/
     ui/                    all components (flat, shadcn convention)
       button.tsx           exports Button and IconButton
-      button.stories.tsx
+      button.stories.tsx   co-located story, titled "Design System/Components/…"
       spinner.tsx          internal — used by Button for loading state
       …                    add new components here
   lib/
     cn.ts                  cn() helper: twMerge + clsx
   index.ts                 barrel — all public exports
   index.css                CSS entry (imports tokens.generated.css)
-stories/                   Storybook stories (*.stories.tsx) and MDX guides
+stories/                   MDX guides, plus stories for the webapp's own components (not this package's)
 tokens/
   tokens.generated.css     compiled CSS custom properties (source of truth for tokens)
   tokens.json              Tokens Studio export

--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -13,16 +13,20 @@ interface DashboardLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
     title?: string;
     /** Optional badge rendered inline after the section title (e.g. an environment badge). */
     titleBadge?: React.ReactNode;
+    /** Optional action rendered on the right of the section header (e.g. the page's primary button). */
+    titleActions?: React.ReactNode;
+    /** Extra classes for the section header's inner row, e.g. the page's content max-width so the actions line up with it. */
+    headerClassName?: string;
 }
 
 const DashboardLayout = React.forwardRef<HTMLDivElement, DashboardLayoutProps>(
-    ({ children, className, fullWidth = false, title, titleBadge, ...props }, ref) => {
+    ({ children, className, fullWidth = false, title, titleBadge, titleActions, headerClassName, ...props }, ref) => {
         return (
             <SidebarProvider>
                 <AppSidebar />
                 <SidebarInset className="max-h-screen overflow-hidden">
                     <AppHeader />
-                    {title != null && <SectionHeader title={title} badge={titleBadge} />}
+                    {title != null && <SectionHeader title={title} badge={titleBadge} actions={titleActions} className={headerClassName} />}
                     <div
                         ref={ref}
                         className={cn('relative w-full flex-1 min-h-0 overflow-auto bg-surface-page min-w-3xl', fullWidth ? 'p-0' : 'p-11')}

--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -5,7 +5,7 @@ import { Playground } from '@/features/Playground';
 import { AppHeader } from '@/layout/AppHeader';
 import { cn } from '@/utils/utils';
 import { AppSidebar } from './AppSidebar';
-import { SectionHeader } from './SectionHeader';
+import { CENTERED_MAX_WIDTH, SectionHeader } from './SectionHeader';
 
 interface DashboardLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
     fullWidth?: boolean;
@@ -15,22 +15,31 @@ interface DashboardLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
     titleBadge?: React.ReactNode;
     /** Optional action rendered on the right of the section header (e.g. the page's primary button). */
     titleActions?: React.ReactNode;
+    /**
+     * Caps and centers the page content *and* the section header row at the same width, so the title
+     * and its action line up with the content's edges. Use on `fullWidth` pages whose content doesn't
+     * read well edge-to-edge on a wide screen.
+     */
+    centered?: boolean;
 }
 
 const DashboardLayout = React.forwardRef<HTMLDivElement, DashboardLayoutProps>(
-    ({ children, className, fullWidth = false, title, titleBadge, titleActions, ...props }, ref) => {
+    ({ children, className, fullWidth = false, title, titleBadge, titleActions, centered = false, ...props }, ref) => {
         return (
             <SidebarProvider>
                 <AppSidebar />
                 <SidebarInset className="max-h-screen overflow-hidden">
                     <AppHeader />
-                    {title != null && <SectionHeader title={title} badge={titleBadge} actions={titleActions} />}
+                    {title != null && <SectionHeader title={title} badge={titleBadge} actions={titleActions} centered={centered} />}
                     <div
                         ref={ref}
                         className={cn('relative w-full flex-1 min-h-0 overflow-auto bg-surface-page min-w-3xl', fullWidth ? 'p-0' : 'p-11')}
                         {...props}
                     >
-                        <div className={cn('grow h-auto mx-auto w-full', fullWidth ? 'p-6' : 'min-w-[968px] max-w-[1056px]', className)}>{children}</div>
+                        <div className={cn('grow h-auto mx-auto w-full', fullWidth ? 'p-6' : 'min-w-[968px] max-w-[1056px]', className)}>
+                            {/* Mirrors SectionHeader's inner row: same cap inside the same padding, so the two line up */}
+                            {centered ? <div className={cn('mx-auto w-full', CENTERED_MAX_WIDTH)}>{children}</div> : children}
+                        </div>
                         <Playground />
                     </div>
                 </SidebarInset>

--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -15,18 +15,16 @@ interface DashboardLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
     titleBadge?: React.ReactNode;
     /** Optional action rendered on the right of the section header (e.g. the page's primary button). */
     titleActions?: React.ReactNode;
-    /** Extra classes for the section header's inner row, e.g. the page's content max-width so the actions line up with it. */
-    headerClassName?: string;
 }
 
 const DashboardLayout = React.forwardRef<HTMLDivElement, DashboardLayoutProps>(
-    ({ children, className, fullWidth = false, title, titleBadge, titleActions, headerClassName, ...props }, ref) => {
+    ({ children, className, fullWidth = false, title, titleBadge, titleActions, ...props }, ref) => {
         return (
             <SidebarProvider>
                 <AppSidebar />
                 <SidebarInset className="max-h-screen overflow-hidden">
                     <AppHeader />
-                    {title != null && <SectionHeader title={title} badge={titleBadge} actions={titleActions} className={headerClassName} />}
+                    {title != null && <SectionHeader title={title} badge={titleBadge} actions={titleActions} />}
                     <div
                         ref={ref}
                         className={cn('relative w-full flex-1 min-h-0 overflow-auto bg-surface-page min-w-3xl', fullWidth ? 'p-0' : 'p-11')}

--- a/packages/webapp/src/layout/SectionHeader.tsx
+++ b/packages/webapp/src/layout/SectionHeader.tsx
@@ -1,5 +1,3 @@
-import { cn } from '@/utils/utils';
-
 interface SectionHeaderProps {
     /** Section/page title shown on the left. */
     title: string;
@@ -7,22 +5,18 @@ interface SectionHeaderProps {
     badge?: React.ReactNode;
     /** Optional content rendered on the right of the row (e.g. the page's primary action). */
     actions?: React.ReactNode;
-    /** Extra classes for the row's inner container — pages cap it to their own content width so actions line up with it. */
-    className?: string;
 }
 
 /**
  * Section header — Figma node 1:5829. A fixed 56px row below the top bar showing the
  * current section title (with an optional inline badge) and the page's primary action on the right.
  */
-export const SectionHeader: React.FC<SectionHeaderProps> = ({ title, badge, actions, className }) => (
-    <div className="flex h-14 shrink-0 items-center border-b-[0.5px] border-border-default bg-surface-page px-6">
-        <div className={cn('flex w-full items-center justify-between', className)}>
-            <div className="flex min-w-0 items-center gap-2.5">
-                <h1 className="type-heading-sm truncate text-text-strong">{title}</h1>
-                {badge}
-            </div>
-            {actions}
+export const SectionHeader: React.FC<SectionHeaderProps> = ({ title, badge, actions }) => (
+    <div className="flex h-14 shrink-0 items-center justify-between border-b-[0.5px] border-border-default bg-surface-page px-6">
+        <div className="flex min-w-0 items-center gap-2.5">
+            <h1 className="type-heading-sm truncate text-text-strong">{title}</h1>
+            {badge}
         </div>
+        {actions}
     </div>
 );

--- a/packages/webapp/src/layout/SectionHeader.tsx
+++ b/packages/webapp/src/layout/SectionHeader.tsx
@@ -1,3 +1,12 @@
+import { cn } from '@/utils/utils';
+
+/**
+ * Width a `centered` page caps its content at — the old 1280 cap plus the 228px (184px side panel +
+ * 44px gap) the tabbed NavigationList used to take up. Shared with `DashboardLayout` so the header
+ * row and the content below it can't drift apart.
+ */
+export const CENTERED_MAX_WIDTH = 'max-w-[1508px]';
+
 interface SectionHeaderProps {
     /** Section/page title shown on the left. */
     title: string;
@@ -5,18 +14,22 @@ interface SectionHeaderProps {
     badge?: React.ReactNode;
     /** Optional content rendered on the right of the row (e.g. the page's primary action). */
     actions?: React.ReactNode;
+    /** Caps and centers the row to match a `centered` page's content. Set by `DashboardLayout`. */
+    centered?: boolean;
 }
 
 /**
  * Section header — Figma node 1:5829. A fixed 56px row below the top bar showing the
  * current section title (with an optional inline badge) and the page's primary action on the right.
  */
-export const SectionHeader: React.FC<SectionHeaderProps> = ({ title, badge, actions }) => (
-    <div className="flex h-14 shrink-0 items-center justify-between border-b-[0.5px] border-border-default bg-surface-page px-6">
-        <div className="flex min-w-0 items-center gap-2.5">
-            <h1 className="type-heading-sm truncate text-text-strong">{title}</h1>
-            {badge}
+export const SectionHeader: React.FC<SectionHeaderProps> = ({ title, badge, actions, centered = false }) => (
+    <div className="flex h-14 shrink-0 items-center border-b-[0.5px] border-border-default bg-surface-page px-6">
+        <div className={cn('flex w-full items-center justify-between', centered && `mx-auto ${CENTERED_MAX_WIDTH}`)}>
+            <div className="flex min-w-0 items-center gap-2.5">
+                <h1 className="type-heading-sm truncate text-text-strong">{title}</h1>
+                {badge}
+            </div>
+            {actions}
         </div>
-        {actions}
     </div>
 );

--- a/packages/webapp/src/layout/SectionHeader.tsx
+++ b/packages/webapp/src/layout/SectionHeader.tsx
@@ -1,19 +1,28 @@
+import { cn } from '@/utils/utils';
+
 interface SectionHeaderProps {
     /** Section/page title shown on the left. */
     title: string;
     /** Optional content rendered inline right after the title (e.g. an environment badge). */
     badge?: React.ReactNode;
+    /** Optional content rendered on the right of the row (e.g. the page's primary action). */
+    actions?: React.ReactNode;
+    /** Extra classes for the row's inner container — pages cap it to their own content width so actions line up with it. */
+    className?: string;
 }
 
 /**
  * Section header — Figma node 1:5829. A fixed 56px row below the top bar showing the
- * current section title (with an optional inline badge). The right side is left blank for now.
+ * current section title (with an optional inline badge) and the page's primary action on the right.
  */
-export const SectionHeader: React.FC<SectionHeaderProps> = ({ title, badge }) => (
-    <div className="flex h-14 shrink-0 items-center justify-between border-b-[0.5px] border-border-default bg-surface-page px-6">
-        <div className="flex min-w-0 items-center gap-2.5">
-            <h1 className="type-heading-sm truncate text-text-strong">{title}</h1>
-            {badge}
+export const SectionHeader: React.FC<SectionHeaderProps> = ({ title, badge, actions, className }) => (
+    <div className="flex h-14 shrink-0 items-center border-b-[0.5px] border-border-default bg-surface-page px-6">
+        <div className={cn('flex w-full items-center justify-between', className)}>
+            <div className="flex min-w-0 items-center gap-2.5">
+                <h1 className="type-heading-sm truncate text-text-strong">{title}</h1>
+                {badge}
+            </div>
+            {actions}
         </div>
     </div>
 );

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -7,17 +7,11 @@ import { permissions } from '@nangohq/authz';
 import { Separator } from '@/components/ui/Separator';
 import { usePermissions } from '@/hooks/usePermissions';
 import { track } from '@/utils/analytics';
-import { cn } from '@/utils/utils';
 import DashboardLayout from '../../../layout/DashboardLayout';
 import { BillingHeaderAction } from './components/BillingHeaderAction';
 import { Payment } from './components/Payment';
 import { Plans } from './components/Plans';
 import { Usage } from './components/Usage';
-
-// The old 1280 cap plus the 228px (184px side panel + 44px gap) the tabbed NavigationList side panel
-// used to take up, now that the sections stack instead. Shared with the header row so the header
-// action right-aligns with the content below it.
-const CONTENT_MAX_WIDTH = 'max-w-[1508px]';
 
 export const TeamBilling: React.FC = () => {
     const { can } = usePermissions();
@@ -40,14 +34,17 @@ export const TeamBilling: React.FC = () => {
     }, [location.hash]);
 
     // Full-width page shell keeps chrome consistent with the other dashboard pages, but the billing
-    // content is capped and left-aligned: the usage charts have a fixed height, so unbounded width
-    // stretches them to an unreadable aspect ratio on wide screens.
+    // content is capped and centered: the usage charts have a fixed height, so unbounded width
+    // stretches them to an unreadable aspect ratio on wide screens. The header action isn't capped —
+    // it stays at the page edge.
     return (
-        <DashboardLayout fullWidth title="Billing & usage" titleActions={<BillingHeaderAction />} headerClassName={CONTENT_MAX_WIDTH}>
+        <DashboardLayout fullWidth title="Billing & usage" titleActions={<BillingHeaderAction />}>
             <Helmet>
                 <title>Billing & usage - Nango</title>
             </Helmet>
-            <div className={cn('flex flex-col gap-8', CONTENT_MAX_WIDTH)}>
+            {/* max-w: the old 1280 cap plus the 228px (184px side panel + 44px gap) the tabbed
+                NavigationList side panel used to take up, now that the sections stack instead */}
+            <div className="flex flex-col gap-8 max-w-[1508px] mx-auto">
                 <div id="usage">
                     <Usage />
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -33,18 +33,15 @@ export const TeamBilling: React.FC = () => {
         document.getElementById(hash)?.scrollIntoView({ block: 'start' });
     }, [location.hash]);
 
-    // Full-width page shell keeps chrome consistent with the other dashboard pages, but the billing
-    // content is capped and centered: the usage charts have a fixed height, so unbounded width
-    // stretches them to an unreadable aspect ratio on wide screens. The header action isn't capped —
-    // it stays at the page edge.
+    // Full-width page shell keeps chrome consistent with the other dashboard pages, but `centered`
+    // caps the content: the usage charts have a fixed height, so unbounded width stretches them to an
+    // unreadable aspect ratio on wide screens.
     return (
-        <DashboardLayout fullWidth title="Billing & usage" titleActions={<BillingHeaderAction />}>
+        <DashboardLayout fullWidth centered title="Billing & usage" titleActions={<BillingHeaderAction />}>
             <Helmet>
                 <title>Billing & usage - Nango</title>
             </Helmet>
-            {/* max-w: the old 1280 cap plus the 228px (184px side panel + 44px gap) the tabbed
-                NavigationList side panel used to take up, now that the sections stack instead */}
-            <div className="flex flex-col gap-8 max-w-[1508px] mx-auto">
+            <div className="flex flex-col gap-8">
                 <div id="usage">
                     <Usage />
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -7,10 +7,17 @@ import { permissions } from '@nangohq/authz';
 import { Separator } from '@/components/ui/Separator';
 import { usePermissions } from '@/hooks/usePermissions';
 import { track } from '@/utils/analytics';
+import { cn } from '@/utils/utils';
 import DashboardLayout from '../../../layout/DashboardLayout';
+import { BillingHeaderAction } from './components/BillingHeaderAction';
 import { Payment } from './components/Payment';
 import { Plans } from './components/Plans';
 import { Usage } from './components/Usage';
+
+// The old 1280 cap plus the 228px (184px side panel + 44px gap) the tabbed NavigationList side panel
+// used to take up, now that the sections stack instead. Shared with the header row so the header
+// action right-aligns with the content below it.
+const CONTENT_MAX_WIDTH = 'max-w-[1508px]';
 
 export const TeamBilling: React.FC = () => {
     const { can } = usePermissions();
@@ -36,13 +43,11 @@ export const TeamBilling: React.FC = () => {
     // content is capped and left-aligned: the usage charts have a fixed height, so unbounded width
     // stretches them to an unreadable aspect ratio on wide screens.
     return (
-        <DashboardLayout fullWidth title="Billing & usage">
+        <DashboardLayout fullWidth title="Billing & usage" titleActions={<BillingHeaderAction />} headerClassName={CONTENT_MAX_WIDTH}>
             <Helmet>
                 <title>Billing & usage - Nango</title>
             </Helmet>
-            {/* max-w: the old 1280 cap plus the 228px (184px side panel + 44px gap) the tabbed
-                NavigationList side panel used to take up, now that the sections stack instead */}
-            <div className="flex flex-col gap-8 max-w-[1508px]">
+            <div className={cn('flex flex-col gap-8', CONTENT_MAX_WIDTH)}>
                 <div id="usage">
                     <Usage />
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/components/BillingHeaderAction.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/BillingHeaderAction.tsx
@@ -1,0 +1,53 @@
+import { ExternalLink } from 'lucide-react';
+
+import { Button } from '@nangohq/design-system';
+
+import { ButtonLink } from '@/components/ui/ButtonLink';
+import { useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
+import { useStore } from '@/store';
+import { track } from '@/utils/analytics';
+
+/**
+ * Primary action in the Billing & usage page header: Free upgrades, everyone else goes to their
+ * invoices (Figma nodes 574:44366 and 563:50025).
+ */
+export const BillingHeaderAction: React.FC = () => {
+    const env = useStore((state) => state.env);
+    const { data: environmentData } = useCurrentPlan(env);
+    const plan = environmentData?.plan;
+    const isFree = plan?.name === 'free';
+
+    // Same query key as <Payment/>'s unfiltered call, so this shares that request instead of adding
+    // one. Free has no Orb customer, so skip it entirely — and wait for `plan` to resolve, since
+    // until it does `isFree` is false and we'd fire a request for a Free account.
+    const { data: usage } = useApiGetBillingUsage(env, undefined, { enabled: plan != null && !isFree });
+    const portalUrl = usage?.data.customer.portalUrl;
+
+    if (!plan) {
+        return null;
+    }
+
+    if (isFree) {
+        const scrollToPlans = () => {
+            track('web:usage:upgrade_clicked', {});
+            document.getElementById('plans')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        };
+
+        return (
+            <Button size="md" onClick={scrollToPlans}>
+                Upgrade
+            </Button>
+        );
+    }
+
+    if (!portalUrl) {
+        return null;
+    }
+
+    return (
+        <ButtonLink to={portalUrl} size="md" target="_blank" rel="noopener noreferrer" onClick={() => track('web:usage:invoice_details_clicked', {})}>
+            All invoices
+            <ExternalLink />
+        </ButtonLink>
+    );
+};

--- a/packages/webapp/src/pages/Team/Billing/components/BillingHeaderAction.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/BillingHeaderAction.tsx
@@ -14,7 +14,7 @@ import { track } from '@/utils/analytics';
  */
 export const BillingHeaderAction: React.FC = () => {
     const env = useStore((state) => state.env);
-    const { data: environmentData } = useCurrentPlan(env);
+    const { data: environmentData, isLoading: isPlanLoading } = useCurrentPlan(env);
     const plan = environmentData?.plan;
     const isFree = plan?.name === 'free';
 
@@ -25,9 +25,10 @@ export const BillingHeaderAction: React.FC = () => {
     const portalUrl = usage?.data.customer.portalUrl;
 
     // Both the plan and (for paid) the portal URL are fetched, so hold a button-sized placeholder
-    // rather than letting the header sit empty and pop the button in a moment later.
+    // rather than letting the header sit empty and pop the button in a moment later. Only while a
+    // request is in flight though — on error there's no action to show, so don't pulse forever.
     if (!plan) {
-        return <Skeleton className="h-8 w-28" />;
+        return isPlanLoading ? <Skeleton className="h-8 w-28" /> : null;
     }
 
     if (isFree) {

--- a/packages/webapp/src/pages/Team/Billing/components/BillingHeaderAction.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/BillingHeaderAction.tsx
@@ -3,6 +3,7 @@ import { ExternalLink } from 'lucide-react';
 import { Button } from '@nangohq/design-system';
 
 import { ButtonLink } from '@/components/ui/ButtonLink';
+import { Skeleton } from '@/components/ui/Skeleton';
 import { useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
@@ -20,11 +21,13 @@ export const BillingHeaderAction: React.FC = () => {
     // Same query key as <Payment/>'s unfiltered call, so this shares that request instead of adding
     // one. Free has no Orb customer, so skip it entirely — and wait for `plan` to resolve, since
     // until it does `isFree` is false and we'd fire a request for a Free account.
-    const { data: usage } = useApiGetBillingUsage(env, undefined, { enabled: plan != null && !isFree });
+    const { data: usage, isLoading: isUsageLoading } = useApiGetBillingUsage(env, undefined, { enabled: plan != null && !isFree });
     const portalUrl = usage?.data.customer.portalUrl;
 
+    // Both the plan and (for paid) the portal URL are fetched, so hold a button-sized placeholder
+    // rather than letting the header sit empty and pop the button in a moment later.
     if (!plan) {
-        return null;
+        return <Skeleton className="h-8 w-28" />;
     }
 
     if (isFree) {
@@ -38,6 +41,10 @@ export const BillingHeaderAction: React.FC = () => {
                 Upgrade
             </Button>
         );
+    }
+
+    if (isUsageLoading) {
+        return <Skeleton className="h-8 w-28" />;
     }
 
     if (!portalUrl) {

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -100,12 +100,6 @@ export const Usage: React.FC = () => {
             </div>
 
             <UsageTable rows={rows} isLoading={isLoading} env={env} timeframe={timeframe} chartMode="daily" showLimits={false} />
-
-            {usage?.data.customer.portalUrl && (
-                <StyledLink icon to={usage.data.customer.portalUrl} type="external" onClick={() => track('web:usage:invoice_details_clicked', {})}>
-                    View invoice details
-                </StyledLink>
-            )}
         </div>
     );
 };

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -26,6 +26,7 @@ export interface AnalyticsEvents {
     'web:usage:value_opened': { metric: UsageMetric; dimension: AnyBreakdownDimension };
     'web:usage:invoice_details_clicked': Record<string, never>;
     'web:usage:billing_portal_clicked': Record<string, never>;
+    'web:usage:upgrade_clicked': Record<string, never>;
 
     // Playground
     'web:playground:opened': { source: 'header' | 'connection' | 'integration' | 'function' };


### PR DESCRIPTION
## Problem

The Billing & usage page header had nothing on the right. The only action a paid account had — "View invoice details" — was a small text link buried under the usage table, and free accounts had no upgrade entry point above the fold.

## Solution

- Free plan: primary **Upgrade** button in the page header that scrolls to the Plans section.
- Paid plans: primary **All invoices** button that opens the billing portal in a new tab, replacing the "View invoice details" link under the usage table. Reuses the existing `ButtonLink`, same as the other external-link buttons in the app.
- New optional `actions` slot on `SectionHeader` (`titleActions` on `DashboardLayout`), plus a `centered` prop that caps and centers the header row and the page content at one shared width, so the title and its action line up with the content between them. Billing opts in — it was left-aligned before and is now centered; every other page is untouched.
- A skeleton holds the button's place while the plan and (for paid) the portal URL load, so the header doesn't sit empty and pop the button in. If those requests fail it falls back to no action rather than a placeholder that pulses forever.
- Adds the `web:usage:upgrade_clicked` event. The invoices button keeps `web:usage:invoice_details_clicked` so the before/after series stays comparable.
- Separate commit: fixes the design-system `AGENTS.md`, which told contributors to put stories in the top-level `stories/` dir while the structure diagram right below showed them co-located. Co-location is what every component actually does.

Fixes [NAN-6582](https://linear.app/nango/issue/NAN-6582/give-the-billing-and-usage-page-a-primary-action-in-its-header)

## Testing

Against `REMOTE_API=dev`: on Free (`matej+dev`) the header shows Upgrade and clicking it scrolls to Plans; on a paid account (`matej+dev-paid`) it shows All invoices pointing at the Orb portal with `target="_blank"`, in light and dark mode. At 1920px the title's left edge and the button's right edge match the content's own edges (318px and 1826px). Connections and Integrations are unchanged, header and content alike.

<img width="3238" height="2006" alt="image" src="https://github.com/user-attachments/assets/494eebb0-5f23-4265-adee-c08112baac0a" />

<img width="3254" height="2006" alt="image" src="https://github.com/user-attachments/assets/7f024e58-3755-437c-845d-5d45d253061b" />
