### PR TITLE
fix(inputs): render placeholders with a dedicated token

### DIFF
--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -11,7 +11,7 @@ import type { VariantProps } from 'class-variance-authority';
 
 const inputGroupVariants = cva(
     [
-        'group/input-group bg-surface-input border-ds-hairline border-border-input text-text-default placeholder:text-text-secondary text-ds-md font-ds-regular leading-ds-normal relative flex w-full items-center rounded-ds-xs transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out outline-none hover:border-border-input-hover',
+        'group/input-group bg-surface-input border-ds-hairline border-border-input text-text-default placeholder:text-text-placeholder text-ds-md font-ds-regular leading-ds-normal relative flex w-full items-center rounded-ds-xs transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out outline-none hover:border-border-input-hover',
         'min-w-0 has-[>textarea]:h-auto',
 
         // Variants based on alignment.

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -12,7 +12,7 @@ export const inputVariants = cva(
         // Typography (Figma text/regular/md)
         'text-ds-md font-ds-regular leading-ds-normal',
         // Default colors
-        'bg-surface-input border-border-input text-text-default placeholder:text-text-secondary',
+        'bg-surface-input border-border-input text-text-default placeholder:text-text-placeholder',
         // Hover border. On focus the hairline border adopts the ring color and 0.5px outset + 0.5px inset shadows draw a 1px ring
         // centered on the field edge (half outside, half inside), continuous with the recolored border.
         'hover:border-border-input-hover',

--- a/packages/design-system/src/components/ui/textarea.tsx
+++ b/packages/design-system/src/components/ui/textarea.tsx
@@ -15,7 +15,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
                 // Typography (Figma text/regular/md)
                 'text-ds-md font-ds-regular leading-ds-normal',
                 // Default colors
-                'bg-surface-input border-border-input text-text-default placeholder:text-text-secondary',
+                'bg-surface-input border-border-input text-text-default placeholder:text-text-placeholder',
                 // Hover border. On focus the hairline border adopts the ring color and 0.5px outset + 0.5px inset shadows draw a 1px ring
                 // centered on the field edge (half outside, half inside), continuous with the recolored border.
                 'hover:border-border-input-hover',

--- a/packages/design-system/tokens/tokens.generated.css
+++ b/packages/design-system/tokens/tokens.generated.css
@@ -280,6 +280,7 @@
     --text-default: #2a2b2f;
     --text-secondary: #626366;
     --text-muted: #76777a;
+    --text-placeholder: #8b8c8f;
     --text-disabled: #76777a;
     --text-inverse: #ffffff;
     --text-on-accent: #ffffff;
@@ -298,7 +299,7 @@
     --border-interactive: #a1a2a5;
     --border-interactive-hover: #8b8c8f;
     --border-input: #8b8c8f;
-    --border-input-hover: #626366;
+    --border-input-hover: #505155;
     --border-selected: #009cc8;
     --border-danger: #f27474;
     --border-danger-hover: #eb2d2d;
@@ -405,6 +406,7 @@
     --text-default: #e0e0e0;
     --text-secondary: #a1a2a5;
     --text-muted: #76777a;
+    --text-placeholder: #626366;
     --text-disabled: #76777a;
     --text-inverse: #000000;
     --text-on-accent: #ffffff;
@@ -423,7 +425,7 @@
     --border-interactive: #ffffff3d;
     --border-interactive-hover: #ffffff66;
     --border-input: #ffffff66;
-    --border-input-hover: #ffffff80;
+    --border-input-hover: #ffffffa3;
     --border-selected: #00b2e3;
     --border-danger: #eb2d2d;
     --border-danger-hover: #f27474;
@@ -534,6 +536,7 @@
     --color-text-default: var(--text-default);
     --color-text-secondary: var(--text-secondary);
     --color-text-muted: var(--text-muted);
+    --color-text-placeholder: var(--text-placeholder);
     --color-text-disabled: var(--text-disabled);
     --color-text-inverse: var(--text-inverse);
     --color-text-on-accent: var(--text-on-accent);

--- a/packages/design-system/tokens/tokens.json
+++ b/packages/design-system/tokens/tokens.json
@@ -442,6 +442,11 @@
                 "$value": "{color.neutral.500}",
                 "$description": "A11Y RULE: do not use at fontSize.2xs (11px) or fontSize.xs (12px) — 4.18:1 on surface.panel, 3.68:1 on panelInset. Use text.secondary at those sizes. See 'Accessibility note — text.muted at small sizes'."
             },
+            "placeholder": {
+                "$type": "color",
+                "$value": "{color.neutral.600}",
+                "$description": "Dedicated placeholder-text token. Was reading as text.default/text.secondary in inputs, which made placeholder copy indistinguishable from real typed content. One stop past text.muted (toward the background) so it sits clearly below every real-text tier while staying legible — 3.12:1 on surface.input (#121212). Caveat: 2.93:1 on surface.inputMuted (readonly-style inputs) — just under 3:1; accepted since placeholder rarely appears in that variant and the ramp has no stop between .500/.600. Intentionally under the 4.5:1 text threshold: placeholder is a hint, not required reading (WCAG 1.4.3 does not apply to it), but stays close to 3:1 so it doesn't disappear. Do not use for real input values, helper text, or error text — use text.default/text.secondary/text.danger for those."
+            },
             "disabled": {
                 "$type": "color",
                 "$value": "{color.neutral.500}",
@@ -479,7 +484,11 @@
                 "$description": "Hover border for interactive controls — strengthens to the same weight as border.input."
             },
             "input": { "$type": "color", "$value": "{color.alpha.white.40}" },
-            "inputHover": { "$type": "color", "$value": "{color.alpha.white.50}" },
+            "inputHover": {
+                "$type": "color",
+                "$value": "{color.alpha.white.64}",
+                "$description": "A11Y/VISIBILITY FIX (2026-08-12): was alpha.white.50 — resolved only 1.4x the resting border's contrast against surface.input (3.84:1 → 5.36:1), reported as not enough visual separation between default and hover. Moved to alpha.white.64 (~7.97:1 on surface.input #121212, 2.08x the default) — now matches Light's hover contrast almost exactly (7.93:1), so the hover state feels consistent across themes. See border.input for the resting value."
+            },
             "selected": { "$type": "color", "$value": "{color.info.500}" },
             "danger": { "$type": "color", "$value": "{color.danger.600}" },
             "dangerHover": { "$type": "color", "$value": "{color.danger.400}" },
@@ -704,6 +713,11 @@
                 "$value": "{color.neutral.500}",
                 "$description": "A11Y RULE: do not use at fontSize.2xs (11px) or fontSize.xs (12px) — fails 4.5:1 on light surfaces (4.28:1 on surface.page). Use text.secondary at those sizes. See 'Accessibility note — text.muted at small sizes'."
             },
+            "placeholder": {
+                "$type": "color",
+                "$value": "{color.neutral.450}",
+                "$description": "Dedicated placeholder-text token. Was reading as text.default/text.secondary in inputs, which made placeholder copy indistinguishable from real typed content. One stop lighter than text.muted so it sits clearly below every real-text tier (strong/default/secondary/muted) while staying legible — 3.36:1 on surface.input (#FFFFFF), 3.08:1 on surface.inputMuted. Intentionally under the 4.5:1 text threshold: placeholder is a hint, not required reading (WCAG 1.4.3 does not apply to it), but stays ≥3:1 so it doesn't disappear. Do not use for real input values, helper text, or error text — use text.default/text.secondary/text.danger for those."
+            },
             "disabled": {
                 "$type": "color",
                 "$value": "{color.neutral.500}",
@@ -737,7 +751,11 @@
                 "$description": "Hover border for interactive controls — strengthens to the same weight as border.input."
             },
             "input": { "$type": "color", "$value": "{color.neutral.450}" },
-            "inputHover": { "$type": "color", "$value": "{color.neutral.600}" },
+            "inputHover": {
+                "$type": "color",
+                "$value": "{color.neutral.650}",
+                "$description": "A11Y/VISIBILITY FIX (2026-08-12): was neutral.600 — only 1.79x the resting border's contrast against surface.input (3.36:1 → 6.01:1), reported as not enough visual separation between default and hover. Moved one stop further to .650 (7.93:1 on surface.input, 2.36x the default) for a hover state that reads as a clear, deliberate darken instead of a near-imperceptible shift. See border.input for the resting value."
+            },
             "selected": { "$type": "color", "$value": "{color.info.600}" },
             "danger": { "$type": "color", "$value": "{color.danger.400}" },
             "dangerHover": { "$type": "color", "$value": "{color.danger.600}" },
@@ -1265,6 +1283,7 @@
                 "text.default": "a2d2c02e7dfa3ca76de9a4aa5869f48f1dec8e5c",
                 "text.secondary": "6d3569ccb69cf87ad27ee5b85811f9c889e29c4d",
                 "text.muted": "a70b5c05339d3d44d46ef9402f8b3431e2013a50",
+                "text.placeholder": "8b68a85a5076bb8afa618a595e0646dabfa3912d",
                 "text.disabled": "c57fe988151c4f6c31e8004a55d206d70d04a1f5",
                 "text.inverse": "2ffea78bb79eac4419f33eb8a5a12d25072937bd",
                 "text.onAccent": "24092c387c561357985fee6ad1376eb0d23d8c48",
@@ -1420,6 +1439,7 @@
                 "text.default": "a2d2c02e7dfa3ca76de9a4aa5869f48f1dec8e5c",
                 "text.secondary": "6d3569ccb69cf87ad27ee5b85811f9c889e29c4d",
                 "text.muted": "a70b5c05339d3d44d46ef9402f8b3431e2013a50",
+                "text.placeholder": "8b68a85a5076bb8afa618a595e0646dabfa3912d",
                 "text.disabled": "c57fe988151c4f6c31e8004a55d206d70d04a1f5",
                 "text.inverse": "2ffea78bb79eac4419f33eb8a5a12d25072937bd",
                 "text.onAccent": "24092c387c561357985fee6ad1376eb0d23d8c48",

--- a/packages/webapp/src/components/patterns/FilterSelect.tsx
+++ b/packages/webapp/src/components/patterns/FilterSelect.tsx
@@ -220,7 +220,7 @@ const FilterValuePane: React.FC<{
                             }}
                             className={cn(
                                 searchable
-                                    ? 'mb-1 h-8 w-full rounded border-[0.5px] border-border-muted bg-surface-canvas pr-8 pl-2.5 text-body-medium-regular text-text-strong outline-none placeholder:text-text-muted'
+                                    ? 'mb-1 h-8 w-full rounded border-[0.5px] border-border-muted bg-surface-canvas pr-8 pl-2.5 text-body-medium-regular text-text-strong outline-none placeholder:text-text-placeholder'
                                     : 'sr-only'
                             )}
                         />

