### PR TITLE
fix(sync): don't resume manually paused syncs on connection reauth

### DIFF
--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -121,6 +121,38 @@ describe('OrchestratorClient', async () => {
             const deleted = await client.deleteSync({ scheduleName });
             expect(deleted.isOk(), `pausing failed ${JSON.stringify(deleted)}`).toBe(true);
         });
+        it('should stay paused when unpauseSync is called with preserveIfPaused', async () => {
+            const scheduleName = nanoid();
+            await client.recurring({
+                name: scheduleName,
+                state: 'STARTED',
+                startsAt: new Date(),
+                frequencyMs: 300_000,
+                group: { key: nanoid(), maxConcurrency: 0 },
+                retry: { max: 0 },
+                timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
+                args: {
+                    type: 'sync',
+                    syncId: 'sync-a',
+                    syncName: nanoid(),
+                    syncJobId: 5678,
+                    connection: {
+                        id: 123,
+                        connection_id: 'C',
+                        provider_config_key: 'P',
+                        environment_id: 456
+                    },
+                    debug: false
+                }
+            });
+            await client.pauseSync({ scheduleName });
+
+            const unpaused = await client.unpauseSync({ scheduleName, preserveIfPaused: true });
+            expect(unpaused.isOk(), `unpausing failed ${JSON.stringify(unpaused)}`).toBe(true);
+
+            const [schedule] = (await client.searchSchedules({ scheduleNames: [scheduleName], limit: 1 })).unwrap();
+            expect(schedule?.state).toBe('PAUSED');
+        });
         it('should be searchable', async () => {
             const name = nanoid();
             await client.recurring({

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -152,7 +152,7 @@ export class OrchestratorClient {
         preserveIfPaused?: boolean | undefined;
     }): Promise<VoidReturn> {
         const res = await this.routeFetch(putRecurringRoute)({
-            body: { schedule: { name: scheduleName, state, ...(preserveIfPaused !== undefined && { preserveIfPaused }) } }
+            body: { schedule: { name: scheduleName, state, ...(preserveIfPaused && { preserveIfPaused }) } }
         });
         if ('error' in res) {
             return Err({

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -115,8 +115,8 @@ export class OrchestratorClient {
         return this.setSyncState({ scheduleName, state: 'PAUSED' });
     }
 
-    public async unpauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
-        return this.setSyncState({ scheduleName, state: 'STARTED' });
+    public async unpauseSync({ scheduleName, preserveIfPaused }: { scheduleName: string; preserveIfPaused?: boolean | undefined }): Promise<VoidReturn> {
+        return this.setSyncState({ scheduleName, state: 'STARTED', preserveIfPaused });
     }
 
     public async deleteSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn> {
@@ -142,9 +142,17 @@ export class OrchestratorClient {
         }
     }
 
-    private async setSyncState({ scheduleName, state }: { scheduleName: string; state: 'STARTED' | 'PAUSED' | 'DELETED' }): Promise<VoidReturn> {
+    private async setSyncState({
+        scheduleName,
+        state,
+        preserveIfPaused
+    }: {
+        scheduleName: string;
+        state: 'STARTED' | 'PAUSED' | 'DELETED';
+        preserveIfPaused?: boolean | undefined;
+    }): Promise<VoidReturn> {
         const res = await this.routeFetch(putRecurringRoute)({
-            body: { schedule: { name: scheduleName, state } }
+            body: { schedule: { name: scheduleName, state, ...(preserveIfPaused !== undefined && { preserveIfPaused }) } }
         });
         if ('error' in res) {
             return Err({

--- a/packages/orchestrator/lib/routes/v1/putRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/putRecurring.ts
@@ -13,7 +13,7 @@ export type PutRecurring = Endpoint<{
     Method: typeof method;
     Path: typeof path;
     Body: {
-        schedule: { name: string; state: 'STARTED' | 'PAUSED' | 'DELETED'; preserveIfPaused?: boolean | undefined } | { name: string; frequencyMs: number };
+        schedule: { name: string; state: 'STARTED' | 'PAUSED' | 'DELETED'; preserveIfPaused?: boolean } | { name: string; frequencyMs: number };
     };
     Error: ApiError<'put_recurring_failed'>;
     Success: { scheduleId: string };
@@ -25,7 +25,7 @@ const bodySchema = z
             z.object({
                 name: z.string().min(1),
                 state: z.union([z.literal('STARTED'), z.literal('PAUSED'), z.literal('DELETED')]),
-                preserveIfPaused: z.boolean().optional()
+                preserveIfPaused: z.boolean().optional().default(false)
             }),
             z.object({
                 name: z.string().min(1),
@@ -47,7 +47,7 @@ const handler = (scheduler: Scheduler) => {
             updatedSchedule = await scheduler.setScheduleState({
                 scheduleName: schedule.name,
                 state: schedule.state,
-                preserveIfPaused: schedule.preserveIfPaused
+                preserveIfPaused: schedule.preserveIfPaused ?? false
             });
         }
         if ('frequencyMs' in schedule) {

--- a/packages/orchestrator/lib/routes/v1/putRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/putRecurring.ts
@@ -13,7 +13,7 @@ export type PutRecurring = Endpoint<{
     Method: typeof method;
     Path: typeof path;
     Body: {
-        schedule: { name: string; state: 'STARTED' | 'PAUSED' | 'DELETED' } | { name: string; frequencyMs: number };
+        schedule: { name: string; state: 'STARTED' | 'PAUSED' | 'DELETED'; preserveIfPaused?: boolean | undefined } | { name: string; frequencyMs: number };
     };
     Error: ApiError<'put_recurring_failed'>;
     Success: { scheduleId: string };
@@ -24,7 +24,8 @@ const bodySchema = z
         schedule: z.union([
             z.object({
                 name: z.string().min(1),
-                state: z.union([z.literal('STARTED'), z.literal('PAUSED'), z.literal('DELETED')])
+                state: z.union([z.literal('STARTED'), z.literal('PAUSED'), z.literal('DELETED')]),
+                preserveIfPaused: z.boolean().optional()
             }),
             z.object({
                 name: z.string().min(1),
@@ -43,7 +44,11 @@ const handler = (scheduler: Scheduler) => {
         const { schedule } = res.locals.parsedBody;
         let updatedSchedule;
         if ('state' in schedule) {
-            updatedSchedule = await scheduler.setScheduleState({ scheduleName: schedule.name, state: schedule.state });
+            updatedSchedule = await scheduler.setScheduleState({
+                scheduleName: schedule.name,
+                state: schedule.state,
+                preserveIfPaused: schedule.preserveIfPaused
+            });
         }
         if ('frequencyMs' in schedule) {
             updatedSchedule = await scheduler.setScheduleFrequency({ scheduleName: schedule.name, frequencyMs: schedule.frequencyMs });

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -260,6 +260,26 @@ describe('Scheduler', () => {
         expect(deleted.state).toBe('DELETED');
         expect(deleted.deletedAt).not.toBe(null);
     });
+    it('should leave a paused schedule paused when resuming with preserveIfPaused', async () => {
+        const paused = await recurring({ scheduler, state: 'PAUSED' });
+        const result = (await scheduler.setScheduleState({ scheduleName: paused.name, state: 'STARTED', preserveIfPaused: true })).unwrap();
+        expect(result.state).toBe('PAUSED');
+    });
+    it('should resume a paused schedule when preserveIfPaused is not set', async () => {
+        const paused = await recurring({ scheduler, state: 'PAUSED' });
+        const result = (await scheduler.setScheduleState({ scheduleName: paused.name, state: 'STARTED' })).unwrap();
+        expect(result.state).toBe('STARTED');
+    });
+    it('should resume a paused schedule when preserveIfPaused is explicitly false', async () => {
+        const paused = await recurring({ scheduler, state: 'PAUSED' });
+        const result = (await scheduler.setScheduleState({ scheduleName: paused.name, state: 'STARTED', preserveIfPaused: false })).unwrap();
+        expect(result.state).toBe('STARTED');
+    });
+    it('should not affect a non-paused schedule when preserveIfPaused is set', async () => {
+        const started = await recurring({ scheduler, state: 'STARTED' });
+        const result = (await scheduler.setScheduleState({ scheduleName: started.name, state: 'STARTED', preserveIfPaused: true })).unwrap();
+        expect(result.state).toBe('STARTED');
+    });
     it('should cancel tasks if schedule is deleted', async () => {
         const schedule = await recurring({ scheduler });
         await immediate(scheduler, { schedule });

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -280,6 +280,16 @@ describe('Scheduler', () => {
         const result = (await scheduler.setScheduleState({ scheduleName: started.name, state: 'STARTED', preserveIfPaused: true })).unwrap();
         expect(result.state).toBe('STARTED');
     });
+    it('should leave a paused schedule paused when deleting with preserveIfPaused', async () => {
+        const paused = await recurring({ scheduler, state: 'PAUSED' });
+        const result = (await scheduler.setScheduleState({ scheduleName: paused.name, state: 'DELETED', preserveIfPaused: true })).unwrap();
+        expect(result.state).toBe('PAUSED');
+    });
+    it('should delete a paused schedule when preserveIfPaused is not set', async () => {
+        const paused = await recurring({ scheduler, state: 'PAUSED' });
+        const result = (await scheduler.setScheduleState({ scheduleName: paused.name, state: 'DELETED' })).unwrap();
+        expect(result.state).toBe('DELETED');
+    });
     it('should cancel tasks if schedule is deleted', async () => {
         const schedule = await recurring({ scheduler });
         await immediate(scheduler, { schedule });

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -562,9 +562,9 @@ export class Scheduler {
      * Set schedule state
      * @param scheduleName - Schedule name
      * @param state - Schedule state
-     * @param preserveIfPaused - When transitioning to `STARTED`, leave a currently `PAUSED` schedule paused
-     * instead of resuming it. Lets a caller request "resume, but don't clobber an existing pause" in one
-     * round trip instead of checking state first and conditionally calling this after.
+     * @param preserveIfPaused - If the schedule is currently `PAUSED`, leave it alone regardless of the
+     * requested `state`. Lets a caller request "do this, but don't clobber an existing pause" in one round
+     * trip instead of checking state first and conditionally calling this after.
      * @notes Cancels all running tasks if the schedule is paused or deleted
      * @returns Schedule
      * @example
@@ -649,8 +649,8 @@ export class Scheduler {
             // No-op if the schedule is already in the desired state
             return Ok({ schedule, cancelledTasks: [] });
         }
-        if (preserveIfPaused && state === 'STARTED' && schedule.state === 'PAUSED') {
-            // The caller asked to resume, but this schedule is paused and they opted not to override that — leave it alone.
+        if (preserveIfPaused && schedule.state === 'PAUSED') {
+            // The caller opted not to override an existing pause, regardless of the requested transition — leave it alone.
             return Ok({ schedule, cancelledTasks: [] });
         }
 

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -562,16 +562,27 @@ export class Scheduler {
      * Set schedule state
      * @param scheduleName - Schedule name
      * @param state - Schedule state
+     * @param preserveIfPaused - When transitioning to `STARTED`, leave a currently `PAUSED` schedule paused
+     * instead of resuming it. Lets a caller request "resume, but don't clobber an existing pause" in one
+     * round trip instead of checking state first and conditionally calling this after.
      * @notes Cancels all running tasks if the schedule is paused or deleted
      * @returns Schedule
      * @example
      * const schedule = await scheduler.setScheduleState({ scheduleName: 'schedule123', state: 'PAUSED' });
      */
-    public async setScheduleState({ scheduleName, state }: { scheduleName: string; state: ScheduleState }): Promise<Result<Schedule>> {
+    public async setScheduleState({
+        scheduleName,
+        state,
+        preserveIfPaused
+    }: {
+        scheduleName: string;
+        state: ScheduleState;
+        preserveIfPaused?: boolean | undefined;
+    }): Promise<Result<Schedule>> {
         let cancelledTasks: Task[] = [];
         try {
             const schedule = await this.db.transaction(async (trx) => {
-                const transitioned = await this.transitionScheduleStateInTrx(trx, { scheduleName, state });
+                const transitioned = await this.transitionScheduleStateInTrx(trx, { scheduleName, state, preserveIfPaused });
                 if (transitioned.isErr()) {
                     throw transitioned.error;
                 }
@@ -623,7 +634,7 @@ export class Scheduler {
      */
     private async transitionScheduleStateInTrx(
         trx: knex.Knex.Transaction,
-        { scheduleName, state }: { scheduleName: string; state: ScheduleState }
+        { scheduleName, state, preserveIfPaused = false }: { scheduleName: string; state: ScheduleState; preserveIfPaused?: boolean | undefined }
     ): Promise<Result<{ schedule: Schedule | null; cancelledTasks: Task[] }>> {
         // forUpdate = true so that the schedule is locked to prevent any concurrent update or concurrent scheduling of tasks
         const found = await schedules.search(trx, { names: [scheduleName], limit: 1, forUpdate: true });
@@ -636,6 +647,10 @@ export class Scheduler {
         }
         if (schedule.state === state) {
             // No-op if the schedule is already in the desired state
+            return Ok({ schedule, cancelledTasks: [] });
+        }
+        if (preserveIfPaused && state === 'STARTED' && schedule.state === 'PAUSED') {
+            // The caller asked to resume, but this schedule is paused and they opted not to override that — leave it alone.
             return Ok({ schedule, cancelledTasks: [] });
         }
 

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -573,11 +573,11 @@ export class Scheduler {
     public async setScheduleState({
         scheduleName,
         state,
-        preserveIfPaused
+        preserveIfPaused = false
     }: {
         scheduleName: string;
         state: ScheduleState;
-        preserveIfPaused?: boolean | undefined;
+        preserveIfPaused?: boolean;
     }): Promise<Result<Schedule>> {
         let cancelledTasks: Task[] = [];
         try {
@@ -634,7 +634,7 @@ export class Scheduler {
      */
     private async transitionScheduleStateInTrx(
         trx: knex.Knex.Transaction,
-        { scheduleName, state, preserveIfPaused = false }: { scheduleName: string; state: ScheduleState; preserveIfPaused?: boolean | undefined }
+        { scheduleName, state, preserveIfPaused = false }: { scheduleName: string; state: ScheduleState; preserveIfPaused?: boolean }
     ): Promise<Result<{ schedule: Schedule | null; cancelledTasks: Task[] }>> {
         // forUpdate = true so that the schedule is locked to prevent any concurrent update or concurrent scheduling of tasks
         const found = await schedules.search(trx, { names: [scheduleName], limit: 1, forUpdate: true });

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -62,7 +62,7 @@ export interface OrchestratorClientInterface {
     executeOnEvent(props: ExecuteOnEventProps & { async: boolean }): Promise<VoidReturn>;
     executeSync(props: ExecuteSyncProps): Promise<VoidReturn>;
     pauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
-    unpauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
+    unpauseSync({ scheduleName, preserveIfPaused }: { scheduleName: string; preserveIfPaused?: boolean | undefined }): Promise<VoidReturn>;
     deleteSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
     deleteSyncs({ scheduleNames }: { scheduleNames: string[] }): Promise<VoidReturn>;
     updateSyncFrequency({ scheduleName, frequencyMs }: { scheduleName: string; frequencyMs: number }): Promise<VoidReturn>;
@@ -637,8 +637,17 @@ export class Orchestrator {
         return res;
     }
 
-    async unpauseSync({ syncId, environmentId }: { syncId: string; environmentId: number }): Promise<Result<void>> {
-        const res = await this.client.unpauseSync({ scheduleName: `environment:${environmentId}:sync:${syncId}` });
+    async unpauseSync({
+        syncId,
+        environmentId,
+        preserveIfPaused
+    }: {
+        syncId: string;
+        environmentId: number;
+        /** Leave the sync paused instead of resuming it if it's currently paused. Defaults to false (always resume). */
+        preserveIfPaused?: boolean;
+    }): Promise<Result<void>> {
+        const res = await this.client.unpauseSync({ scheduleName: `environment:${environmentId}:sync:${syncId}`, preserveIfPaused });
         if (res.isErr()) {
             errorManager.report(res.error, {
                 source: ErrorSourceEnum.PLATFORM,

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -1,5 +1,5 @@
 import db from '@nangohq/database';
-import { getCheckpointKey, getLogger, stringifyError } from '@nangohq/utils';
+import { getCheckpointKey, getLogger, report, stringifyError } from '@nangohq/utils';
 
 import { SyncJobsType, SyncStatus } from '../../models/Sync.js';
 import { NangoError } from '../../utils/error.js';
@@ -24,7 +24,7 @@ import type { Orchestrator, RecordsServiceInterface } from '../../clients/orches
 import type { ServiceResponse } from '../../models/Generic.js';
 import type { NangoConfig, NangoIntegration, NangoIntegrationData } from '../../models/NangoConfig.js';
 import type { Config as ProviderConfig } from '../../models/Provider.js';
-import type { SyncCommand, SyncWithConnectionId } from '../../models/Sync.js';
+import type { Sync, SyncCommand, SyncWithConnectionId } from '../../models/Sync.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import type {
     CLIDeployFlowConfig,
@@ -32,9 +32,11 @@ import type {
     DBConnection,
     DBConnectionDecrypted,
     DBEnvironment,
+    DBSyncConfig,
     ReportedSyncJobStatus,
     SyncDeploymentResult
 } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
 
 // Should be in "logs" package but impossible thanks to CLI
 export const syncCommandToOperation = {
@@ -90,6 +92,8 @@ export class SyncManagerService {
 
         const syncObject = integrations[providerConfigKey] as unknown as Record<string, NangoIntegration>;
         const syncNames = Object.keys(syncObject);
+
+        const pending: { syncName: string; syncData: NangoIntegrationData; syncConfig: DBSyncConfig; existing: Result<Sync> }[] = [];
         for (const syncName of syncNames) {
             const syncData = syncObject[syncName] as unknown as NangoIntegrationData;
 
@@ -103,8 +107,21 @@ export class SyncManagerService {
 
             // Resume soft-deleted syncs if needed
             const existing = await undeleteSync({ connectionId, name: syncName, variant: syncVariant });
+            pending.push({ syncName, syncData, syncConfig, existing });
+        }
+
+        // Batch the sync pause check into a single orchestrator call instead of one per sync.
+        const candidates: { syncId: string; environmentId: number }[] = [];
+        for (const { syncData, existing } of pending) {
+            if (existing.isOk() && syncData.auto_start !== false) {
+                candidates.push({ syncId: existing.value.id, environmentId: nangoConnection.environment_id });
+            }
+        }
+        const pausedSyncIds = await this.getPausedSyncIds({ syncs: candidates, orchestrator });
+
+        for (const { syncName, syncData, syncConfig, existing } of pending) {
             if (existing.isOk()) {
-                if (syncData.auto_start !== false) {
+                if (syncData.auto_start !== false && !pausedSyncIds.has(existing.value.id)) {
                     await orchestrator.unpauseSync({ syncId: existing.value.id, environmentId: nangoConnection.environment_id });
                 }
                 continue;
@@ -153,6 +170,7 @@ export class SyncManagerService {
             if (!providerConfig) {
                 throw new Error(`Provider config not found for ${providerConfigKey} in environment ${environmentId}`);
             }
+            const pending: { connection: ConnectionInternal; syncConfig: DBSyncConfig; existing: Result<Sync> }[] = [];
             for (const connection of connections) {
                 const syncConfig = await getSyncConfigByParams(connection.environment_id, syncName, providerConfigKey);
                 if (!syncConfig) {
@@ -160,8 +178,23 @@ export class SyncManagerService {
                 }
                 // Resume soft-deleted syncs if needed
                 const existing = await undeleteSync({ connectionId: connection.id, name: syncName, variant: syncVariant });
+                pending.push({ connection, syncConfig, existing });
+            }
+
+            // Batch the sync pause check into a single orchestrator call instead of one per sync.
+            const candidates: { syncId: string; environmentId: number }[] = [];
+            if (flowConfig.auto_start !== false) {
+                for (const { connection, existing } of pending) {
+                    if (existing.isOk()) {
+                        candidates.push({ syncId: existing.value.id, environmentId: connection.environment_id });
+                    }
+                }
+            }
+            const pausedSyncIds = await this.getPausedSyncIds({ syncs: candidates, orchestrator });
+
+            for (const { connection, syncConfig, existing } of pending) {
                 if (existing.isOk()) {
-                    if (flowConfig.auto_start !== false) {
+                    if (flowConfig.auto_start !== false && !pausedSyncIds.has(existing.value.id)) {
                         await orchestrator.unpauseSync({ syncId: existing.value.id, environmentId: connection.environment_id });
                     }
                     continue;
@@ -191,6 +224,36 @@ export class SyncManagerService {
 
             return false;
         }
+    }
+
+    private async getPausedSyncIds({
+        syncs,
+        orchestrator
+    }: {
+        syncs: { syncId: string; environmentId: number }[];
+        orchestrator: Orchestrator;
+    }): Promise<Set<string>> {
+        const paused = new Set<string>();
+        const searchSchedulesMaxNames = 1000;
+        for (let i = 0; i < syncs.length; i += searchSchedulesMaxNames) {
+            const chunk = syncs.slice(i, i + searchSchedulesMaxNames);
+            const schedules = await orchestrator.searchSchedules(chunk);
+            if (schedules.isErr()) {
+                logger.error(`Failed to search schedules to determine paused syncs: ${stringifyError(schedules.error)}`);
+                report(new Error('failed_to_search_schedules_for_paused_syncs', { cause: schedules.error }));
+                // Fail closed: if we can't determine a sync's paused state, treat it as paused so callers don't unpause it by mistake.
+                for (const { syncId } of chunk) {
+                    paused.add(syncId);
+                }
+                continue;
+            }
+            for (const [syncId, schedule] of schedules.value) {
+                if (schedule.state === 'PAUSED') {
+                    paused.add(syncId);
+                }
+            }
+        }
+        return paused;
     }
 
     public async createSyncs(

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -1,5 +1,5 @@
 import db from '@nangohq/database';
-import { getCheckpointKey, getLogger, report, stringifyError } from '@nangohq/utils';
+import { getCheckpointKey, getLogger, stringifyError } from '@nangohq/utils';
 
 import { SyncJobsType, SyncStatus } from '../../models/Sync.js';
 import { NangoError } from '../../utils/error.js';
@@ -24,7 +24,7 @@ import type { Orchestrator, RecordsServiceInterface } from '../../clients/orches
 import type { ServiceResponse } from '../../models/Generic.js';
 import type { NangoConfig, NangoIntegration, NangoIntegrationData } from '../../models/NangoConfig.js';
 import type { Config as ProviderConfig } from '../../models/Provider.js';
-import type { Sync, SyncCommand, SyncWithConnectionId } from '../../models/Sync.js';
+import type { SyncCommand, SyncWithConnectionId } from '../../models/Sync.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import type {
     CLIDeployFlowConfig,
@@ -32,11 +32,9 @@ import type {
     DBConnection,
     DBConnectionDecrypted,
     DBEnvironment,
-    DBSyncConfig,
     ReportedSyncJobStatus,
     SyncDeploymentResult
 } from '@nangohq/types';
-import type { Result } from '@nangohq/utils';
 
 // Should be in "logs" package but impossible thanks to CLI
 export const syncCommandToOperation = {
@@ -93,7 +91,6 @@ export class SyncManagerService {
         const syncObject = integrations[providerConfigKey] as unknown as Record<string, NangoIntegration>;
         const syncNames = Object.keys(syncObject);
 
-        const pending: { syncName: string; syncData: NangoIntegrationData; syncConfig: DBSyncConfig; existing: Result<Sync> }[] = [];
         for (const syncName of syncNames) {
             const syncData = syncObject[syncName] as unknown as NangoIntegrationData;
 
@@ -107,22 +104,13 @@ export class SyncManagerService {
 
             // Resume soft-deleted syncs if needed
             const existing = await undeleteSync({ connectionId, name: syncName, variant: syncVariant });
-            pending.push({ syncName, syncData, syncConfig, existing });
-        }
-
-        // Batch the sync pause check into a single orchestrator call instead of one per sync.
-        const candidates: { syncId: string; environmentId: number }[] = [];
-        for (const { syncData, existing } of pending) {
-            if (existing.isOk() && syncData.auto_start !== false) {
-                candidates.push({ syncId: existing.value.id, environmentId: nangoConnection.environment_id });
-            }
-        }
-        const pausedSyncIds = await this.getPausedSyncIds({ syncs: candidates, orchestrator });
-
-        for (const { syncName, syncData, syncConfig, existing } of pending) {
             if (existing.isOk()) {
-                if (syncData.auto_start !== false && !pausedSyncIds.has(existing.value.id)) {
-                    await orchestrator.unpauseSync({ syncId: existing.value.id, environmentId: nangoConnection.environment_id });
+                if (syncData.auto_start !== false) {
+                    await orchestrator.unpauseSync({
+                        syncId: existing.value.id,
+                        environmentId: nangoConnection.environment_id,
+                        preserveIfPaused: true
+                    });
                 }
                 continue;
             }
@@ -170,7 +158,6 @@ export class SyncManagerService {
             if (!providerConfig) {
                 throw new Error(`Provider config not found for ${providerConfigKey} in environment ${environmentId}`);
             }
-            const pending: { connection: ConnectionInternal; syncConfig: DBSyncConfig; existing: Result<Sync> }[] = [];
             for (const connection of connections) {
                 const syncConfig = await getSyncConfigByParams(connection.environment_id, syncName, providerConfigKey);
                 if (!syncConfig) {
@@ -178,23 +165,8 @@ export class SyncManagerService {
                 }
                 // Resume soft-deleted syncs if needed
                 const existing = await undeleteSync({ connectionId: connection.id, name: syncName, variant: syncVariant });
-                pending.push({ connection, syncConfig, existing });
-            }
-
-            // Batch the sync pause check into a single orchestrator call instead of one per sync.
-            const candidates: { syncId: string; environmentId: number }[] = [];
-            if (flowConfig.auto_start !== false) {
-                for (const { connection, existing } of pending) {
-                    if (existing.isOk()) {
-                        candidates.push({ syncId: existing.value.id, environmentId: connection.environment_id });
-                    }
-                }
-            }
-            const pausedSyncIds = await this.getPausedSyncIds({ syncs: candidates, orchestrator });
-
-            for (const { connection, syncConfig, existing } of pending) {
                 if (existing.isOk()) {
-                    if (flowConfig.auto_start !== false && !pausedSyncIds.has(existing.value.id)) {
+                    if (flowConfig.auto_start !== false) {
                         await orchestrator.unpauseSync({ syncId: existing.value.id, environmentId: connection.environment_id });
                     }
                     continue;
@@ -224,36 +196,6 @@ export class SyncManagerService {
 
             return false;
         }
-    }
-
-    private async getPausedSyncIds({
-        syncs,
-        orchestrator
-    }: {
-        syncs: { syncId: string; environmentId: number }[];
-        orchestrator: Orchestrator;
-    }): Promise<Set<string>> {
-        const paused = new Set<string>();
-        const searchSchedulesMaxNames = 1000;
-        for (let i = 0; i < syncs.length; i += searchSchedulesMaxNames) {
-            const chunk = syncs.slice(i, i + searchSchedulesMaxNames);
-            const schedules = await orchestrator.searchSchedules(chunk);
-            if (schedules.isErr()) {
-                logger.error(`Failed to search schedules to determine paused syncs: ${stringifyError(schedules.error)}`);
-                report(new Error('failed_to_search_schedules_for_paused_syncs', { cause: schedules.error }));
-                // Fail closed: if we can't determine a sync's paused state, treat it as paused so callers don't unpause it by mistake.
-                for (const { syncId } of chunk) {
-                    paused.add(syncId);
-                }
-                continue;
-            }
-            for (const [syncId, schedule] of schedules.value) {
-                if (schedule.state === 'PAUSED') {
-                    paused.add(syncId);
-                }
-            }
-        }
-        return paused;
     }
 
     public async createSyncs(

--- a/packages/shared/lib/services/sync/sync.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/sync.service.unit.test.ts
@@ -28,7 +28,7 @@ const orchestratorClientNoop: OrchestratorClientInterface = {
     deleteSync: () => Promise.resolve({}) as any,
     deleteSyncs: () => Promise.resolve({}) as any,
     updateSyncFrequency: () => Promise.resolve({}) as any,
-    searchSchedules: () => Promise.resolve({}) as any,
+    searchSchedules: () => Promise.resolve(Ok([])) as any,
     getOutput: () => Promise.resolve({}) as any
 };
 const mockOrchestrator = new Orchestrator(orchestratorClientNoop);
@@ -404,6 +404,97 @@ describe('createSyncForConnection — auto_start respected on reauth', () => {
 
         expect(unpauseSyncSpy).toHaveBeenCalledWith({ syncId: 'sync-uuid-1', environmentId: 1 });
     });
+
+    it('does not unpause an existing sync that was manually paused, even when auto_start is true', async () => {
+        vi.spyOn(syncConfigService, 'getSyncConfig').mockResolvedValue({
+            integrations: {
+                github: {
+                    'my-sync': {
+                        sync_config_id: 1,
+                        runs: 'every 1h',
+                        type: 'sync',
+                        returns: ['MyModel'],
+                        input: undefined,
+                        track_deletes: false,
+                        auto_start: true,
+                        attributes: {},
+                        fileLocation: '/tmp/my-sync.js',
+                        version: '1',
+                        metadata: {} as any,
+                        enabled: true
+                    }
+                }
+            },
+            models: {}
+        } as any);
+        vi.spyOn(syncService, 'undeleteSync').mockResolvedValue(Ok(makeExistingSync()));
+        vi.spyOn(mockOrchestrator, 'searchSchedules').mockResolvedValue(Ok(new Map([['sync-uuid-1', { state: 'PAUSED' } as any]])));
+
+        await syncManager.createSyncForConnection({
+            connectionId: 1,
+            syncVariant: 'base',
+            logContextGetter,
+            orchestrator: mockOrchestrator
+        });
+
+        expect(unpauseSyncSpy).not.toHaveBeenCalled();
+    });
+
+    it('checks paused state for multiple syncs in a single batched searchSchedules call', async () => {
+        vi.spyOn(syncConfigService, 'getSyncConfig').mockResolvedValue({
+            integrations: {
+                github: {
+                    'sync-a': {
+                        sync_config_id: 1,
+                        runs: 'every 1h',
+                        type: 'sync',
+                        returns: ['MyModel'],
+                        input: undefined,
+                        track_deletes: false,
+                        auto_start: true,
+                        attributes: {},
+                        fileLocation: '/tmp/sync-a.js',
+                        version: '1',
+                        metadata: {} as any,
+                        enabled: true
+                    },
+                    'sync-b': {
+                        sync_config_id: 2,
+                        runs: 'every 1h',
+                        type: 'sync',
+                        returns: ['MyModel'],
+                        input: undefined,
+                        track_deletes: false,
+                        auto_start: true,
+                        attributes: {},
+                        fileLocation: '/tmp/sync-b.js',
+                        version: '1',
+                        metadata: {} as any,
+                        enabled: true
+                    }
+                }
+            },
+            models: {}
+        } as any);
+        vi.spyOn(syncService, 'undeleteSync').mockImplementation(({ name }) => Promise.resolve(Ok(makeExistingSync({ id: `${name}-uuid`, name }))));
+        const searchSchedulesSpy = vi.spyOn(mockOrchestrator, 'searchSchedules').mockResolvedValue(Ok(new Map()));
+
+        await syncManager.createSyncForConnection({
+            connectionId: 1,
+            syncVariant: 'base',
+            logContextGetter,
+            orchestrator: mockOrchestrator
+        });
+
+        expect(searchSchedulesSpy).toHaveBeenCalledTimes(1);
+        expect(searchSchedulesSpy).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                { syncId: 'sync-a-uuid', environmentId: 1 },
+                { syncId: 'sync-b-uuid', environmentId: 1 }
+            ])
+        );
+        expect(unpauseSyncSpy).toHaveBeenCalledTimes(2);
+    });
 });
 
 describe('createSyncForConnections — auto_start respected on deploy', () => {
@@ -454,5 +545,24 @@ describe('createSyncForConnections — auto_start respected on deploy', () => {
         });
 
         expect(unpauseSyncSpy).toHaveBeenCalledWith({ syncId: 'sync-uuid-1', environmentId: 1 });
+    });
+
+    it('does not unpause an existing sync that was manually paused, even when auto_start is true', async () => {
+        vi.spyOn(syncService, 'undeleteSync').mockResolvedValue(Ok(makeExistingSync()));
+        vi.spyOn(mockOrchestrator, 'searchSchedules').mockResolvedValue(Ok(new Map([['sync-uuid-1', { state: 'PAUSED' } as any]])));
+
+        await syncManager.createSyncForConnections({
+            connections: [makeConnection()],
+            syncName: 'my-sync',
+            syncVariant: 'base',
+            providerConfigKey: 'github',
+            environmentId: 1,
+            flowConfig: makeFlow({ auto_start: true }),
+            logContextGetter,
+            orchestrator: mockOrchestrator,
+            debug: false
+        });
+
+        expect(unpauseSyncSpy).not.toHaveBeenCalled();
     });
 });

--- a/packages/shared/lib/services/sync/sync.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/sync.service.unit.test.ts
@@ -402,10 +402,12 @@ describe('createSyncForConnection — auto_start respected on reauth', () => {
             orchestrator: mockOrchestrator
         });
 
-        expect(unpauseSyncSpy).toHaveBeenCalledWith({ syncId: 'sync-uuid-1', environmentId: 1 });
+        // preserveIfPaused: true — a reauth must not silently resume a sync the user manually paused.
+        // The actual "leave it paused" decision is made atomically by the orchestrator/scheduler, not here.
+        expect(unpauseSyncSpy).toHaveBeenCalledWith({ syncId: 'sync-uuid-1', environmentId: 1, preserveIfPaused: true });
     });
 
-    it('does not unpause an existing sync that was manually paused, even when auto_start is true', async () => {
+    it('does not need to look up paused state itself — it delegates that decision to the orchestrator', async () => {
         vi.spyOn(syncConfigService, 'getSyncConfig').mockResolvedValue({
             integrations: {
                 github: {
@@ -428,7 +430,7 @@ describe('createSyncForConnection — auto_start respected on reauth', () => {
             models: {}
         } as any);
         vi.spyOn(syncService, 'undeleteSync').mockResolvedValue(Ok(makeExistingSync()));
-        vi.spyOn(mockOrchestrator, 'searchSchedules').mockResolvedValue(Ok(new Map([['sync-uuid-1', { state: 'PAUSED' } as any]])));
+        const searchSchedulesSpy = vi.spyOn(mockOrchestrator, 'searchSchedules');
 
         await syncManager.createSyncForConnection({
             connectionId: 1,
@@ -437,10 +439,11 @@ describe('createSyncForConnection — auto_start respected on reauth', () => {
             orchestrator: mockOrchestrator
         });
 
-        expect(unpauseSyncSpy).not.toHaveBeenCalled();
+        expect(searchSchedulesSpy).not.toHaveBeenCalled();
+        expect(unpauseSyncSpy).toHaveBeenCalledWith({ syncId: 'sync-uuid-1', environmentId: 1, preserveIfPaused: true });
     });
 
-    it('checks paused state for multiple syncs in a single batched searchSchedules call', async () => {
+    it('passes preserveIfPaused: true for every sync on the connection', async () => {
         vi.spyOn(syncConfigService, 'getSyncConfig').mockResolvedValue({
             integrations: {
                 github: {
@@ -477,7 +480,6 @@ describe('createSyncForConnection — auto_start respected on reauth', () => {
             models: {}
         } as any);
         vi.spyOn(syncService, 'undeleteSync').mockImplementation(({ name }) => Promise.resolve(Ok(makeExistingSync({ id: `${name}-uuid`, name }))));
-        const searchSchedulesSpy = vi.spyOn(mockOrchestrator, 'searchSchedules').mockResolvedValue(Ok(new Map()));
 
         await syncManager.createSyncForConnection({
             connectionId: 1,
@@ -486,14 +488,9 @@ describe('createSyncForConnection — auto_start respected on reauth', () => {
             orchestrator: mockOrchestrator
         });
 
-        expect(searchSchedulesSpy).toHaveBeenCalledTimes(1);
-        expect(searchSchedulesSpy).toHaveBeenCalledWith(
-            expect.arrayContaining([
-                { syncId: 'sync-a-uuid', environmentId: 1 },
-                { syncId: 'sync-b-uuid', environmentId: 1 }
-            ])
-        );
         expect(unpauseSyncSpy).toHaveBeenCalledTimes(2);
+        expect(unpauseSyncSpy).toHaveBeenCalledWith({ syncId: 'sync-a-uuid', environmentId: 1, preserveIfPaused: true });
+        expect(unpauseSyncSpy).toHaveBeenCalledWith({ syncId: 'sync-b-uuid', environmentId: 1, preserveIfPaused: true });
     });
 });
 
@@ -547,9 +544,12 @@ describe('createSyncForConnections — auto_start respected on deploy', () => {
         expect(unpauseSyncSpy).toHaveBeenCalledWith({ syncId: 'sync-uuid-1', environmentId: 1 });
     });
 
-    it('does not unpause an existing sync that was manually paused, even when auto_start is true', async () => {
+    it('unpauses an existing sync even if its schedule is currently paused (e.g. flow re-enable, deploy)', async () => {
+        // Unlike createSyncForConnection (reauth), every caller here is an explicit "make this run"
+        // action, so a prior paused state must never block the unpause — and it shouldn't even need
+        // to ask the orchestrator about current pause state to know that.
         vi.spyOn(syncService, 'undeleteSync').mockResolvedValue(Ok(makeExistingSync()));
-        vi.spyOn(mockOrchestrator, 'searchSchedules').mockResolvedValue(Ok(new Map([['sync-uuid-1', { state: 'PAUSED' } as any]])));
+        const searchSchedulesSpy = vi.spyOn(mockOrchestrator, 'searchSchedules').mockResolvedValue(Ok(new Map([['sync-uuid-1', { state: 'PAUSED' } as any]])));
 
         await syncManager.createSyncForConnections({
             connections: [makeConnection()],
@@ -563,6 +563,7 @@ describe('createSyncForConnections — auto_start respected on deploy', () => {
             debug: false
         });
 
-        expect(unpauseSyncSpy).not.toHaveBeenCalled();
+        expect(searchSchedulesSpy).not.toHaveBeenCalled();
+        expect(unpauseSyncSpy).toHaveBeenCalledWith({ syncId: 'sync-uuid-1', environmentId: 1 });
     });
 });


### PR DESCRIPTION
## Describe the problem and your solution

- Manually paused syncs were being silently resumed on connection reauth. Fixes it with a `preserveIfPaused` flag on `unpauseSync`, checked atomically inside the scheduler's own transaction (no extra round trip), only the reauth path opts in, every other caller (deploy, flow-enable, pre-built) keeps its existing unconditional resume.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

