### PR TITLE
chore(design-system): put Design System first in Storybook

### DIFF
--- a/packages/design-system/.storybook/preview.ts
+++ b/packages/design-system/.storybook/preview.ts
@@ -29,8 +29,11 @@ const preview: Preview = {
     ],
     parameters: {
         options: {
+            // Design System first — it's what people reach for. Alphabetical would put "App Components"
+            // (the not-yet-lifted webapp components) on top and auto-expand it on load.
             storySort: {
-                method: 'alphabetical'
+                method: 'alphabetical',
+                order: ['Design System', 'App Components', '*']
             }
         },
         controls: {

--- a/packages/design-system/stories/Alert.stories.tsx
+++ b/packages/design-system/stories/Alert.stories.tsx
@@ -5,7 +5,7 @@ import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle } from '
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Alert',
+    title: 'App Components/UI/Alert',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Avatar.stories.tsx
+++ b/packages/design-system/stories/Avatar.stories.tsx
@@ -3,7 +3,7 @@ import { Avatar } from '@/components/ui/Avatar';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Avatar',
+    title: 'App Components/UI/Avatar',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/BinaryToggle.stories.tsx
+++ b/packages/design-system/stories/BinaryToggle.stories.tsx
@@ -5,7 +5,7 @@ import { BinaryToggle } from '@/components/ui/BinaryToggle';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/BinaryToggle',
+    title: 'App Components/UI/BinaryToggle',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/ButtonLink.stories.tsx
+++ b/packages/design-system/stories/ButtonLink.stories.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ButtonLink> = {
     component: ButtonLink,
-    title: 'Components/UI/ButtonLink',
+    title: 'App Components/UI/ButtonLink',
     parameters: { layout: 'padded' },
     decorators: [
         (Story) => (

--- a/packages/design-system/stories/Chart.stories.tsx
+++ b/packages/design-system/stories/Chart.stories.tsx
@@ -18,7 +18,7 @@ const chartConfig: ChartConfig = {
 };
 
 const meta: Meta = {
-    title: 'Components/UI/Chart',
+    title: 'App Components/UI/Chart',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Checkbox.stories.tsx
+++ b/packages/design-system/stories/Checkbox.stories.tsx
@@ -4,7 +4,7 @@ import { FieldLabel } from '../src/components/ui/field';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Checkbox',
+    title: 'App Components/UI/Checkbox',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/CodeBlock.stories.tsx
+++ b/packages/design-system/stories/CodeBlock.stories.tsx
@@ -11,7 +11,7 @@ console.log(connection.credentials);`;
 
 const meta: Meta<typeof CodeBlock> = {
     component: CodeBlock,
-    title: 'Components/UI/CodeBlock',
+    title: 'App Components/UI/CodeBlock',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Collapsible.stories.tsx
+++ b/packages/design-system/stories/Collapsible.stories.tsx
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Collapsible> = {
     component: Collapsible,
-    title: 'Components/UI/Collapsible',
+    title: 'App Components/UI/Collapsible',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/ColorInput.stories.tsx
+++ b/packages/design-system/stories/ColorInput.stories.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ColorInput> = {
     component: ColorInput,
-    title: 'Components/UI/ColorInput',
+    title: 'App Components/UI/ColorInput',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/Combobox.stories.tsx
+++ b/packages/design-system/stories/Combobox.stories.tsx
@@ -13,7 +13,7 @@ const options = [
 ];
 
 const meta: Meta = {
-    title: 'Components/UI/Combobox',
+    title: 'App Components/UI/Combobox',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/ConditionalTooltip.stories.tsx
+++ b/packages/design-system/stories/ConditionalTooltip.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ConditionalTooltip> = {
     component: ConditionalTooltip,
-    title: 'Components/Patterns/ConditionalTooltip',
+    title: 'App Components/Patterns/ConditionalTooltip',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/CopyButton.stories.tsx
+++ b/packages/design-system/stories/CopyButton.stories.tsx
@@ -3,7 +3,7 @@ import { CopyButton } from '@/components/ui/CopyButton';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/CopyButton',
+    title: 'App Components/UI/CopyButton',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/DestructiveActionModal.stories.tsx
+++ b/packages/design-system/stories/DestructiveActionModal.stories.tsx
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DestructiveActionModal> = {
     component: DestructiveActionModal,
-    title: 'Components/Patterns/DestructiveActionModal',
+    title: 'App Components/Patterns/DestructiveActionModal',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/Dot.stories.tsx
+++ b/packages/design-system/stories/Dot.stories.tsx
@@ -3,7 +3,7 @@ import { Dot } from '@/components/ui/Dot';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Dot',
+    title: 'App Components/UI/Dot',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/DropdownMenu.stories.tsx
+++ b/packages/design-system/stories/DropdownMenu.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenu> = {
     component: DropdownMenu,
-    title: 'Components/UI/DropdownMenu',
+    title: 'App Components/UI/DropdownMenu',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/EditableInput.stories.tsx
+++ b/packages/design-system/stories/EditableInput.stories.tsx
@@ -5,7 +5,7 @@ import { EditableInput } from '@/components/patterns/EditableInput';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/Patterns/EditableInput',
+    title: 'App Components/Patterns/EditableInput',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/EmptyCard.stories.tsx
+++ b/packages/design-system/stories/EmptyCard.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof EmptyCard> = {
     component: EmptyCard,
-    title: 'Components/UI/EmptyCard',
+    title: 'App Components/UI/EmptyCard',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/InfoTooltip.stories.tsx
+++ b/packages/design-system/stories/InfoTooltip.stories.tsx
@@ -3,7 +3,7 @@ import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/InfoTooltip',
+    title: 'App Components/UI/InfoTooltip',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/InputOTP.stories.tsx
+++ b/packages/design-system/stories/InputOTP.stories.tsx
@@ -3,7 +3,7 @@ import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/InputOTP'
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/InputOTP',
+    title: 'App Components/UI/InputOTP',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/KeyValueBadge.stories.tsx
+++ b/packages/design-system/stories/KeyValueBadge.stories.tsx
@@ -3,7 +3,7 @@ import { KeyValueBadge } from '@/components/ui/KeyValueBadge';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/KeyValueBadge',
+    title: 'App Components/UI/KeyValueBadge',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/LineSnippet.stories.tsx
+++ b/packages/design-system/stories/LineSnippet.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof LineSnippet> = {
     component: LineSnippet,
-    title: 'Components/UI/LineSnippet',
+    title: 'App Components/UI/LineSnippet',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/MultiLanguageCodeBlock.stories.tsx
+++ b/packages/design-system/stories/MultiLanguageCodeBlock.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof MultiLanguageCodeBlock> = {
     component: MultiLanguageCodeBlock,
-    title: 'Components/UI/MultiLanguageCodeBlock',
+    title: 'App Components/UI/MultiLanguageCodeBlock',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/MultiSelect.stories.tsx
+++ b/packages/design-system/stories/MultiSelect.stories.tsx
@@ -13,7 +13,7 @@ const options = [
 ];
 
 const meta: Meta = {
-    title: 'Components/UI/MultiSelect',
+    title: 'App Components/UI/MultiSelect',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/Navigation.stories.tsx
+++ b/packages/design-system/stories/Navigation.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Navigation> = {
     component: Navigation,
-    title: 'Components/UI/Navigation',
+    title: 'App Components/UI/Navigation',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/PeriodSelector.stories.tsx
+++ b/packages/design-system/stories/PeriodSelector.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof PeriodSelector> = {
     component: PeriodSelector,
-    title: 'Components/Patterns/PeriodSelector',
+    title: 'App Components/Patterns/PeriodSelector',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Popover.stories.tsx
+++ b/packages/design-system/stories/Popover.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Popover> = {
     component: Popover,
-    title: 'Components/UI/Popover',
+    title: 'App Components/UI/Popover',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/SecretInput.stories.tsx
+++ b/packages/design-system/stories/SecretInput.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof SecretInput> = {
     component: SecretInput,
-    title: 'Components/Patterns/SecretInput',
+    title: 'App Components/Patterns/SecretInput',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/SecretTextArea.stories.tsx
+++ b/packages/design-system/stories/SecretTextArea.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof SecretTextArea> = {
     component: SecretTextArea,
-    title: 'Components/Patterns/SecretTextArea',
+    title: 'App Components/Patterns/SecretTextArea',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/Select.stories.tsx
+++ b/packages/design-system/stories/Select.stories.tsx
@@ -3,7 +3,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Select',
+    title: 'App Components/UI/Select',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Separator.stories.tsx
+++ b/packages/design-system/stories/Separator.stories.tsx
@@ -3,7 +3,7 @@ import { Separator } from '@/components/ui/Separator';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Separator',
+    title: 'App Components/UI/Separator',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Sheet.stories.tsx
+++ b/packages/design-system/stories/Sheet.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Sheet> = {
     component: Sheet,
-    title: 'Components/UI/Sheet',
+    title: 'App Components/UI/Sheet',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/SideInfo.stories.tsx
+++ b/packages/design-system/stories/SideInfo.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof SideInfo> = {
     component: SideInfo,
-    title: 'Components/UI/SideInfo',
+    title: 'App Components/UI/SideInfo',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Sidebar.stories.tsx
+++ b/packages/design-system/stories/Sidebar.stories.tsx
@@ -22,7 +22,7 @@ const navItems = [
 ];
 
 const meta: Meta = {
-    title: 'Components/UI/Sidebar',
+    title: 'App Components/UI/Sidebar',
     parameters: { layout: 'fullscreen' }
 };
 export default meta;

--- a/packages/design-system/stories/SimpleCodeBlock.stories.tsx
+++ b/packages/design-system/stories/SimpleCodeBlock.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof SimpleCodeBlock> = {
     component: SimpleCodeBlock,
-    title: 'Components/UI/SimpleCodeBlock',
+    title: 'App Components/UI/SimpleCodeBlock',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Skeleton.stories.tsx
+++ b/packages/design-system/stories/Skeleton.stories.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/Skeleton';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Skeleton',
+    title: 'App Components/UI/Skeleton',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Spinner.stories.tsx
+++ b/packages/design-system/stories/Spinner.stories.tsx
@@ -3,7 +3,7 @@ import { Spinner } from '@/components/ui/Spinner';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Spinner',
+    title: 'App Components/UI/Spinner',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/StatusWithIcon.stories.tsx
+++ b/packages/design-system/stories/StatusWithIcon.stories.tsx
@@ -5,7 +5,7 @@ import { StatusWithIcon } from '@/components/ui/StatusWithIcon';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/StatusWithIcon',
+    title: 'App Components/UI/StatusWithIcon',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Switch.stories.tsx
+++ b/packages/design-system/stories/Switch.stories.tsx
@@ -4,7 +4,7 @@ import { FieldLabel } from '../src/components/ui/field';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Switch',
+    title: 'App Components/UI/Switch',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Table.stories.tsx
+++ b/packages/design-system/stories/Table.stories.tsx
@@ -10,7 +10,7 @@ const rows = [
 
 const meta: Meta<typeof Table> = {
     component: Table,
-    title: 'Components/UI/Table',
+    title: 'App Components/UI/Table',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Tabs.stories.tsx
+++ b/packages/design-system/stories/Tabs.stories.tsx
@@ -3,7 +3,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Tabs',
+    title: 'App Components/UI/Tabs',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Tag.stories.tsx
+++ b/packages/design-system/stories/Tag.stories.tsx
@@ -3,7 +3,7 @@ import { Tag } from '@/components/ui/Tag';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Tag',
+    title: 'App Components/UI/Tag',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Toast.stories.tsx
+++ b/packages/design-system/stories/Toast.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Toast> = {
     component: Toast,
-    title: 'Components/UI/Toast',
+    title: 'App Components/UI/Toast',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Tooltip.stories.tsx
+++ b/packages/design-system/stories/Tooltip.stories.tsx
@@ -4,7 +4,7 @@ import { Button } from '../src/components/ui/button';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/UI/Tooltip',
+    title: 'App Components/UI/Tooltip',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v2-patterns/CriticalErrorAlert.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/CriticalErrorAlert.stories.tsx
@@ -5,7 +5,7 @@ import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/Patterns/CriticalErrorAlert',
+    title: 'App Components/Patterns/CriticalErrorAlert',
     parameters: { layout: 'padded' },
     decorators: [
         (Story) => (

--- a/packages/design-system/stories/v2-patterns/FilterMultiSelect.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/FilterMultiSelect.stories.tsx
@@ -33,7 +33,7 @@ const GROUP_OPTIONS = [
 ];
 
 const meta: Meta = {
-    title: 'Components/Patterns/FilterMultiSelect',
+    title: 'App Components/Patterns/FilterMultiSelect',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/v2-patterns/FilterSelect.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/FilterSelect.stories.tsx
@@ -7,7 +7,7 @@ import type { FilterSelectGroupData } from '@/components/patterns/FilterSelect';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/Patterns/FilterSelect',
+    title: 'App Components/Patterns/FilterSelect',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/v2-patterns/GoogleButton.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/GoogleButton.stories.tsx
@@ -3,7 +3,7 @@ import GoogleButton from '@/components/patterns/GoogleButton';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/Patterns/GoogleButton',
+    title: 'App Components/Patterns/GoogleButton',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v2-patterns/IntegrationLogo.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/IntegrationLogo.stories.tsx
@@ -3,7 +3,7 @@ import { IntegrationLogo } from '@/components/patterns/IntegrationLogo';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/Patterns/IntegrationLogo',
+    title: 'App Components/Patterns/IntegrationLogo',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v2-patterns/KeyValueInput.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/KeyValueInput.stories.tsx
@@ -5,7 +5,7 @@ import { KeyValueInput } from '@/components/patterns/KeyValueInput';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/Patterns/KeyValueInput',
+    title: 'App Components/Patterns/KeyValueInput',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v2-patterns/PermissionGate.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/PermissionGate.stories.tsx
@@ -4,7 +4,7 @@ import { Button } from '../../src/components/ui/button';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/Patterns/PermissionGate',
+    title: 'App Components/Patterns/PermissionGate',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v2-patterns/ScopesInput.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/ScopesInput.stories.tsx
@@ -3,7 +3,7 @@ import { ScopesInput } from '@/components/patterns/ScopesInput';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components/Patterns/ScopesInput',
+    title: 'App Components/Patterns/ScopesInput',
     parameters: { layout: 'padded' }
 };
 export default meta;


### PR DESCRIPTION
## Problem

The Storybook sidebar sorts alphabetically, so `Components` — the webapp components not yet lifted into the design system — comes first and auto-expands on load. The design-system list, which is what people reach for, sits below the fold and needs scrolling past the legacy tree every time.

## Solution

- Renames that section `Components` → `App Components`, so its scope is obvious next to `Design System`.
- Pins the sidebar order explicitly: `order: ['Design System', 'App Components', '*']`. On name alone "App Components" would still sort first, so the rename isn't enough by itself.

50 story titles change; no behaviour or component code is touched.

## Testing

- `Design System` now renders first and expanded; `App Components` follows.
- `build-storybook` clean, and `ts-build` / `lint` / `format:check` pass.
