### PR TITLE
fix(mfa): allow reusing the last verified TOTP step (NAN-6614)

### DIFF
--- a/packages/shared/lib/services/mfa.service.integration.test.ts
+++ b/packages/shared/lib/services/mfa.service.integration.test.ts
@@ -20,7 +20,7 @@ describe('MFA service', () => {
         vi.restoreAllMocks();
     });
 
-    it('activates a TOTP factor, prevents replay, and consumes recovery codes once', async () => {
+    it('activates a TOTP factor, rejects stale steps, and consumes recovery codes once', async () => {
         vi.useFakeTimers();
         vi.setSystemTime(new Date('2026-07-14T12:00:00Z'));
 
@@ -36,7 +36,12 @@ describe('MFA service', () => {
         vi.setSystemTime(new Date('2026-07-14T12:00:30Z'));
         const token = totp.generate();
         expect((await mfaService.verifyTotp(user.id, token)).unwrap()).toBe(true);
-        expect((await mfaService.verifyTotp(user.id, token)).unwrap()).toBe(false);
+        // same code again inside its own step, which is what signing in then impersonating does
+        expect((await mfaService.verifyTotp(user.id, token)).unwrap()).toBe(true);
+
+        // the step before the one we just accepted is stale and stays refused
+        const staleToken = totp.generate({ timestamp: Date.now() - STEP_MS });
+        expect((await mfaService.verifyTotp(user.id, staleToken)).unwrap()).toBe(false);
 
         vi.setSystemTime(new Date('2026-07-14T12:01:00Z'));
         const previousStepToken = totp.generate();

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -137,8 +137,22 @@ class MFAService {
                 }
 
                 const verified = this.verifyToken(factor, token, TOTP_WINDOW);
-                if (verified === null || (factor.last_accepted_counter !== null && verified.counter <= BigInt(factor.last_accepted_counter))) {
+                if (verified === null) {
                     return false;
+                }
+
+                if (factor.last_accepted_counter !== null) {
+                    const lastAcceptedCounter = BigInt(factor.last_accepted_counter);
+                    if (verified.counter < lastAcceptedCounter) {
+                        return false;
+                    }
+
+                    // The last accepted step can be replayed while it is still current, so signing in
+                    // and immediately impersonating does not need a fresh code. Nothing to record, and
+                    // the offset a replay reports is off by the time we spent on the first use.
+                    if (verified.counter === lastAcceptedCounter) {
+                        return true;
+                    }
                 }
 
                 const updated = await trx<DBMFAFactor>(FACTORS_TABLE)


### PR DESCRIPTION
Verification required the submitted step to be strictly greater than the last accepted one, so a code could only ever be used once. Signing in and then going straight to impersonate reuses the same code and gets rejected as invalid.

The comparison is now greater or equal. A replay of the current step returns true without writing anything back, since the offset a second use reports is skewed by the time spent on the first one. Anything older than the last accepted step is still refused.

This does mean a code can be replayed to log in again. We are fine with that as long as it is the current step, or the current step for the recorded clock offset. Ross is ok with it. There is no separate branch for impersonation, the same rule applies everywhere.

NAN-6614

## Test plan

- [x] `mfa.service.integration.test.ts` passes, including a new case for reusing a code inside its own step and one for refusing the step before it
- [ ] Sign in with MFA, then impersonate an account with the same code still on screen
- [ ] Sign in with MFA, wait for the code to roll over, confirm the old one is refused

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

