### PR TITLE
feat(metrics): add provider config key to metrics - opt in only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,8 @@ NANGO_INTEGRATIONS_FULL_PATH=
 # Internal Datadog Telemetry
 # This telemetry logs metrics/traces in your own Datadog instance
 NANGO_TELEMETRY_SDK=false
+# Tag selected operational metrics with providerConfigKey (high cardinality; off by default)
+NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY=false
 
 # ----- Logs
 NANGO_LOGS_ENABLED="false"

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -137,7 +137,7 @@ Yes, metrics and logs can be exported to any monitoring tool using our OpenTelem
 
 Self-hosted deployments that send DogStatsD metrics to their own Datadog instance can opt into tagging selected operational metrics with `providerConfigKey` (the unique key of a configured integration, for example `github-prod`).
 
-This is **off by default**. Leave it off unless you need per-integration granularity; `providerConfigKey` has much higher cardinality than account count.
+This is **off by default**. Leave it off unless you need per-integration granularity; `providerConfigKey` usually has much higher cardinality than account count.
 
 ```sh
 NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY=true

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -133,6 +133,18 @@ Yes, Nango is flexible with data store setups. However, we recommend a separate 
 
 Yes, metrics and logs can be exported to any monitoring tool using our OpenTelemetry Export add-on. Additional metrics and logs can be added upon request.
 
+### Datadog `providerConfigKey` metric tag
+
+Self-hosted deployments that send DogStatsD metrics to their own Datadog instance can opt into tagging selected operational metrics with `providerConfigKey` (the unique key of a configured integration, for example `github-prod`).
+
+This is **off by default**. Leave it off unless you need per-integration granularity; `providerConfigKey` has much higher cardinality than account count.
+
+```sh
+NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY=true
+```
+
+Set this on the **server** and **jobs** services and restart them. When enabled, auth, proxy, credential refresh, connection lifecycle, and incoming webhook dispatch metrics include a `providerConfigKey` tag whenever that identifier is known at the call site.
+
 ## Email service
 
 Nango uses emails for account verification, password reset, and sending invitations, etc...

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6798,6 +6798,18 @@ Yes, Nango is flexible with data store setups. However, we recommend a separate 
 
 Yes, metrics and logs can be exported to any monitoring tool using our OpenTelemetry Export add-on. Additional metrics and logs can be added upon request.
 
+### Datadog `providerConfigKey` metric tag
+
+Self-hosted deployments that send DogStatsD metrics to their own Datadog instance can opt into tagging selected operational metrics with `providerConfigKey` (the unique key of a configured integration, for example `github-prod`).
+
+This is **off by default**. Leave it off unless you need per-integration granularity; `providerConfigKey` has much higher cardinality than account count.
+
+```sh
+NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY=true
+```
+
+Set this on the **server** and **jobs** services and restart them. When enabled, auth, proxy, credential refresh, connection lifecycle, and incoming webhook dispatch metrics include a `providerConfigKey` tag whenever that identifier is known at the call site.
+
 ## Email service
 
 Nango uses emails for account verification, password reset, and sending invitations, etc...

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6802,7 +6802,7 @@ Yes, metrics and logs can be exported to any monitoring tool using our OpenTelem
 
 Self-hosted deployments that send DogStatsD metrics to their own Datadog instance can opt into tagging selected operational metrics with `providerConfigKey` (the unique key of a configured integration, for example `github-prod`).
 
-This is **off by default**. Leave it off unless you need per-integration granularity; `providerConfigKey` has much higher cardinality than account count.
+This is **off by default**. Leave it off unless you need per-integration granularity; `providerConfigKey` usually has much higher cardinality than account count.
 
 ```sh
 NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY=true

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -129,7 +129,7 @@ export class DispatchQueueConsumer {
             tags: { 'webhook.dispatch.received': messages.length }
         });
 
-        return await tracer.scope().activate(span, async () => {
+        return void (await tracer.scope().activate(span, async () => {
             try {
                 const entries = await this.filterMessages(messages);
                 if (entries.length === 0) {
@@ -185,7 +185,7 @@ export class DispatchQueueConsumer {
             } finally {
                 span.finish();
             }
-        });
+        }));
     }
 
     private async filterMessages(messages: Message[]): Promise<ParsedEntry[]> {
@@ -206,10 +206,17 @@ export class DispatchQueueConsumer {
             const sentTimestampMs = Number(msg.Attributes?.['SentTimestamp'] ?? '0');
             if (sentTimestampMs > 0) {
                 const dwellMs = Date.now() - sentTimestampMs;
-                metrics.duration(metrics.Types.WEBHOOK_DISPATCH_DWELL_MS, dwellMs, { provider: message.provider });
+                metrics.duration(metrics.Types.WEBHOOK_DISPATCH_DWELL_MS, dwellMs, {
+                    provider: message.provider,
+                    providerConfigKey: message.connection.provider_config_key
+                });
 
                 if (this.maxAgeMs > 0 && dwellMs > this.maxAgeMs) {
-                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_DROPPED, 1, { reason: 'stale', accountId: message.accountId });
+                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_DROPPED, 1, {
+                        reason: 'stale',
+                        accountId: message.accountId,
+                        providerConfigKey: message.connection.provider_config_key
+                    });
                     const logCtx = logContextGetter.get({ id: message.activityLogId, accountId: message.accountId });
                     await logCtx.warn('Webhook was discarded: it spent too long in the queue and was not processed.', { dwell_ms: dwellMs });
                     await this.tryDeleteMessage(msg.ReceiptHandle);
@@ -232,15 +239,16 @@ export class DispatchQueueConsumer {
             const group = groupedEntries[i]!;
             const result = results[i];
             const provider = group[0]!.parsed.provider;
+            const providerConfigKey = group[0]!.parsed.connection.provider_config_key;
             const count = group.length;
             if (!result) {
                 // Server should return one result per request entry; missing entries are a server bug.
-                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'failure', provider });
+                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'failure', provider, providerConfigKey });
                 continue;
             }
 
             if (result.isOk()) {
-                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'success', provider });
+                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'success', provider, providerConfigKey });
                 await this.deleteGroup(group);
                 continue;
             }
