### PR TITLE
feat(design-system): catalog every StyledLink variant in Storybook

### DIFF
--- a/packages/design-system/stories/StyledLink.stories.tsx
+++ b/packages/design-system/stories/StyledLink.stories.tsx
@@ -26,3 +26,55 @@ export const Internal: Story = {
 export const External: Story = {
     args: { to: 'https://docs.nango.dev', children: 'Read the docs', type: 'external', icon: true }
 };
+
+const VARIANTS = ['default', 'muted', 'info', 'error'] as const;
+const SIZES = ['default', 'sm'] as const;
+
+// Reference catalog of every StyledLink variant/size/icon combination, ahead of NAN-6419's migration to
+// the design-system Button. Figma's Button component only defines Link/Link-Destructive (no muted/info
+// treatment), so this exists to compare StyledLink's actual shipped look against what Button covers today
+// before deciding whether Button needs new variants or these usages should consolidate onto the existing
+// link variant.
+export const AllVariants: Story = {
+    name: 'All variants',
+    render: () => (
+        <div className="flex flex-col gap-10">
+            {VARIANTS.map((variant) => (
+                <div key={variant} className="flex items-center gap-6 flex-wrap">
+                    <span className="text-ds-xs text-text-secondary w-16 shrink-0">{variant}</span>
+                    <StyledLink to="/integrations" variant={variant}>
+                        Default
+                    </StyledLink>
+                    <StyledLink to="https://docs.nango.dev" type="external" variant={variant} icon>
+                        With icon
+                    </StyledLink>
+                    <StyledLink to="/integrations" variant={variant} size="sm">
+                        Small
+                    </StyledLink>
+                    <StyledLink to="https://docs.nango.dev" type="external" variant={variant} size="sm" icon>
+                        Small with icon
+                    </StyledLink>
+                </div>
+            ))}
+        </div>
+    )
+};
+
+export const AllSizes: Story = {
+    name: 'All sizes',
+    render: () => (
+        <div className="flex flex-col gap-10">
+            {SIZES.map((size) => (
+                <div key={size} className="flex items-center gap-6">
+                    <span className="text-ds-xs text-text-secondary w-16 shrink-0">{size}</span>
+                    <StyledLink to="/integrations" size={size}>
+                        Link
+                    </StyledLink>
+                    <StyledLink to="https://docs.nango.dev" type="external" size={size} icon>
+                        With icon
+                    </StyledLink>
+                </div>
+            ))}
+        </div>
+    )
+};


### PR DESCRIPTION
## Problem

NAN-6419 is migrating every `StyledLink` usage to the design-system Button's `link`/`link-danger` variants, but Figma's Button component only defines `Link`/`Link-Destructive` — there's no muted or info treatment. That migration mapped StyledLink's `muted` and `info` variants onto the plain `link` variant, which makes some previously subdued links noticeably more prominent than intended.

## Solution

- Add `All variants` / `All sizes` stories to `StyledLink.stories.tsx`, covering all 4 variants (`default`/`muted`/`info`/`error`), both sizes, and icon on/off — the same catalog pattern `Button` already has
- No component or behavior changes — this is a Storybook reference only

## Testing

Verified live in Storybook: `default` (#0089B0) and `info` (#016886) render as distinct-but-easy-to-confuse blues, `muted` (#626366) is a clear grey, `error` is red.

## Follow-ups

- Design review using this catalog to decide whether `Button` needs new `link-muted`/`link-info` variants, or whether those `StyledLink` usages should consolidate onto the existing `link` variant — tracked as an open question on NAN-6419.
