### PR TITLE
fix(mfa): reuse the session's recent MFA verification for impersonation (NAN-6614)

### DIFF
--- a/packages/server/lib/controllers/v1/account/mfa/elevation.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/elevation.ts
@@ -12,5 +12,12 @@ export function markMfaVerified(req: Request): void {
 
 export function hasRecentMfa(req: Request, maxAgeMs: number): boolean {
     const verifiedAt = req.session.mfaVerifiedAt;
-    return verifiedAt !== undefined && Date.now() - verifiedAt < maxAgeMs;
+    if (verifiedAt === undefined) {
+        return false;
+    }
+
+    // A marker dated in the future only happens if the host clock moved backwards, and it would
+    // otherwise read as fresh until the clock caught up.
+    const age = Date.now() - verifiedAt;
+    return age >= 0 && age < maxAgeMs;
 }

--- a/packages/server/lib/controllers/v1/account/mfa/elevation.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/elevation.ts
@@ -1,0 +1,16 @@
+import type { Request } from 'express';
+
+/**
+ * Tracks that this session presented a second factor, so a sensitive action can rely on the earlier
+ * verification instead of asking for another code. The factor itself stays single use.
+ *
+ * Must be called after req.login, which regenerates the session and would drop the marker.
+ */
+export function markMfaVerified(req: Request): void {
+    req.session.mfaVerifiedAt = Date.now();
+}
+
+export function hasRecentMfa(req: Request, maxAgeMs: number): boolean {
+    const verifiedAt = req.session.mfaVerifiedAt;
+    return verifiedAt !== undefined && Date.now() - verifiedAt < maxAgeMs;
+}

--- a/packages/server/lib/controllers/v1/account/mfa/elevation.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/elevation.ts
@@ -4,7 +4,7 @@ import type { Request } from 'express';
  * Tracks that this session presented a second factor, so a sensitive action can rely on the earlier
  * verification instead of asking for another code. The factor itself stays single use.
  *
- * Must be called after req.login, which regenerates the session and would drop the marker.
+ * req.login regenerates the session, so a marker set before it is dropped rather than carried over.
  */
 export function markMfaVerified(req: Request): void {
     req.session.mfaVerifiedAt = Date.now();
@@ -16,8 +16,6 @@ export function hasRecentMfa(req: Request, maxAgeMs: number): boolean {
         return false;
     }
 
-    // A marker dated in the future only happens if the host clock moved backwards, and it would
-    // otherwise read as fresh until the clock caught up.
     const age = Date.now() - verifiedAt;
     return age >= 0 && age < maxAgeMs;
 }

--- a/packages/server/lib/controllers/v1/account/mfa/elevation.unit.test.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/elevation.unit.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { hasRecentMfa, markMfaVerified } from './elevation.js';
+
+import type { Request } from 'express';
+
+const MAX_AGE_MS = 5 * 60 * 1000;
+
+function reqWithSession(session: Record<string, unknown> = {}): Request {
+    return { session } as unknown as Request;
+}
+
+describe('MFA elevation', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('treats a session that never verified as not elevated', () => {
+        expect(hasRecentMfa(reqWithSession(), MAX_AGE_MS)).toBe(false);
+    });
+
+    it('elevates a session that just verified', () => {
+        const req = reqWithSession();
+        markMfaVerified(req);
+        expect(hasRecentMfa(req, MAX_AGE_MS)).toBe(true);
+    });
+
+    it('stops elevating once the marker is older than the max age', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
+
+        const req = reqWithSession();
+        markMfaVerified(req);
+
+        vi.setSystemTime(new Date('2026-08-14T12:04:59Z'));
+        expect(hasRecentMfa(req, MAX_AGE_MS)).toBe(true);
+
+        vi.setSystemTime(new Date('2026-08-14T12:05:00Z'));
+        expect(hasRecentMfa(req, MAX_AGE_MS)).toBe(false);
+    });
+});

--- a/packages/server/lib/controllers/v1/account/mfa/elevation.unit.test.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/elevation.unit.test.ts
@@ -38,4 +38,11 @@ describe('MFA elevation', () => {
         vi.setSystemTime(new Date('2026-08-14T12:05:00Z'));
         expect(hasRecentMfa(req, MAX_AGE_MS)).toBe(false);
     });
+
+    it('refuses a marker dated in the future', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
+
+        expect(hasRecentMfa(reqWithSession({ mfaVerifiedAt: Date.now() + 60 * 60 * 1000 }), MAX_AGE_MS)).toBe(false);
+    });
 });

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -3,6 +3,7 @@ import { getFlags } from '@nangohq/feature-flags';
 import { accountService, mfaService, userService } from '@nangohq/shared';
 
 import { safeReturnTo } from '../returnTo.js';
+import { markMfaVerified } from './elevation.js';
 
 import type { DBUser, PostMFALoginVerification } from '@nangohq/types';
 import type { Request } from 'express';