@@ -250,13 +258,13 @@ export class DispatchQueueConsumer {
             // - task_cap_exceeded: the group is saturated, so redelivering won't help, so we drop the message.
             // - anything else: leave for redelivery (SQS visibility timeout → eventual DLQ).
             if (result.error.name === 'duplicate_task_name') {
-                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'success', provider });
+                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'success', provider, providerConfigKey });
                 await this.deleteGroup(group);
             } else if (result.error.name === 'task_cap_exceeded') {
-                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_DROPPED, count, { reason: 'task_cap', provider });
+                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_DROPPED, count, { reason: 'task_cap', provider, providerConfigKey });
                 await this.deleteGroup(group);
             } else {
-                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'failure', provider });
+                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'failure', provider, providerConfigKey });
             }
         }
     }

--- a/packages/server/lib/controllers/auth/postApiKey.ts
+++ b/packages/server/lib/controllers/auth/postApiKey.ts
@@ -231,7 +231,7 @@ export const postPublicApiKeyAuthorization = asyncWrapperWithEnvironment<PostPub
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -263,7 +263,10 @@ export const postPublicApiKeyAuthorization = asyncWrapperWithEnvironment<PostPub
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'API_KEY', ...(config ? { provider: config.provider } : {}) });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+            auth_mode: 'API_KEY',
+            ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+        });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postAwsSigV4.ts
+++ b/packages/server/lib/controllers/auth/postAwsSigV4.ts
@@ -331,7 +331,7 @@ export const postPublicAwsSigV4Authorization = asyncWrapperWithEnvironment<PostP
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: 'AWS_SIGV4', provider: config.provider });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: 'AWS_SIGV4', provider: config.provider, providerConfigKey: config.unique_key });
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
         void connectionCreationFailedHook(
@@ -356,7 +356,10 @@ export const postPublicAwsSigV4Authorization = asyncWrapperWithEnvironment<PostP
             void logCtx.error('uncaught error', { error: err });
             await logCtx.failed();
         }
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'AWS_SIGV4', ...(config ? { provider: config.provider } : {}) });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+            auth_mode: 'AWS_SIGV4',
+            ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+        });
         next(err);
     }
 });

--- a/packages/server/lib/controllers/auth/postBasic.ts
+++ b/packages/server/lib/controllers/auth/postBasic.ts
@@ -230,7 +230,7 @@ export const postPublicBasicAuthorization = asyncWrapperWithEnvironment<PostPubl
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -262,7 +262,10 @@ export const postPublicBasicAuthorization = asyncWrapperWithEnvironment<PostPubl
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'BASIC', ...(config ? { provider: config.provider } : {}) });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+            auth_mode: 'BASIC',
+            ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+        });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postBill.ts
+++ b/packages/server/lib/controllers/auth/postBill.ts
@@ -233,7 +233,7 @@ export const postPublicBillAuthorization = asyncWrapperWithEnvironment<PostPubli
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -265,7 +265,10 @@ export const postPublicBillAuthorization = asyncWrapperWithEnvironment<PostPubli
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'BILL', ...(config ? { provider: config.provider } : {}) });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+            auth_mode: 'BILL',
+            ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+        });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -247,7 +247,7 @@ export const postPublicJwtAuthorization = asyncWrapperWithEnvironment<PostPublic
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -279,7 +279,10 @@ export const postPublicJwtAuthorization = asyncWrapperWithEnvironment<PostPublic
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'JWT', ...(config ? { provider: config.provider } : {}) });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+            auth_mode: 'JWT',
+            ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+        });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postOauthOutbound.ts
+++ b/packages/server/lib/controllers/auth/postOauthOutbound.ts
@@ -204,7 +204,7 @@ export const postPublicOauthOutboundAuthorization = asyncWrapperWithEnvironment<
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -237,7 +237,10 @@ export const postPublicOauthOutboundAuthorization = asyncWrapperWithEnvironment<
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2', ...(config ? { provider: config.provider } : {}) });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+            auth_mode: 'OAUTH2',
+            ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+        });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postSignature.ts
+++ b/packages/server/lib/controllers/auth/postSignature.ts
@@ -248,7 +248,7 @@ export const postPublicSignatureAuthorization = asyncWrapperWithEnvironment<Post
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -280,7 +280,10 @@ export const postPublicSignatureAuthorization = asyncWrapperWithEnvironment<Post
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'SIGNATURE', ...(config ? { provider: config.provider } : {}) });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+            auth_mode: 'SIGNATURE',
+            ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+        });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -264,7 +264,7 @@ export const postPublicTbaAuthorization = asyncWrapperWithEnvironment<PostPublic
             logContextGetter
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -296,7 +296,10 @@ export const postPublicTbaAuthorization = asyncWrapperWithEnvironment<PostPublic
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'TBA', ...(config ? { provider: config.provider } : {}) });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+            auth_mode: 'TBA',
+            ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+        });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -242,7 +242,7 @@ export const postPublicTwoStepAuthorization = asyncWrapperWithEnvironment<PostPu
             undefined
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -274,7 +274,10 @@ export const postPublicTwoStepAuthorization = asyncWrapperWithEnvironment<PostPu
             metadata: { providerConfigKey, connectionId }
         });
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'TWO_STEP', ...(config ? { provider: config.provider } : {}) });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+            auth_mode: 'TWO_STEP',
+            ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+        });
 
         next(err);
     }

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -197,7 +197,7 @@ export const postPublicUnauthenticated = asyncWrapperWithEnvironment<PostPublicU
             undefined
         );
 
-        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+        metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
         res.status(200).send({ connectionId, providerConfigKey });
     } catch (err) {
@@ -219,7 +219,10 @@ export const postPublicUnauthenticated = asyncWrapperWithEnvironment<PostPublicU
             await logCtx.failed();
         }
 
-        metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'NONE', ...(config ? { provider: config.provider } : {}) });
+        metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+            auth_mode: 'NONE',
+            ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+        });
 
         errorManager.handleGenericError(err, req, res);
     }

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -600,7 +600,11 @@ class OAuthController {
                 logContextGetter
             );
 
-            metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+            metrics.increment(metrics.Types.AUTH_SUCCESS, 1, {
+                auth_mode: provider.auth_mode,
+                provider: config.provider,
+                providerConfigKey: config.unique_key
+            });
 
             res.status(200).send({ providerConfigKey: providerConfigKey, connectionId: connectionId });
         } catch (err) {
@@ -635,7 +639,10 @@ class OAuthController {
                 }
             });
 