--- a/packages/webapp/src/components/patterns/PeriodSelector.tsx
+++ b/packages/webapp/src/components/patterns/PeriodSelector.tsx
@@ -122,7 +122,7 @@ export const PeriodSelector = ({ period, isLive, onChange, presets, defaultPrese
                                 <input
                                     type="text"
                                     placeholder={customPeriodInputExample}
-                                    className="w-full bg-transparent text-sm text-text-strong placeholder:text-text-disabled focus:outline-hidden focus:ring-0 border-none"
+                                    className="w-full bg-transparent text-sm text-text-strong placeholder:text-text-placeholder focus:outline-hidden focus:ring-0 border-none"
                                     value={customPeriodInputValue}
                                     onChange={(e) => setCustomPeriodInputValue(e.target.value)}
                                 />

--- a/packages/webapp/src/components/ui/Combobox.tsx
+++ b/packages/webapp/src/components/ui/Combobox.tsx
@@ -384,7 +384,7 @@ export function ComboboxSelect<T extends string = string>(props: ComboboxProps<T
                                 placeholder={searchPlaceholder}
                                 value={search}
                                 onChange={(e) => setSearch(e.target.value)}
-                                className="text-body-medium-regular text-text-muted placeholder:text-text-muted"
+                                className="text-body-medium-regular text-text-muted placeholder:text-text-placeholder"
                             />
                         </InputGroup>
                     </div>
@@ -583,7 +583,7 @@ function ComboboxChipsInput({ className, ...props }: ComboboxPrimitive.Input.Pro
         <ComboboxPrimitive.Input
             data-slot="combobox-chip-input"
             className={cn(
-                'min-w-16 flex-1 bg-transparent border-0 outline-none ring-0 focus:ring-0 focus:outline-none focus:shadow-none focus:border-transparent text-sm text-text-strong placeholder:text-text-muted',
+                'min-w-16 flex-1 bg-transparent border-0 outline-none ring-0 focus:ring-0 focus:outline-none focus:shadow-none focus:border-transparent text-sm text-text-strong placeholder:text-text-placeholder',
                 className
             )}
             {...props}

--- a/packages/webapp/src/components/ui/MultiSelect.tsx
+++ b/packages/webapp/src/components/ui/MultiSelect.tsx
@@ -163,7 +163,7 @@ export function MultiSelect<T extends string = string>({
                             placeholder={searchPlaceholder}
                             value={search}
                             onChange={handleInputChange}
-                            className="text-body-medium-regular text-text-muted placeholder:text-text-muted"
+                            className="text-body-medium-regular text-text-muted placeholder:text-text-placeholder"
                         />
                     </InputGroup>
                 </div>

--- a/packages/webapp/src/pages/Connection/CreateLegacy.tsx
+++ b/packages/webapp/src/pages/Connection/CreateLegacy.tsx
@@ -635,7 +635,7 @@ nango.${integration.meta.authMode === 'NONE' ? 'create' : 'auth'}('${integration
                                         <select
                                             id="integration_unique_key"
                                             name="integration_unique_key"
-                                            className="border-border-default bg-surface-input text-text-secondary focus:border-border-selected focus:ring-border-selected block w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder:text-text-disabled shadow-xs focus:outline-hidden"
+                                            className="border-border-default bg-surface-input text-text-secondary focus:border-border-selected focus:ring-border-selected block w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder:text-text-placeholder shadow-xs focus:outline-hidden"
                                             onChange={handleIntegrationUniqueKeyChange}
                                             defaultValue={integration?.unique_key}
                                         >
@@ -665,7 +665,7 @@ nango.${integration.meta.authMode === 'NONE' ? 'create' : 'auth'}('${integration
                                             defaultValue={connectionId}
                                             autoComplete="new-password"
                                             required
-                                            className="border-border-default bg-surface-input text-text-secondary focus:border-border-selected focus:ring-border-selected block w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder:text-text-disabled shadow-xs focus:outline-hidden"
+                                            className="border-border-default bg-surface-input text-text-secondary focus:border-border-selected focus:ring-border-selected block w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder:text-text-placeholder shadow-xs focus:outline-hidden"
                                             onChange={handleConnectionIdChange}
                                         />
                                     </div>
@@ -891,7 +891,7 @@ nango.${integration.meta.authMode === 'NONE' ? 'create' : 'auth'}('${integration
                                             type="text"
                                             required
                                             autoComplete="new-password"
-                                            className="border-border-default bg-surface-input text-text-secondary focus:border-border-selected focus:ring-border-selected block w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder:text-text-disabled shadow-xs focus:outline-hidden"
+                                            className="border-border-default bg-surface-input text-text-secondary focus:border-border-selected focus:ring-border-selected block w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder:text-text-placeholder shadow-xs focus:outline-hidden"
                                             onChange={handleConnectionConfigParamsChange}
                                         />
                                     </div>
@@ -1026,7 +1026,7 @@ nango.${integration.meta.authMode === 'NONE' ? 'create' : 'auth'}('${integration
                                             defaultValue="{ }"
                                             className={`${authorizationParamsError ? 'border-border-danger' : 'border-border-default'}  ${
                                                 authorizationParamsError ? 'text-status-danger-text' : 'text-text-secondary'
-                                            } focus:ring-border-selected bg-surface-input block focus:border-border-selected w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder:text-text-disabled shadow-xs focus:outline-hidden`}
+                                            } focus:ring-border-selected bg-surface-input block focus:border-border-selected w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder:text-text-placeholder shadow-xs focus:outline-hidden`}
                                             onChange={handleAuthorizationParamsChange}
                                         />
                                     </div>
@@ -1055,7 +1055,7 @@ nango.${integration.meta.authMode === 'NONE' ? 'create' : 'auth'}('${integration
                                             defaultValue="{ }"
                                             className={`${authorizationParamsError ? 'border-border-danger' : 'border-border-default'}  ${
                                                 authorizationParamsError ? 'text-status-danger-text' : 'text-text-secondary'
-                                            } focus:ring-border-selected bg-surface-input block focus:border-border-selected focus:ring-border-selected block w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder:text-text-disabled shadow-xs focus:outline-hidden`}
+                                            } focus:ring-border-selected bg-surface-input block focus:border-border-selected focus:ring-border-selected block w-full appearance-none rounded-md border px-3 py-1 text-sm placeholder:text-text-placeholder shadow-xs focus:outline-hidden`}
                                             onChange={handleAuthorizationParamsChange}
                                         />
                                     </div>


### PR DESCRIPTION
## Problem

Placeholder copy had no token of its own, so every input picked something else — `text.secondary` in the design-system controls, `text.muted` in `Combobox`/`MultiSelect`/`FilterSelect`, `text.disabled` in `PeriodSelector` and the legacy connection form. The stronger tiers made an empty field read as a filled one; `text.disabled` made it read as a disabled field. Separately, `border.inputHover` sat close enough to the resting border that hover was near-imperceptible.

## Solution

- Add `text.placeholder` — light `neutral.450` (3.36:1 on `surface.input`), dark `neutral.600` (3.12:1). Under the 4.5:1 text minimum on purpose, since a placeholder is a hint rather than required reading, but near 3:1 so it stays legible.
- Raise `border.inputHover` — light `neutral.600` → `.650`, dark `alpha.white.50` → `.64`. Both themes now land at near-identical hover contrast (7.93:1 and ~7.97:1).
- Point all 14 placeholder usages at the new token; disabled inputs keep their `text.disabled` treatment.

Tokens were applied by hand rather than via `npm run tokens:fetch` — see Follow-ups.

Fixes [NAN-6589](https://linear.app/nango/issue/NAN-6589/make-input-placeholders-read-as-hints-instead-of-typed-text)

## Testing

Ran the webapp against the dev API and confirmed on `/dev/connections` and the sign-in form, in both themes, that a placeholder reads clearly weaker than a typed value and that hover is a visible darken. Checked the served CSS vars resolve to the new values (`--text-placeholder` #8b8c8f light / #626366 dark, `--border-input-hover` #505155 / #ffffffa3).

Suggested screenshots to attach: the sign-in form in dark mode, and `/dev/connections` search field resting vs hovered in light mode.

## Follow-ups

- `color.danger.750` is referenced by `interactive.dangerHover`, `text.linkDangerHover` and `icon.linkDangerHover` on the `design/tokens` branch but was never pushed to Primitives. Until it is, a full `tokens:fetch` silently drops those three and breaks the danger button's hover fill — which is why this PR hand-applies the two tokens instead of syncing.
- When the rest of the `design/tokens` work lands (danger/link restructure, `border.interactive` removal, light `text.danger` → `danger.500`), `InvoicingEmailsField.tsx:141` needs `border-border-interactive` → `border-border-input`.
- `packages/connect-ui` has its own `input.tsx` on a separate palette — out of scope until Connect UI adopts the design system.