@@ -53,6 +54,7 @@ export async function verifyPendingMfaLogin(req: Request, credential: PostMFALog
     const returnTo = pending.returnTo;
     delete req.session.pendingMfaLogin;
     await loginUser(req, currentUser);
+    markMfaVerified(req);
     await saveSession(req);
     return { user: currentUser, returnTo };
 }

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.integration.test.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.integration.test.ts
@@ -182,6 +182,16 @@ describe(`POST ${endpoint} with a dashboard session`, () => {
         mfaFlagSpy.mockResolvedValue(true);
     });
 
+    async function enrollAndActivate(session: string) {
+        const enrollment = await api.fetch('/api/v1/account/mfa/enroll', { method: 'POST', session });
+        isSuccess(enrollment.json);
+        const totp = OTPAuth.URI.parse(enrollment.json.data.otpauthUri) as OTPAuth.TOTP;
+        const activation = await api.fetch('/api/v1/account/mfa/activate', { method: 'POST', session, body: { code: totp.generate() } });
+        expect(activation.res.status).toBe(200);
+
+        return totp;
+    }
+
     /** Signs in first, because a user with an active factor would land in the pending MFA flow. */
     async function seedAdmin({ withFactor }: { withFactor: boolean }) {
         const { account, user } = await seeders.seedAccountEnvAndUser();
@@ -193,13 +203,7 @@ describe(`POST ${endpoint} with a dashboard session`, () => {
             return { session, totp: null };
         }
 
-        const enrollment = await api.fetch('/api/v1/account/mfa/enroll', { method: 'POST', session });
-        isSuccess(enrollment.json);
-        const totp = OTPAuth.URI.parse(enrollment.json.data.otpauthUri) as OTPAuth.TOTP;
-        const activation = await api.fetch('/api/v1/account/mfa/activate', { method: 'POST', session, body: { code: totp.generate() } });
-        expect(activation.res.status).toBe(200);
-
-        return { session, totp };
+        return { session, totp: await enrollAndActivate(session) };
     }
 
     /** Enrolls a factor, then signs in again through the MFA challenge so the session carries the verification. */
@@ -208,12 +212,7 @@ describe(`POST ${endpoint} with a dashboard session`, () => {
         flags.hasAdminCapabilities = true;
         envs.NANGO_ADMIN_UUID = account.uuid;
 
-        const enrollSession = await authenticateUser(api, user);
-        const enrollment = await api.fetch('/api/v1/account/mfa/enroll', { method: 'POST', session: enrollSession });
-        isSuccess(enrollment.json);
-        const totp = OTPAuth.URI.parse(enrollment.json.data.otpauthUri) as OTPAuth.TOTP;
-        const activation = await api.fetch('/api/v1/account/mfa/activate', { method: 'POST', session: enrollSession, body: { code: totp.generate() } });
-        expect(activation.res.status).toBe(200);
+        const totp = await enrollAndActivate(await authenticateUser(api, user));
 
         const signin = await api.fetch('/api/v1/account/signin', { method: 'POST', body: { email: user.email, password: 'Password123!' } });
         isSuccess(signin.json);

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.integration.test.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.integration.test.ts
@@ -319,6 +319,31 @@ describe(`POST ${endpoint} with a dashboard session`, () => {
         expect(res.json).toStrictEqual<typeof res.json>({ success: true });
     });
 
+    it('should keep the verification when the target is rejected, so a retry costs no second code', async () => {
+        const { session, totp } = await seedAdmin({ withFactor: true });
+
+        const missingTarget = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { env: 'dev' },
+            session,
+            body: { accountUUID: 'f8ca4c4e-8c5a-4502-93f9-cd89d7551362', loginReason: 'support', code: nextCode(totp!) }
+        });
+        isError(missingTarget.json);
+        expect(missingTarget.json).toStrictEqual<typeof missingTarget.json>({ error: { code: 'invalid_body', message: 'Account not found' } });
+
+        // The code is spent, and this path never reached req.login, so the session kept the verification.
+        const accountUUID = await seedTarget();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { env: 'dev' },
+            session,
+            body: { accountUUID, loginReason: 'support' }
+        });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(200);
+    });
+
     it('should challenge even when the account MFA feature flag is off', async () => {
         const { session, totp } = await seedAdmin({ withFactor: true });
         const accountUUID = await seedTarget();

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.integration.test.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.integration.test.ts
@@ -202,6 +202,34 @@ describe(`POST ${endpoint} with a dashboard session`, () => {
         return { session, totp };
     }
 
+    /** Enrolls a factor, then signs in again through the MFA challenge so the session carries the verification. */
+    async function seedAdminSignedInWithMfa() {
+        const { account, user } = await seeders.seedAccountEnvAndUser();
+        flags.hasAdminCapabilities = true;
+        envs.NANGO_ADMIN_UUID = account.uuid;
+
+        const enrollSession = await authenticateUser(api, user);
+        const enrollment = await api.fetch('/api/v1/account/mfa/enroll', { method: 'POST', session: enrollSession });
+        isSuccess(enrollment.json);
+        const totp = OTPAuth.URI.parse(enrollment.json.data.otpauthUri) as OTPAuth.TOTP;
+        const activation = await api.fetch('/api/v1/account/mfa/activate', { method: 'POST', session: enrollSession, body: { code: totp.generate() } });
+        expect(activation.res.status).toBe(200);
+
+        const signin = await api.fetch('/api/v1/account/signin', { method: 'POST', body: { email: user.email, password: 'Password123!' } });
+        isSuccess(signin.json);
+        expect(signin.json).toEqual({ data: { mfaRequired: true } });
+        const pendingSession = signin.res.headers.getSetCookie()[0]!.split(';')[0]!;
+
+        const verification = await api.fetch('/api/v1/account/mfa/login/verify', {
+            method: 'POST',
+            session: pendingSession,
+            body: { type: 'code', code: nextCode(totp) }
+        });
+        expect(verification.res.status).toBe(200);
+
+        return { session: verification.res.headers.getSetCookie()[0]!.split(';')[0]!, totp };
+    }
+
     async function seedTarget() {
         const { account } = await seeders.seedAccountEnvAndUser();
         return account.uuid;
@@ -260,7 +288,7 @@ describe(`POST ${endpoint} with a dashboard session`, () => {
         expect(res.json).toStrictEqual<typeof res.json>({ error: { code: 'invalid_mfa_code' } });
     });
 
-    it('should refuse a missing code', async () => {
+    it('should ask for a code when the session has no recent verification', async () => {
         const { session } = await seedAdmin({ withFactor: true });
         const accountUUID = await seedTarget();
 
@@ -273,7 +301,23 @@ describe(`POST ${endpoint} with a dashboard session`, () => {
 
         isError(res.json);
         expect(res.res.status).toBe(400);
-        expect(res.json).toStrictEqual<typeof res.json>({ error: { code: 'invalid_mfa_code' } });
+        expect(res.json).toStrictEqual<typeof res.json>({ error: { code: 'mfa_code_required' } });
+    });
+
+    it('should impersonate without a code when the session just verified MFA at sign-in', async () => {
+        const { session } = await seedAdminSignedInWithMfa();
+        const accountUUID = await seedTarget();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { env: 'dev' },
+            session,
+            body: { accountUUID, loginReason: 'support' }
+        });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(200);
+        expect(res.json).toStrictEqual<typeof res.json>({ success: true });
     });
 
     it('should challenge even when the account MFA feature flag is off', async () => {

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
@@ -78,9 +78,6 @@ async function challengeAdmin({
         return false;
     }
 
-    // Dropped by the session regeneration in req.login on the happy path, which is what keeps
-    // elevation out of the impersonated session. It survives on the paths that reject the target
-    // below, so a mistyped account UUID does not cost another code.
     markMfaVerified(req);
     return true;
 }

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
@@ -78,6 +78,9 @@ async function challengeAdmin({
         return false;
     }
 
+    // Dropped by the session regeneration in req.login on the happy path, which is what keeps
+    // elevation out of the impersonated session. It survives on the paths that reject the target
+    // below, so a mistyped account UUID does not cost another code.
     markMfaVerified(req);
     return true;
 }

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
@@ -6,11 +6,12 @@ import { flags, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils
 
 import { envs } from '../../../../env.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { hasRecentMfa, markMfaVerified } from '../../account/mfa/elevation.js';
 
 import type { RequestLocals } from '../../../../utils/express.js';
 import type { LogContext } from '@nangohq/logs';
 import type { DBUser, PostImpersonate } from '@nangohq/types';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 
 const schemaBody = z
     .object({
@@ -24,21 +25,27 @@ const schemaBody = z
     .strict();
 
 const IMPERSONATE_SESSION_EXPIRATION_MS = 600 * 1000;
+const RECENT_MFA_MAX_AGE_MS = 5 * 60 * 1000;
 
 /**
  * Verifies the admin's own factor, not the target user's. This is a step-up check on an already
  * authenticated session, so it verifies inline instead of parking a pending login the way
  * `loginOrStartPendingMfa` does for sign-in.
  *
+ * A factor presented in the last RECENT_MFA_MAX_AGE_MS on this session counts, which is what makes
+ * signing in and impersonating straight away work without a second code.
+ *
  * Deliberately not gated on the per-account MFA feature flag: the admin account may not carry it,
  * and that would silently turn the whole challenge into a no-op.
  */
 async function challengeAdmin({
+    req,
     res,
     logCtx,
     adminUser,
     code
 }: {
+    req: Request;
     res: Response<PostImpersonate['Reply'], RequestLocals>;
     logCtx: LogContext;
     adminUser: DBUser;
@@ -50,9 +57,14 @@ async function challengeAdmin({
         return false;
     }
 
+    if (hasRecentMfa(req, RECENT_MFA_MAX_AGE_MS)) {
+        void logCtx.info('Impersonation accepted on an MFA verification from earlier in this session');
+        return true;
+    }
+
     if (!code) {
         void logCtx.error('Impersonation refused, no MFA code provided');
-        res.status(400).send({ error: { code: 'invalid_mfa_code' } });
+        res.status(400).send({ error: { code: 'mfa_code_required' } });
         return false;
     }
 
@@ -66,6 +78,7 @@ async function challengeAdmin({
         return false;
     }
 
+    markMfaVerified(req);
     return true;
 }
 
@@ -116,7 +129,7 @@ export const postImpersonate = asyncWrapper<PostImpersonate>(async (req, res) =>
         }
 
         if (envs.NANGO_IMPERSONATION_MFA_REQUIRED) {
-            if (!(await challengeAdmin({ res, logCtx, adminUser, code: body.code }))) {
+            if (!(await challengeAdmin({ req, res, logCtx, adminUser, code: body.code }))) {
                 await logCtx.failed();
                 return;
             }

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
@@ -25,14 +25,14 @@ const schemaBody = z
     .strict();
 
 const IMPERSONATE_SESSION_EXPIRATION_MS = 600 * 1000;
-const RECENT_MFA_MAX_AGE_MS = 5 * 60 * 1000;
+const IMPERSONATE_MFA_MAX_AGE_MS = 5 * 60 * 1000;
 
 /**
  * Verifies the admin's own factor, not the target user's. This is a step-up check on an already
  * authenticated session, so it verifies inline instead of parking a pending login the way
  * `loginOrStartPendingMfa` does for sign-in.
  *
- * A factor presented in the last RECENT_MFA_MAX_AGE_MS on this session counts, which is what makes
+ * A factor presented in the last IMPERSONATE_MFA_MAX_AGE_MS on this session counts, which is what makes
  * signing in and impersonating straight away work without a second code.
  *
  * Deliberately not gated on the per-account MFA feature flag: the admin account may not carry it,
@@ -57,8 +57,7 @@ async function challengeAdmin({
         return false;
     }
 
-    if (hasRecentMfa(req, RECENT_MFA_MAX_AGE_MS)) {
-        void logCtx.info('Impersonation accepted on an MFA verification from earlier in this session');
+    if (hasRecentMfa(req, IMPERSONATE_MFA_MAX_AGE_MS)) {
         return true;
     }
 

--- a/packages/server/lib/express.d.ts
+++ b/packages/server/lib/express.d.ts
@@ -37,6 +37,7 @@ declare module 'express-session' {
             returnTo: string;
             createdAt: number;
         };
+        mfaVerifiedAt?: number;
         pendingAccountDiscovery?: {
             userId: number;
             expiresAt: number;

--- a/packages/types/lib/admin/http.api.ts
+++ b/packages/types/lib/admin/http.api.ts
@@ -12,6 +12,6 @@ export type PostImpersonate = ApiEndpoint<{
         loginReason: string;
         code?: string | undefined;
     };
-    Error: ApiError<'invalid_mfa_code'> | ApiError<'mfa_not_enabled'>;
+    Error: ApiError<'invalid_mfa_code'> | ApiError<'mfa_code_required'> | ApiError<'mfa_not_enabled'>;
     Success: { success: true };
 }>;

--- a/packages/webapp/src/hooks/useAdmin.tsx
+++ b/packages/webapp/src/hooks/useAdmin.tsx
@@ -8,8 +8,13 @@ export async function apiAdminImpersonate(env: string, body: PostImpersonate['Bo
         body: JSON.stringify(body)
     });
 
+    // A 200 already switched the session through Set-Cookie, so the body must never decide that.
+    if (res.status === 200) {
+        return { res, json: null };
+    }
+
     return {
         res,
-        json: (await res.json()) as PostImpersonate['Reply']
+        json: (await res.json().catch(() => null)) as PostImpersonate['Reply'] | null
     };
 }

--- a/packages/webapp/src/hooks/useAdmin.tsx
+++ b/packages/webapp/src/hooks/useAdmin.tsx
@@ -2,19 +2,13 @@ import { apiFetch } from '../utils/api';
 
 import type { PostImpersonate } from '@nangohq/types';
 
-export async function apiAdminImpersonate(env: string, body: PostImpersonate['Body']) {
+export async function apiAdminImpersonate(env: string, body: PostImpersonate['Body'], signal?: AbortSignal) {
     const res = await apiFetch(`/api/v1/admin/impersonate?env=${env}`, {
         method: 'POST',
-        body: JSON.stringify(body)
+        body: JSON.stringify(body),
+        signal
     });
 
-    // A 200 already switched the session through Set-Cookie, so the body must never decide that.
-    if (res.status === 200) {
-        return { res, json: null };
-    }
-
-    return {
-        res,
-        json: (await res.json().catch(() => null)) as PostImpersonate['Reply'] | null
-    };
+    const json = (await res.json().catch(() => null)) as PostImpersonate['Reply'] | null;
+    return { ok: res.status === 200, errorCode: json && 'error' in json ? json.error.code : undefined };
 }

--- a/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
+++ b/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
@@ -12,25 +12,29 @@ import { Form, FormControl, FormField, FormItem, FormMessage } from '../../../co
 import { apiAdminImpersonate } from '../../../hooks/useAdmin';
 import { useStore } from '../../../store';
 
+const codeSchema = z.string().regex(/^\d{6}$/, 'Enter the 6-digit code from your authenticator');
+
 const ImpersonateFormSchema = z.object({
     account_uuid: z.string().uuid(),
     login_reason: z.string().min(1).max(1024),
-    code: z.string().regex(/^\d{6}$/, 'Enter the 6-digit code from your authenticator')
+    code: z.string()
 });
 
 type ImpersonateFormData = z.infer<typeof ImpersonateFormSchema>;
 
 const errorMessages: Record<string, string> = {
     mfa_not_enabled: 'You need to enroll MFA before you can impersonate an account.',
+    mfa_code_required: 'Enter your 2FA code to continue.',
     invalid_mfa_code: 'Invalid MFA code.'
 };
 
 export const ImpersonateForm: React.FC = () => {
     const env = useStore((state) => state.env);
     const [needsEnrollment, setNeedsEnrollment] = useState(false);
+    const [needsCode, setNeedsCode] = useState(false);
 
     const form = useForm<ImpersonateFormData>({
-        resolver: zodResolver(ImpersonateFormSchema),
+        resolver: zodResolver(needsCode ? ImpersonateFormSchema.extend({ code: codeSchema }) : ImpersonateFormSchema),
         defaultValues: {
             account_uuid: '',
             login_reason: '',
@@ -39,7 +43,11 @@ export const ImpersonateForm: React.FC = () => {
     });
 
     const onSubmit = async (data: ImpersonateFormData) => {
-        const res = await apiAdminImpersonate(env, { accountUUID: data.account_uuid, loginReason: data.login_reason, code: data.code });
+        const res = await apiAdminImpersonate(env, {
+            accountUUID: data.account_uuid,
+            loginReason: data.login_reason,
+            code: data.code || undefined
+        });
         if (res.res.status === 200) {
             window.location.reload();
             return;
@@ -50,6 +58,9 @@ export const ImpersonateForm: React.FC = () => {
             form.setError('root', { message: errorMessages[code] });
             setNeedsEnrollment(true);
             return;
+        }
+        if (code === 'mfa_code_required' || code === 'invalid_mfa_code') {
+            setNeedsCode(true);
         }
         form.setError('root', { message: (code && errorMessages[code]) || JSON.stringify(res.json) });
         form.resetField('code');
@@ -92,21 +103,23 @@ export const ImpersonateForm: React.FC = () => {
                             )}
                         />
                     </div>
-                    <div className="flex flex-col gap-2">
-                        <FieldLabel htmlFor="code">Your 2FA code</FieldLabel>
-                        <FormField
-                            control={form.control}
-                            name="code"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormControl>
-                                        <Input placeholder="123456" autoComplete="one-time-code" inputMode="numeric" maxLength={6} {...field} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                    </div>
+                    {needsCode && (
+                        <div className="flex flex-col gap-2">
+                            <FieldLabel htmlFor="code">Your 2FA code</FieldLabel>
+                            <FormField
+                                control={form.control}
+                                name="code"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormControl>
+                                            <Input placeholder="123456" autoComplete="one-time-code" inputMode="numeric" maxLength={6} {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+                    )}
                     <Alert variant="warning">
                         <TriangleAlert />
                         <AlertDescription>

--- a/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
+++ b/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
@@ -31,10 +31,18 @@ const ImpersonateFormSchema = z.object({
 
 type ImpersonateFormData = z.infer<typeof ImpersonateFormSchema>;
 
+const MFA_NOT_ENABLED_MESSAGE = 'You need to enroll MFA before you can impersonate an account.';
+
 const errorMessages: Record<string, string> = {
-    mfa_not_enabled: 'You need to enroll MFA before you can impersonate an account.',
     invalid_mfa_code: 'Invalid MFA code.'
 };
+
+const IMPERSONATE_TIMEOUT_MS = 15_000;
+
+// The request may have switched the session before it stalled, so a reload is the only way to tell.
+function timedOut(err: unknown) {
+    return err instanceof DOMException && err.name === 'TimeoutError';
+}
 
 export const ImpersonateForm: React.FC = () => {
     const env = useStore((state) => state.env);
@@ -59,39 +67,45 @@ export const ImpersonateForm: React.FC = () => {
         setCodeError(null);
     };
 
-    const onCancel = () => {
-        if (verifying) {
-            window.location.reload();
-            return;
-        }
-        closeChallenge();
-    };
+    const attempt = async (mfaCode?: string) => {
+        const values = form.getValues();
+        const showError =
+            mfaCode === undefined
+                ? (message: string) => form.setError('root', { message })
+                : (message: string) => {
+                      setCode('');
+                      setCodeError(message);
+                  };
 
-    const impersonate = async (data: ImpersonateFormData, mfaCode?: string) => {
-        return await apiAdminImpersonate(env, { accountUUID: data.account_uuid, loginReason: data.login_reason, code: mfaCode });
-    };
-
-    const onSubmit = async (data: ImpersonateFormData) => {
         try {
-            const res = await impersonate(data);
-            if (res.res.status === 200) {
+            const result = await apiAdminImpersonate(
+                env,
+                { accountUUID: values.account_uuid, loginReason: values.login_reason, code: mfaCode },
+                AbortSignal.timeout(IMPERSONATE_TIMEOUT_MS)
+            );
+
+            if (result.ok) {
                 window.location.reload();
                 return;
             }
 
-            const code = res.json && 'error' in res.json ? res.json.error.code : undefined;
-            if (code === 'mfa_code_required') {
+            if (result.errorCode === 'mfa_code_required') {
                 setChallengeOpen(true);
                 return;
             }
-            if (code === 'mfa_not_enabled') {
-                form.setError('root', { message: errorMessages[code] });
+            if (result.errorCode === 'mfa_not_enabled') {
+                closeChallenge();
+                form.setError('root', { message: MFA_NOT_ENABLED_MESSAGE });
                 setNeedsEnrollment(true);
                 return;
             }
-            form.setError('root', { message: (code && errorMessages[code]) || 'Could not impersonate this account.' });
-        } catch {
-            form.setError('root', { message: 'Could not reach the server. Try again.' });
+            showError((result.errorCode && errorMessages[result.errorCode]) || 'Could not impersonate this account.');
+        } catch (err) {
+            if (timedOut(err)) {
+                window.location.reload();
+                return;
+            }
+            showError('Could not reach the server. Try again.');
         }
     };
 
@@ -99,24 +113,7 @@ export const ImpersonateForm: React.FC = () => {
         setVerifying(true);
         setCodeError(null);
         try {
-            const res = await impersonate(form.getValues(), code);
-            if (res.res.status === 200) {
-                window.location.reload();
-                return;
-            }
-
-            const errorCode = res.json && 'error' in res.json ? res.json.error.code : undefined;
-            setCode('');
-            if (errorCode === 'mfa_not_enabled') {
-                closeChallenge();
-                form.setError('root', { message: errorMessages[errorCode] });
-                setNeedsEnrollment(true);
-                return;
-            }
-            setCodeError((errorCode && errorMessages[errorCode]) || 'Could not impersonate this account.');
-        } catch {
-            setCode('');
-            setCodeError('Could not reach the server. Try again.');
+            await attempt(code);
         } finally {
             setVerifying(false);
         }
@@ -127,7 +124,7 @@ export const ImpersonateForm: React.FC = () => {
             <h3 className="text-heading-sm text-text-strong absolute top-[-12px] left-3 bg-surface-canvas px-1">Nango admin</h3>
             <h3 className="text-heading-sm text-text-strong">Impersonate account</h3>
             <Form {...form}>
-                <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-3">
+                <form onSubmit={form.handleSubmit(() => attempt())} className="flex flex-col gap-3">
                     <div className="flex flex-col gap-2">
                         <FieldLabel htmlFor="account_uuid">Account UUID</FieldLabel>
                         <FormField
@@ -181,7 +178,7 @@ export const ImpersonateForm: React.FC = () => {
                 </form>
             </Form>
 
-            <Dialog open={challengeOpen} onOpenChange={(open) => !open && onCancel()}>
+            <Dialog open={challengeOpen} onOpenChange={(open) => !open && !verifying && closeChallenge()}>
                 <DialogContent>
                     <DialogHeader>
                         <DialogTitle>Confirm with two-factor authentication</DialogTitle>
@@ -201,7 +198,7 @@ export const ImpersonateForm: React.FC = () => {
                         </div>
                     </DialogBody>
                     <DialogFooter>
-                        <Button variant="outline" size="sm" onClick={onCancel}>
+                        <Button variant="outline" size="sm" onClick={closeChallenge} disabled={verifying}>
                             Cancel
                         </Button>
                         <Button variant="danger" size="sm" onClick={() => void onConfirmCode()} loading={verifying} disabled={!hasValidCode}>

--- a/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
+++ b/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
@@ -102,6 +102,9 @@ export const ImpersonateForm: React.FC = () => {
                 return;
             }
             setCodeError((errorCode && errorMessages[errorCode]) || JSON.stringify(res.json));
+        } catch {
+            setCode('');
+            setCodeError('Could not reach the server. Try again.');
         } finally {
             setVerifying(false);
         }
@@ -166,7 +169,7 @@ export const ImpersonateForm: React.FC = () => {
                 </form>
             </Form>
 
-            <Dialog open={challengeOpen} onOpenChange={(open) => !open && closeChallenge()}>
+            <Dialog open={challengeOpen} onOpenChange={(open) => !open && !verifying && closeChallenge()}>
                 <DialogContent>
                     <DialogHeader>
                         <DialogTitle>Confirm with two-factor authentication</DialogTitle>
@@ -186,7 +189,7 @@ export const ImpersonateForm: React.FC = () => {
                         </div>
                     </DialogBody>
                     <DialogFooter>
-                        <Button variant="outline" size="sm" onClick={closeChallenge}>
+                        <Button variant="outline" size="sm" onClick={closeChallenge} disabled={verifying}>
                             Cancel
                         </Button>
                         <Button variant="danger" size="sm" onClick={() => void onConfirmCode()} loading={verifying} disabled={!hasValidCode}>

--- a/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
+++ b/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
@@ -59,28 +59,40 @@ export const ImpersonateForm: React.FC = () => {
         setCodeError(null);
     };
 
+    const onCancel = () => {
+        if (verifying) {
+            window.location.reload();
+            return;
+        }
+        closeChallenge();
+    };
+
     const impersonate = async (data: ImpersonateFormData, mfaCode?: string) => {
         return await apiAdminImpersonate(env, { accountUUID: data.account_uuid, loginReason: data.login_reason, code: mfaCode });
     };
 
     const onSubmit = async (data: ImpersonateFormData) => {
-        const res = await impersonate(data);
-        if (res.res.status === 200) {
-            window.location.reload();
-            return;
-        }
+        try {
+            const res = await impersonate(data);
+            if (res.res.status === 200) {
+                window.location.reload();
+                return;
+            }
 
-        const code = 'error' in res.json ? res.json.error.code : undefined;
-        if (code === 'mfa_code_required') {
-            setChallengeOpen(true);
-            return;
+            const code = res.json && 'error' in res.json ? res.json.error.code : undefined;
+            if (code === 'mfa_code_required') {
+                setChallengeOpen(true);
+                return;
+            }
+            if (code === 'mfa_not_enabled') {
+                form.setError('root', { message: errorMessages[code] });
+                setNeedsEnrollment(true);
+                return;
+            }
+            form.setError('root', { message: (code && errorMessages[code]) || 'Could not impersonate this account.' });
+        } catch {
+            form.setError('root', { message: 'Could not reach the server. Try again.' });
         }
-        if (code === 'mfa_not_enabled') {
-            form.setError('root', { message: errorMessages[code] });
-            setNeedsEnrollment(true);
-            return;
-        }
-        form.setError('root', { message: (code && errorMessages[code]) || JSON.stringify(res.json) });
     };
 
     const onConfirmCode = async () => {
@@ -93,7 +105,7 @@ export const ImpersonateForm: React.FC = () => {
                 return;
             }
 
-            const errorCode = 'error' in res.json ? res.json.error.code : undefined;
+            const errorCode = res.json && 'error' in res.json ? res.json.error.code : undefined;
             setCode('');
             if (errorCode === 'mfa_not_enabled') {
                 closeChallenge();
@@ -101,7 +113,7 @@ export const ImpersonateForm: React.FC = () => {
                 setNeedsEnrollment(true);
                 return;
             }
-            setCodeError((errorCode && errorMessages[errorCode]) || JSON.stringify(res.json));
+            setCodeError((errorCode && errorMessages[errorCode]) || 'Could not impersonate this account.');
         } catch {
             setCode('');
             setCodeError('Could not reach the server. Try again.');
@@ -169,7 +181,7 @@ export const ImpersonateForm: React.FC = () => {
                 </form>
             </Form>
 
-            <Dialog open={challengeOpen} onOpenChange={(open) => !open && !verifying && closeChallenge()}>
+            <Dialog open={challengeOpen} onOpenChange={(open) => !open && onCancel()}>
                 <DialogContent>
                     <DialogHeader>
                         <DialogTitle>Confirm with two-factor authentication</DialogTitle>
@@ -189,7 +201,7 @@ export const ImpersonateForm: React.FC = () => {
                         </div>
                     </DialogBody>
                     <DialogFooter>
-                        <Button variant="outline" size="sm" onClick={closeChallenge} disabled={verifying}>
+                        <Button variant="outline" size="sm" onClick={onCancel}>
                             Cancel
                         </Button>
                         <Button variant="danger" size="sm" onClick={() => void onConfirmCode()} loading={verifying} disabled={!hasValidCode}>

--- a/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
+++ b/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
@@ -5,65 +5,106 @@ import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 import z from 'zod';
 
-import { Button, FieldLabel, Input } from '@nangohq/design-system';
+import {
+    Button,
+    Dialog,
+    DialogBody,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    FieldLabel,
+    Input
+} from '@nangohq/design-system';
 
 import { Alert, AlertDescription } from '@/components/ui/Alert';
+import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/InputOTP';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '../../../components/ui/Form';
 import { apiAdminImpersonate } from '../../../hooks/useAdmin';
 import { useStore } from '../../../store';
 
-const codeSchema = z.string().regex(/^\d{6}$/, 'Enter the 6-digit code from your authenticator');
-
 const ImpersonateFormSchema = z.object({
     account_uuid: z.string().uuid(),
-    login_reason: z.string().min(1).max(1024),
-    code: z.string()
+    login_reason: z.string().min(1).max(1024)
 });
 
 type ImpersonateFormData = z.infer<typeof ImpersonateFormSchema>;
 
 const errorMessages: Record<string, string> = {
     mfa_not_enabled: 'You need to enroll MFA before you can impersonate an account.',
-    mfa_code_required: 'Enter your 2FA code to continue.',
     invalid_mfa_code: 'Invalid MFA code.'
 };
 
 export const ImpersonateForm: React.FC = () => {
     const env = useStore((state) => state.env);
     const [needsEnrollment, setNeedsEnrollment] = useState(false);
-    const [needsCode, setNeedsCode] = useState(false);
+    const [challengeOpen, setChallengeOpen] = useState(false);
+    const [code, setCode] = useState('');
+    const [codeError, setCodeError] = useState<string | null>(null);
+    const [verifying, setVerifying] = useState(false);
+    const hasValidCode = /^\d{6}$/.test(code);
 
     const form = useForm<ImpersonateFormData>({
-        resolver: zodResolver(needsCode ? ImpersonateFormSchema.extend({ code: codeSchema }) : ImpersonateFormSchema),
+        resolver: zodResolver(ImpersonateFormSchema),
         defaultValues: {
             account_uuid: '',
-            login_reason: '',
-            code: ''
+            login_reason: ''
         }
     });
 
+    const closeChallenge = () => {
+        setChallengeOpen(false);
+        setCode('');
+        setCodeError(null);
+    };
+
+    const impersonate = async (data: ImpersonateFormData, mfaCode?: string) => {
+        return await apiAdminImpersonate(env, { accountUUID: data.account_uuid, loginReason: data.login_reason, code: mfaCode });
+    };
+
     const onSubmit = async (data: ImpersonateFormData) => {
-        const res = await apiAdminImpersonate(env, {
-            accountUUID: data.account_uuid,
-            loginReason: data.login_reason,
-            code: data.code || undefined
-        });
+        const res = await impersonate(data);
         if (res.res.status === 200) {
             window.location.reload();
             return;
         }
 
         const code = 'error' in res.json ? res.json.error.code : undefined;
+        if (code === 'mfa_code_required') {
+            setChallengeOpen(true);
+            return;
+        }
         if (code === 'mfa_not_enabled') {
             form.setError('root', { message: errorMessages[code] });
             setNeedsEnrollment(true);
             return;
         }
-        if (code === 'mfa_code_required' || code === 'invalid_mfa_code') {
-            setNeedsCode(true);
-        }
         form.setError('root', { message: (code && errorMessages[code]) || JSON.stringify(res.json) });
-        form.resetField('code');
+    };
+
+    const onConfirmCode = async () => {
+        setVerifying(true);
+        setCodeError(null);
+        try {
+            const res = await impersonate(form.getValues(), code);
+            if (res.res.status === 200) {
+                window.location.reload();
+                return;
+            }
+
+            const errorCode = 'error' in res.json ? res.json.error.code : undefined;
+            setCode('');
+            if (errorCode === 'mfa_not_enabled') {
+                closeChallenge();
+                form.setError('root', { message: errorMessages[errorCode] });
+                setNeedsEnrollment(true);
+                return;
+            }
+            setCodeError((errorCode && errorMessages[errorCode]) || JSON.stringify(res.json));
+        } finally {
+            setVerifying(false);
+        }
     };
 
     return (
@@ -103,23 +144,6 @@ export const ImpersonateForm: React.FC = () => {
                             )}
                         />
                     </div>
-                    {needsCode && (
-                        <div className="flex flex-col gap-2">
-                            <FieldLabel htmlFor="code">Your 2FA code</FieldLabel>
-                            <FormField
-                                control={form.control}
-                                name="code"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormControl>
-                                            <Input placeholder="123456" autoComplete="one-time-code" inputMode="numeric" maxLength={6} {...field} />
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
-                        </div>
-                    )}
                     <Alert variant="warning">
                         <TriangleAlert />
                         <AlertDescription>
@@ -141,6 +165,36 @@ export const ImpersonateForm: React.FC = () => {
                     )}
                 </form>
             </Form>
+
+            <Dialog open={challengeOpen} onOpenChange={(open) => !open && closeChallenge()}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Confirm with two-factor authentication</DialogTitle>
+                        <DialogDescription>Enter the 6-digit code from your authenticator app to impersonate this account</DialogDescription>
+                    </DialogHeader>
+                    <DialogBody>
+                        <div className="flex flex-col items-center gap-3">
+                            <span className="text-body-small-medium text-text-strong">Enter your verification code:</span>
+                            <InputOTP maxLength={6} value={code} onChange={setCode} autoFocus>
+                                <InputOTPGroup>
+                                    {[0, 1, 2, 3, 4, 5].map((i) => (
+                                        <InputOTPSlot key={i} index={i} />
+                                    ))}
+                                </InputOTPGroup>
+                            </InputOTP>
+                            {codeError && <p className="text-sm text-status-danger-text">{codeError}</p>}
+                        </div>
+                    </DialogBody>
+                    <DialogFooter>
+                        <Button variant="outline" size="sm" onClick={closeChallenge}>
+                            Cancel
+                        </Button>
+                        <Button variant="danger" size="sm" onClick={() => void onConfirmCode()} loading={verifying} disabled={!hasValidCode}>
+                            Impersonate
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 };


### PR DESCRIPTION
Signing in and going straight to impersonate asked for a second code. The first one was already burned by replay protection, so the same code came back as invalid.

With this we reuse the authentication result `mfaVerifiedAt` is recorded on the session when a factor is verified, and impersonation accepts a verification from the last 5 minutes rather than prompting again. Same idea as GitHub's sudo mode.

NAN-6614

## Test plan

- [x] `elevation.unit.test.ts` covers fresh, expired, and never-verified sessions
- [x] `postImpersonate.integration.test.ts` covers impersonating with no code after an MFA sign-in, and still being asked for one otherwise
- [x] account and user integration suites pass
- [X] Sign in with MFA, impersonate with no prompt
- [X] Wait 5 minutes, impersonate again, confirm the dialog appears and a fresh code works
- [X] Confirm a reused code is still refused in the dialog