-            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2_CC', ...(config ? { provider: config.provider } : {}) });
+            metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
+                auth_mode: 'OAUTH2_CC',
+                ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
+            });
 
             next(err);
         }
@@ -1084,7 +1091,11 @@ class OAuthController {
             let clientInformation: OAuthClientInformation;
             const cimdUrl = getGlobalClientMetadataDocumentUrl(environment.uuid, config.unique_key);
             const clientIdMethod = genericMcpClient.chooseMcpClientIdMethod(metadata, cimdUrl);
-            metrics.increment(metrics.Types.MCP_CLIENT_ID_METHOD, 1, { method: clientIdMethod, provider: config.provider });
+            metrics.increment(metrics.Types.MCP_CLIENT_ID_METHOD, 1, {
+                method: clientIdMethod,
+                provider: config.provider,
+                providerConfigKey: config.unique_key
+            });
             if (clientIdMethod === 'cimd' && cimdUrl) {
                 clientInformation = { client_id: cimdUrl };
             } else if (clientIdMethod === 'dcr') {
@@ -1336,7 +1347,7 @@ class OAuthController {
             void logCtx?.error('Unknown error', { error: err, url: req.originalUrl });
             await logCtx?.failed();
 
-            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2', provider: session.provider });
+            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2', provider: session.provider, providerConfigKey });
 
             return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError(prettyError));
         }
@@ -2021,7 +2032,11 @@ class OAuthController {
 
             await logCtx.success();
 
-            metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+            metrics.increment(metrics.Types.AUTH_SUCCESS, 1, {
+                auth_mode: provider.auth_mode,
+                provider: config.provider,
+                providerConfigKey: config.unique_key
+            });
 
             if (res) {
                 await publisher.notifySuccess({
@@ -2064,7 +2079,7 @@ class OAuthController {
                 config
             );
 
-            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2', provider: config.provider });
+            metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH2', provider: config.provider, providerConfigKey: config.unique_key });
 
             if (res) {
                 return publisher.notifyErr(res, channel, providerConfigKey, connectionId, {
@@ -2364,7 +2379,11 @@ class OAuthController {
                 );
                 await logCtx.success();
 
-                metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider });
+                metrics.increment(metrics.Types.AUTH_SUCCESS, 1, {
+                    auth_mode: provider.auth_mode,
+                    provider: config.provider,
+                    providerConfigKey: config.unique_key
+                });
 
                 return publisher.notifySuccess({
                     res,
@@ -2405,7 +2424,7 @@ class OAuthController {
                     account,
                     config
                 );
-                metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH1', provider: config.provider });
+                metrics.increment(metrics.Types.AUTH_FAILURE, 1, { auth_mode: 'OAUTH1', provider: config.provider, providerConfigKey: config.unique_key });
 
                 return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError(prettyError));
             });
@@ -2535,7 +2554,8 @@ class OAuthController {
 
             metrics.increment(metrics.Types.AUTH_SUCCESS, 1, {
                 auth_mode: 'MCP_OAUTH2_GENERIC',
-                provider: config.provider
+                provider: config.provider,
+                providerConfigKey: config.unique_key
             });
 
             await publisher.notifySuccess({
@@ -2578,7 +2598,8 @@ class OAuthController {
 
             metrics.increment(metrics.Types.AUTH_FAILURE, 1, {
                 auth_mode: 'MCP_OAUTH2_GENERIC',
-                provider: config.provider
+                provider: config.provider,
+                providerConfigKey: config.unique_key
             });
 
             return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.UnknownError(prettyError));

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -155,7 +155,7 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
     const isDryRun = parsedHeaders['nango-is-dry-run'] === 'true';
     try {
         if (!isSync) {
-            metrics.increment(metrics.Types.PROXY, 1, { accountId: account.id });
+            metrics.increment(metrics.Types.PROXY, 1, { accountId: account.id, providerConfigKey });
         }
 
         logCtx = existingActivityLogId
@@ -169,7 +169,7 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
         if (baseUrlOverride && !envs.NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED) {
             void logCtx.error('Base URL override is disabled by server configuration');
             await logCtx.failed();
-            metrics.increment(metrics.Types.PROXY_FAILURE);
+            metrics.increment(metrics.Types.PROXY_FAILURE, 1, { providerConfigKey });
             res.status(400).send({
                 error: {
                     code: 'base_url_override_disabled',
@@ -179,10 +179,10 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
             return;
         }
         if (baseUrlOverride && isBaseUrlOverrideDenied(baseUrlOverride, baseUrlOverrideDenylist)) {
-            metrics.increment(metrics.Types.PROXY_BASE_URL_OVERRIDE_DENIED, 1, { accountId: account.id });
+            metrics.increment(metrics.Types.PROXY_BASE_URL_OVERRIDE_DENIED, 1, { accountId: account.id, providerConfigKey });
             void logCtx.error('Base URL override is not allowed by server configuration');
             await logCtx.failed();
-            metrics.increment(metrics.Types.PROXY_FAILURE);
+            metrics.increment(metrics.Types.PROXY_FAILURE, 1, { providerConfigKey });
             res.status(400).send({
                 error: {
                     code: 'base_url_override_not_allowed',
@@ -218,7 +218,7 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
         if (!integration) {
             void logCtx.error('Provider configuration not found');
             await logCtx.failed();
-            metrics.increment(metrics.Types.PROXY_FAILURE);
+            metrics.increment(metrics.Types.PROXY_FAILURE, 1, { providerConfigKey });
             res.status(404).send({
                 error: {
                     code: 'unknown_provider_config',
@@ -235,7 +235,7 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
         if (customBaseUrl && !envs.NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED) {
             void logCtx.error('Integration base URL override is disabled by server configuration');
             await logCtx.failed();
-            metrics.increment(metrics.Types.PROXY_FAILURE);
+            metrics.increment(metrics.Types.PROXY_FAILURE, 1, { providerConfigKey });
             res.status(400).send({
                 error: { code: 'base_url_override_disabled', message: 'Base URL override is disabled by server configuration.' }
             });
@@ -244,7 +244,7 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
         if (customBaseUrl && isBaseUrlOverrideDenied(customBaseUrl, baseUrlOverrideDenylist)) {
             void logCtx.error('Integration base URL is not allowed by server configuration');
             await logCtx.failed();
-            metrics.increment(metrics.Types.PROXY_FAILURE);
+            metrics.increment(metrics.Types.PROXY_FAILURE, 1, { providerConfigKey });
             res.status(400).send({
                 error: { code: 'base_url_override_not_allowed', message: 'This base URL is not allowed by server configuration.' }
             });
@@ -278,7 +278,7 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
             if (err.type === 'connection_refresh_backoff') {
                 res.status(err.status).send({ error: { code: err.type, message: err.message } });
             } else {
-                metrics.increment(metrics.Types.PROXY_FAILURE);
+                metrics.increment(metrics.Types.PROXY_FAILURE, 1, { providerConfigKey });
                 res.status(err.status).send({ error: { code: 'server_error', message: `Failed to get connection credentials: '${err.message}'` } });
             }
             return;
@@ -329,7 +329,7 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
                               },
                               validateProxyRedirectUrl: (absoluteUrl: string) => {
                                   if (isBaseUrlOverrideDenied(absoluteUrl, baseUrlOverrideDenylist)) {
-                                      metrics.increment(metrics.Types.PROXY_BASE_URL_OVERRIDE_DENIED, 1, { accountId: account.id });
+                                      metrics.increment(metrics.Types.PROXY_BASE_URL_OVERRIDE_DENIED, 1, { accountId: account.id, providerConfigKey });
                                       let redirectHostForLog: string;
                                       try {
                                           redirectHostForLog = new URL(absoluteUrl).hostname;
@@ -409,7 +409,8 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
                 responseStream,
                 logCtx,
                 onEgressedBytes: recordEgressedBytes,
-                forwardAllResponseHeaders
+                forwardAllResponseHeaders,
+                providerConfigKey
             });
             success = true;
         } catch (err) {
@@ -422,7 +423,7 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
                 forwardAllResponseHeaders
             });
             await logCtx.failed();
-            metrics.increment(metrics.Types.PROXY_FAILURE);
+            metrics.increment(metrics.Types.PROXY_FAILURE, 1, { providerConfigKey });
         }
 
         void pubsub.publisher.publish({
@@ -457,7 +458,7 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
             void logCtx.error('uncaught error', { error: err });
             await logCtx.failed();
         }
-        metrics.increment(metrics.Types.PROXY_FAILURE);
+        metrics.increment(metrics.Types.PROXY_FAILURE, 1, { providerConfigKey });
         next(err);
     } finally {
         const reqHeaders = getHeaders(req.headers);
@@ -544,13 +545,15 @@ export async function handleResponse({
     responseStream,
     logCtx,
     onEgressedBytes,
-    forwardAllResponseHeaders = false
+    forwardAllResponseHeaders = false,
+    providerConfigKey
 }: {
     res: Response;
     responseStream: AxiosResponse;
     logCtx: LogContext;
     onEgressedBytes?: ((egressedBytes: number) => void) | undefined;
     forwardAllResponseHeaders?: boolean;
+    providerConfigKey: string;
 }) {
     const contentDisposition = responseStream.headers['content-disposition'] || '';
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
@@ -579,7 +582,7 @@ export async function handleResponse({
         passThroughStream.pipe(res);
         res.writeHead(responseStream.status, passthroughHeaders);
 
-        metrics.increment(metrics.Types.PROXY_SUCCESS);
+        metrics.increment(metrics.Types.PROXY_SUCCESS, 1, { providerConfigKey });
         await logCtx.success();
         return;
     }
@@ -603,7 +606,7 @@ export async function handleResponse({
             }
             res.status(204).end();
             onEgressedBytes?.(0);
-            metrics.increment(metrics.Types.PROXY_SUCCESS);
+            metrics.increment(metrics.Types.PROXY_SUCCESS, 1, { providerConfigKey });
             await logCtx.success();
             return;
         }
@@ -620,12 +623,12 @@ export async function handleResponse({
         } catch (err) {
             void logCtx.error('Failed to write response', { error: err });
             await logCtx.failed();
-            metrics.increment(metrics.Types.PROXY_FAILURE);
+            metrics.increment(metrics.Types.PROXY_FAILURE, 1, { providerConfigKey });
             return;
         }
 
         await logCtx.success();
-        metrics.increment(metrics.Types.PROXY_SUCCESS);
+        metrics.increment(metrics.Types.PROXY_SUCCESS, 1, { providerConfigKey });
     });
 }
 

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -133,7 +133,7 @@ describe('handleResponse', () => {
         const mockRes = createMockResponse();
         const mockResponseStream = createMockResponseStream('', { status: 204 });
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, providerConfigKey: 'test-integration' });
         await mockRes.waitForSend();
 
         expect(mockRes.res.status).toHaveBeenCalledWith(204);
@@ -145,7 +145,7 @@ describe('handleResponse', () => {
         const mockRes = createMockResponse();
         const mockResponseStream = createMockResponseStream(validJson);
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, providerConfigKey: 'test-integration' });
         await mockRes.waitForSend();
 
         expect(mockRes.getSentData()!.toString()).toBe(validJson);
@@ -159,7 +159,7 @@ describe('handleResponse', () => {
         const mockRes = createMockResponse();
         const mockResponseStream = createMockResponseStream(jsonWithBigInt);
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, providerConfigKey: 'test-integration' });
         await mockRes.waitForSend();
 
         const sentData = mockRes.getSentData();
@@ -173,7 +173,7 @@ describe('handleResponse', () => {
         const mockRes = createMockResponse();
         const mockResponseStream = createMockResponseStream(nonJsonPayload, { contentType: 'text/xml' });
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, providerConfigKey: 'test-integration' });
         await mockRes.waitForSend();
 
         const sentData = mockRes.getSentData();
@@ -196,7 +196,13 @@ describe('handleResponse', () => {
             }
         });
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: true });
+        handleResponse({
+            res: mockRes.res,
+            responseStream: mockResponseStream,
+            logCtx: mockLogCtx,
+            providerConfigKey: 'test-integration',
+            forwardAllResponseHeaders: true
+        });
         await mockRes.waitForSend();
 
         expect(mockRes.res.setHeader).toHaveBeenCalledWith('content-type', 'application/json');
@@ -221,7 +227,13 @@ describe('handleResponse', () => {
             }
         });
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: false });
+        handleResponse({
+            res: mockRes.res,
+            responseStream: mockResponseStream,
+            logCtx: mockLogCtx,
+            providerConfigKey: 'test-integration',
+            forwardAllResponseHeaders: false
+        });
         await mockRes.waitForSend();
 
         expect(mockRes.res.setHeader).toHaveBeenCalledWith('content-type', 'application/json');
@@ -246,7 +258,13 @@ describe('handleResponse', () => {
             }
         });
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: true });
+        handleResponse({
+            res: mockRes.res,
+            responseStream: mockResponseStream,
+            logCtx: mockLogCtx,
+            providerConfigKey: 'test-integration',
+            forwardAllResponseHeaders: true
+        });
         await mockRes.waitForSend();
 
         expect(mockRes.res.setHeader).not.toHaveBeenCalledWith('connection', expect.anything());
@@ -270,7 +288,13 @@ describe('handleResponse', () => {
             }
         });
 
-        await handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: true });
+        await handleResponse({
+            res: mockRes.res,
+            responseStream: mockResponseStream,
+            logCtx: mockLogCtx,
+            providerConfigKey: 'test-integration',
+            forwardAllResponseHeaders: true
+        });
 
         const [, headersArg] = vi.mocked(mockRes.res.writeHead).mock.calls[0]!;
         expect(headersArg).toHaveProperty('content-length', '18');
@@ -296,7 +320,13 @@ describe('handleResponse', () => {
             }
         });
 
-        await handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: true });
+        await handleResponse({
+            res: mockRes.res,
+            responseStream: mockResponseStream,
+            logCtx: mockLogCtx,
+            providerConfigKey: 'test-integration',
+            forwardAllResponseHeaders: true
+        });
 
         const [, headersArg] = vi.mocked(mockRes.res.writeHead).mock.calls[0]!;
         expect(headersArg).not.toHaveProperty('content-length');
@@ -313,7 +343,13 @@ describe('handleResponse', () => {
             }
         });
 
-        await handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: true });
+        await handleResponse({
+            res: mockRes.res,
+            responseStream: mockResponseStream,
+            logCtx: mockLogCtx,
+            providerConfigKey: 'test-integration',
+            forwardAllResponseHeaders: true
+        });
 
         const [, headersArg] = vi.mocked(mockRes.res.writeHead).mock.calls[0]!;
         expect(headersArg).toHaveProperty('content-length', '18');

--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -67,7 +67,8 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
 
             metrics.increment(metrics.Types.WEBHOOK_INCOMING_RECEIVED, 1, {
                 accountId: account.id,
-                provider: integration.provider
+                provider: integration.provider,
+                providerConfigKey: integration.unique_key
             });
 
             const provider = getProvider(integration.provider);

--- a/packages/server/lib/hooks/connection/post-connection.ts
+++ b/packages/server/lib/hooks/connection/post-connection.ts
@@ -46,10 +46,10 @@ async function execute(createdConnection: RecentlyCreatedConnection, providerNam
             await handler(internalNango);
             void logCtx.info(`post-connection-creation script succeeded`);
             await logCtx.success();
-            metrics.increment(metrics.Types.POST_CONNECTION_SUCCESS, 1, { provider: providerName });
+            metrics.increment(metrics.Types.POST_CONNECTION_SUCCESS, 1, { provider: providerName, providerConfigKey: upsertedConnection.provider_config_key });
         }
     } catch (err) {
-        metrics.increment(metrics.Types.POST_CONNECTION_FAILURE, 1, { provider: providerName });
+        metrics.increment(metrics.Types.POST_CONNECTION_FAILURE, 1, { provider: providerName, providerConfigKey: upsertedConnection.provider_config_key });
         void logCtx?.error('Post-connection script failed', { error: err });
         await logCtx?.failed();
     }

--- a/packages/server/lib/hooks/connection/pre-connection.ts
+++ b/packages/server/lib/hooks/connection/pre-connection.ts
@@ -49,10 +49,10 @@ async function execute({
             await handler(internalNango);
             void logCtx.info(`pre-connection-deletion script succeeded`);
             await logCtx.success();
-            metrics.increment(metrics.Types.PRE_CONNECTION_DELETION_SUCCESS, 1, { provider: providerName });
+            metrics.increment(metrics.Types.PRE_CONNECTION_DELETION_SUCCESS, 1, { provider: providerName, providerConfigKey: connection.provider_config_key });
         }
     } catch (err) {
-        metrics.increment(metrics.Types.PRE_CONNECTION_DELETION_FAILURE, 1, { provider: providerName });
+        metrics.increment(metrics.Types.PRE_CONNECTION_DELETION_FAILURE, 1, { provider: providerName, providerConfigKey: connection.provider_config_key });
         void logCtx?.error('Pre-connection deletion script failed', { error: err });
         await logCtx?.failed();
     }

--- a/packages/server/lib/webhook/dispatch-queue/publisher.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.ts
@@ -108,16 +108,17 @@ export class DispatchQueuePublisher {
                 span.setTag('nango.retriedBatches', retriedBatches);
 
                 const provider = firstMessage.provider;
+                const providerConfigKey = firstMessage.connection.provider_config_key;
 
                 if (enqueued > 0) {
-                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_PUBLISH_SUCCESS, enqueued, { provider });
+                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_PUBLISH_SUCCESS, enqueued, { provider, providerConfigKey });
                 }
                 if (failed > 0) {
                     const error = new Error(`Failed to enqueue ${failed} webhook dispatch message${failed === 1 ? '' : 's'}`);
                     span.setTag('error', error);
                     span.setTag('nango.partialFailure', true);
 
-                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_PUBLISH_FAILURE, failed, { provider });
+                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_PUBLISH_FAILURE, failed, { provider, providerConfigKey });
                 }
 
                 return { enqueued, failed, failedActivityLogIds };

