### PR TITLE
fix(webapp): Improve usability of billing emails input field

### DIFF
--- a/packages/webapp/src/components/ui/Combobox.tsx
+++ b/packages/webapp/src/components/ui/Combobox.tsx
@@ -545,7 +545,9 @@ const ComboboxChips = React.forwardRef<HTMLDivElement, React.ComponentPropsWitho
                 ref={ref}
                 data-slot="combobox-chips"
                 className={cn(
-                    'flex flex-wrap items-center gap-1.5 rounded border border-border-muted bg-surface-canvas px-2 py-1.5 text-sm outline-none focus:outline-none focus-visible:outline-none focus-within:border-border-muted has-data-[slot=combobox-chip]:px-1.5',
+                    // cursor-text on the container, cursor-default on the chips: the empty area is
+                    // where typing starts, the chips are tokens.
+                    'flex cursor-text flex-wrap items-center gap-1.5 rounded border border-border-muted bg-surface-canvas px-2 py-1.5 text-sm outline-none focus:outline-none focus-visible:outline-none focus-within:border-border-muted has-data-[slot=combobox-chip]:px-1.5',
                     className
                 )}
                 {...props}
@@ -559,7 +561,9 @@ function ComboboxChip({ className, children, showRemove = true, ...props }: Comb
         <ComboboxPrimitive.Chip
             data-slot="combobox-chip"
             className={cn(
-                'focus-default inline-flex h-[21px] max-w-full min-w-0 items-center justify-center gap-[2px] rounded bg-surface-page border border-border-default px-[6px] text-sm font-normal text-text-secondary outline-none has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0.5',
+                // cursor-default/select-none: the label is an atomic token, so don't show an I-beam
+                // promising a text selection that Base UI's mousedown handler prevents.
+                'focus-default inline-flex h-[21px] max-w-full min-w-0 cursor-default items-center justify-center gap-[2px] rounded bg-surface-page border border-border-default px-[6px] text-sm font-normal text-text-secondary select-none outline-none has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0.5',
                 className
             )}
             {...props}
@@ -568,10 +572,10 @@ function ComboboxChip({ className, children, showRemove = true, ...props }: Comb
             {showRemove && (
                 <ComboboxPrimitive.ChipRemove
                     render={<IconButton variant="ghost" size="2xs" label="Remove" />}
-                    className="size-4 opacity-50 hover:opacity-100 p-0 flex items-center justify-center"
+                    className="size-4 p-0 flex items-center justify-center rounded-sm text-text-muted hover:text-text-strong hover:bg-state-hover"
                     data-slot="combobox-chip-remove"
                 >
-                    <XIcon className="pointer-events-none size-3" />
+                    <XIcon className="pointer-events-none size-3.5" />
                 </ComboboxPrimitive.ChipRemove>
             )}
         </ComboboxPrimitive.Chip>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -96,6 +96,8 @@ export const InvoicingDetailsForm: React.FC<{
                 address: data.address,
                 taxId: data.taxId
             });
+            // Clears isDirty, which also re-enables the effect above that re-syncs from `customer`.
+            form.reset(data);
             toast({ title: 'Invoicing details updated', variant: 'success' });
         } catch {
             toast({ title: 'Failed to update invoicing details', variant: 'error' });
@@ -142,10 +144,13 @@ export const InvoicingDetailsForm: React.FC<{
                     )}
                 </Card>
 
-                <div className="pt-4">
+                <div className="pt-4 flex items-center gap-3">
                     <Button type="submit" variant="primary" size="md" loading={isPending} disabled={!customer}>
                         Save changes
                     </Button>
+                    <span aria-live="polite" className="text-text-secondary text-body-small-regular">
+                        {form.formState.isDirty ? 'Unsaved changes' : ''}
+                    </span>
                 </div>
             </form>
         </Form>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -12,7 +12,7 @@ import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
 import { countryCodes, taxIdTypes } from '../invoicingConstants';
 import { InvoicingAddressFields } from './InvoicingAddressFields';
-import { parseEmailTokens } from './invoicingEmails';
+import { MAX_EMAILS, parseEmailTokens } from './invoicingEmails';
 import { InvoicingEmailsField } from './InvoicingEmailsField';
 import { toFormData } from './invoicingFormData.js';
 import { InvoicingTaxIdFields } from './InvoicingTaxIdFields';
@@ -45,7 +45,7 @@ const schema = z
         emails: z
             .array(z.string().email('Invalid email address'))
             .min(1, 'At least one billing email required')
-            .max(50, 'Maximum 50 billing email addresses')
+            .max(MAX_EMAILS, `Maximum ${MAX_EMAILS} billing email addresses`)
             .refine((emails) => new Set(emails.map((email) => email.toLowerCase())).size === emails.length, 'Duplicate billing email address'),
         // Uncommitted chip-input text; not sent to the API, just fails validation so Save can't drop it.
         emailsDraft: z.string().optional(),
