### PR TITLE
fix(cli): generate type-safe function tests

### DIFF
--- a/docs/guides/functions/testing.mdx
+++ b/docs/guides/functions/testing.mdx
@@ -239,6 +239,7 @@ When you run `nango generate:tests`, Nango creates test files for all your integ
 
 **Sync test example:**
 ```typescript
+import { NangoSyncMock } from 'nango/test';
 import { vi, expect, it, describe, beforeAll } from 'vitest';
 import createSync from '../syncs/fetch-tickets.js';
 
@@ -246,7 +247,7 @@ describe('github fetch-tickets tests', () => {
   let nangoMock;
 
   beforeAll(async () => {
-    nangoMock = new global.vitest.NangoSyncMock({
+    nangoMock = new NangoSyncMock({
       dirname: __dirname,
       name: "fetch-tickets",
       Model: "Ticket"
@@ -288,6 +289,7 @@ describe('github fetch-tickets tests', () => {
 
 **Action test example:**
 ```typescript
+import { NangoActionMock } from 'nango/test';
 import { vi, expect, it, describe, beforeAll } from 'vitest';
 import createAction from '../actions/create-ticket.js';
 
@@ -295,7 +297,7 @@ describe('github create-ticket tests', () => {
   let nangoMock;
 
   beforeAll(async () => {
-    nangoMock = new global.vitest.NangoActionMock({
+    nangoMock = new NangoActionMock({
       dirname: __dirname,
       name: "create-ticket",
       Model: "Ticket"
@@ -399,27 +401,30 @@ npm test -- --coverage
 Vitest is configured via `vite.config.ts` in your project root:
 
 ```typescript
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    globals: true,
-    environment: 'node',
-    setupFiles: ['./vitest.setup.ts'],
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
   },
 });
 ```
 
-The `vitest.setup.ts` file makes Nango mocks available globally:
+New tests import `NangoSyncMock` or `NangoActionMock` directly from `nango/test`, so they don't require a setup file.
+
+Projects with older generated tests may still have a `vitest.setup.ts` file that makes the mocks available through `global.vitest`. Nango keeps that setup configured while legacy tests remain, so existing tests continue to run. To migrate an older test, replace the global constructor with a direct import:
 
 ```typescript
-import { NangoActionMock, NangoSyncMock } from "nango/test";
+import { NangoSyncMock } from 'nango/test';
 
-globalThis.vitest = {
-  NangoActionMock,
-  NangoSyncMock,
-};
+const nangoMock = new NangoSyncMock({
+  dirname: __dirname,
+  name: 'fetch-tickets',
+  Model: 'Ticket',
+});
 ```
+
+Once no tests reference `global.vitest`, you can remove `vitest.setup.ts` and its `setupFiles` entry from your Vitest configuration.
 
 ## Customizing tests with business logic
 
@@ -430,6 +435,7 @@ While auto-generated tests validate basic data flow, you often need custom tests
 Extend the generated tests with additional assertions:
 
 ```typescript
+import { NangoSyncMock } from 'nango/test';
 import { vi, expect, it, describe, beforeAll } from 'vitest';
 import createSync from '../syncs/fetch-tickets.js';
 
@@ -437,7 +443,7 @@ describe('github fetch-tickets tests', () => {
   let nangoMock;
 
   beforeAll(async () => {
-    nangoMock = new global.vitest.NangoSyncMock({
+    nangoMock = new NangoSyncMock({
       dirname: __dirname,
       name: "fetch-tickets",
       Model: "Ticket"
@@ -485,7 +491,7 @@ Test how your integration handles errors:
 ```typescript
 it('should handle API errors gracefully', async () => {
   // Create a mock that will throw an error
-  const errorMock = new global.vitest.NangoSyncMock({
+  const errorMock = new NangoSyncMock({
     dirname: __dirname,
     name: "fetch-tickets-error",
     Model: "Ticket"
@@ -561,6 +567,7 @@ it('should only fetch tickets after checkpoint date', async () => {
 Test multiple scenarios with different inputs:
 
 ```typescript
+import { NangoSyncMock } from 'nango/test';
 import { it, describe, expect, beforeAll } from 'vitest';
 
 describe.each([
@@ -572,7 +579,7 @@ describe.each([
   let nangoMock;
 
   beforeAll(async () => {
-    nangoMock = new global.vitest.NangoSyncMock({
+    nangoMock = new NangoSyncMock({
       dirname: __dirname,
       name: `fetch-tickets-${priority}`,
       Model: "Ticket"

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5278,6 +5278,7 @@ When you run `nango generate:tests`, Nango creates test files for all your integ
 
 **Sync test example:**
 ```typescript
+import { NangoSyncMock } from 'nango/test';
 import { vi, expect, it, describe, beforeAll } from 'vitest';
 import createSync from '../syncs/fetch-tickets.js';
 
@@ -5285,7 +5286,7 @@ describe('github fetch-tickets tests', () => {
   let nangoMock;
 
   beforeAll(async () => {
-    nangoMock = new global.vitest.NangoSyncMock({
+    nangoMock = new NangoSyncMock({
       dirname: __dirname,
       name: "fetch-tickets",
       Model: "Ticket"
@@ -5327,6 +5328,7 @@ describe('github fetch-tickets tests', () => {
 
 **Action test example:**
 ```typescript
+import { NangoActionMock } from 'nango/test';
 import { vi, expect, it, describe, beforeAll } from 'vitest';
 import createAction from '../actions/create-ticket.js';
 
@@ -5334,7 +5336,7 @@ describe('github create-ticket tests', () => {
   let nangoMock;
 
   beforeAll(async () => {
-    nangoMock = new global.vitest.NangoActionMock({
+    nangoMock = new NangoActionMock({
       dirname: __dirname,
       name: "create-ticket",
       Model: "Ticket"
@@ -5438,27 +5440,30 @@ npm test -- --coverage
 Vitest is configured via `vite.config.ts` in your project root:
 
 ```typescript
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    globals: true,
-    environment: 'node',
-    setupFiles: ['./vitest.setup.ts'],
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
   },
 });
 ```
 
-The `vitest.setup.ts` file makes Nango mocks available globally:
+New tests import `NangoSyncMock` or `NangoActionMock` directly from `nango/test`, so they don't require a setup file.
+
+Projects with older generated tests may still have a `vitest.setup.ts` file that makes the mocks available through `global.vitest`. Nango keeps that setup configured while legacy tests remain, so existing tests continue to run. To migrate an older test, replace the global constructor with a direct import:
 
 ```typescript
-import { NangoActionMock, NangoSyncMock } from "nango/test";
+import { NangoSyncMock } from 'nango/test';
 
-globalThis.vitest = {
-  NangoActionMock,
-  NangoSyncMock,
-};
+const nangoMock = new NangoSyncMock({
+  dirname: __dirname,
+  name: 'fetch-tickets',
+  Model: 'Ticket',
+});
 ```
+
+Once no tests reference `global.vitest`, you can remove `vitest.setup.ts` and its `setupFiles` entry from your Vitest configuration.
 
 ## Customizing tests with business logic
 
@@ -5469,6 +5474,7 @@ While auto-generated tests validate basic data flow, you often need custom tests
 Extend the generated tests with additional assertions:
 
 ```typescript
+import { NangoSyncMock } from 'nango/test';
 import { vi, expect, it, describe, beforeAll } from 'vitest';
 import createSync from '../syncs/fetch-tickets.js';
 
@@ -5476,7 +5482,7 @@ describe('github fetch-tickets tests', () => {
   let nangoMock;
 
   beforeAll(async () => {
-    nangoMock = new global.vitest.NangoSyncMock({
+    nangoMock = new NangoSyncMock({
       dirname: __dirname,
       name: "fetch-tickets",
       Model: "Ticket"
@@ -5524,7 +5530,7 @@ Test how your integration handles errors:
 ```typescript
 it('should handle API errors gracefully', async () => {
   // Create a mock that will throw an error
-  const errorMock = new global.vitest.NangoSyncMock({
+  const errorMock = new NangoSyncMock({
     dirname: __dirname,
     name: "fetch-tickets-error",
     Model: "Ticket"
@@ -5600,6 +5606,7 @@ it('should only fetch tickets after checkpoint date', async () => {
 Test multiple scenarios with different inputs:
 
 ```typescript
+import { NangoSyncMock } from 'nango/test';
 import { it, describe, expect, beforeAll } from 'vitest';
 
 describe.each([
@@ -5611,7 +5618,7 @@ describe.each([
   let nangoMock;
 
   beforeAll(async () => {
-    nangoMock = new global.vitest.NangoSyncMock({
+    nangoMock = new NangoSyncMock({
       dirname: __dirname,
       name: `fetch-tickets-${priority}`,
       Model: "Ticket"

--- a/packages/cli/lib/services/test.service.ts
+++ b/packages/cli/lib/services/test.service.ts
@@ -8,6 +8,7 @@ import readline from 'readline';
 import axios from 'axios';
 import chalk from 'chalk';
 import ejs from 'ejs';
+import { glob } from 'glob';
 
 import { detectPackageManager, printDebug } from '../utils.js';
 import { Spinner } from '../utils/spinner.js';
@@ -390,10 +391,35 @@ export async function generateActionTest({
     return outputPath;
 }
 
-async function generateTestConfigs({ debug, force = false }: { debug: boolean; force?: boolean }): Promise<boolean> {
-    try {
-        const rootPath = await getProjectRoot();
+async function hasLegacyGlobalTests(absolutePath: string): Promise<boolean> {
+    const testFiles = await glob('**/*.test.ts', {
+        absolute: true,
+        cwd: absolutePath,
+        ignore: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/.nango/**']
+    });
 
+    for (const testFile of testFiles) {
+        const content = await fs.readFile(testFile, 'utf8');
+        if (content.includes('global.vitest.NangoSyncMock') || content.includes('global.vitest.NangoActionMock')) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export async function generateTestConfigs({
+    absolutePath,
+    rootPath,
+    debug,
+    force = false
+}: {
+    absolutePath: string;
+    rootPath: string;
+    debug: boolean;
+    force?: boolean;
+}): Promise<boolean> {
+    try {
         if (debug) {
             printDebug(`Resolved project root: ${rootPath}`);
             printDebug(`Generating config files in: ${rootPath}`);
@@ -401,24 +427,28 @@ async function generateTestConfigs({ debug, force = false }: { debug: boolean; f
 
         const viteConfigPath = path.resolve(rootPath, 'vite.config.ts');
         const vitestSetupPath = path.resolve(rootPath, 'vitest.setup.ts');
+        const legacySetupRequired = (await pathExists(vitestSetupPath)) || (await hasLegacyGlobalTests(absolutePath));
 
         const viteTemplate = await fs.readFile(VITE_CONFIG_TEMPLATE, 'utf8');
-        const vitestTemplateSource = await fs.readFile(VITEST_SETUP_TEMPLATE, 'utf8');
-
-        const vitestTemplate = ejs.render(vitestTemplateSource);
+        const renderedViteTemplate = ejs.render(viteTemplate, { legacySetupRequired });
 
         if (force || !(await pathExists(viteConfigPath))) {
-            await fs.writeFile(viteConfigPath, viteTemplate);
+            await fs.writeFile(viteConfigPath, renderedViteTemplate);
             if (debug) printDebug(`Created/Overwritten vite.config.ts at ${viteConfigPath}`);
         } else if (debug) {
             printDebug(`vite.config.ts already exists and force is not enabled, skipping`);
         }
 
-        if (force || !(await pathExists(vitestSetupPath))) {
-            await fs.writeFile(vitestSetupPath, vitestTemplate);
-            if (debug) printDebug(`Created/Overwritten vitest.setup.ts at ${vitestSetupPath}`);
-        } else if (debug) {
-            printDebug(`vitest.setup.ts already exists and force is not enabled, skipping`);
+        if (legacySetupRequired) {
+            const vitestTemplateSource = await fs.readFile(VITEST_SETUP_TEMPLATE, 'utf8');
+            const vitestTemplate = ejs.render(vitestTemplateSource);
+
+            if (force || !(await pathExists(vitestSetupPath))) {
+                await fs.writeFile(vitestSetupPath, vitestTemplate);
+                if (debug) printDebug(`Created/Overwritten vitest.setup.ts at ${vitestSetupPath}`);
+            } else if (debug) {
+                printDebug(`vitest.setup.ts already exists and force is not enabled, skipping`);
+            }
         }
 
         return true;
@@ -483,7 +513,7 @@ export async function generateTests({
             }
         }
 
-        await generateTestConfigs({ debug, force: forceOverwrite });
+        await generateTestConfigs({ absolutePath, rootPath, debug, force: forceOverwrite });
 
         let integrationsToProcess: Record<string, any> = {};
 

--- a/packages/cli/lib/services/test.service.unit.cli-test.ts
+++ b/packages/cli/lib/services/test.service.unit.cli-test.ts
@@ -4,7 +4,14 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { generateActionTest, generateSyncTest, shouldProcessAction, shouldProcessSync, validateAndFilterIntegrations } from './test.service.js';
+import {
+    generateActionTest,
+    generateSyncTest,
+    generateTestConfigs,
+    shouldProcessAction,
+    shouldProcessSync,
+    validateAndFilterIntegrations
+} from './test.service.js';
 
 import type { IntegrationDefinition } from './test.service.js';
 
@@ -462,8 +469,11 @@ describe('generateSyncTest', () => {
         const content = await fs.readFile(outputPath, 'utf8');
 
         // Check imports
+        expect(content).toContain("import { NangoSyncMock } from 'nango/test'");
         expect(content).toContain("import { afterEach, vi, expect, it, describe } from 'vitest'");
         expect(content).toContain("import createSync from '../syncs/fetch-issues.js'");
+        expect(content).toContain('const nangoMock = new NangoSyncMock({');
+        expect(content).not.toContain('global.vitest');
 
         // Check describe block
         expect(content).toContain("describe('github fetch-issues tests'");
@@ -528,8 +538,11 @@ describe('generateActionTest', () => {
         const content = await fs.readFile(outputPath, 'utf8');
 
         // Check imports
-        expect(content).toContain("import { vi, expect, it, describe } from 'vitest'");
+        expect(content).toContain("import { NangoActionMock } from 'nango/test'");
+        expect(content).toContain("import { expect, it, describe } from 'vitest'");
         expect(content).toContain("import createAction from '../actions/send-message.js'");
+        expect(content).toContain('const nangoMock = new NangoActionMock({');
+        expect(content).not.toContain('global.vitest');
 
         // Check describe block
         expect(content).toContain("describe('slack send-message tests'");
@@ -558,5 +571,53 @@ describe('generateActionTest', () => {
 
         // Null output should be rendered as empty string or null
         expect(content).toContain('Model: ""');
+    });
+});
+
+describe('generateTestConfigs', () => {
+    let tmpDir: string;
+
+    afterEach(async () => {
+        if (tmpDir) {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('does not generate a setup file for a new project', async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-test-config-'));
+
+        const success = await generateTestConfigs({ absolutePath: tmpDir, rootPath: tmpDir, debug: false });
+
+        expect(success).toBe(true);
+        expect(await fs.readFile(path.join(tmpDir, 'vite.config.ts'), 'utf8')).not.toContain('setupFiles');
+        await expect(fs.access(path.join(tmpDir, 'vitest.setup.ts'))).rejects.toThrow();
+    });
+
+    it('preserves the setup path for tests that use the legacy global', async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-test-config-'));
+        const testDir = path.join(tmpDir, 'github', 'tests');
+        await fs.mkdir(testDir, { recursive: true });
+        await fs.writeFile(path.join(testDir, 'github-issues.test.ts'), 'void global.vitest.NangoSyncMock;');
+
+        const success = await generateTestConfigs({ absolutePath: tmpDir, rootPath: tmpDir, debug: false });
+
+        expect(success).toBe(true);
+        expect(await fs.readFile(path.join(tmpDir, 'vite.config.ts'), 'utf8')).toContain('setupFiles: "vitest.setup.ts"');
+        const setup = await fs.readFile(path.join(tmpDir, 'vitest.setup.ts'), 'utf8');
+        expect(setup).toContain('declare global');
+        expect(setup).toContain('NangoSyncMock: typeof NangoSyncMock');
+        expect(setup).toContain('NangoActionMock: typeof NangoActionMock');
+    });
+
+    it('does not overwrite an existing setup file without confirmation', async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nango-test-config-'));
+        const setupPath = path.join(tmpDir, 'vitest.setup.ts');
+        await fs.writeFile(setupPath, '// Custom setup\n');
+
+        const success = await generateTestConfigs({ absolutePath: tmpDir, rootPath: tmpDir, debug: false });
+
+        expect(success).toBe(true);
+        expect(await fs.readFile(setupPath, 'utf8')).toBe('// Custom setup\n');
+        expect(await fs.readFile(path.join(tmpDir, 'vite.config.ts'), 'utf8')).toContain('setupFiles: "vitest.setup.ts"');
     });
 });

--- a/packages/cli/lib/templates/action-test-template.ejs
+++ b/packages/cli/lib/templates/action-test-template.ejs
@@ -1,9 +1,10 @@
-import { vi, expect, it, describe } from 'vitest';
+import { NangoActionMock } from 'nango/test';
+import { expect, it, describe } from 'vitest';
 
 import createAction from '../actions/<%= actionName %>.js';
 
 describe('<%= integration %> <%= actionName %> tests', () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
+  const nangoMock = new NangoActionMock({
       dirname: __dirname,
       name: "<%= actionName %>",
       Model: "<%= output %>"

--- a/packages/cli/lib/templates/sync-test-template.ejs
+++ b/packages/cli/lib/templates/sync-test-template.ejs
@@ -1,3 +1,4 @@
+import { NangoSyncMock } from 'nango/test';
 import { afterEach, vi, expect, it, describe } from 'vitest';
 
 import createSync from '../syncs/<%= syncName %>.js';
@@ -6,7 +7,7 @@ describe('<%= integration %> <%= syncName %> tests', () => {
   const models = '<%= modelName %>'.split(',');
 
   const createTestContext = () => {
-    const nangoMock = new global.vitest.NangoSyncMock({
+    const nangoMock = new NangoSyncMock({
       dirname: __dirname,
       name: "<%= syncName %>",
       Model: "<%= modelName %>"

--- a/packages/cli/lib/templates/vite.config.ejs
+++ b/packages/cli/lib/templates/vite.config.ejs
@@ -7,6 +7,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+<% if (legacySetupRequired) { -%>
     setupFiles: "vitest.setup.ts",
+<% } -%>
   },
 });

--- a/packages/cli/lib/templates/vitest.setup.ejs
+++ b/packages/cli/lib/templates/vitest.setup.ejs
@@ -1,5 +1,12 @@
 import { NangoActionMock, NangoSyncMock } from "nango/test";
 
+declare global {
+  var vitest: {
+    NangoActionMock: typeof NangoActionMock;
+    NangoSyncMock: typeof NangoSyncMock;
+  };
+}
+
 globalThis.vitest = {
   NangoActionMock,
   NangoSyncMock,


### PR DESCRIPTION
## Summary

Fixes NAN-5981 by generating function tests that import `NangoSyncMock` and `NangoActionMock` directly from `nango/test` instead of reading them from `global.vitest`.

Fresh projects no longer need a `vitest.setup.ts` file. Existing projects remain compatible: the CLI detects legacy `global.vitest` tests or an existing setup file, preserves the `setupFiles` configuration, and provides typed global mocks when the generated setup is refreshed.

## Before

Generated tests depended on an implicit global:

```ts
import { afterEach, describe, expect, it, vi } from 'vitest';

const nangoMock = new global.vitest.NangoSyncMock({
    dirname: __dirname,
    name: 'fetch-issues',
    Model: 'GithubIssue'
});
```

Every project also received this setup:

```ts
import { NangoActionMock, NangoSyncMock } from 'nango/test';

globalThis.vitest = {
    NangoActionMock,
    NangoSyncMock
};
```

Because the global property was not declared, both the setup and generated tests produced TS7017 under Nango's strict TypeScript configuration.

## After

New tests use explicit, fully typed imports:

```ts
import { NangoSyncMock } from 'nango/test';
import { afterEach, describe, expect, it, vi } from 'vitest';

const nangoMock = new NangoSyncMock({
    dirname: __dirname,
    name: 'fetch-issues',
    Model: 'GithubIssue'
});
```

Fresh projects receive a Vitest config without `setupFiles` and no `vitest.setup.ts`. When legacy tests or an existing setup are detected, the setup remains enabled and declares the mock constructors using their actual exported types.

## Pros and cons

### Pros

- Uses the real `nango/test` types without duplicated `any`-based declarations.
- Makes each test's dependencies explicit.
- Avoids using `vitest` as a custom global namespace in new tests.
- Removes an unnecessary setup file from fresh projects.
- Preserves existing global-based tests without requiring an immediate migration.

### Cons

- Each generated test has one additional import.
- Legacy projects retain the setup compatibility layer until their old tests are migrated.
- Test generation performs a small scan of `*.test.ts` files to detect legacy references.

## Migration path

No immediate action is required for existing projects. Tests using `global.vitest` continue to load the compatibility setup.

To migrate an existing test:

1. Import the relevant mock from `nango/test`.
2. Replace `new global.vitest.NangoSyncMock(...)` or `new global.vitest.NangoActionMock(...)` with the directly imported constructor.
3. Repeat for the remaining tests.
4. Once `global.vitest` is no longer referenced, remove `vitest.setup.ts` and the `setupFiles` entry from the Vitest configuration.

The CLI does not automatically delete or disable an existing setup file, so custom and partially migrated projects remain safe.

## Validation

- `npm run test:cli -- packages/cli/lib/services/test.service.unit.cli-test.ts` — 42 tests passed
- `npm run ts-build`
- `npm run lint` — passed with existing repository warnings
- `npm run format:check`
- Strict TypeScript compilation of fresh and legacy generated project fixtures


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

