### PR TITLE
refactor(action): extract a non-HTTP action executor from runAction (NAN-6591)

### DIFF
--- a/packages/server/lib/controllers/action/runAction.ts
+++ b/packages/server/lib/controllers/action/runAction.ts
@@ -1,17 +1,23 @@
-import { defaultOperationExpiration, logContextGetter, OtlpSpan } from '@nangohq/logs';
-import { configService, connectionService, errorManager, getSyncConfigRaw, pubsub } from '@nangohq/shared';
-import { truncateJson } from '@nangohq/utils';
+import { errorManager } from '@nangohq/shared';
 
-import { envs } from '../../env.js';
-import { getOrchestrator } from '../../utils/utils.js';
+import { executeAction } from '../../services/action.service.js';
 
+import type { ActionExecutionErrorCode } from '../../services/action.service.js';
 import type { LogContextOrigin } from '@nangohq/logs';
 import type { DBEnvironment, DBTeam } from '@nangohq/types';
 import type { Span } from 'dd-trace';
 import type { Response } from 'express';
 
+const httpErrors: Record<Exclude<ActionExecutionErrorCode, 'action_failed'>, { status: number; code: string }> = {
+    unknown_connection: { status: 400, code: 'unknown_connection' },
+    unknown_provider: { status: 400, code: 'unknown_provider' },
+    unknown_action: { status: 404, code: 'not_found' },
+    disabled_action: { status: 404, code: 'disabled_resource' },
+    internal_error: { status: 500, code: 'internal_server_error' }
+};
+
 /**
- * Core action execution logic shared between the public trigger endpoint and the
+ * HTTP adapter over `executeAction`, shared between the public trigger endpoint and the
  * internal session-authenticated trigger function endpoint.
  *
  * Returns the created `LogContextOrigin` so callers can attach additional metadata
@@ -40,96 +46,34 @@ export async function runAction({
     res: Response;
     span: Span;
 }): Promise<LogContextOrigin | undefined> {
-    let logCtx: LogContextOrigin | undefined;
-    try {
-        const { success, response: connection } = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);
-        if (!success || !connection) {
-            res.status(400).send({ error: { code: 'unknown_connection', message: 'Failed to find connection' } });
-            return logCtx;
-        }
+    const { logCtx, result } = await executeAction({
+        account,
+        environment,
+        connectionId,
+        providerConfigKey,
+        actionName,
+        input,
+        isAsync,
+        retryMax,
+        span
+    });
 
-        const provider = await configService.getProviderConfig(providerConfigKey, environment.id);
-        if (!provider) {
-            res.status(400).json({ error: { code: 'unknown_provider', message: 'Failed to find provider' } });
-            return logCtx;
-        }
-
-        const syncConfig = await getSyncConfigRaw({ environmentId: environment.id, config_id: provider.id!, name: actionName, isAction: true });
-        if (!syncConfig) {
-            res.status(404).json({ error: { code: 'not_found', message: 'Action not found' } });
-            return logCtx;
-        }
-
-        if (!syncConfig.enabled) {
-            res.status(404).json({ error: { code: 'disabled_resource', message: 'The action is disabled' } });
-            return logCtx;
-        }
-
-        span.setTag('nango.actionName', actionName)
-            .setTag('nango.connectionId', connectionId)
-            .setTag('nango.environmentId', environment.id)
-            .setTag('nango.providerConfigKey', providerConfigKey);
-
-        logCtx = await logContextGetter.create(
-            { operation: { type: 'action', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
-            {
-                account,
-                environment,
-                integration: { id: provider.id!, name: connection.provider_config_key, provider: provider.provider },
-                connection: { id: connection.id, name: connection.connection_id },
-                syncConfig: { id: syncConfig.id, name: syncConfig.sync_name },
-                meta: truncateJson({ input })
-            }
-        );
-        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
-
-        const actionResponse = await getOrchestrator().triggerAction({
-            accountId: account.id,
-            connection,
-            actionName,
-            input,
-            async: isAsync,
-            retryMax,
-            maxConcurrency: envs.ACTION_ENVIRONMENT_MAX_CONCURRENCY,
-            logCtx
-        });
-
-        if (actionResponse.isOk()) {
-            if ('statusUrl' in actionResponse.value) {
-                res.status(202).location(actionResponse.value.statusUrl).json(actionResponse.value);
-            } else {
-                res.status(200).json(actionResponse.value.data);
-            }
-
-            void pubsub.publisher.publish({
-                subject: 'usage',
-                type: 'usage.actions',
-                idempotencyKey: logCtx.id,
-                payload: {
-                    value: 1,
-                    properties: {
-                        accountId: account.id,
-                        connectionId: connection.connection_id,
-                        environmentId: environment.id,
-                        environmentName: environment.name,
-                        integrationId: providerConfigKey,
-                        actionName
-                    }
-                }
-            });
+    if (result.isOk()) {
+        if ('statusUrl' in result.value) {
+            res.status(202).location(result.value.statusUrl).json(result.value);
         } else {
-            span.setTag('nango.error', actionResponse.error);
-            await logCtx.failed();
-            errorManager.errResFromNangoErr(res, actionResponse.error);
+            res.status(200).json(result.value.data);
         }
-    } catch (err) {
-        span.setTag('nango.error', err);
-        if (logCtx) {
-            void logCtx.error('Failed to run action', { error: err });
-            await logCtx.failed();
-        }
-        res.status(500).send({ error: { code: 'internal_server_error', message: 'Failed to run action' } });
+        return logCtx;
     }
+
+    if (result.error.code === 'action_failed') {
+        errorManager.errResFromNangoErr(res, result.error.nangoError ?? null);
+        return logCtx;
+    }
+
+    const { status, code } = httpErrors[result.error.code];
+    res.status(status).send({ error: { code, message: result.error.message } });
 
     return logCtx;
 }

--- a/packages/server/lib/services/action.service.ts
+++ b/packages/server/lib/services/action.service.ts
@@ -1,0 +1,148 @@
+import { defaultOperationExpiration, logContextGetter, OtlpSpan } from '@nangohq/logs';
+import { configService, connectionService, getSyncConfigRaw, pubsub } from '@nangohq/shared';
+import { Err, Ok, truncateJson } from '@nangohq/utils';
+
+import { envs } from '../env.js';
+import { getOrchestrator } from '../utils/utils.js';
+
+import type { LogContextOrigin } from '@nangohq/logs';
+import type { NangoError } from '@nangohq/shared';
+import type { AsyncActionResponse, DBEnvironment, DBTeam, Result } from '@nangohq/types';
+import type { Span } from 'dd-trace';
+
+export type ActionExecutionSuccess = AsyncActionResponse | { data: unknown };
+
+export type ActionExecutionErrorCode = 'unknown_connection' | 'unknown_provider' | 'unknown_action' | 'disabled_action' | 'action_failed' | 'internal_error';
+
+export class ActionExecutionError extends Error {
+    readonly code: ActionExecutionErrorCode;
+    /** Set when the orchestrator ran the action and it failed, so callers can report the underlying failure. */
+    readonly nangoError: NangoError | undefined;
+
+    constructor({ code, message, nangoError }: { code: ActionExecutionErrorCode; message: string; nangoError?: NangoError }) {
+        super(message);
+        this.name = 'ActionExecutionError';
+        this.code = code;
+        this.nangoError = nangoError;
+    }
+}
+
+export interface ActionExecution {
+    /** Created once the action is known to exist, so callers can enrich the operation afterwards. */
+    logCtx: LogContextOrigin | undefined;
+    result: Result<ActionExecutionSuccess, ActionExecutionError>;
+}
+
+/**
+ * Executes an action and reports the outcome as a value.
+ *
+ * Transport agnostic on purpose: HTTP handlers, MCP tool calls and agent sessions all
+ * map the outcome to their own response shape.
+ */
+export async function executeAction({
+    account,
+    environment,
+    connectionId,
+    providerConfigKey,
+    actionName,
+    input,
+    isAsync,
+    retryMax,
+    span
+}: {
+    account: DBTeam;
+    environment: DBEnvironment;
+    connectionId: string;
+    providerConfigKey: string;
+    actionName: string;
+    input?: unknown;
+    isAsync: boolean;
+    retryMax: number;
+    span: Span;
+}): Promise<ActionExecution> {
+    let logCtx: LogContextOrigin | undefined;
+    try {
+        const { success, response: connection } = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);
+        if (!success || !connection) {
+            return { logCtx, result: Err(new ActionExecutionError({ code: 'unknown_connection', message: 'Failed to find connection' })) };
+        }
+
+        const provider = await configService.getProviderConfig(providerConfigKey, environment.id);
+        if (!provider) {
+            return { logCtx, result: Err(new ActionExecutionError({ code: 'unknown_provider', message: 'Failed to find provider' })) };
+        }
+
+        const syncConfig = await getSyncConfigRaw({ environmentId: environment.id, config_id: provider.id!, name: actionName, isAction: true });
+        if (!syncConfig) {
+            return { logCtx, result: Err(new ActionExecutionError({ code: 'unknown_action', message: 'Action not found' })) };
+        }
+
+        if (!syncConfig.enabled) {
+            return { logCtx, result: Err(new ActionExecutionError({ code: 'disabled_action', message: 'The action is disabled' })) };
+        }
+
+        span.setTag('nango.actionName', actionName)
+            .setTag('nango.connectionId', connectionId)
+            .setTag('nango.environmentId', environment.id)
+            .setTag('nango.providerConfigKey', providerConfigKey);
+
+        logCtx = await logContextGetter.create(
+            { operation: { type: 'action', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
+            {
+                account,
+                environment,
+                integration: { id: provider.id!, name: connection.provider_config_key, provider: provider.provider },
+                connection: { id: connection.id, name: connection.connection_id },
+                syncConfig: { id: syncConfig.id, name: syncConfig.sync_name },
+                meta: truncateJson({ input })
+            }
+        );
+        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
+        const actionResponse = await getOrchestrator().triggerAction({
+            accountId: account.id,
+            connection,
+            actionName,
+            input,
+            async: isAsync,
+            retryMax,
+            maxConcurrency: envs.ACTION_ENVIRONMENT_MAX_CONCURRENCY,
+            logCtx
+        });
+
+        if (actionResponse.isErr()) {
+            span.setTag('nango.error', actionResponse.error);
+            await logCtx.failed();
+            return {
+                logCtx,
+                result: Err(new ActionExecutionError({ code: 'action_failed', message: actionResponse.error.message, nangoError: actionResponse.error }))
+            };
+        }
+
+        void pubsub.publisher.publish({
+            subject: 'usage',
+            type: 'usage.actions',
+            idempotencyKey: logCtx.id,
+            payload: {
+                value: 1,
+                properties: {
+                    accountId: account.id,
+                    connectionId: connection.connection_id,
+                    environmentId: environment.id,
+                    environmentName: environment.name,
+                    integrationId: providerConfigKey,
+                    actionName
+                }
+            }
+        });
+
+        return { logCtx, result: Ok(actionResponse.value) };
+    } catch (err) {
+        span.setTag('nango.error', err);
+        if (logCtx) {
+            void logCtx.error('Failed to run action', { error: err });
+            await logCtx.failed();
+        }
+        return { logCtx, result: Err(new ActionExecutionError({ code: 'internal_error', message: 'Failed to run action' })) };
+    }
+}


### PR DESCRIPTION
`runAction` took `res` and wrote the http response itself, so anything that is not an express handler had to reimplement it. `connectionToolsServer` already did, and the agent session work needs the same thing again.

`executeAction` in `packages/server/lib/services/action.service.ts` now owns the work: connection, provider and sync config lookups, span tags, log context creation, the orchestrator call and the usage event. It returns `{ logCtx, result }` where result is a `Result` carrying either the orchestrator value or an `ActionExecutionError` with a code.

`runAction` is the http mapping on top of that. Same signature, same status codes and bodies, so `postTriggerAction` and `postTriggerFunction` are untouched.

`connectionToolsServer` is left alone on purpose (open to change it here though). It uses a different retry count and does not publish the usage event, so folding it in is a behaviour change rather than a refactor. It can move over when the session executor lands.

Test plan:

- [x] `npm run ts-build`
- [x] `npm run test:integration -- packages/server/lib/controllers/v1/trigger/postTriggerFunction.integration.test.ts packages/server/lib/controllers/action/getAsyncActionResult.integration.test.ts`

NAN-6591


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