--- a/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
@@ -198,7 +198,10 @@ describe('DispatchQueuePublisher', () => {
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedEntries', 0);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedBatches', 0);
         expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledTimes(1);
-        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.publish.success', 25, { provider: 'github' });
+        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.publish.success', 25, {
+            provider: 'github',
+            providerConfigKey: 'github-dev'
+        });
         expect(tracerMocks.span.finish).toHaveBeenCalledTimes(1);
     });
 
@@ -311,8 +314,14 @@ describe('DispatchQueuePublisher', () => {
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.partialFailure', true);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('error', expect.any(Error));
         expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledTimes(2);
-        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.publish.success', 2, { provider: 'github' });
-        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.publish.failure', 1, { provider: 'github' });
+        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.publish.success', 2, {
+            provider: 'github',
+            providerConfigKey: 'github-dev'
+        });
+        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.publish.failure', 1, {
+            provider: 'github',
+            providerConfigKey: 'github-dev'
+        });
         expect(tracerMocks.span.finish).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -265,7 +265,10 @@ export class InternalNango {
         }
 
         const dispatchResult = await this.dispatchExecutionsViaOrchestrator(executions, body);
-        metrics.increment(metrics.Types.WEBHOOK_DIRECT_TRIGGER_SUCCESS, dispatchResult.succeededCount, { provider: this.integration.provider });
+        metrics.increment(metrics.Types.WEBHOOK_DIRECT_TRIGGER_SUCCESS, dispatchResult.succeededCount, {
+            provider: this.integration.provider,
+            providerConfigKey: this.integration.unique_key
+        });
     }
 
     private async dispatchExecutionsViaOrchestrator(
@@ -451,7 +454,8 @@ export class InternalNango {
             metrics.increment(metrics.Types.WEBHOOK_DISPATCH_LARGE_FANOUT, 1, {
                 provider: this.integration.provider,
                 accountId: this.team.id,
-                environmentId: this.environment.id
+                environmentId: this.environment.id,
+                providerConfigKey: this.integration.unique_key
             });
         }
 
@@ -502,7 +506,8 @@ export class InternalNango {
             metrics.increment(metrics.Types.WEBHOOK_DISPATCH_BYPASS_OVERSIZE, oversizedExecutions.length, {
                 provider: this.integration.provider,
                 accountId: this.team.id,
-                environmentId: this.environment.id
+                environmentId: this.environment.id,
+                providerConfigKey: this.integration.unique_key
             });
 
             for (const {

--- a/packages/server/lib/webhook/internal-nango.unit.test.ts
+++ b/packages/server/lib/webhook/internal-nango.unit.test.ts
@@ -197,7 +197,10 @@ describe('InternalNango queue dispatch', () => {
         expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
         expect(logContextGetter.create).toHaveBeenCalledTimes(2);
         expect(publisher.publish).not.toHaveBeenCalled();
-        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 2, { provider: 'github' });
+        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 2, {
+            provider: 'github',
+            providerConfigKey: 'github-dev'
+        });
     });
 
     it('continues direct orchestrator dispatch when one execution fails', async () => {
@@ -217,7 +220,10 @@ describe('InternalNango queue dispatch', () => {
         expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
         expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
         expect(publisher.publish).not.toHaveBeenCalled();
-        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 1, { provider: 'github' });
+        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 1, {
+            provider: 'github',
+            providerConfigKey: 'github-dev'
+        });
     });
 
     it('creates log contexts concurrently before publishing queue messages', async () => {
@@ -387,7 +393,8 @@ describe('InternalNango queue dispatch', () => {
         expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.bypass_oversize', 2, {
             provider: 'github',
             accountId: 1,
-            environmentId: 2
+            environmentId: 2,
+            providerConfigKey: 'github-dev'
         });
         expect(logCtx1.warn).toHaveBeenCalledWith(
             'The webhook payload exceeds the queue size limit and will be dispatched directly',

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -124,7 +124,7 @@ export async function refreshOrTestCredentials(props: RefreshProps): Promise<Res
             case 'CUSTOM':
             case 'OAUTH1':
             case undefined: {
-                metrics.increment(metrics.Types.REFRESH_CONNECTIONS_UNKNOWN);
+                metrics.increment(metrics.Types.REFRESH_CONNECTIONS_UNKNOWN, 1, { providerConfigKey: props.integration.unique_key });
                 res = Ok(props.connection);
                 break;
             }
@@ -221,7 +221,7 @@ async function refreshCredentials(
         );
         logCtx.merge(logsBuffer);
 
-        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FAILED);
+        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FAILED, 1, { providerConfigKey: integration.unique_key });
         void logCtx.error('Failed to refresh credentials', err);
         await logCtx.failed();
 
@@ -247,14 +247,14 @@ async function refreshCredentials(
 
     const value = refreshRes.value;
     if (value.refreshed) {
-        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_SUCCESS);
+        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_SUCCESS, 1, { providerConfigKey: integration.unique_key });
         await onRefreshSuccess({
             connection: value.connection,
             environment,
             config: integration as ProviderConfig
         });
     } else {
-        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FRESH);
+        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FRESH, 1, { providerConfigKey: integration.unique_key });
     }
 
     return Ok(value.connection);