@@ -60,6 +60,9 @@ const schema = z
             ctx.addIssue({ code: 'custom', path: ['emails'], message: `Invalid email address: ${draft}` });
         } else if (data.emails.some((email) => email.toLowerCase() === draft.toLowerCase())) {
             ctx.addIssue({ code: 'custom', path: ['emails'], message: `Already added: ${draft}` });
+        } else if (data.emails.length >= MAX_EMAILS) {
+            // onSubmit folds the draft in, so it has to count against the cap here too.
+            ctx.addIssue({ code: 'custom', path: ['emails'], message: `Maximum ${MAX_EMAILS} billing email addresses` });
         }
     });
 

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -12,6 +12,7 @@ import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
 import { countryCodes, taxIdTypes } from '../invoicingConstants';
 import { InvoicingAddressFields } from './InvoicingAddressFields';
+import { parseEmailTokens } from './invoicingEmails';
 import { InvoicingEmailsField } from './InvoicingEmailsField';
 import { toFormData } from './invoicingFormData.js';
 import { InvoicingTaxIdFields } from './InvoicingTaxIdFields';
@@ -88,16 +89,21 @@ export const InvoicingDetailsForm: React.FC<{
     }, [customer]);
 
     const onSubmit = async (data: InvoicingFormData) => {
+        // Validation only lets a complete, non-duplicate address through as a draft, so fold it in
+        // here rather than relying on blur having committed it to a chip first.
+        const draft = (data.emailsDraft ?? '').trim();
+        const emails = draft ? [...data.emails, ...parseEmailTokens(draft)] : data.emails;
+
         try {
             await putAsync({
                 legalEntityName: data.legalEntityName,
-                email: data.emails[0]!,
-                additionalEmails: data.emails.slice(1),
+                email: emails[0]!,
+                additionalEmails: emails.slice(1),
                 address: data.address,
                 taxId: data.taxId
             });
             // Clears isDirty, which also re-enables the effect above that re-syncs from `customer`.
-            form.reset(data);
+            form.reset({ ...data, emails, emailsDraft: '' });
             toast({ title: 'Invoicing details updated', variant: 'success' });
         } catch {
             toast({ title: 'Failed to update invoicing details', variant: 'error' });

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
-import { z } from 'zod';
 
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
 import { Combobox, ComboboxChip, ComboboxChips, ComboboxChipsInput, ComboboxValue } from '../../../../components/ui/Combobox';
+import { isCompleteEmail, isFullyTokenizable, parseEmailTokens } from './invoicingEmails';
 
 import type { InvoicingFormData } from './InvoicingDetailsForm';
-
-const emailSchema = z.string().email();
 
 export const InvoicingEmailsField: React.FC = () => {
     const { control, setValue, setError, clearErrors } = useFormContext<InvoicingFormData>();
@@ -40,10 +38,7 @@ export const InvoicingEmailsField: React.FC = () => {
     // Splits on commas and whitespace so a multi-address paste or a space-separated typed list
     // adds each one instead of one long invalid chip.
     const addEmailsFromText = (text: string) => {
-        const candidates = text
-            .split(/[,\s]+/)
-            .map((e) => e.trim())
-            .filter(Boolean);
+        const candidates = parseEmailTokens(text);
         if (candidates.length === 0) return;
 
         const existingLower = new Set(emails.map((e) => e.toLowerCase()));
@@ -51,7 +46,7 @@ export const InvoicingEmailsField: React.FC = () => {
         const invalid: string[] = [];
         const duplicate: string[] = [];
         for (const c of candidates) {
-            if (!emailSchema.safeParse(c).success) {
+            if (!isCompleteEmail(c)) {
                 invalid.push(c);
                 continue;
             }
@@ -84,7 +79,15 @@ export const InvoicingEmailsField: React.FC = () => {
         }
     };
 
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const handleKeyDown: NonNullable<React.ComponentProps<typeof ComboboxChipsInput>['onKeyDown']> = (e) => {
+        // Base UI clears the whole selection on Escape whenever its popup isn't mounted, which for
+        // this field is always. preventDefault() doesn't stop it — mergeProps only skips Base UI's
+        // handler when the consumer's handler calls this.
+        if (e.key === 'Escape') {
+            e.preventBaseUIHandler();
+            return;
+        }
+
         // Don't intercept while an IME composition is in progress, e.g. the space that finalizes
         // a composed CJK character shouldn't be swallowed as a commit trigger.
         if (e.nativeEvent.isComposing) return;
@@ -109,11 +112,37 @@ export const InvoicingEmailsField: React.FC = () => {
         undoLastRemoval();
     };
 
+    // The container is mostly padding and wrapped-row gaps; without this, clicking anywhere that
+    // isn't a chip or the input itself does nothing, which makes the field look read-only.
+    const handleContainerMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (e.target instanceof Element && e.target.closest('[data-slot="combobox-chip"], input')) return;
+        const input = e.currentTarget.querySelector<HTMLInputElement>('input[data-slot="combobox-chip-input"]');
+        if (!input) return;
+        e.preventDefault();
+        input.focus();
+        input.setSelectionRange(input.value.length, input.value.length);
+    };
+
     const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
         const text = e.clipboardData.getData('text');
-        if (!/[,\s]/.test(text.trim())) return;
+        if (!text.trim()) return;
+
+        // Splice at the caret instead of replacing, so pasting into half-typed text keeps it.
+        const input = e.currentTarget;
+        const start = input.selectionStart ?? input.value.length;
+        const end = input.selectionEnd ?? start;
+        const merged = input.value.slice(0, start) + text + input.value.slice(end);
         e.preventDefault();
-        addEmailsFromText(text);
+
+        // Tokenize only once the draft is made up entirely of complete addresses. Pasting a
+        // fragment to build one up leaves editable text rather than an invalid-email error.
+        if (isFullyTokenizable(merged)) {
+            addEmailsFromText(merged);
+            return;
+        }
+
+        clearErrors('emails');
+        setInputValue(merged);
     };
 
     const handleBlur = () => {
@@ -138,6 +167,7 @@ export const InvoicingEmailsField: React.FC = () => {
                             ring, not this one too. */}
                             <ComboboxChips
                                 onKeyDown={handleUndoShortcut}
+                                onMouseDown={handleContainerMouseDown}
                                 className="min-h-8 rounded-ds-xs border-ds-hairline bg-surface-input border-border-interactive
                                 has-[input:focus]:border-[var(--focus-ring-default)]
                                 has-[input:focus]:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]"
@@ -150,7 +180,7 @@ export const InvoicingEmailsField: React.FC = () => {
                                     </ComboboxValue>
                                 )}
                                 <ComboboxChipsInput
-                                    placeholder={emails.length === 0 ? 'billing@company.com' : ''}
+                                    placeholder={emails.length === 0 ? 'billing@company.com' : 'Add another email'}
                                     value={inputValue}
                                     onChange={(e) => {
                                         setInputValue((e.target as HTMLInputElement).value);

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -143,6 +143,14 @@ export const InvoicingEmailsField: React.FC = () => {
 
         clearErrors('emails');
         setInputValue(merged);
+        // The input is controlled, so re-rendering with a new value drops the caret to the end.
+        // Put it back after the pasted text so typing continues where the user was.
+        const caret = start + text.length;
+        requestAnimationFrame(() => {
+            if (document.activeElement === input) {
+                input.setSelectionRange(caret, caret);
+            }
+        });
     };
 
     const handleBlur = () => {

--- a/packages/webapp/src/pages/Team/Billing/components/invoicingEmails.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/invoicingEmails.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 
 const emailSchema = z.string().email();
 
+/** One primary plus the server's 49-address `additionalEmails` cap (Orb allows 50 in total). */
+export const MAX_EMAILS = 50;
+
 /** Commas and whitespace both separate addresses, so a pasted list splits the same way a typed one does. */
 export function parseEmailTokens(text: string): string[] {
     return text

--- a/packages/webapp/src/pages/Team/Billing/components/invoicingEmails.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/invoicingEmails.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+const emailSchema = z.string().email();
+
+/** Commas and whitespace both separate addresses, so a pasted list splits the same way a typed one does. */
+export function parseEmailTokens(text: string): string[] {
+    return text
+        .split(/[,\s]+/)
+        .map((token) => token.trim())
+        .filter(Boolean);
+}
+
+export function isCompleteEmail(value: string): boolean {
+    return emailSchema.safeParse(value).success;
+}
+
+/** True when every token is a complete address, i.e. the text is safe to turn into chips. */
+export function isFullyTokenizable(text: string): boolean {
+    const tokens = parseEmailTokens(text);
+    return tokens.length > 0 && tokens.every(isCompleteEmail);
+}

--- a/packages/webapp/src/pages/Team/Billing/components/invoicingEmails.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/invoicingEmails.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCompleteEmail, isFullyTokenizable, parseEmailTokens } from './invoicingEmails';
+
+describe('parseEmailTokens', () => {
+    it('splits on commas, spaces and newlines', () => {
+        expect(parseEmailTokens('a@b.com, c@d.com')).toEqual(['a@b.com', 'c@d.com']);
+        expect(parseEmailTokens('a@b.com c@d.com')).toEqual(['a@b.com', 'c@d.com']);
+        expect(parseEmailTokens('a@b.com\nc@d.com')).toEqual(['a@b.com', 'c@d.com']);
+    });
+
+    it('drops empty segments from repeated or trailing separators', () => {
+        expect(parseEmailTokens('a@b.com,,  ,c@d.com,')).toEqual(['a@b.com', 'c@d.com']);
+    });
+
+    it('returns nothing for blank input', () => {
+        expect(parseEmailTokens('')).toEqual([]);
+        expect(parseEmailTokens('   ')).toEqual([]);
+    });
+});
+
+describe('isFullyTokenizable', () => {
+    // A pasted address has to become a chip immediately — leaving it as plain text is what made
+    // customers think the field hadn't accepted their new billing email.
+    it('accepts a single complete address', () => {
+        expect(isFullyTokenizable('ted@concourse.co')).toBe(true);
+    });
+
+    it('accepts a list where every entry is complete', () => {
+        expect(isFullyTokenizable('a@b.com, c@d.com')).toBe(true);
+    });
+
+    it('rejects a partial address so it stays editable text', () => {
+        expect(isFullyTokenizable('ted@')).toBe(false);
+        expect(isFullyTokenizable('ted')).toBe(false);
+    });
+
+    it('rejects a list containing any incomplete entry', () => {
+        expect(isFullyTokenizable('a@b.com, nope')).toBe(false);
+    });
+
+    it('rejects blank input', () => {
+        expect(isFullyTokenizable('')).toBe(false);
+        expect(isFullyTokenizable('  ')).toBe(false);
+    });
+});
+
+describe('isCompleteEmail', () => {
+    it('distinguishes complete addresses from fragments', () => {
+        expect(isCompleteEmail('ted@concourse.co')).toBe(true);
+        expect(isCompleteEmail('ted@concourse')).toBe(false);
+        expect(isCompleteEmail('ted')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Problem

A customer reported he couldn't change his billing email on `/team/billing`. Both symptoms trace to #6908, which replaced the billing email text input with a chip field.

- **Pasting an address didn't tokenize it.** `handlePaste` bailed unless the text contained a comma or whitespace, so pasting a single address — the common case — left plain text with no chip and no sign the field had accepted it.
- **Escape wiped every saved address.** The combobox renders with `open={false}` so Base UI's popup never mounts, and its unmounted-Escape branch clears the whole selection. `preventDefault()` doesn't stop it — `mergeProps` only skips Base UI's handler for `preventBaseUIHandler()`.
- **The field read as read-only.** The saved address became a chip whose only edit affordance was a faint × icon; clicking the container's padding did nothing, the placeholder was blanked once an address existed, and the chip label showed an I-beam promising a selection that Base UI cancels.

## Solution

- Neutralise Escape in the field's own key handler via `preventBaseUIHandler()`, scoped to Escape so Backspace-removes-last-chip and Home/End still work
- Tokenize a paste whenever every token is a complete address, splicing at the caret instead of discarding half-typed text; a pasted fragment stays editable rather than raising an invalid-email error mid-typing
- Extract the tokenizing decision into pure helpers with unit coverage
- Restore edit affordances: click anywhere in the field to focus, a persistent "Add another email" placeholder, `cursor-default`/`select-none` on chips with `cursor-text` on the container, and a higher-contrast remove icon
- Reset the form after a successful save (`isDirty` previously stayed true forever, permanently disabling the re-sync from a refetched customer) and show an "Unsaved changes" hint while dirty

Fixes [NAN-6616](https://linear.app/nango/issue/NAN-6616)

## Testing

- 9 new unit tests for the tokenizing helpers (single address, mixed lists, fragments, separator handling)
- Verified in the browser against the dev API on a paid account: reproduced the Escape wipe with the guard removed and confirmed it's gone with it in place; changed the billing address end to end (remove → type → Enter → Save → reload) and confirmed it persisted as the Orb primary; checked padding-click focus, Backspace removal, and the unsaved hint clearing on save

## Follow-ups

- The paste path itself is covered by unit tests but wasn't exercised in a real browser — Chromium's clipboard read is permission-blocked headless and synthetic Cmd+V doesn't fire a native paste
- `ScopesInput` has the same underlying Escape exposure and is **not** fixed here — the guard is deliberately at this call site rather than in the shared `ComboboxChipsInput` wrapper to keep the blast radius to billing. That one is worse: it `PATCH`es the integration with empty scopes and toasts "Scope successfully removed"
- Remaining cleanups in this field (manual `setError` clobbered by revalidation, the undiscoverable Cmd+Z undo stack) deferred
