### PR TITLE
feat(kvstore): sliding window rate limiter (NAN-6609)

### DIFF
--- a/packages/kvstore/lib/SlidingWindowRateLimiter.integration.test.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.integration.test.ts
@@ -1,0 +1,99 @@
+import { createClient } from 'redis';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getRedis } from './index.js';
+import { getRedisClientOptions } from './redisClient.js';
+import { RedisSlidingWindowRateLimiter } from './SlidingWindowRateLimiter.js';
+
+import type { NangoRedisClient } from './redisClient.js';
+
+describe('RedisSlidingWindowRateLimiter', () => {
+    const redisKey = (prefix: string, limit: number, windowMs: number, key: string) =>
+        `sliding-window-rate-limit:${prefix.length}:{${prefix}}:${limit}:${windowMs}:${key}`;
+    let client: NangoRedisClient;
+
+    beforeAll(async () => {
+        const url = process.env['NANGO_REDIS_URL'];
+        if (!url) {
+            throw new Error('NANGO_REDIS_URL environment variable is not set.');
+        }
+        client = await getRedis(url);
+    });
+
+    afterAll(async () => {
+        await client.flushAll();
+    });
+
+    beforeEach(async () => {
+        await client.flushAll();
+    });
+
+    it('partially admits units and derives retry delay from the oldest entry', async () => {
+        const windowMs = 500;
+        const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'partial', limit: 10, windowMs });
+
+        await expect(limiter.consume('partial', 6)).resolves.toMatchObject({ admitted: 6, rejected: 0, remaining: 4, currentUsage: 6 });
+        const limited = await limiter.consume('partial', 8);
+
+        expect(limited).toMatchObject({ admitted: 4, rejected: 4, remaining: 0, currentUsage: 10 });
+        expect(limited.retryAfterMs).toBeGreaterThan(0);
+        expect(limited.retryAfterMs).toBeLessThanOrEqual(windowMs);
+
+        await new Promise((resolve) => setTimeout(resolve, limited.retryAfterMs + 20));
+        await expect(limiter.consume('partial', 6)).resolves.toMatchObject({ admitted: 6, rejected: 0 });
+    });
+
+    it('keeps the limit across a fixed-window boundary', async () => {
+        const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'boundary', limit: 4, windowMs: 1000 });
+
+        await limiter.consume('boundary', 4);
+        await new Promise((resolve) => setTimeout(resolve, 600));
+
+        await expect(limiter.consume('boundary', 1)).resolves.toMatchObject({ admitted: 0, rejected: 1 });
+    });
+
+    it('does not exceed the limit under concurrent callers', async () => {
+        const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'concurrent', limit: 25, windowMs: 10_000 });
+        const results = await Promise.all(Array.from({ length: 100 }, () => limiter.consume('concurrent', 1)));
+
+        expect(results.reduce((total, value) => total + value.admitted, 0)).toBe(25);
+        expect(results.reduce((total, value) => total + value.rejected, 0)).toBe(75);
+        expect(await client.zCard(redisKey('concurrent', 25, 10_000, 'concurrent'))).toBe(25);
+    });
+
+    it('isolates policies that consume the same key', async () => {
+        const first = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'first', limit: 1, windowMs: 1000 });
+        const second = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'second', limit: 2, windowMs: 1000 });
+
+        await expect(first.consume('shared', 2)).resolves.toMatchObject({ admitted: 1, rejected: 1 });
+        await expect(second.consume('shared', 2)).resolves.toMatchObject({ admitted: 2, rejected: 0 });
+    });
+
+    it('expires idle keys', async () => {
+        const windowMs = 100;
+        const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'expiry', limit: 1, windowMs });
+
+        await limiter.consume('idle', 1);
+        expect(await client.exists(redisKey('expiry', 1, windowMs, 'idle'))).toBe(1);
+
+        await new Promise((resolve) => setTimeout(resolve, windowMs * 2));
+        expect(await client.exists(redisKey('expiry', 1, windowMs, 'idle'))).toBe(0);
+    });
+
+    it('fails open when Redis is unreachable', async () => {
+        const unavailableClient = createClient({
+            ...getRedisClientOptions('redis://127.0.0.1:1'),
+            socket: { reconnectStrategy: () => false, connectTimeout: 50 }
+        });
+        unavailableClient.on('error', () => undefined);
+        const limiter = new RedisSlidingWindowRateLimiter(() => unavailableClient.connect(), { keyPrefix: 'unreachable', limit: 1, windowMs: 1000 });
+
+        await expect(limiter.consume('unreachable', 5)).resolves.toEqual({
+            admitted: 5,
+            rejected: 0,
+            remaining: null,
+            currentUsage: null,
+            retryAfterMs: 0
+        });
+    });
+});

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.integration.test.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.integration.test.ts
@@ -8,9 +8,22 @@ import { RedisSlidingWindowRateLimiter } from './SlidingWindowRateLimiter.js';
 import type { NangoRedisClient } from './redisClient.js';
 
 describe('RedisSlidingWindowRateLimiter', () => {
-    const redisKey = (prefix: string, limit: number, windowMs: number, key: string) =>
-        `sliding-window-rate-limit:${prefix.length}:{${prefix}}:${limit}:${windowMs}:${key}`;
+    const testKeys = new Set<string>();
     let client: NangoRedisClient;
+
+    function redisKey(prefix: string, limit: number, windowMs: number, key: string): string {
+        const value = `sliding-window-rate-limit:${prefix.length}:{${prefix}}:${limit}:${windowMs}:${key}`;
+        testKeys.add(value);
+        return value;
+    }
+
+    async function cleanupTestKeys(): Promise<void> {
+        if (testKeys.size === 0) {
+            return;
+        }
+        await client.unlink([...testKeys]);
+        testKeys.clear();
+    }
 
     async function getRedisTimeMs(): Promise<number> {
         const [seconds, microseconds] = await client.time();
@@ -26,15 +39,16 @@ describe('RedisSlidingWindowRateLimiter', () => {
     });
 
     afterAll(async () => {
-        await client.flushAll();
+        await cleanupTestKeys();
     });
 
     beforeEach(async () => {
-        await client.flushAll();
+        await cleanupTestKeys();
     });
 
     it('partially admits units and derives retry delay from weighted usage', async () => {
         const windowMs = 1000;
+        redisKey('partial', 10, windowMs, 'partial');
         const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'partial', limit: 10, windowMs });
 
         await expect(limiter.consume('partial', 6)).resolves.toMatchObject({ admitted: 6, rejected: 0, remaining: 4, estimatedUsage: 6 });
@@ -75,15 +89,18 @@ describe('RedisSlidingWindowRateLimiter', () => {
     });
 
     it('does not exceed the limit under concurrent callers', async () => {
+        const key = redisKey('concurrent', 25, 10_000, 'concurrent');
         const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'concurrent', limit: 25, windowMs: 10_000 });
         const results = await Promise.all(Array.from({ length: 100 }, () => limiter.consume('concurrent', 1)));
 
         expect(results.reduce((total, value) => total + value.admitted, 0)).toBe(25);
         expect(results.reduce((total, value) => total + value.rejected, 0)).toBe(75);
-        expect(await client.hLen(redisKey('concurrent', 25, 10_000, 'concurrent'))).toBe(3);
+        expect(await client.hLen(key)).toBe(3);
     });
 
     it('isolates policies that consume the same key', async () => {
+        redisKey('first', 1, 1000, 'shared');
+        redisKey('second', 2, 1000, 'shared');
         const first = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'first', limit: 1, windowMs: 1000 });
         const second = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'second', limit: 2, windowMs: 1000 });
 