@@ -297,7 +297,7 @@ async function testCredentials(
         void logCtx.error('Failed to verify connection', result.error);
         await logCtx.failed();
 
-        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FAILED);
+        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FAILED, 1, { providerConfigKey: integration.unique_key });
         await onRefreshFailed({
             connection: oldConnection,
             logCtx,
@@ -338,7 +338,7 @@ async function testCredentials(
             );
         }
 
-        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_SUCCESS);
+        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_SUCCESS, 1, { providerConfigKey: integration.unique_key });
         await onRefreshSuccess({
             connection: oldConnection,
             environment,
@@ -347,7 +347,7 @@ async function testCredentials(
 
         return Ok(connection);
     } else {
-        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_UNKNOWN);
+        metrics.increment(metrics.Types.REFRESH_CONNECTIONS_UNKNOWN, 1, { providerConfigKey: integration.unique_key });
     }
 
     return Ok(oldConnection);

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -791,6 +791,7 @@ const ENVS_SHAPE = z.object({
     NANGO_CLOUD: z.stringbool().optional().default(false),
     NANGO_ENTERPRISE: z.stringbool().optional().default(false),
     NANGO_TELEMETRY_SDK: z.stringbool().optional().default(false),
+    NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY: z.stringbool().optional().default(false),
     NANGO_ADMIN_KEY: z.string().optional(),
     NANGO_INTEGRATIONS_FULL_PATH: z.string().optional(),
     LOG_LEVEL: z.enum(['info', 'debug', 'warn', 'error']).optional().default('info')

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -19,6 +19,16 @@ describe('parse', () => {
         expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
     });
 
+    it('defaults NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY to false', () => {
+        const res = parseEnvs(ENVS, {});
+        expect(res.NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY).toBe(false);
+    });
+
+    it('parses NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', () => {
+        expect(parseEnvs(ENVS, { NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY: 'true' }).NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY).toBe(true);
+        expect(parseEnvs(ENVS, { NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY: 'false' }).NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY).toBe(false);
+    });
+
     it('should parse the sandbox compiler template', () => {
         const res = parseEnvs(ENVS, { E2B_SANDBOX_COMPILER_TEMPLATE: 'blank-workspace:dev' });
         expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:dev');

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -227,7 +227,7 @@ export function decrement(metricName: Types, value = 1, dimensions?: Dimensions)
     if (value === 0) {
         return;
     }
-    tracer.dogstatsd.decrement(metricName, value, dimensions ?? {});
+    tracer.dogstatsd.decrement(metricName, value, applyDimensionPolicy(metricName, dimensions) ?? {});
 }
 
 export function gauge(metricName: Types, value?: number, dimensions?: Dimensions): void {

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -1,9 +1,5 @@
 import tracer from 'dd-trace';
 
-import { ENVS, parseEnvs } from '../environment/parse.js';
-
-const envs = parseEnvs(ENVS);
-
 export enum Types {
     ACCOUNT_CREATED = 'nango.account.created',
 
@@ -209,7 +205,7 @@ export function applyDimensionPolicy(metricName: Types, dimensions?: Dimensions)
     if (!CARDINALITY_GATED_PROVIDER_CONFIG_KEY_METRICS.has(metricName)) {
         return dimensions;
     }
-    if (envs.NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY) {
+    if (process.env['NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY']?.toLowerCase() === 'true') {
         return dimensions;
     }
     const { providerConfigKey: _providerConfigKey, ...rest } = dimensions;

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -1,5 +1,9 @@
 import tracer from 'dd-trace';
 
+import { ENVS, parseEnvs } from '../environment/parse.js';
+
+const envs = parseEnvs(ENVS);
+
 export enum Types {
     ACCOUNT_CREATED = 'nango.account.created',
 
@@ -171,11 +175,52 @@ export enum Types {
 
 type Dimensions = Record<string, string | number> | undefined;
 
+const CARDINALITY_GATED_PROVIDER_CONFIG_KEY_METRICS = new Set<Types>([
+    Types.REFRESH_CONNECTIONS_FAILED,
+    Types.REFRESH_CONNECTIONS_FRESH,
+    Types.REFRESH_CONNECTIONS_SUCCESS,
+    Types.REFRESH_CONNECTIONS_UNKNOWN,
+    Types.AUTH_SUCCESS,
+    Types.AUTH_FAILURE,
+    Types.POST_CONNECTION_SUCCESS,
+    Types.POST_CONNECTION_FAILURE,
+    Types.PRE_CONNECTION_DELETION_SUCCESS,
+    Types.PRE_CONNECTION_DELETION_FAILURE,
+    Types.WEBHOOK_INCOMING_RECEIVED,
+    Types.WEBHOOK_DIRECT_TRIGGER_SUCCESS,
+    Types.WEBHOOK_DISPATCH_LARGE_FANOUT,
+    Types.WEBHOOK_DISPATCH_BYPASS_OVERSIZE,
+    Types.WEBHOOK_DISPATCH_PUBLISH_SUCCESS,
+    Types.WEBHOOK_DISPATCH_PUBLISH_FAILURE,
+    Types.WEBHOOK_DISPATCH_DWELL_MS,
+    Types.WEBHOOK_DISPATCH_CONSUME,
+    Types.WEBHOOK_DISPATCH_DROPPED,
+    Types.MCP_CLIENT_ID_METHOD,
+    Types.PROXY,
+    Types.PROXY_FAILURE,
+    Types.PROXY_SUCCESS,
+    Types.PROXY_BASE_URL_OVERRIDE_DENIED
+]);
+
+export function applyDimensionPolicy(metricName: Types, dimensions?: Dimensions): Dimensions {
+    if (!dimensions) {
+        return dimensions;
+    }
+    if (!CARDINALITY_GATED_PROVIDER_CONFIG_KEY_METRICS.has(metricName)) {
+        return dimensions;
+    }
+    if (envs.NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY) {
+        return dimensions;
+    }
+    const { providerConfigKey: _providerConfigKey, ...rest } = dimensions;
+    return rest;
+}
+
 export function increment(metricName: Types, value = 1, dimensions?: Dimensions): void {
     if (value === 0) {
         return;
     }
-    tracer.dogstatsd.increment(metricName, value, dimensions ?? {});
+    tracer.dogstatsd.increment(metricName, value, applyDimensionPolicy(metricName, dimensions) ?? {});
 }
 
 export function decrement(metricName: Types, value = 1, dimensions?: Dimensions): void {
@@ -186,7 +231,7 @@ export function decrement(metricName: Types, value = 1, dimensions?: Dimensions)
 }
 
 export function gauge(metricName: Types, value?: number, dimensions?: Dimensions): void {
-    tracer.dogstatsd.gauge(metricName, value ?? 1, dimensions ?? {});
+    tracer.dogstatsd.gauge(metricName, value ?? 1, applyDimensionPolicy(metricName, dimensions) ?? {});
 }
 
 export function histogram(metricName: Types, value: number): void {
@@ -194,11 +239,11 @@ export function histogram(metricName: Types, value: number): void {
 }
 
 export function duration(metricName: Types, value: number, dimensions?: Dimensions): void {
-    tracer.dogstatsd.distribution(metricName, value, dimensions ?? {});
+    tracer.dogstatsd.distribution(metricName, value, applyDimensionPolicy(metricName, dimensions) ?? {});
 }
 
 export function distribution(metricName: Types, value: number, dimensions?: Dimensions): void {
-    tracer.dogstatsd.distribution(metricName, value, dimensions ?? {});
+    tracer.dogstatsd.distribution(metricName, value, applyDimensionPolicy(metricName, dimensions) ?? {});
 }
 
 export function time<F extends (...args: unknown[]) => unknown>(metricName: Types, func: F, dimensions?: Dimensions): F {

--- a/packages/utils/lib/telemetry/metrics.unit.test.ts
+++ b/packages/utils/lib/telemetry/metrics.unit.test.ts
@@ -91,4 +91,12 @@ describe('applyDimensionPolicy', () => {
         increment(Types.DEPLOY_SECURITY_SCAN, 1, { providerConfigKey: 'github-prod', result: 'pass' });
         expect(dogstatsd.increment).toHaveBeenCalledWith(Types.DEPLOY_SECURITY_SCAN, 1, { providerConfigKey: 'github-prod', result: 'pass' });
     });
+
+    it('forwards stripped dimensions from decrement when the flag is off', async () => {
+        vi.stubEnv('NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', 'false');
+        vi.resetModules();
+        const { decrement, Types } = await loadMetrics();
+        decrement(Types.AUTH_SUCCESS, 1, { provider: 'github', providerConfigKey: 'github-prod' });
+        expect(dogstatsd.decrement).toHaveBeenCalledWith(Types.AUTH_SUCCESS, 1, { provider: 'github' });
+    });
 });

--- a/packages/utils/lib/telemetry/metrics.unit.test.ts
+++ b/packages/utils/lib/telemetry/metrics.unit.test.ts
@@ -25,6 +25,12 @@ describe('applyDimensionPolicy', () => {
         return await import('./metrics.js');
     }
 
+    it('imports without parsing the full env schema', async () => {
+        vi.stubEnv('EMAIL_HTTP_URL', 'https://mail.example.com/send');
+        vi.resetModules();
+        await expect(loadMetrics()).resolves.toBeDefined();
+    });
+
     it('strips providerConfigKey from a gated metric when the flag is off', async () => {
         vi.stubEnv('NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', 'false');
         vi.resetModules();

--- a/packages/utils/lib/telemetry/metrics.unit.test.ts
+++ b/packages/utils/lib/telemetry/metrics.unit.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const dogstatsd = vi.hoisted(() => ({
+    increment: vi.fn(),
+    decrement: vi.fn(),
+    gauge: vi.fn(),
+    histogram: vi.fn(),
+    distribution: vi.fn()
+}));
+
+vi.mock('dd-trace', () => ({
+    default: {
+        dogstatsd
+    }
+}));
+
+describe('applyDimensionPolicy', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+        vi.clearAllMocks();
+    });
+
+    async function loadMetrics() {
+        return await import('./metrics.js');
+    }
+
+    it('strips providerConfigKey from a gated metric when the flag is off', async () => {
+        vi.stubEnv('NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', 'false');
+        vi.resetModules();
+        const { applyDimensionPolicy, Types } = await loadMetrics();
+        expect(applyDimensionPolicy(Types.AUTH_SUCCESS, { provider: 'github', providerConfigKey: 'github-prod' })).toEqual({ provider: 'github' });
+    });
+
+    it('keeps providerConfigKey on a gated metric when the flag is on', async () => {
+        vi.stubEnv('NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', 'true');
+        vi.resetModules();
+        const { applyDimensionPolicy, Types } = await loadMetrics();
+        const dimensions = { provider: 'github', providerConfigKey: 'github-prod' };
+        expect(applyDimensionPolicy(Types.AUTH_SUCCESS, dimensions)).toBe(dimensions);
+    });
+
+    it('keeps providerConfigKey on DEPLOY_SECURITY_SCAN when the flag is off', async () => {
+        vi.stubEnv('NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', 'false');
+        vi.resetModules();
+        const { applyDimensionPolicy, Types } = await loadMetrics();
+        const dimensions = { providerConfigKey: 'github-prod', result: 'pass' };
+        expect(applyDimensionPolicy(Types.DEPLOY_SECURITY_SCAN, dimensions)).toBe(dimensions);
+    });
+
+    it('passes through an unlisted metric that includes providerConfigKey regardless of flag state', async () => {
+        const dimensions = { providerConfigKey: 'github-prod', queue: 'sync' };
+
+        vi.stubEnv('NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', 'false');
+        vi.resetModules();
+        const off = await loadMetrics();
+        expect(off.applyDimensionPolicy(off.Types.TASKS_QUEUE_DEPTH, dimensions)).toBe(dimensions);
+
+        vi.stubEnv('NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', 'true');
+        vi.resetModules();
+        const on = await loadMetrics();
+        expect(on.applyDimensionPolicy(on.Types.TASKS_QUEUE_DEPTH, dimensions)).toBe(dimensions);
+    });
+
+    it('returns undefined when dimensions are undefined', async () => {
+        vi.resetModules();
+        const { applyDimensionPolicy, Types } = await loadMetrics();
+        expect(applyDimensionPolicy(Types.AUTH_SUCCESS, undefined)).toBeUndefined();
+    });
+
+    it('forwards stripped dimensions from increment when the flag is off', async () => {
+        vi.stubEnv('NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', 'false');
+        vi.resetModules();
+        const { increment, Types } = await loadMetrics();
+        increment(Types.AUTH_SUCCESS, 1, { provider: 'github', providerConfigKey: 'github-prod' });
+        expect(dogstatsd.increment).toHaveBeenCalledWith(Types.AUTH_SUCCESS, 1, { provider: 'github' });
+    });
+
+    it('forwards providerConfigKey from increment when the flag is on', async () => {
+        vi.stubEnv('NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', 'true');
+        vi.resetModules();
+        const { increment, Types } = await loadMetrics();
+        increment(Types.AUTH_SUCCESS, 1, { provider: 'github', providerConfigKey: 'github-prod' });
+        expect(dogstatsd.increment).toHaveBeenCalledWith(Types.AUTH_SUCCESS, 1, { provider: 'github', providerConfigKey: 'github-prod' });
+    });
+
+    it('does not strip providerConfigKey from DEPLOY_SECURITY_SCAN via increment when the flag is off', async () => {
+        vi.stubEnv('NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY', 'false');
+        vi.resetModules();
+        const { increment, Types } = await loadMetrics();
+        increment(Types.DEPLOY_SECURITY_SCAN, 1, { providerConfigKey: 'github-prod', result: 'pass' });
+        expect(dogstatsd.increment).toHaveBeenCalledWith(Types.DEPLOY_SECURITY_SCAN, 1, { providerConfigKey: 'github-prod', result: 'pass' });
+    });
+});


### PR DESCRIPTION
## Summary
- Opt in `providerConfigKey` on selected auth, proxy, refresh, connection-lifecycle, and webhook metrics via `NANGO_METRICS_INCLUDE_PROVIDER_CONFIG_KEY` (default off).
- Cardinality is gated in `applyDimensionPolicy` by an explicit metric allowlist, so existing tags such as `DEPLOY_SECURITY_SCAN` are unchanged when the flag is off.
- Self-hosted deployments can enable the tag on **server** and **jobs**; Cloud timeseries counts stay the same.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