@@ -93,13 +110,14 @@ describe('RedisSlidingWindowRateLimiter', () => {
 
     it('expires idle keys', async () => {
         const windowMs = 100;
+        const key = redisKey('expiry', 1, windowMs, 'idle');
         const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'expiry', limit: 1, windowMs });
 
         await limiter.consume('idle', 1);
-        expect(await client.exists(redisKey('expiry', 1, windowMs, 'idle'))).toBe(1);
+        expect(await client.exists(key)).toBe(1);
 
         await new Promise((resolve) => setTimeout(resolve, windowMs * 3));
-        expect(await client.exists(redisKey('expiry', 1, windowMs, 'idle'))).toBe(0);
+        expect(await client.exists(key)).toBe(0);
     });
 
     it('fails open when Redis is unreachable', async () => {

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.integration.test.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.integration.test.ts
@@ -12,6 +12,11 @@ describe('RedisSlidingWindowRateLimiter', () => {
         `sliding-window-rate-limit:${prefix.length}:{${prefix}}:${limit}:${windowMs}:${key}`;
     let client: NangoRedisClient;
 
+    async function getRedisTimeMs(): Promise<number> {
+        const [seconds, microseconds] = await client.time();
+        return Number(seconds) * 1000 + Math.floor(Number(microseconds) / 1000);
+    }
+
     beforeAll(async () => {
         const url = process.env['NANGO_REDIS_URL'];
         if (!url) {
@@ -28,28 +33,45 @@ describe('RedisSlidingWindowRateLimiter', () => {
         await client.flushAll();
     });
 
-    it('partially admits units and derives retry delay from the oldest entry', async () => {
-        const windowMs = 500;
+    it('partially admits units and derives retry delay from weighted usage', async () => {
+        const windowMs = 1000;
         const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'partial', limit: 10, windowMs });
 
-        await expect(limiter.consume('partial', 6)).resolves.toMatchObject({ admitted: 6, rejected: 0, remaining: 4, currentUsage: 6 });
+        await expect(limiter.consume('partial', 6)).resolves.toMatchObject({ admitted: 6, rejected: 0, remaining: 4, estimatedUsage: 6 });
         const limited = await limiter.consume('partial', 8);
 
-        expect(limited).toMatchObject({ admitted: 4, rejected: 4, remaining: 0, currentUsage: 10 });
+        expect(limited).toMatchObject({ admitted: 4, rejected: 4, remaining: 0, estimatedUsage: 10 });
         expect(limited.retryAfterMs).toBeGreaterThan(0);
-        expect(limited.retryAfterMs).toBeLessThanOrEqual(windowMs);
+        expect(limited.retryAfterMs).toBeLessThanOrEqual(windowMs + Math.ceil(windowMs / 10));
 
         await new Promise((resolve) => setTimeout(resolve, limited.retryAfterMs + 20));
-        await expect(limiter.consume('partial', 6)).resolves.toMatchObject({ admitted: 6, rejected: 0 });
+        await expect(limiter.consume('partial', 1)).resolves.toMatchObject({ admitted: 1, rejected: 0 });
     });
 
     it('keeps the limit across a fixed-window boundary', async () => {
-        const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'boundary', limit: 4, windowMs: 5000 });
+        const windowMs = 5000;
+        const key = redisKey('boundary', 4, windowMs, 'boundary');
+        const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'boundary', limit: 4, windowMs });
+        let redisTimeMs: number | undefined;
 
-        await limiter.consume('boundary', 4);
-        await new Promise((resolve) => setTimeout(resolve, 3000));
+        for (let attempt = 0; attempt < 3; attempt++) {
+            const before = await getRedisTimeMs();
+            await limiter.consume('boundary', 4);
+            const after = await getRedisTimeMs();
+            if (Math.floor(before / windowMs) === Math.floor(after / windowMs)) {
+                redisTimeMs = after;
+                break;
+            }
+            await client.del(key);
+        }
+        if (redisTimeMs === undefined) {
+            throw new Error('Failed to consume within one Redis window');
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, windowMs - (redisTimeMs % windowMs) + 100));
 
         await expect(limiter.consume('boundary', 1)).resolves.toMatchObject({ admitted: 0, rejected: 1 });
+        await expect(client.hGetAll(key)).resolves.toMatchObject({ current: '0', previous: '4' });
     });
 
     it('does not exceed the limit under concurrent callers', async () => {
@@ -58,7 +80,7 @@ describe('RedisSlidingWindowRateLimiter', () => {
 
         expect(results.reduce((total, value) => total + value.admitted, 0)).toBe(25);
         expect(results.reduce((total, value) => total + value.rejected, 0)).toBe(75);
-        expect(await client.zCard(redisKey('concurrent', 25, 10_000, 'concurrent'))).toBe(25);
+        expect(await client.hLen(redisKey('concurrent', 25, 10_000, 'concurrent'))).toBe(3);
     });
 
     it('isolates policies that consume the same key', async () => {
@@ -76,7 +98,7 @@ describe('RedisSlidingWindowRateLimiter', () => {
         await limiter.consume('idle', 1);
         expect(await client.exists(redisKey('expiry', 1, windowMs, 'idle'))).toBe(1);
 
-        await new Promise((resolve) => setTimeout(resolve, windowMs * 2));
+        await new Promise((resolve) => setTimeout(resolve, windowMs * 3));
         expect(await client.exists(redisKey('expiry', 1, windowMs, 'idle'))).toBe(0);
     });
 
@@ -92,7 +114,7 @@ describe('RedisSlidingWindowRateLimiter', () => {
             admitted: 5,
             rejected: 0,
             remaining: null,
-            currentUsage: null,
+            estimatedUsage: null,
             retryAfterMs: 0
         });
     });

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.integration.test.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.integration.test.ts
@@ -44,10 +44,10 @@ describe('RedisSlidingWindowRateLimiter', () => {
     });
 
     it('keeps the limit across a fixed-window boundary', async () => {
-        const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'boundary', limit: 4, windowMs: 1000 });
+        const limiter = new RedisSlidingWindowRateLimiter(client, { keyPrefix: 'boundary', limit: 4, windowMs: 5000 });
 
         await limiter.consume('boundary', 4);
-        await new Promise((resolve) => setTimeout(resolve, 600));
+        await new Promise((resolve) => setTimeout(resolve, 3000));
 
         await expect(limiter.consume('boundary', 1)).resolves.toMatchObject({ admitted: 0, rejected: 1 });
     });

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.ts
@@ -42,9 +42,11 @@ local requested = tonumber(ARGV[3])
 local redis_time = redis.call('TIME')
 local now_ms = tonumber(redis_time[1]) * 1000 + math.floor(tonumber(redis_time[2]) / 1000)
 local window_index = math.floor(now_ms / window_ms)
-local stored_index = tonumber(redis.call('HGET', KEYS[1], 'index'))
-local current = tonumber(redis.call('HGET', KEYS[1], 'current')) or 0
-local previous = tonumber(redis.call('HGET', KEYS[1], 'previous')) or 0
+local state = redis.call('HMGET', KEYS[1], 'index', 'current', 'previous')
+local stored_index = tonumber(state[1])
+local current = tonumber(state[2]) or 0
+local previous = tonumber(state[3]) or 0
+local needs_expire = stored_index ~= window_index
 
 if stored_index == nil or window_index < stored_index or window_index > stored_index + 1 then
   current = 0
@@ -64,30 +66,11 @@ current = current + admitted
 estimated_numerator = estimated_numerator + admitted * window_ms
 
 redis.call('HSET', KEYS[1], 'index', window_index, 'current', current, 'previous', previous)
-redis.call('PEXPIRE', KEYS[1], window_ms * 2)
-
-local retry_after_ms = 0
-if admitted < requested then
-  local needed_numerator = estimated_numerator - (limit - 1) * window_ms
-  if previous > 0 then
-    local decay_delay_ms = math.ceil(needed_numerator / previous)
-    if decay_delay_ms <= remaining_window_ms then
-      retry_after_ms = math.max(1, decay_delay_ms)
-    end
-  end
-
-  if retry_after_ms == 0 then
-    if current < limit then
-      retry_after_ms = math.max(1, remaining_window_ms)
-    elseif current > 0 then
-      local next_window_delay_ms = math.ceil((current - limit + 1) * window_ms / current)
-      retry_after_ms = math.max(1, remaining_window_ms + next_window_delay_ms)
-    end
-  end
+if needs_expire then
+  redis.call('PEXPIRE', KEYS[1], window_ms * 2)
 end
 
-local estimated_usage = math.ceil(estimated_numerator / window_ms)
-return { admitted, estimated_usage, retry_after_ms }
+return { admitted, estimated_numerator, remaining_window_ms, current, previous }
 `;
 
 function validateOptions(options: SlidingWindowRateLimiterOptions): void {
@@ -130,14 +113,6 @@ function result(requested: number, admitted: number, estimatedUsage: number | nu
     };
 }
 
-function recordUsage(estimatedUsage: number): void {
-    try {
-        metrics.distribution(metrics.Types.KVSTORE_SLIDING_WINDOW_USAGE, estimatedUsage);
-    } catch (err) {
-        logger.error('Failed to record sliding window rate limiter usage.', { error: err });
-    }
-}
-
 function rotateWindow(window: InMemoryWindow | undefined, windowIndex: number, expiresAt: number): InMemoryWindow {
     if (!window || windowIndex < window.index || windowIndex > window.index + 1) {
         return { index: windowIndex, current: 0, previous: 0, expiresAt };
@@ -175,14 +150,6 @@ function getRetryAfterMs({
         return Math.max(1, remainingWindowMs);
     }
     return Math.max(1, remainingWindowMs + Math.ceil(((current - limit + 1) * windowMs) / current));
-}
-
-function recordFailOpen(): void {
-    try {
-        metrics.increment(metrics.Types.KVSTORE_SLIDING_WINDOW_FAIL_OPEN);
-    } catch (err) {
-        logger.error('Failed to record sliding window rate limiter fail-open.', { error: err });
-    }
 }
 
 export class InMemorySlidingWindowRateLimiter implements SlidingWindowRateLimiter {
@@ -227,7 +194,7 @@ export class InMemorySlidingWindowRateLimiter implements SlidingWindowRateLimite
                   })
                 : 0;
 
-        recordUsage(estimatedUsage);
+        metrics.distribution(metrics.Types.KVSTORE_SLIDING_WINDOW_USAGE, estimatedUsage);
         return Promise.resolve(result(units, admitted, estimatedUsage, this.options.limit, retryAfterMs));
     }
 
@@ -259,6 +226,8 @@ export class RedisSlidingWindowRateLimiter implements SlidingWindowRateLimiter {
     public async consume(key: string, units: number): Promise<SlidingWindowRateLimitResult> {
         validateConsume(key, units);
 
+        let estimatedUsage: number;
+        let rateLimitResult: SlidingWindowRateLimitResult;
         try {
             const client = typeof this.client === 'function' ? await this.client() : this.client;
             const response = await client.eval(CONSUME_SLIDING_WINDOW, {
@@ -267,24 +236,41 @@ export class RedisSlidingWindowRateLimiter implements SlidingWindowRateLimiter {
                 ],
                 arguments: [String(this.options.limit), String(this.options.windowMs), String(units)]
             });
-            if (!Array.isArray(response) || response.length !== 3) {
+            if (!Array.isArray(response) || response.length !== 5) {
                 throw new Error('Unexpected Redis sliding window response');
             }
 
             const admitted = Number(response[0]);
-            const estimatedUsage = Number(response[1]);
-            const retryAfterMs = Number(response[2]);
-            if (![admitted, estimatedUsage, retryAfterMs].every(Number.isSafeInteger)) {
+            const estimatedNumerator = Number(response[1]);
+            const remainingWindowMs = Number(response[2]);
+            const current = Number(response[3]);
+            const previous = Number(response[4]);
+            if (![admitted, estimatedNumerator, remainingWindowMs, current, previous].every(Number.isSafeInteger)) {
                 throw new Error('Invalid Redis sliding window response');
             }
 
-            recordUsage(estimatedUsage);
-            return result(units, admitted, estimatedUsage, this.options.limit, retryAfterMs);
+            estimatedUsage = Math.ceil(estimatedNumerator / this.options.windowMs);
+            const retryAfterMs =
+                admitted < units
+                    ? getRetryAfterMs({
+                          limit: this.options.limit,
+                          windowMs: this.options.windowMs,
+                          remainingWindowMs,
+                          current,
+                          previous,
+                          estimatedNumerator
+                      })
+                    : 0;
+
+            rateLimitResult = result(units, admitted, estimatedUsage, this.options.limit, retryAfterMs);
         } catch (err) {
             logger.error('Redis sliding window rate limiter failed. Admitting all requested units.', { error: err });
-            recordFailOpen();
+            metrics.increment(metrics.Types.KVSTORE_SLIDING_WINDOW_FAIL_OPEN);
             return result(units, units, null, this.options.limit);
         }
+
+        metrics.distribution(metrics.Types.KVSTORE_SLIDING_WINDOW_USAGE, estimatedUsage);
+        return rateLimitResult;
     }
 
     public async destroy(): Promise<void> {

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from 'node:crypto';
+
+import { getLogger, metrics } from '@nangohq/utils';
+
+import type { NangoRedisClient } from './redisClient.js';
+
+export interface SlidingWindowRateLimiterOptions {
+    keyPrefix: string;
+    limit: number;
+    windowMs: number;
+}
+
+export interface SlidingWindowRateLimitResult {
+    admitted: number;
+    rejected: number;
+    remaining: number | null;
+    currentUsage: number | null;
+    retryAfterMs: number;
+}
+
+export interface SlidingWindowRateLimiter {
+    consume(key: string, units: number): Promise<SlidingWindowRateLimitResult>;
+    destroy(): Promise<void>;
+}
+
+interface InMemoryWindow {
+    timestamps: number[];
+    expiresAt: number;
+}
+
+const logger = getLogger('kvstore.slidingWindowRateLimiter');
+const REDIS_KEY_PREFIX = 'sliding-window-rate-limit';
+
+const CONSUME_SLIDING_WINDOW = `
+local limit = tonumber(ARGV[1])
+local window_ms = tonumber(ARGV[2])
+local requested = tonumber(ARGV[3])
+local member_prefix = ARGV[4]
+
+local redis_time = redis.call('TIME')
+local now_ms = tonumber(redis_time[1]) * 1000 + math.floor(tonumber(redis_time[2]) / 1000)
+local cutoff = now_ms - window_ms
+
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', cutoff)
+
+local current = redis.call('ZCARD', KEYS[1])
+local available = math.max(0, limit - current)
+local admitted = math.min(requested, available)
+
+for i = 1, admitted do
+  redis.call('ZADD', KEYS[1], now_ms, member_prefix .. ':' .. i)
+end
+
+current = current + admitted
+redis.call('PEXPIRE', KEYS[1], window_ms)
+
+local retry_after_ms = 0
+if admitted < requested then
+  local oldest = redis.call('ZRANGE', KEYS[1], 0, 0, 'WITHSCORES')
+  if #oldest > 0 then
+    retry_after_ms = math.max(1, tonumber(oldest[2]) + window_ms - now_ms)
+  end
+end
+
+return { admitted, current, retry_after_ms }
+`;
+
+function validateOptions(options: SlidingWindowRateLimiterOptions): void {
+    if (options.keyPrefix.length === 0) {
+        throw new Error('keyPrefix must not be empty');
+    }
+    if (options.keyPrefix.includes('{') || options.keyPrefix.includes('}')) {
+        throw new Error('keyPrefix must not contain braces');
+    }
+    validatePositiveInteger(options.limit, 'limit');
+    validatePositiveInteger(options.windowMs, 'windowMs');
+}
+
+function validateConsume(key: string, units: number): void {
+    if (key.length === 0) {
+        throw new Error('key must not be empty');
+    }
+    validatePositiveInteger(units, 'units');
+}
+
+function validatePositiveInteger(value: number, name: string): void {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new Error(`${name} must be a positive safe integer`);
+    }
+}
+
+function result(requested: number, admitted: number, currentUsage: number | null, limit: number, retryAfterMs = 0): SlidingWindowRateLimitResult {
+    return {
+        admitted,
+        rejected: requested - admitted,
+        remaining: currentUsage === null ? null : Math.max(0, limit - currentUsage),
+        currentUsage,
+        retryAfterMs
+    };
+}
+
+function recordCardinality(currentUsage: number): void {
+    try {
+        metrics.distribution(metrics.Types.KVSTORE_SLIDING_WINDOW_CARDINALITY, currentUsage);
+    } catch (err) {
+        logger.error('Failed to record sliding window rate limiter cardinality.', { error: err });
+    }
+}
+
+function recordFailOpen(): void {
+    try {
+        metrics.increment(metrics.Types.KVSTORE_SLIDING_WINDOW_FAIL_OPEN);
+    } catch (err) {
+        logger.error('Failed to record sliding window rate limiter fail-open.', { error: err });
+    }
+}
+
+export class InMemorySlidingWindowRateLimiter implements SlidingWindowRateLimiter {
+    private readonly windows = new Map<string, InMemoryWindow>();
+    private readonly cleanupTimer: NodeJS.Timeout;
+
+    constructor(private readonly options: SlidingWindowRateLimiterOptions) {
+        validateOptions(options);
+        this.cleanupTimer = setInterval(() => this.clearExpired(), Math.min(options.windowMs, 10_000));
+        this.cleanupTimer.unref();
+    }
+
+    public consume(key: string, units: number): Promise<SlidingWindowRateLimitResult> {
+        try {
+            validateConsume(key, units);
+        } catch (err) {
+            return Promise.reject(err);
+        }
+
+        const now = Date.now();
+        const cutoff = now - this.options.windowMs;
+        const window = this.windows.get(key);
+        const timestamps = window?.timestamps.filter((timestamp) => timestamp > cutoff) ?? [];
+        const admitted = Math.min(units, Math.max(0, this.options.limit - timestamps.length));
+
+        for (let i = 0; i < admitted; i++) {
+            timestamps.push(now);
+        }
+
+        const currentUsage = timestamps.length;
+        this.windows.set(key, { timestamps, expiresAt: now + this.options.windowMs });
+        const retryAfterMs = admitted < units && timestamps[0] !== undefined ? Math.max(1, timestamps[0] + this.options.windowMs - now) : 0;
+
+        recordCardinality(currentUsage);
+        return Promise.resolve(result(units, admitted, currentUsage, this.options.limit, retryAfterMs));
+    }
+
+    public destroy(): Promise<void> {
+        clearInterval(this.cleanupTimer);
+        this.windows.clear();
+        return Promise.resolve();
+    }
+
+    private clearExpired(): void {
+        const now = Date.now();
+        for (const [key, window] of this.windows) {
+            if (window.expiresAt <= now) {
+                this.windows.delete(key);
+            }
+        }
+    }
+}
+
+export class RedisSlidingWindowRateLimiter implements SlidingWindowRateLimiter {
+    constructor(
+        private readonly client: NangoRedisClient | (() => Promise<NangoRedisClient>),
+        private readonly options: SlidingWindowRateLimiterOptions,
+        private readonly destroyClient?: () => Promise<void>
+    ) {
+        validateOptions(options);
+    }
+
+    public async consume(key: string, units: number): Promise<SlidingWindowRateLimitResult> {
+        validateConsume(key, units);
+
+        try {
+            const client = typeof this.client === 'function' ? await this.client() : this.client;
+            const response = await client.eval(CONSUME_SLIDING_WINDOW, {
+                keys: [
+                    `${REDIS_KEY_PREFIX}:${this.options.keyPrefix.length}:{${this.options.keyPrefix}}:${this.options.limit}:${this.options.windowMs}:${key}`
+                ],
+                arguments: [String(this.options.limit), String(this.options.windowMs), String(units), randomUUID()]
+            });
+            if (!Array.isArray(response) || response.length !== 3) {
+                throw new Error('Unexpected Redis sliding window response');
+            }
+
+            const admitted = Number(response[0]);
+            const currentUsage = Number(response[1]);
+            const retryAfterMs = Number(response[2]);
+            if (![admitted, currentUsage, retryAfterMs].every(Number.isSafeInteger)) {
+                throw new Error('Invalid Redis sliding window response');
+            }
+
+            recordCardinality(currentUsage);
+            return result(units, admitted, currentUsage, this.options.limit, retryAfterMs);
+        } catch (err) {
+            logger.error('Redis sliding window rate limiter failed. Admitting all requested units.', { error: err });
+            recordFailOpen();
+            return result(units, units, null, this.options.limit);
+        }
+    }
+
+    public async destroy(): Promise<void> {
+        await this.destroyClient?.();
+    }
+}

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { getLogger, metrics } from '@nangohq/utils';
 
 import type { NangoRedisClient } from './redisClient.js';
@@ -14,7 +12,8 @@ export interface SlidingWindowRateLimitResult {
     admitted: number;
     rejected: number;
     remaining: number | null;
-    currentUsage: number | null;
+    estimatedUsage: number | null;
+    /** Approximate delay until the weighted estimate has room for one unit. */
     retryAfterMs: number;
 }
 
@@ -24,45 +23,71 @@ export interface SlidingWindowRateLimiter {
 }
 
 interface InMemoryWindow {
-    timestamps: number[];
+    index: number;
+    current: number;
+    previous: number;
     expiresAt: number;
 }
 
 const logger = getLogger('kvstore.slidingWindowRateLimiter');
 const REDIS_KEY_PREFIX = 'sliding-window-rate-limit';
 
+// Approximate the rolling window by weighting the previous fixed-window count
+// by the fraction of the current window that remains.
 const CONSUME_SLIDING_WINDOW = `
 local limit = tonumber(ARGV[1])
 local window_ms = tonumber(ARGV[2])
 local requested = tonumber(ARGV[3])
-local member_prefix = ARGV[4]
 
 local redis_time = redis.call('TIME')
 local now_ms = tonumber(redis_time[1]) * 1000 + math.floor(tonumber(redis_time[2]) / 1000)
-local cutoff = now_ms - window_ms
+local window_index = math.floor(now_ms / window_ms)
+local stored_index = tonumber(redis.call('HGET', KEYS[1], 'index'))
+local current = tonumber(redis.call('HGET', KEYS[1], 'current')) or 0
+local previous = tonumber(redis.call('HGET', KEYS[1], 'previous')) or 0
 
-redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', cutoff)
-
-local current = redis.call('ZCARD', KEYS[1])
-local available = math.max(0, limit - current)
-local admitted = math.min(requested, available)
-
-for i = 1, admitted do
-  redis.call('ZADD', KEYS[1], now_ms, member_prefix .. ':' .. i)
+if stored_index == nil or window_index < stored_index or window_index > stored_index + 1 then
+  current = 0
+  previous = 0
+elseif window_index == stored_index + 1 then
+  previous = current
+  current = 0
 end
 
+local elapsed_ms = now_ms - window_index * window_ms
+local remaining_window_ms = window_ms - elapsed_ms
+local estimated_numerator = previous * remaining_window_ms + current * window_ms
+local available = math.max(0, math.floor((limit * window_ms - estimated_numerator) / window_ms))
+local admitted = math.min(requested, available)
+
 current = current + admitted
-redis.call('PEXPIRE', KEYS[1], window_ms)
+estimated_numerator = estimated_numerator + admitted * window_ms
+
+redis.call('HSET', KEYS[1], 'index', window_index, 'current', current, 'previous', previous)
+redis.call('PEXPIRE', KEYS[1], window_ms * 2)
 
 local retry_after_ms = 0
 if admitted < requested then
-  local oldest = redis.call('ZRANGE', KEYS[1], 0, 0, 'WITHSCORES')
-  if #oldest > 0 then
-    retry_after_ms = math.max(1, tonumber(oldest[2]) + window_ms - now_ms)
+  local needed_numerator = estimated_numerator - (limit - 1) * window_ms
+  if previous > 0 then
+    local decay_delay_ms = math.ceil(needed_numerator / previous)
+    if decay_delay_ms <= remaining_window_ms then
+      retry_after_ms = math.max(1, decay_delay_ms)
+    end
+  end
+
+  if retry_after_ms == 0 then
+    if current < limit then
+      retry_after_ms = math.max(1, remaining_window_ms)
+    elseif current > 0 then
+      local next_window_delay_ms = math.ceil((current - limit + 1) * window_ms / current)
+      retry_after_ms = math.max(1, remaining_window_ms + next_window_delay_ms)
+    end
   end
 end
 
-return { admitted, current, retry_after_ms }
+local estimated_usage = math.ceil(estimated_numerator / window_ms)
+return { admitted, estimated_usage, retry_after_ms }
 `;
 
 function validateOptions(options: SlidingWindowRateLimiterOptions): void {
@@ -74,6 +99,12 @@ function validateOptions(options: SlidingWindowRateLimiterOptions): void {
     }
     validatePositiveInteger(options.limit, 'limit');
     validatePositiveInteger(options.windowMs, 'windowMs');
+    if (!Number.isSafeInteger(options.limit * options.windowMs)) {
+        throw new Error('limit multiplied by windowMs must be a safe integer');
+    }
+    if (!Number.isSafeInteger(options.windowMs * 2)) {
+        throw new Error('windowMs multiplied by 2 must be a safe integer');
+    }
 }
 
 function validateConsume(key: string, units: number): void {
@@ -89,22 +120,61 @@ function validatePositiveInteger(value: number, name: string): void {
     }
 }
 
-function result(requested: number, admitted: number, currentUsage: number | null, limit: number, retryAfterMs = 0): SlidingWindowRateLimitResult {
+function result(requested: number, admitted: number, estimatedUsage: number | null, limit: number, retryAfterMs = 0): SlidingWindowRateLimitResult {
     return {
         admitted,
         rejected: requested - admitted,
-        remaining: currentUsage === null ? null : Math.max(0, limit - currentUsage),
-        currentUsage,
+        remaining: estimatedUsage === null ? null : Math.max(0, limit - estimatedUsage),
+        estimatedUsage,
         retryAfterMs
     };
 }
 
-function recordCardinality(currentUsage: number): void {
+function recordUsage(estimatedUsage: number): void {
     try {
-        metrics.distribution(metrics.Types.KVSTORE_SLIDING_WINDOW_CARDINALITY, currentUsage);
+        metrics.distribution(metrics.Types.KVSTORE_SLIDING_WINDOW_USAGE, estimatedUsage);
     } catch (err) {
-        logger.error('Failed to record sliding window rate limiter cardinality.', { error: err });
+        logger.error('Failed to record sliding window rate limiter usage.', { error: err });
     }
+}
+
+function rotateWindow(window: InMemoryWindow | undefined, windowIndex: number, expiresAt: number): InMemoryWindow {
+    if (!window || windowIndex < window.index || windowIndex > window.index + 1) {
+        return { index: windowIndex, current: 0, previous: 0, expiresAt };
+    }
+    if (windowIndex === window.index + 1) {
+        return { index: windowIndex, current: 0, previous: window.current, expiresAt };
+    }
+    return { ...window, expiresAt };
+}
+
+function getRetryAfterMs({
+    limit,
+    windowMs,
+    remainingWindowMs,
+    current,
+    previous,
+    estimatedNumerator
+}: {
+    limit: number;
+    windowMs: number;
+    remainingWindowMs: number;
+    current: number;
+    previous: number;
+    estimatedNumerator: number;
+}): number {
+    const neededNumerator = estimatedNumerator - (limit - 1) * windowMs;
+    if (previous > 0) {
+        const decayDelayMs = Math.ceil(neededNumerator / previous);
+        if (decayDelayMs <= remainingWindowMs) {
+            return Math.max(1, decayDelayMs);
+        }
+    }
+
+    if (current < limit) {
+        return Math.max(1, remainingWindowMs);
+    }
+    return Math.max(1, remainingWindowMs + Math.ceil(((current - limit + 1) * windowMs) / current));
 }
 
 function recordFailOpen(): void {
@@ -133,21 +203,32 @@ export class InMemorySlidingWindowRateLimiter implements SlidingWindowRateLimite
         }
 
         const now = Date.now();
-        const cutoff = now - this.options.windowMs;
-        const window = this.windows.get(key);
-        const timestamps = window?.timestamps.filter((timestamp) => timestamp > cutoff) ?? [];
-        const admitted = Math.min(units, Math.max(0, this.options.limit - timestamps.length));
+        const windowIndex = Math.floor(now / this.options.windowMs);
+        const remainingWindowMs = this.options.windowMs - (now - windowIndex * this.options.windowMs);
+        const window = rotateWindow(this.windows.get(key), windowIndex, now + this.options.windowMs * 2);
+        let estimatedNumerator = window.previous * remainingWindowMs + window.current * this.options.windowMs;
+        const available = Math.max(0, Math.floor((this.options.limit * this.options.windowMs - estimatedNumerator) / this.options.windowMs));
+        const admitted = Math.min(units, available);
 
-        for (let i = 0; i < admitted; i++) {
-            timestamps.push(now);
-        }
+        window.current += admitted;
+        estimatedNumerator += admitted * this.options.windowMs;
+        this.windows.set(key, window);
 
-        const currentUsage = timestamps.length;
-        this.windows.set(key, { timestamps, expiresAt: now + this.options.windowMs });
-        const retryAfterMs = admitted < units && timestamps[0] !== undefined ? Math.max(1, timestamps[0] + this.options.windowMs - now) : 0;
+        const estimatedUsage = Math.ceil(estimatedNumerator / this.options.windowMs);
+        const retryAfterMs =
+            admitted < units
+                ? getRetryAfterMs({
+                      limit: this.options.limit,
+                      windowMs: this.options.windowMs,
+                      remainingWindowMs,
+                      current: window.current,
+                      previous: window.previous,
+                      estimatedNumerator
+                  })
+                : 0;
 
-        recordCardinality(currentUsage);
-        return Promise.resolve(result(units, admitted, currentUsage, this.options.limit, retryAfterMs));
+        recordUsage(estimatedUsage);
+        return Promise.resolve(result(units, admitted, estimatedUsage, this.options.limit, retryAfterMs));
     }
 
     public destroy(): Promise<void> {
@@ -184,21 +265,21 @@ export class RedisSlidingWindowRateLimiter implements SlidingWindowRateLimiter {
                 keys: [
                     `${REDIS_KEY_PREFIX}:${this.options.keyPrefix.length}:{${this.options.keyPrefix}}:${this.options.limit}:${this.options.windowMs}:${key}`
                 ],
-                arguments: [String(this.options.limit), String(this.options.windowMs), String(units), randomUUID()]
+                arguments: [String(this.options.limit), String(this.options.windowMs), String(units)]
             });
             if (!Array.isArray(response) || response.length !== 3) {
                 throw new Error('Unexpected Redis sliding window response');
             }
 
             const admitted = Number(response[0]);
-            const currentUsage = Number(response[1]);
+            const estimatedUsage = Number(response[1]);
             const retryAfterMs = Number(response[2]);
-            if (![admitted, currentUsage, retryAfterMs].every(Number.isSafeInteger)) {
+            if (![admitted, estimatedUsage, retryAfterMs].every(Number.isSafeInteger)) {
                 throw new Error('Invalid Redis sliding window response');
             }
 
-            recordCardinality(currentUsage);
-            return result(units, admitted, currentUsage, this.options.limit, retryAfterMs);
+            recordUsage(estimatedUsage);
+            return result(units, admitted, estimatedUsage, this.options.limit, retryAfterMs);
         } catch (err) {
             logger.error('Redis sliding window rate limiter failed. Admitting all requested units.', { error: err });
             recordFailOpen();

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.unit.test.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.unit.test.ts
@@ -75,7 +75,7 @@ describe('InMemorySlidingWindowRateLimiter', () => {
         await expect(limiter.consume('key', 2)).resolves.toMatchObject({ admitted: 2, rejected: 0, retryAfterMs: 0 });
     });
 
-    it('does not exceed the limit under concurrent callers', async () => {
+    it('caps aggregate admitted units across many callers', async () => {
         const results = await Promise.all(Array.from({ length: 20 }, () => limiter.consume('key', 1)));
 
         expect(results.reduce((total, value) => total + value.admitted, 0)).toBe(10);

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.unit.test.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.unit.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InMemorySlidingWindowRateLimiter } from './SlidingWindowRateLimiter.js';
+
+describe('InMemorySlidingWindowRateLimiter', () => {
+    let limiter: InMemorySlidingWindowRateLimiter;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+        limiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: 10, windowMs: 1000 });
+    });
+
+    afterEach(async () => {
+        await limiter.destroy();
+        vi.useRealTimers();
+    });
+
+    it('partially admits units when the window has limited room', async () => {
+        await expect(limiter.consume('key', 6)).resolves.toEqual({
+            admitted: 6,
+            rejected: 0,
+            remaining: 4,
+            currentUsage: 6,
+            retryAfterMs: 0
+        });
+        await expect(limiter.consume('key', 8)).resolves.toEqual({
+            admitted: 4,
+            rejected: 4,
+            remaining: 0,
+            currentUsage: 10,
+            retryAfterMs: 1000
+        });
+    });
+
+    it('keeps the limit across a fixed-window boundary', async () => {
+        await limiter.destroy();
+        limiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: 4, windowMs: 1000 });
+
+        await limiter.consume('key', 4);
+        vi.advanceTimersByTime(600);
+
+        await expect(limiter.consume('key', 1)).resolves.toMatchObject({ admitted: 0, rejected: 1, retryAfterMs: 400 });
+    });
+
+    it('only releases entries that have left the rolling window', async () => {
+        await limiter.destroy();
+        limiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: 4, windowMs: 1000 });
+
+        await limiter.consume('key', 2);
+        vi.advanceTimersByTime(600);
+        await limiter.consume('key', 2);
+        vi.advanceTimersByTime(401);
+
+        await expect(limiter.consume('key', 3)).resolves.toEqual({
+            admitted: 2,
+            rejected: 1,
+            remaining: 0,
+            currentUsage: 4,
+            retryAfterMs: 599
+        });
+    });
+
+    it('derives retry delay from the oldest entry', async () => {
+        await limiter.destroy();
+        limiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: 3, windowMs: 1000 });
+
+        await limiter.consume('key', 2);
+        vi.advanceTimersByTime(500);
+
+        await expect(limiter.consume('key', 2)).resolves.toMatchObject({ admitted: 1, rejected: 1, retryAfterMs: 500 });
+        vi.advanceTimersByTime(499);
+        await expect(limiter.consume('key', 1)).resolves.toMatchObject({ admitted: 0, rejected: 1, retryAfterMs: 1 });
+        vi.advanceTimersByTime(1);
+        await expect(limiter.consume('key', 2)).resolves.toMatchObject({ admitted: 2, rejected: 0, retryAfterMs: 0 });
+    });
+
+    it('does not exceed the limit under concurrent callers', async () => {
+        const results = await Promise.all(Array.from({ length: 20 }, () => limiter.consume('key', 1)));
+
+        expect(results.reduce((total, value) => total + value.admitted, 0)).toBe(10);
+        expect(results.reduce((total, value) => total + value.rejected, 0)).toBe(10);
+    });
+
+    it('isolates keys', async () => {
+        await limiter.consume('first', 10);
+
+        await expect(limiter.consume('second', 10)).resolves.toMatchObject({ admitted: 10, rejected: 0 });
+    });
+
+    it.each([
+        ['', 1, 'key must not be empty'],
+        ['key', 0, 'units must be a positive safe integer'],
+        ['key', 1.5, 'units must be a positive safe integer']
+    ])('rejects invalid consumption arguments', async (key, units, message) => {
+        await expect(limiter.consume(key, units)).rejects.toThrow(message);
+    });
+
+    it.each([
+        [{ keyPrefix: '', limit: 10, windowMs: 1000 }, 'keyPrefix must not be empty'],
+        [{ keyPrefix: '{test}', limit: 10, windowMs: 1000 }, 'keyPrefix must not contain braces'],
+        [{ keyPrefix: 'test', limit: 0, windowMs: 1000 }, 'limit must be a positive safe integer'],
+        [{ keyPrefix: 'test', limit: 10, windowMs: 0 }, 'windowMs must be a positive safe integer']
+    ])('rejects invalid options', (options, message) => {
+        expect(() => new InMemorySlidingWindowRateLimiter(options)).toThrow(message);
+    });
+});

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.unit.test.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.unit.test.ts
@@ -21,58 +21,56 @@ describe('InMemorySlidingWindowRateLimiter', () => {
             admitted: 6,
             rejected: 0,
             remaining: 4,
-            currentUsage: 6,
+            estimatedUsage: 6,
             retryAfterMs: 0
         });
         await expect(limiter.consume('key', 8)).resolves.toEqual({
             admitted: 4,
             rejected: 4,
             remaining: 0,
-            currentUsage: 10,
-            retryAfterMs: 1000
+            estimatedUsage: 10,
+            retryAfterMs: 1100
         });
     });
 
-    it('keeps the limit across a fixed-window boundary', async () => {
+    it('does not reset usage at a fixed-window boundary', async () => {
         await limiter.destroy();
         limiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: 4, windowMs: 1000 });
 
         await limiter.consume('key', 4);
-        vi.advanceTimersByTime(600);
+        vi.advanceTimersByTime(1001);
 
-        await expect(limiter.consume('key', 1)).resolves.toMatchObject({ admitted: 0, rejected: 1, retryAfterMs: 400 });
+        await expect(limiter.consume('key', 1)).resolves.toMatchObject({ admitted: 0, rejected: 1, retryAfterMs: 249 });
     });
 
-    it('only releases entries that have left the rolling window', async () => {
+    it('partially admits as weighted usage decays', async () => {
         await limiter.destroy();
         limiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: 4, windowMs: 1000 });
 
-        await limiter.consume('key', 2);
-        vi.advanceTimersByTime(600);
-        await limiter.consume('key', 2);
-        vi.advanceTimersByTime(401);
+        await limiter.consume('key', 4);
+        vi.advanceTimersByTime(1250);
 
         await expect(limiter.consume('key', 3)).resolves.toEqual({
-            admitted: 2,
-            rejected: 1,
+            admitted: 1,
+            rejected: 2,
             remaining: 0,
-            currentUsage: 4,
-            retryAfterMs: 599
+            estimatedUsage: 4,
+            retryAfterMs: 250
         });
     });
 
-    it('derives retry delay from the oldest entry', async () => {
+    it('derives retry delay from weighted usage decay', async () => {
         await limiter.destroy();
         limiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: 3, windowMs: 1000 });
 
-        await limiter.consume('key', 2);
-        vi.advanceTimersByTime(500);
+        await limiter.consume('key', 3);
+        vi.advanceTimersByTime(1001);
 
-        await expect(limiter.consume('key', 2)).resolves.toMatchObject({ admitted: 1, rejected: 1, retryAfterMs: 500 });
-        vi.advanceTimersByTime(499);
+        await expect(limiter.consume('key', 1)).resolves.toMatchObject({ admitted: 0, rejected: 1, retryAfterMs: 333 });
+        vi.advanceTimersByTime(332);
         await expect(limiter.consume('key', 1)).resolves.toMatchObject({ admitted: 0, rejected: 1, retryAfterMs: 1 });
         vi.advanceTimersByTime(1);
-        await expect(limiter.consume('key', 2)).resolves.toMatchObject({ admitted: 2, rejected: 0, retryAfterMs: 0 });
+        await expect(limiter.consume('key', 1)).resolves.toMatchObject({ admitted: 1, rejected: 0, retryAfterMs: 0 });
     });
 
     it('caps aggregate admitted units across many callers', async () => {
@@ -100,7 +98,9 @@ describe('InMemorySlidingWindowRateLimiter', () => {
         [{ keyPrefix: '', limit: 10, windowMs: 1000 }, 'keyPrefix must not be empty'],
         [{ keyPrefix: '{test}', limit: 10, windowMs: 1000 }, 'keyPrefix must not contain braces'],
         [{ keyPrefix: 'test', limit: 0, windowMs: 1000 }, 'limit must be a positive safe integer'],
-        [{ keyPrefix: 'test', limit: 10, windowMs: 0 }, 'windowMs must be a positive safe integer']
+        [{ keyPrefix: 'test', limit: 10, windowMs: 0 }, 'windowMs must be a positive safe integer'],
+        [{ keyPrefix: 'test', limit: 10_000_000_000, windowMs: 1_000_000 }, 'limit multiplied by windowMs must be a safe integer'],
+        [{ keyPrefix: 'test', limit: 1, windowMs: 4_503_599_627_370_496 }, 'windowMs multiplied by 2 must be a safe integer']
     ])('rejects invalid options', (options, message) => {
         expect(() => new InMemorySlidingWindowRateLimiter(options)).toThrow(message);
     });

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -25,6 +25,9 @@ export {
 
 type KvBoundary = RedisBoundary;
 
+const RATE_LIMITER_REDIS_CONNECT_TIMEOUT_MS = 1000;
+const RATE_LIMITER_REDIS_RETRY_DELAY_MS = 5000;
+
 const mapRedis = new Map<string, NangoRedisClient>();
 
 function redisClientCacheKey(url: string, boundary: RedisBoundary): string {
@@ -56,33 +59,56 @@ export function createSlidingWindowRateLimiter(options: SlidingWindowRateLimiter
 
         let client: NangoRedisClient | undefined;
         let connection: Promise<NangoRedisClient> | undefined;
+        let retryAt = 0;
+        let destroyed = false;
 
         const getClient = async (): Promise<NangoRedisClient> => {
+            if (destroyed) {
+                throw new Error('Sliding window rate limiter has been destroyed');
+            }
             if (client?.isReady) {
                 return client;
             }
             if (connection) {
                 return await connection;
             }
+            if (Date.now() < retryAt) {
+                throw new Error('Redis sliding window rate limiter connection is cooling down');
+            }
 
-            const redisOptions = getRedisClientOptions(url);
-            const redis = createClient({
-                ...redisOptions,
-                socket: {
-                    ...redisOptions.socket,
-                    reconnectStrategy: () => false,
-                    connectTimeout: 1000
+            connection = (async () => {
+                const staleClient = client;
+                client = undefined;
+                if (staleClient?.isOpen) {
+                    await staleClient.disconnect();
                 }
-            });
-            redis.on('error', (err: Error) => {
-                console.error(`Redis (sliding-window-rate-limiter) error: ${err}`);
-            });
 
-            connection = redis
-                .connect()
-                .then((connected) => {
-                    client = connected;
-                    return connected;
+                const redisOptions = getRedisClientOptions(url);
+                const redis = createClient({
+                    ...redisOptions,
+                    socket: {
+                        ...redisOptions.socket,
+                        reconnectStrategy: () => false,
+                        connectTimeout: RATE_LIMITER_REDIS_CONNECT_TIMEOUT_MS
+                    }
+                });
+                redis.on('error', (err: Error) => {
+                    console.error(`Redis (sliding-window-rate-limiter) error: ${err}`);
+                });
+
+                const connected = await redis.connect();
+                if (destroyed) {
+                    await connected.disconnect();
+                    throw new Error('Sliding window rate limiter was destroyed while connecting');
+                }
+
+                client = connected;
+                retryAt = 0;
+                return connected;
+            })()
+                .catch((err: unknown) => {
+                    retryAt = Date.now() + RATE_LIMITER_REDIS_RETRY_DELAY_MS;
+                    throw err;
                 })
                 .finally(() => {
                     connection = undefined;
@@ -91,9 +117,15 @@ export function createSlidingWindowRateLimiter(options: SlidingWindowRateLimiter
         };
 
         const destroyClient = async (): Promise<void> => {
-            const connected = client ?? (await connection?.catch(() => undefined));
-            if (connected?.isOpen) {
-                await connected.disconnect();
+            destroyed = true;
+            const activeClient = client;
+            client = undefined;
+            const connectingClient = await connection?.catch(() => undefined);
+
+            for (const connected of new Set([activeClient, connectingClient])) {
+                if (connected?.isOpen) {
+                    await connected.disconnect();
+                }
             }
         };
 

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -4,20 +4,27 @@ import { InMemoryKVStore } from './InMemoryStore.js';
 import { Locking } from './Locking.js';
 import { getCustomerRedisUrl, getRedisClientOptions, getRedisUrl } from './redisClient.js';
 import { RedisKVStore } from './RedisStore.js';
+import { InMemorySlidingWindowRateLimiter, RedisSlidingWindowRateLimiter } from './SlidingWindowRateLimiter.js';
 
 import type { KVStore } from './KVStore.js';
 import type { NangoRedisClient, RedisBoundary } from './redisClient.js';
+import type { SlidingWindowRateLimiter, SlidingWindowRateLimiterOptions } from './SlidingWindowRateLimiter.js';
 
 export { InMemoryKVStore } from './InMemoryStore.js';
 export { RedisKVStore } from './RedisStore.js';
 export type { DeleteIfValueEqualsWithCompanionArgs, KVStore, SetIfValueEqualsWithCompanionArgs, SetNxWithCompanionArgs } from './KVStore.js';
 export { type Lock, Locking } from './Locking.js';
 export { type NangoRedisClient, type RedisBoundary, getCustomerRedisUrl, getRedisClientOptions, getRedisUrl } from './redisClient.js';
+export {
+    InMemorySlidingWindowRateLimiter,
+    RedisSlidingWindowRateLimiter,
+    type SlidingWindowRateLimiter,
+    type SlidingWindowRateLimiterOptions,
+    type SlidingWindowRateLimitResult
+} from './SlidingWindowRateLimiter.js';
 
 type KvBoundary = RedisBoundary;
 
-// Those getters can be accessed at any point so we store the promise to avoid race condition
-// Not my best code
 const mapRedis = new Map<string, NangoRedisClient>();
 
 function redisClientCacheKey(url: string, boundary: RedisBoundary): string {
@@ -38,6 +45,62 @@ export async function getRedis(url: string, boundary: RedisBoundary = 'system'):
     await redis.connect();
     mapRedis.set(cacheKey, redis);
     return redis;
+}
+
+export function createSlidingWindowRateLimiter(options: SlidingWindowRateLimiterOptions): Promise<SlidingWindowRateLimiter> {
+    try {
+        const url = getRedisUrl();
+        if (!url) {
+            return Promise.resolve(new InMemorySlidingWindowRateLimiter(options));
+        }
+
+        let client: NangoRedisClient | undefined;
+        let connection: Promise<NangoRedisClient> | undefined;
+
+        const getClient = async (): Promise<NangoRedisClient> => {
+            if (client?.isReady) {
+                return client;
+            }
+            if (connection) {
+                return await connection;
+            }
+
+            const redisOptions = getRedisClientOptions(url);
+            const redis = createClient({
+                ...redisOptions,
+                socket: {
+                    ...redisOptions.socket,
+                    reconnectStrategy: () => false,
+                    connectTimeout: 1000
+                }
+            });
+            redis.on('error', (err: Error) => {
+                console.error(`Redis (sliding-window-rate-limiter) error: ${err}`);
+            });
+
+            connection = redis
+                .connect()
+                .then((connected) => {
+                    client = connected;
+                    return connected;
+                })
+                .finally(() => {
+                    connection = undefined;
+                });
+            return await connection;
+        };
+
+        const destroyClient = async (): Promise<void> => {
+            const connected = client ?? (await connection?.catch(() => undefined));
+            if (connected?.isOpen) {
+                await connected.disconnect();
+            }
+        };
+
+        return Promise.resolve(new RedisSlidingWindowRateLimiter(getClient, options, destroyClient));
+    } catch (err) {
+        return Promise.reject(err);
+    }
 }
 
 export async function destroy() {

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -83,6 +83,10 @@ export function createSlidingWindowRateLimiter(options: SlidingWindowRateLimiter
                     await staleClient.disconnect();
                 }
 
+                if (destroyed) {
+                    throw new Error('Sliding window rate limiter was destroyed while reconnecting');
+                }
+
                 const redisOptions = getRedisClientOptions(url);
                 const redis = createClient({
                     ...redisOptions,

--- a/packages/kvstore/lib/index.unit.test.ts
+++ b/packages/kvstore/lib/index.unit.test.ts
@@ -92,6 +92,35 @@ describe('getKVStore', () => {
         expect(store).toBeInstanceOf(InMemoryKVStore);
     });
 
+    it('should return an in-memory sliding window limiter when no Redis config is provided', async () => {
+        vi.resetModules();
+
+        const { createSlidingWindowRateLimiter, InMemorySlidingWindowRateLimiter } = await import('./index.js');
+        const limiter = await createSlidingWindowRateLimiter({ keyPrefix: 'test', limit: 10, windowMs: 1000 });
+
+        expect(limiter).toBeInstanceOf(InMemorySlidingWindowRateLimiter);
+        await limiter.destroy();
+    });
+
+    it('should return a Redis sliding window limiter when Redis is configured', async () => {
+        mockEnvs.NANGO_REDIS_URL = 'redis://localhost:6379';
+        vi.resetModules();
+
+        const { createSlidingWindowRateLimiter, RedisSlidingWindowRateLimiter } = await import('./index.js');
+        const limiter = await createSlidingWindowRateLimiter({ keyPrefix: 'test', limit: 10, windowMs: 1000 });
+
+        expect(limiter).toBeInstanceOf(RedisSlidingWindowRateLimiter);
+        await limiter.destroy();
+    });
+
+    it('should reject invalid sliding window limiter options asynchronously', async () => {
+        vi.resetModules();
+
+        const { createSlidingWindowRateLimiter } = await import('./index.js');
+
+        await expect(createSlidingWindowRateLimiter({ keyPrefix: '', limit: 10, windowMs: 1000 })).rejects.toThrow('keyPrefix must not be empty');
+    });
+
     it('should return different instances for different boundaries', async () => {
         vi.resetModules();
 

--- a/packages/kvstore/lib/index.unit.test.ts
+++ b/packages/kvstore/lib/index.unit.test.ts
@@ -113,6 +113,62 @@ describe('getKVStore', () => {
         await limiter.destroy();
     });
 
+    it('should cool down Redis connection attempts after a failure', async () => {
+        mockEnvs.NANGO_REDIS_URL = 'redis://localhost:6379';
+        vi.resetModules();
+        const { createClient } = await import('redis');
+        const connect = vi.fn().mockRejectedValue(new Error('unavailable'));
+        vi.mocked(createClient).mockReturnValueOnce({
+            connect,
+            disconnect: vi.fn().mockResolvedValue(undefined),
+            on: vi.fn(),
+            isOpen: false,
+            isReady: false
+        } as never);
+
+        const { createSlidingWindowRateLimiter } = await import('./index.js');
+        const limiter = await createSlidingWindowRateLimiter({ keyPrefix: 'test', limit: 1, windowMs: 1000 });
+
+        await expect(limiter.consume('key', 1)).resolves.toMatchObject({ admitted: 1, rejected: 0 });
+        await expect(limiter.consume('key', 1)).resolves.toMatchObject({ admitted: 1, rejected: 0 });
+        expect(connect).toHaveBeenCalledTimes(1);
+        await limiter.destroy();
+    });
+
+    it('should wait for an in-flight Redis connection during destroy', async () => {
+        mockEnvs.NANGO_REDIS_URL = 'redis://localhost:6379';
+        vi.resetModules();
+        const { createClient } = await import('redis');
+        let resolveConnection: ((client: unknown) => void) | undefined;
+        const connection = new Promise((resolve) => {
+            resolveConnection = resolve;
+        });
+        const disconnect = vi.fn().mockResolvedValue(undefined);
+        const redis = {
+            connect: vi.fn().mockReturnValue(connection),
+            disconnect,
+            on: vi.fn(),
+            isOpen: true,
+            isReady: false
+        };
+        vi.mocked(createClient).mockReturnValueOnce(redis as never);
+
+        const { createSlidingWindowRateLimiter } = await import('./index.js');
+        const limiter = await createSlidingWindowRateLimiter({ keyPrefix: 'test', limit: 1, windowMs: 1000 });
+        const consume = limiter.consume('key', 1);
+        let destroyCompleted = false;
+        const destroy = limiter.destroy().then(() => {
+            destroyCompleted = true;
+        });
+
+        await Promise.resolve();
+        expect(destroyCompleted).toBe(false);
+        resolveConnection?.(redis);
+        await destroy;
+        await expect(consume).resolves.toMatchObject({ admitted: 1, rejected: 0 });
+        expect(disconnect).toHaveBeenCalledOnce();
+    });
+
     it('should reject invalid sliding window limiter options asynchronously', async () => {
         vi.resetModules();
 

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -26,6 +26,8 @@ export enum Types {
     CRON_TRIAL = 'nango.cron.trial',
 
     LOGS_LOG = 'nango.logs.log',
+    KVSTORE_SLIDING_WINDOW_CARDINALITY = 'nango.kvstore.sliding_window.cardinality',
+    KVSTORE_SLIDING_WINDOW_FAIL_OPEN = 'nango.kvstore.sliding_window.fail_open',
     BILLED_RECORDS_COUNT = 'nango.billed.records.count',
     MONTHLY_ACTIVE_RECORDS_COUNT = 'nango.monthly.active.records.count',
     PERSIST_RECORDS_COUNT = 'nango.persist.records.count',

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -26,7 +26,7 @@ export enum Types {
     CRON_TRIAL = 'nango.cron.trial',
 
     LOGS_LOG = 'nango.logs.log',
-    KVSTORE_SLIDING_WINDOW_CARDINALITY = 'nango.kvstore.sliding_window.cardinality',
+    KVSTORE_SLIDING_WINDOW_USAGE = 'nango.kvstore.sliding_window.usage',
     KVSTORE_SLIDING_WINDOW_FAIL_OPEN = 'nango.kvstore.sliding_window.fail_open',
     BILLED_RECORDS_COUNT = 'nango.billed.records.count',
     MONTHLY_ACTIVE_RECORDS_COUNT = 'nango.monthly.active.records.count',


### PR DESCRIPTION
Adds a generic approximate sliding-window rate limiter with partial admission, weighted retry timing, Redis atomicity, and an in-memory fallback. Redis failures are logged and fail open. Idle Redis keys expire.

The limiter stores only the current and previous fixed-window counts. It estimates rolling usage by weighting the previous count by the fraction of the current window that remains. This keeps memory and Lua work constant while smoothing the fixed-window boundary.

This approximation fits webhook dispatch because Standard SQS buffers fanout, consumers process bounded batches, and NAN-6404 will back off rejected work. The generic limit remains the actual enforcement threshold. NAN-6404 should initially pass 80 to 85 percent of the desired ceiling and tune it with production metrics.

Reference: https://blog.cloudflare.com/counting-things-a-lot-of-different-things/#sliding-windows-to-the-rescue

NAN-6404 is the first consumer.

Test plan:
- [x] Run kvstore unit tests
- [x] Run kvstore Redis integration tests
- [x] Run the full TypeScript build
- [x] Run lint and formatting checks