### PR TITLE
feat(webapp): align Billing & usage page with the latest designs

### DIFF
--- a/packages/design-system/src/components/ui/alert.tsx
+++ b/packages/design-system/src/components/ui/alert.tsx
@@ -152,13 +152,16 @@ export const AlertActions = forwardRef<HTMLDivElement, React.ComponentProps<'div
 AlertActions.displayName = 'AlertActions';
 
 /**
- * Figma "AlertButton": borderless pill, no underline, coloured from the parent alert's status via
- * `--alert-link`, so it never has to be told which status it sits in. Inline icons render at 12px —
- * pass one (typically `ExternalLink`) at the call site.
+ * Figma "AlertButton": borderless, coloured from the parent alert's status via `--alert-link`, so it
+ * never has to be told which status it sits in. Inline icons render at 12px — pass one (typically
+ * `ExternalLink`) at the call site.
+ *
+ * Deliberately has no corner radius. It renders as inline text with no border or background, so a
+ * radius only shows up on the focus ring, where a pill around a few words reads as a stray capsule.
  */
 export const alertButtonVariants = cva([
     'inline-flex w-fit shrink-0 cursor-pointer items-center justify-center gap-1 whitespace-nowrap',
-    'type-text-regular-sm rounded-ds-full py-0',
+    'type-text-regular-sm py-0',
     'text-[var(--alert-link)] active:text-[var(--alert-link-active)]',
     'decoration-from-font decoration-solid [text-underline-position:from-font]',
     'hover:underline focus-visible:underline active:underline',

--- a/packages/design-system/src/components/ui/alert.tsx
+++ b/packages/design-system/src/components/ui/alert.tsx
@@ -156,12 +156,13 @@ AlertActions.displayName = 'AlertActions';
  * never has to be told which status it sits in. Inline icons render at 12px — pass one (typically
  * `ExternalLink`) at the call site.
  *
- * Deliberately has no corner radius. It renders as inline text with no border or background, so a
- * radius only shows up on the focus ring, where a pill around a few words reads as a stray capsule.
+ * Carries the same 2px radius as a regular Button. It renders as inline text with no border or
+ * background, so the radius only shows up on the focus ring — 2px keeps that ring consistent with
+ * every other focusable control, where the previous pill read as a stray capsule.
  */
 export const alertButtonVariants = cva([
     'inline-flex w-fit shrink-0 cursor-pointer items-center justify-center gap-1 whitespace-nowrap',
-    'type-text-regular-sm py-0',
+    'type-text-regular-sm rounded-ds-xs py-0',
     'text-[var(--alert-link)] active:text-[var(--alert-link-active)]',
     'decoration-from-font decoration-solid [text-underline-position:from-font]',
     'hover:underline focus-visible:underline active:underline',

--- a/packages/design-system/src/components/ui/button.tsx
+++ b/packages/design-system/src/components/ui/button.tsx
@@ -135,8 +135,10 @@ export const buttonVariants = cva(
             // Figma's link text/icon scale is its own two-tier scale, distinct from the solid-button sizes:
             // xs/sm render at 12px text (md/lg keep the base 14px text-ds-md, so no override needed there).
             { variant: ['link-accent', 'link-danger', 'link-neutral'], size: ['xs', 'sm'], className: 'text-ds-xs gap-1' },
-            // xs is fully pill-rounded with the smallest (12px) icon; sm's icon is 14px, between xs and md/lg.
-            { variant: ['link-accent', 'link-danger', 'link-neutral'], size: 'xs', className: "rounded-ds-full [&_svg:not([class*='size-'])]:size-3" },
+            // xs takes the smallest (12px) icon; sm's icon is 14px, between xs and md/lg. No radius override:
+            // link variants are bare text with no border or background, so a pill only ever showed up as a
+            // capsule-shaped focus ring around a few words.
+            { variant: ['link-accent', 'link-danger', 'link-neutral'], size: 'xs', className: "[&_svg:not([class*='size-'])]:size-3" },
             { variant: ['link-accent', 'link-danger', 'link-neutral'], size: 'sm', className: "[&_svg:not([class*='size-'])]:size-3.5" }
         ],
         defaultVariants: {

--- a/packages/webapp/src/pages/Environment/Settings/General.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/General.tsx
@@ -92,7 +92,7 @@ export const General: React.FC = () => {
                             <AlertDescription>
                                 <span>
                                     When using the CLI for custom functions, add this to your .env:{' '}
-                                    <code className="font-mono text-sm font-semibold">
+                                    <code className="text-text-strong">
                                         NANGO_SECRET_KEY_{env.toUpperCase()}={'<secret-key>'}
                                     </code>
                                     .

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -11,7 +11,7 @@ import { Separator } from '@/components/ui/Separator';
 import { OverdueInvoiceAlert } from '@/features/Billing/OverdueInvoiceAlert';
 import { usePlanOverrideStore } from '@/features/planOverride';
 import { usePermissions } from '@/hooks/usePermissions';
-import { useApiGetOverdueInvoices, useApiGetPlans, useApiGetUsage, useCurrentPlan } from '@/hooks/usePlan';
+import { useApiGetBillingUsage, useApiGetOverdueInvoices, useApiGetPlans, useApiGetUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
 import { getAggregateUsageState } from '@/utils/usage';
@@ -45,9 +45,15 @@ export const TeamBilling: React.FC = () => {
     // Free is the only capped plan, and the sidebar alert already runs this query app-wide.
     const { data: caps } = useApiGetUsage(env);
 
+    // The dev override fabricates the overdue response, so it has to be handed a real portal URL for
+    // the previewed "View invoices" link to open anything. Fetched only while the override is on, and
+    // on the same key as <Payment/>'s unfiltered call, so it never costs a production request.
+    const overdueOverride = usePlanOverrideStore((s) => s.overdueOverride);
+    const { data: billingUsage } = useApiGetBillingUsage(env, undefined, { enabled: overdueOverride });
+
     // Owned here rather than by <Usage/> so a usage outage can't hide a payment warning, and so it
     // sits above the cap warning: money owed outranks a limit being approached.
-    const { data: overdue } = useApiGetOverdueInvoices(env, environmentData?.plan);
+    const { data: overdue } = useApiGetOverdueInvoices(env, environmentData?.plan, billingUsage?.data.customer.portalUrl);
     const overdueBanner = overdue?.data.hasOverdue && (
         <OverdueInvoiceAlert size="wide" canManageBilling={canManageBilling}>
             {overdue.data.portalUrl && (

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -1,19 +1,24 @@
+import { ArrowUpRight, ExternalLink } from 'lucide-react';
 import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom';
 
 import { permissions } from '@nangohq/authz';
+import { AlertButton } from '@nangohq/design-system';
 
+import { AlertButtonLink } from '@/components/ui/AlertButtonLink';
 import { Separator } from '@/components/ui/Separator';
+import { OverdueInvoiceAlert } from '@/features/Billing/OverdueInvoiceAlert';
 import { usePlanOverrideStore } from '@/features/planOverride';
 import { usePermissions } from '@/hooks/usePermissions';
-import { useApiGetPlans, useApiGetUsage, useCurrentPlan } from '@/hooks/usePlan';
+import { useApiGetOverdueInvoices, useApiGetPlans, useApiGetUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
 import { getAggregateUsageState } from '@/utils/usage';
 import DashboardLayout from '../../../layout/DashboardLayout';
 import { BillingHeaderAction } from './components/BillingHeaderAction';
 import { Payment } from './components/Payment';
+import { PaymentMethodDialog } from './components/PaymentMethodDialog';
 import { Plans } from './components/Plans';
 import { ScheduledPlanChangeAlert } from './components/ScheduledPlanChangeAlert';
 import { Summary } from './components/Summary';
@@ -40,6 +45,29 @@ export const TeamBilling: React.FC = () => {
     // Free is the only capped plan, and the sidebar alert already runs this query app-wide.
     const { data: caps } = useApiGetUsage(env);
 
+    // Owned here rather than by <Usage/> so a usage outage can't hide a payment warning, and so it
+    // sits above the cap warning: money owed outranks a limit being approached.
+    const { data: overdue } = useApiGetOverdueInvoices(env, environmentData?.plan);
+    const overdueBanner = overdue?.data.hasOverdue && (
+        <OverdueInvoiceAlert size="wide" canManageBilling={canManageBilling}>
+            {overdue.data.portalUrl && (
+                <AlertButtonLink
+                    to={overdue.data.portalUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => track('web:usage:invoice_details_clicked', {})}
+                >
+                    View invoices <ExternalLink />
+                </AlertButtonLink>
+            )}
+            <PaymentMethodDialog replace>
+                <AlertButton onClick={() => track('web:usage:edit_payment_method_clicked', { source: 'billing_page' })}>
+                    Edit payment method <ArrowUpRight />
+                </AlertButton>
+            </PaymentMethodDialog>
+        </OverdueInvoiceAlert>
+    );
+
     useEffect(() => {
         track('web:usage:viewed', {});
     }, []);
@@ -65,14 +93,18 @@ export const TeamBilling: React.FC = () => {
                 <title>Billing & usage - Nango</title>
             </Helmet>
             <div className="flex flex-col gap-8">
-                {showSummary && (
+                {showSummary ? (
                     <>
                         <div id="summary" className="flex flex-col gap-3">
                             <Summary />
+                            {overdueBanner}
                             <UsageLimitBanner state={usageLimitOverride ?? getAggregateUsageState(caps?.data ?? {})} />
                         </div>
                         <Separator />
                     </>
+                ) : (
+                    // Legacy, enterprise and free-uncapped get no strip, but can still owe an invoice.
+                    overdueBanner
                 )}
                 <div id="usage">
                     <Usage />

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -15,6 +15,7 @@ import DashboardLayout from '../../../layout/DashboardLayout';
 import { BillingHeaderAction } from './components/BillingHeaderAction';
 import { Payment } from './components/Payment';
 import { Plans } from './components/Plans';
+import { ScheduledPlanChangeAlert } from './components/ScheduledPlanChangeAlert';
 import { Summary } from './components/Summary';
 import { Usage } from './components/Usage';
 import { UsageLimitBanner } from './components/UsageLimitBanner';
@@ -79,6 +80,8 @@ export const TeamBilling: React.FC = () => {
                 <Separator />
                 <div id="plans" className="flex flex-col gap-4">
                     <span className="text-text-strong text-body-medium-medium">Plans</span>
+                    {/* Outside the scroll container below, so the full-width alert doesn't scroll with the plan cards. */}
+                    <ScheduledPlanChangeAlert />
                     <div className="w-full overflow-x-auto">
                         <Plans />
                     </div>

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -67,10 +67,10 @@ export const TeamBilling: React.FC = () => {
             <div className="flex flex-col gap-8">
                 {showSummary && (
                     <>
-                        <div id="summary">
+                        <div id="summary" className="flex flex-col gap-3">
                             <Summary />
+                            <UsageLimitBanner state={usageLimitOverride ?? getAggregateUsageState(caps?.data ?? {})} />
                         </div>
-                        <UsageLimitBanner state={usageLimitOverride ?? getAggregateUsageState(caps?.data ?? {})} />
                         <Separator />
                     </>
                 )}

--- a/packages/webapp/src/pages/Team/Billing/components/BillingHeaderAction.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/BillingHeaderAction.tsx
@@ -1,7 +1,5 @@
 import { ExternalLink } from 'lucide-react';
 
-import { Button } from '@nangohq/design-system';
-
 import { ButtonLink } from '@/components/ui/ButtonLink';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
@@ -9,8 +7,8 @@ import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
 
 /**
- * Primary action in the Billing & usage page header: Free upgrades, everyone else goes to their
- * invoices (Figma nodes 574:44366 and 563:50025).
+ * Primary action in the Billing & usage page header: paid accounts go to their invoices, Free has
+ * no header action (its upgrade CTAs live in the usage banner and the plan cards).
  */
 export const BillingHeaderAction: React.FC = () => {
     const env = useStore((state) => state.env);
@@ -32,16 +30,7 @@ export const BillingHeaderAction: React.FC = () => {
     }
 
     if (isFree) {
-        const scrollToPlans = () => {
-            track('web:usage:upgrade_clicked', {});
-            document.getElementById('plans')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        };
-
-        return (
-            <Button size="md" onClick={scrollToPlans}>
-                Upgrade
-            </Button>
-        );
+        return null;
     }
 
     if (isUsageLoading) {

--- a/packages/webapp/src/pages/Team/Billing/components/BillingHeaderAction.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/BillingHeaderAction.tsx
@@ -5,21 +5,23 @@ import { Skeleton } from '@/components/ui/Skeleton';
 import { useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
+import { isBilledPlan } from '../planVisibility';
 
 /**
- * Primary action in the Billing & usage page header: paid accounts go to their invoices, Free has
- * no header action (its upgrade CTAs live in the usage banner and the plan cards).
+ * Primary action in the Billing & usage page header: billed accounts go to their invoices. Neither
+ * free tier has invoices to link to, so they get no header action — their upgrade CTAs live in the
+ * usage banner and the plan cards instead.
  */
 export const BillingHeaderAction: React.FC = () => {
     const env = useStore((state) => state.env);
     const { data: environmentData, isLoading: isPlanLoading } = useCurrentPlan(env);
     const plan = environmentData?.plan;
-    const isFree = plan?.name === 'free';
+    // False until the plan resolves, so an unbilled account never fires the request below.
+    const isBilled = isBilledPlan(plan);
 
     // Same query key as <Payment/>'s unfiltered call, so this shares that request instead of adding
-    // one. Free has no Orb customer, so skip it entirely — and wait for `plan` to resolve, since
-    // until it does `isFree` is false and we'd fire a request for a Free account.
-    const { data: usage, isLoading: isUsageLoading } = useApiGetBillingUsage(env, undefined, { enabled: plan != null && !isFree });
+    // one. The free tiers have no Orb customer, so skip it entirely for them.
+    const { data: usage, isLoading: isUsageLoading } = useApiGetBillingUsage(env, undefined, { enabled: isBilled });
     const portalUrl = usage?.data.customer.portalUrl;
 
     // Both the plan and (for paid) the portal URL are fetched, so hold a button-sized placeholder
@@ -29,7 +31,7 @@ export const BillingHeaderAction: React.FC = () => {
         return isPlanLoading ? <Skeleton className="h-8 w-28" /> : null;
     }
 
-    if (isFree) {
+    if (!isBilled) {
         return null;
     }
 

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -28,6 +28,7 @@ import { fetchCurrentPlan, useApiGetPlans, useApiPostPlanChange, useCurrentPlan 
 import { useStripePaymentMethods } from '@/hooks/useStripe.js';
 import { useToast } from '@/hooks/useToast.js';
 import { queryClient, useStore } from '@/store';
+import { track } from '@/utils/analytics';
 import { stripePromise } from '@/utils/stripe.js';
 import { cn } from '@/utils/utils';
 import { PaymentMethodDialog } from './PaymentMethodDialog.js';
@@ -168,6 +169,7 @@ const PlanCard: React.FC<{
     const [planChangeDialogOpen, setPlanChangeDialogOpen] = useState(false);
 
     const onUpgradeClicked = useCallback(() => {
+        track('web:usage:upgrade_clicked', {});
         if (!paymentMethod) {
             setPaymentMethodDialogOpen(true);
         } else {

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -1,5 +1,4 @@
-import { format } from 'date-fns';
-import { ArrowRight, Check, Clock9, ExternalLink, Loader } from 'lucide-react';
+import { ArrowRight, Check, ExternalLink, Loader } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { permissions } from '@nangohq/authz';
@@ -75,33 +74,12 @@ export const Plans: React.FC = () => {
         return { list, activePlan: curr };
     }, [currentPlan, plansList]);
 
-    // The target of a scheduled downgrade/cancellation, shown as an inline notice on the
-    // *active* plan's card (Figma: the "Your plan" card carries the "Scheduled plan change" alert).
-    const scheduledChange = useMemo(() => {
-        if (!currentPlan?.orb_future_plan || !currentPlan.orb_future_plan_at) {
-            return null;
-        }
-
-        const targetPlan = plansList?.data.find((p) => p.code === currentPlan.orb_future_plan);
-        if (!targetPlan) {
-            return null;
-        }
-
-        return { targetPlan, at: format(new Date(currentPlan.orb_future_plan_at), 'MMM d, yyyy') };
-    }, [currentPlan, plansList]);
-
     return (
         <div className="flex flex-col gap-4">
-            {plans?.activePlan.hidden && <CurrentPlanCard plan={plans.activePlan} scheduledChange={scheduledChange} />}
+            {plans?.activePlan.hidden && <CurrentPlanCard plan={plans.activePlan} />}
             <div className="grid grid-cols-4 gap-4">
                 {plans?.list.map((plan) => (
-                    <PlanCard
-                        key={plan.plan.code}
-                        planDefinition={plan}
-                        activePlan={plans?.activePlan}
-                        paymentMethod={paymentMethod}
-                        scheduledChange={plan.active ? scheduledChange : null}
-                    />
+                    <PlanCard key={plan.plan.code} planDefinition={plan} activePlan={plans?.activePlan} paymentMethod={paymentMethod} />
                 ))}
             </div>
             <div className="self-start">
@@ -117,40 +95,14 @@ export const Plans: React.FC = () => {
 };
 
 /** Compact "CURRENT PLAN" summary shown when the account's active plan isn't one of the 4 self-serve cards below (legacy plan). */
-const CurrentPlanCard: React.FC<{ plan: PlanDefinition; scheduledChange: { targetPlan: PlanDefinition; at: string } | null }> = ({ plan, scheduledChange }) => {
+const CurrentPlanCard: React.FC<{ plan: PlanDefinition }> = ({ plan }) => {
     return (
         <Card selected>
-            <div className="flex flex-col gap-2 p-4">
-                <div className="flex flex-col gap-1">
-                    <span className="text-text-disabled text-body-medium-regular uppercase">Current plan</span>
-                    <span className="text-text-default text-body-medium-regular">{plan.title}</span>
-                </div>
-                <ScheduledChangeNotice scheduledChange={scheduledChange} />
+            <div className="flex flex-col gap-1 p-4">
+                <span className="text-text-disabled text-body-medium-regular uppercase">Current plan</span>
+                <span className="text-text-default text-body-medium-regular">{plan.title}</span>
             </div>
         </Card>
-    );
-};
-
-/** Inline "Scheduled plan change" notice, shown on whichever card represents the account's current plan. */
-const ScheduledChangeNotice: React.FC<{ scheduledChange: { targetPlan: PlanDefinition; at: string } | null }> = ({ scheduledChange }) => {
-    if (!scheduledChange) {
-        return null;
-    }
-
-    return (
-        <div className="flex flex-col gap-1 rounded-sm border-[0.5px] border-status-warning-border bg-status-warning-bg p-2">
-            <div className="flex gap-2 items-start">
-                <Clock9 className="size-4 shrink-0 mt-0.5 text-status-warning-text" />
-                <div className="flex flex-col gap-0.5">
-                    <span className="text-status-warning-text text-body-small-regular">Scheduled plan change</span>
-                    <span className="text-text-default text-body-small-regular">
-                        {scheduledChange.targetPlan.code === 'free'
-                            ? `Your subscription will be cancelled on ${scheduledChange.at}`
-                            : `Switches to ${scheduledChange.targetPlan.title} on ${scheduledChange.at}`}
-                    </span>
-                </div>
-            </div>
-        </div>
     );
 };
 
@@ -158,8 +110,7 @@ const PlanCard: React.FC<{
     planDefinition: PlanDefinitionList;
     activePlan?: PlanDefinition;
     paymentMethod?: StripePaymentMethod | null;
-    scheduledChange?: { targetPlan: PlanDefinition; at: string } | null;
-}> = ({ planDefinition, activePlan, paymentMethod, scheduledChange }) => {
+}> = ({ planDefinition, activePlan, paymentMethod }) => {
     const { plan, active, isFuture, isDowngrade, isUpgrade } = planDefinition;
 
     const { can } = usePermissions();
@@ -243,7 +194,6 @@ const PlanCard: React.FC<{
                         <span className="text-text-secondary text-body-medium-regular whitespace-nowrap">${plan.basePrice}/mo</span>
                     )}
                 </div>
-                <ScheduledChangeNotice scheduledChange={scheduledChange ?? null} />
                 {limits ? (
                     limits.map((limit) => (
                         <div key={limit} className="flex gap-2 items-center">

--- a/packages/webapp/src/pages/Team/Billing/components/ScheduledPlanChangeAlert.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/ScheduledPlanChangeAlert.tsx
@@ -8,22 +8,20 @@ import { useStore } from '@/store';
 import { pendingPlanChange } from '../summaryState';
 
 /**
- * Pending downgrade or cancellation, shown above the plan cards rather than inside the current
- * plan's card (Figma node 743:50491). The summary strip states the same change at the top of the
- * page, but legacy and enterprise accounts get no strip and still need to see it here.
+ * The summary strip states the same change at the top of the page, but legacy and enterprise
+ * accounts get no strip and still need to see it here.
  *
- * Both queries are already cached by the plans section, so this reads them itself rather than
- * threading props through the cards.
+ * Self-fetching because both queries are already cached by the plans section.
  */
 export const ScheduledPlanChangeAlert: React.FC = () => {
     const env = useStore((state) => state.env);
     const { data: environmentData } = useCurrentPlan(env);
     const plan = environmentData?.plan;
-    // Titles fall back to raw plan codes until the list settles, and "switches to growth-v2" is not
-    // a sentence to show a customer.
     const { data: plansList, isPending: arePlansPending } = useApiGetPlans(env);
 
     const change = useMemo(() => {
+        // Until the plans list settles a title falls back to its raw plan code, and
+        // "Switches to growth-v2" is not a sentence to show a customer.
         if (!plan || arePlansPending) {
             return null;
         }

--- a/packages/webapp/src/pages/Team/Billing/components/ScheduledPlanChangeAlert.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/ScheduledPlanChangeAlert.tsx
@@ -1,0 +1,48 @@
+import { Clock9 } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { Alert, AlertDescription, AlertTitle } from '@nangohq/design-system';
+
+import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
+import { useStore } from '@/store';
+import { pendingPlanChange } from '../summaryState';
+
+/**
+ * Pending downgrade or cancellation, shown above the plan cards rather than inside the current
+ * plan's card (Figma node 743:50491). The summary strip states the same change at the top of the
+ * page, but legacy and enterprise accounts get no strip and still need to see it here.
+ *
+ * Both queries are already cached by the plans section, so this reads them itself rather than
+ * threading props through the cards.
+ */
+export const ScheduledPlanChangeAlert: React.FC = () => {
+    const env = useStore((state) => state.env);
+    const { data: environmentData } = useCurrentPlan(env);
+    const plan = environmentData?.plan;
+    // Titles fall back to raw plan codes until the list settles, and "switches to growth-v2" is not
+    // a sentence to show a customer.
+    const { data: plansList, isPending: arePlansPending } = useApiGetPlans(env);
+
+    const change = useMemo(() => {
+        if (!plan || arePlansPending) {
+            return null;
+        }
+        return pendingPlanChange({ plan, plans: plansList?.data, now: new Date() });
+    }, [plan, plansList, arePlansPending]);
+
+    if (!change) {
+        return null;
+    }
+
+    return (
+        <Alert variant="warning">
+            <Clock9 />
+            <AlertTitle>Scheduled plan change</AlertTitle>
+            <AlertDescription>
+                {change.toCode === 'free' || change.toCode === 'free-uncapped'
+                    ? `Your subscription will be cancelled on ${change.at}`
+                    : `Switches to ${change.toPlanTitle} on ${change.at}`}
+            </AlertDescription>
+        </Alert>
+    );
+};

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -59,7 +59,7 @@ export const Summary: React.FC = () => {
     }
 
     return (
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3">
             <h3 className="text-text-strong text-body-medium-medium">Summary</h3>
             <SummaryStrip
                 headline={state?.headline ?? null}

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -2,7 +2,7 @@ import { ArrowUpRight, ExternalLink, Info } from 'lucide-react';
 import { useMemo } from 'react';
 
 import { permissions } from '@nangohq/authz';
-import { Alert, AlertButton, AlertDescription, AlertTitle, Button } from '@nangohq/design-system';
+import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle, Button } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { AlertButtonLink } from '@/components/ui/AlertButtonLink';
@@ -108,27 +108,26 @@ export const Usage: React.FC = () => {
             {isLegacy && (
                 <Alert variant="info">
                     <Info />
-                    <AlertTitle>You&apos;re on a legacy plan</AlertTitle>
+                    <AlertTitle>Legacy plan</AlertTitle>
                     <AlertDescription>
                         Legacy plans have different usage metrics.
-                        {usage?.data.customer.portalUrl && (
-                            <>
-                                {' '}
-                                You can see your usage in the{' '}
-                                <Button asChild variant="link-accent" size="xs">
-                                    <a
-                                        href={usage?.data.customer.portalUrl}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        onClick={() => track('web:usage:billing_portal_clicked', {})}
-                                    >
-                                        billing portal
-                                        <ExternalLink />
-                                    </a>
-                                </Button>
-                            </>
-                        )}
+                        {usage?.data.customer.portalUrl && ' You can see your usage in your billing portal.'}
                     </AlertDescription>
+                    {usage?.data.customer.portalUrl && (
+                        <AlertActions>
+                            <Button asChild variant="link-accent" size="xs">
+                                <a
+                                    href={usage.data.customer.portalUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    onClick={() => track('web:usage:billing_portal_clicked', {})}
+                                >
+                                    View billing portal
+                                    <ExternalLink />
+                                </a>
+                            </Button>
+                        </AlertActions>
+                    )}
                 </Alert>
             )}
 

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -1,21 +1,16 @@
-import { ArrowUpRight, ExternalLink, Info } from 'lucide-react';
+import { ExternalLink, Info } from 'lucide-react';
 import { useMemo } from 'react';
 
-import { permissions } from '@nangohq/authz';
-import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle, Button } from '@nangohq/design-system';
+import { Alert, AlertActions, AlertDescription, AlertTitle, Button } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
-import { AlertButtonLink } from '@/components/ui/AlertButtonLink';
-import { OverdueInvoiceAlert } from '@/features/Billing/OverdueInvoiceAlert';
-import { usePermissions } from '@/hooks/usePermissions';
-import { useApiGetBillingUsage, useApiGetOverdueInvoices, useCurrentPlan } from '@/hooks/usePlan';
+import { useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
 import { isLegacyPlan } from '../planVisibility';
 import { useSelectedMonth } from '../useSelectedMonth';
 import { FreeUsage } from './FreeUsage';
 import { MonthSelector } from './MonthSelector';
-import { PaymentMethodDialog } from './PaymentMethodDialog';
 import { USAGE_METRIC_LABELS, USAGE_METRICS } from './usageMetrics';
 import { UsageTable } from './UsageTable';
 
@@ -43,35 +38,10 @@ export const Usage: React.FC = () => {
     // avgPerDay: connections/records come back as the concurrent daily count rather than the
     // billing running-average, matching what each row's drill-in chart also requests.
     const { data: usage, isLoading, error: usageError } = useApiGetBillingUsage(env, timeframe, { avgPerDay: true, enabled: plan != null && !isFree });
-    const { data: overdue } = useApiGetOverdueInvoices(env, plan, usage?.data.customer.portalUrl);
-    const { can } = usePermissions();
-    const canManageBilling = can(permissions.canManageBilling);
-
-    // Kept out of the usageError branch below so a usage outage can't hide a payment warning.
-    const overdueBanner = overdue?.data.hasOverdue && (
-        <OverdueInvoiceAlert size="wide" canManageBilling={canManageBilling}>
-            {overdue.data.portalUrl && (
-                <AlertButtonLink
-                    to={overdue.data.portalUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={() => track('web:usage:invoice_details_clicked', {})}
-                >
-                    View invoices <ExternalLink />
-                </AlertButtonLink>
-            )}
-            <PaymentMethodDialog replace>
-                <AlertButton onClick={() => track('web:usage:edit_payment_method_clicked', { source: 'billing_page' })}>
-                    Edit payment method <ArrowUpRight />
-                </AlertButton>
-            </PaymentMethodDialog>
-        </OverdueInvoiceAlert>
-    );
 
     if (usageError) {
         return (
             <div className="w-full flex flex-col gap-6">
-                {overdueBanner}
                 <CriticalErrorAlert message="Error loading usage" />
             </div>
         );
@@ -82,7 +52,6 @@ export const Usage: React.FC = () => {
     if (isFree) {
         return (
             <div className="w-full flex flex-col gap-4">
-                {overdueBanner}
                 <FreeUsage />
             </div>
         );
@@ -103,8 +72,6 @@ export const Usage: React.FC = () => {
 
     return (
         <div className="w-full flex flex-col gap-4">
-            {overdueBanner}
-
             {isLegacy && (
                 <Alert variant="info">
                     <Info />

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -2,7 +2,7 @@ import { ChevronDown } from 'lucide-react';
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/Collapsible';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { formatLimit, formatUsage, getUsageState, getUsageStateTextColor } from '@/utils/usage';
+import { formatLimit, formatUsage, formatUsageExact, getUsageState, getUsageStateTextColor } from '@/utils/usage';
 import { cn } from '@/utils/utils';
 import { UsageBar } from './UsageBar';
 import { UsageChartCard } from './UsageChartCard';
@@ -78,7 +78,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                                 <Skeleton className="h-5 w-32" />
                             ) : (
                                 <>
-                                    <span className="text-text-default text-body-medium-regular">
+                                    <span className="text-text-default text-body-medium-regular" title={formatUsageExact(usage)}>
                                         {formatUsage(usage)}
                                         {limit != null && <span className="text-text-muted"> / {formatLimit(limit)}</span>}
                                     </span>
@@ -96,7 +96,9 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                             {limit == null ? '—' : state === 'over' ? 'Limit reached' : `${percent}%`}
                         </div>
                     ) : (
-                        <div className="text-text-default text-body-medium-regular">{formatUsage(usage)}</div>
+                        <div className="text-text-default text-body-medium-regular" title={formatUsageExact(usage)}>
+                            {formatUsage(usage)}
+                        </div>
                     )}
                     <ChevronDown className="size-5 text-text-muted transition-transform group-data-[state=open]:rotate-180" />
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -2,7 +2,7 @@ import { ChevronDown } from 'lucide-react';
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/Collapsible';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { formatLimit, formatUsage, formatUsageExact, getUsageState, getUsageStateTextColor } from '@/utils/usage';
+import { formatMetricExact, formatMetricLimit, formatMetricUsage, getUsageState, getUsageStateTextColor } from '@/utils/usage';
 import { cn } from '@/utils/utils';
 import { UsageBar } from './UsageBar';
 import { UsageChartCard } from './UsageChartCard';
@@ -78,9 +78,9 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                                 <Skeleton className="h-5 w-32" />
                             ) : (
                                 <>
-                                    <span className="text-text-default text-body-medium-regular" title={formatUsageExact(usage)}>
-                                        {formatUsage(usage)}
-                                        {limit != null && <span className="text-text-muted"> / {formatLimit(limit)}</span>}
+                                    <span className="text-text-default text-body-medium-regular" title={formatMetricExact(metric, usage)}>
+                                        {formatMetricUsage(metric, usage)}
+                                        {limit != null && <span className="text-text-muted"> / {formatMetricLimit(metric, limit)}</span>}
                                     </span>
                                     {limit != null && <UsageBar usage={usage} limit={limit} className="max-w-[280px]" />}
                                 </>
@@ -96,8 +96,8 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                             {limit == null ? '—' : state === 'over' ? 'Limit reached' : `${percent}%`}
                         </div>
                     ) : (
-                        <div className="text-text-default text-body-medium-regular" title={formatUsageExact(usage)}>
-                            {formatUsage(usage)}
+                        <div className="text-text-default text-body-medium-regular" title={formatMetricExact(metric, usage)}>
+                            {formatMetricUsage(metric, usage)}
                         </div>
                     )}
                     <ChevronDown className="size-5 text-text-muted transition-transform group-data-[state=open]:rotate-180" />

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -2,7 +2,7 @@ import { ChevronDown } from 'lucide-react';
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/Collapsible';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { formatMetricExact, formatMetricLimit, formatMetricUsage, getUsageState, getUsageStateTextColor } from '@/utils/usage';
+import { formatLimit, formatUsage, formatUsageExact, getUsageState, getUsageStateTextColor } from '@/utils/usage';
 import { cn } from '@/utils/utils';
 import { UsageBar } from './UsageBar';
 import { UsageChartCard } from './UsageChartCard';
@@ -78,9 +78,9 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                                 <Skeleton className="h-5 w-32" />
                             ) : (
                                 <>
-                                    <span className="text-text-default text-body-medium-regular" title={formatMetricExact(metric, usage)}>
-                                        {formatMetricUsage(metric, usage)}
-                                        {limit != null && <span className="text-text-muted"> / {formatMetricLimit(metric, limit)}</span>}
+                                    <span className="text-text-default text-body-medium-regular" title={formatUsageExact(usage)}>
+                                        {formatUsage(usage)}
+                                        {limit != null && <span className="text-text-muted"> / {formatLimit(limit)}</span>}
                                     </span>
                                     {limit != null && <UsageBar usage={usage} limit={limit} className="max-w-[280px]" />}
                                 </>
@@ -96,8 +96,8 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                             {limit == null ? '—' : state === 'over' ? 'Limit reached' : `${percent}%`}
                         </div>
                     ) : (
-                        <div className="text-text-default text-body-medium-regular" title={formatMetricExact(metric, usage)}>
-                            {formatMetricUsage(metric, usage)}
+                        <div className="text-text-default text-body-medium-regular" title={formatUsageExact(usage)}>
+                            {formatUsage(usage)}
                         </div>
                     )}
                     <ChevronDown className="size-5 text-text-muted transition-transform group-data-[state=open]:rotate-180" />

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -10,9 +10,12 @@ import { UsageChartCard } from './UsageChartCard';
 import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 
 /** Shared column template so the header row and each metric row line up, on both Free and paid —
- *  paid just leaves the used/limit slot blank and puts its usage figure in the % of limit slot, so
- *  it lands in the exact same spot (rather than recomputing a different set of column widths). */
-export const USAGE_ROW_GRID = 'grid grid-cols-[minmax(0,2fr)_minmax(0,2.2fr)_minmax(0,1fr)_20px] items-center gap-4 px-6';
+ *  paid just leaves the used/limit slot blank and puts its usage figure in the last slot, so it
+ *  lands in the exact same spot (rather than recomputing a different set of column widths).
+ *  That last column is fixed at the design's 124px rather than a fraction: as a fraction it grew
+ *  with the viewport and left the figure stranded mid-row, a long way from its caret — most visible
+ *  on paid, where the used/limit column beside it is empty. */
+export const USAGE_ROW_GRID = 'grid grid-cols-[minmax(0,2fr)_minmax(0,2.2fr)_124px_20px] items-center gap-4 px-6';
 
 interface UsageRowProps {
     metric: UsageMetric;

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -38,12 +38,7 @@ export const UsageTable: React.FC<UsageTableProps> = ({ rows, isLoading, env, ti
     return (
         <div className="w-full flex flex-col gap-4">
             <div className="rounded border border-border-default overflow-hidden">
-                <div
-                    className={cn(
-                        USAGE_ROW_GRID,
-                        'bg-surface-panel py-3 border-b border-border-default text-text-secondary text-body-extra-small-semi uppercase'
-                    )}
-                >
+                <div className={cn(USAGE_ROW_GRID, 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
                     <span>Metric</span>
                     {showLimits ? <span>Used / Limit</span> : <span />}
                     <span>{showLimits ? '% of limit' : 'This period'}</span>

--- a/packages/webapp/src/pages/Team/Billing/components/usageMetrics.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/usageMetrics.ts
@@ -13,11 +13,13 @@ export const USAGE_METRICS: UsageMetric[] = [
 ];
 
 // Primary labels, kept accurate to the underlying values (not the design's shorthand, which renames
-// e.g. compute to "Compute hours" without converting units).
+// e.g. compute to "Compute hours" without converting units). Where a figure isn't a count of the
+// thing the row is named after, the label carries its unit — compute is a raw millisecond total, so
+// "1.05M" alone says nothing. The server's own label for it does the same ("Function time (ms)").
 export const USAGE_METRIC_LABELS: Record<UsageMetric, string> = {
     connections: 'Connections',
     proxy: 'Proxy requests',
-    function_compute_gbms: 'Function compute time',
+    function_compute_gbms: 'Function compute time (ms)',
     function_executions: 'Function runs',
     function_logs: 'Function logs',
     records: 'Sync records',

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -2,8 +2,7 @@ import type { ApiPlan, DBPlan } from '@nangohq/types';
 
 // Which plans are on the current usage model. Anything else is a legacy plan, measured with usage
 // metrics the app can no longer show. This is purely about the metrics: a custom or negotiated
-// contract does not make a plan legacy, which is why Enterprise counts as current — it bills on the
-// current metrics even though its terms are bespoke.
+// contract does not make a plan legacy, which is why Enterprise counts as current.
 // Exhaustive over `DBPlan['name']` rather than an allowlist, so adding a plan to the DB type fails
 // to compile until it's classified here — otherwise a new current plan would silently be treated as
 // legacy and lose its reset date.

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -58,6 +58,24 @@ const SHOWS_SPEND_HEADLINE: Record<DBPlan['name'], boolean> = {
     'growth-legacy': false
 };
 
+// Plans that are actually billed. Both free tiers have a $0 base and no overage, so they have no
+// invoices to link to — the header's "All invoices" action is pointless on them. Exhaustive over
+// `DBPlan['name']` for the same reason as the maps above.
+const PLAN_IS_BILLED: Record<DBPlan['name'], boolean> = {
+    'starter-v2': true,
+    'growth-v2': true,
+    enterprise: true,
+    'enterprise-cloud-hosted': true,
+    'startup-deal': true,
+    starter: true,
+    growth: true,
+    'starter-legacy': true,
+    'scale-legacy': true,
+    'growth-legacy': true,
+    free: false,
+    'free-uncapped': false
+};
+
 export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {
     if (!plan) {
         return false;
@@ -77,4 +95,12 @@ export function showsSpendHeadline(plan: ApiPlan | null | undefined): boolean {
         return false;
     }
     return SHOWS_SPEND_HEADLINE[plan.name];
+}
+
+/** Whether the plan is billed at all, and so has invoices worth linking to. */
+export function isBilledPlan(plan: ApiPlan | null | undefined): boolean {
+    if (!plan) {
+        return false;
+    }
+    return PLAN_IS_BILLED[plan.name];
 }

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -1,8 +1,9 @@
 import type { ApiPlan, DBPlan } from '@nangohq/types';
 
-// Which plans are on the current usage model. Anything else is a legacy plan: different usage
-// metrics, and billing terms negotiated per customer (several are annual, so there's no monthly
-// reset to show).
+// Which plans are on the current usage model. Anything else is a legacy plan, measured with usage
+// metrics the app can no longer show. This is purely about the metrics: a custom or negotiated
+// contract does not make a plan legacy, which is why Enterprise counts as current — it bills on the
+// current metrics even though its terms are bespoke.
 // Exhaustive over `DBPlan['name']` rather than an allowlist, so adding a plan to the DB type fails
 // to compile until it's classified here — otherwise a new current plan would silently be treated as
 // legacy and lose its reset date.
@@ -10,10 +11,10 @@ const PLAN_IS_CURRENT: Record<DBPlan['name'], boolean> = {
     free: true,
     'free-uncapped': true,
     'startup-deal': true,
+    enterprise: true,
     'enterprise-cloud-hosted': true,
     'starter-v2': true,
     'growth-v2': true,
-    enterprise: false,
     starter: false,
     growth: false,
     'starter-legacy': false,
@@ -22,9 +23,9 @@ const PLAN_IS_CURRENT: Record<DBPlan['name'], boolean> = {
 };
 
 // Plans the summary strip renders for. A deliberately different question from `isLegacyPlan` above:
-// `free-uncapped` and `enterprise-cloud-hosted` are current plans that still get no strip, because
-// nothing is billable or the contract is custom. Both maps are exhaustive over `DBPlan['name']`, so
-// a new plan fails to compile until it is classified for both.
+// `free-uncapped`, `enterprise` and `enterprise-cloud-hosted` are current plans that still get no
+// strip, because nothing is billable or the contract is custom. Both maps are exhaustive over
+// `DBPlan['name']`, so a new plan fails to compile until it is classified for both.
 const SHOWS_SUMMARY_STRIP: Record<DBPlan['name'], boolean> = {
     free: true,
     'starter-v2': true,

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -31,7 +31,7 @@ export interface SummaryStripState {
     /** Null hides the slot entirely — Free, no card on file, or a viewer who can't manage billing. */
     payment: { card: StripePaymentMethod } | null;
     /** Renders the footer sentence; set only when a plan change is actually pending. */
-    change: { toPlanTitle: string; at: string; detail: string | null } | null;
+    change: { toCode: string; toPlanTitle: string; at: string; detail: string | null } | null;
 }
 
 function planTitleOf(code: string, plans: PlanDefinition[] | undefined): string {
@@ -84,6 +84,30 @@ function buildHeadline({
 }
 
 /**
+ * The account's pending plan change, or null when there isn't one worth showing.
+ *
+ * A change only counts while it's still ahead of us and actually moves the customer somewhere else.
+ * Same-plan rows are Orb-side repricings, and past-dated ones are stale mirrors that nothing clears
+ * — neither is a plan change from the customer's point of view. Shared with the alert above the plan
+ * cards so both surfaces agree on what counts as pending.
+ */
+export function pendingPlanChange({ plan, plans, now }: { plan: ApiPlan; plans: PlanDefinition[] | undefined; now: Date }): SummaryStripState['change'] {
+    const changeAt = plan.orb_future_plan_at ? new Date(plan.orb_future_plan_at) : null;
+    const changeTo = plan.orb_future_plan;
+
+    if (!changeTo || changeTo === plan.name || !changeAt || changeAt.getTime() <= now.getTime()) {
+        return null;
+    }
+
+    return {
+        toCode: changeTo,
+        toPlanTitle: planTitleOf(changeTo, plans),
+        at: formatBillingDate(changeAt),
+        detail: changeDetail({ from: plan.name, toCode: changeTo, toTitle: planTitleOf(changeTo, plans) })
+    };
+}
+
+/**
  * Everything the strip shows, derived in one place so the rules are testable without React.
  *
  * The date slot carries three different meanings, which is why it isn't a single "reset" value:
@@ -107,20 +131,7 @@ export function buildSummaryState({
 }): SummaryStripState {
     const planTitle = planTitleOf(plan.name, plans);
     const isFree = plan.name === 'free';
-
-    // A change only counts while it's still ahead of us and actually moves the customer somewhere
-    // else. Same-plan rows are Orb-side repricings, and past-dated ones are stale mirrors that
-    // nothing clears — neither is a plan change from the customer's point of view.
-    const changeAt = plan.orb_future_plan_at ? new Date(plan.orb_future_plan_at) : null;
-    const changeTo = plan.orb_future_plan;
-    const change =
-        changeTo && changeTo !== plan.name && changeAt && changeAt.getTime() > now.getTime()
-            ? {
-                  toPlanTitle: planTitleOf(changeTo, plans),
-                  at: formatBillingDate(changeAt),
-                  detail: changeDetail({ from: plan.name, toCode: changeTo, toTitle: planTitleOf(changeTo, plans) })
-              }
-            : null;
+    const change = pendingPlanChange({ plan, plans, now });
 
     let date: SummaryStripState['date'] = null;
     if (change) {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -95,7 +95,9 @@ export function pendingPlanChange({ plan, plans, now }: { plan: ApiPlan; plans: 
     const changeAt = plan.orb_future_plan_at ? new Date(plan.orb_future_plan_at) : null;
     const changeTo = plan.orb_future_plan;
 
-    if (!changeTo || changeTo === plan.name || !changeAt || changeAt.getTime() <= now.getTime()) {
+    // A malformed timestamp parses to NaN, and every comparison against NaN is false, so it would
+    // slip past the past-dated check and render "Invalid Date".
+    if (!changeTo || changeTo === plan.name || !changeAt || Number.isNaN(changeAt.getTime()) || changeAt.getTime() <= now.getTime()) {
         return null;
     }
 

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -99,11 +99,19 @@ export function pendingPlanChange({ plan, plans, now }: { plan: ApiPlan; plans: 
         return null;
     }
 
+    // Without the plans list the only available name is the raw Orb code, so say nothing rather than
+    // "Switches to growth-v2". A cancellation names no destination, so it still renders.
+    const toPlanTitle = plans?.find((p) => p.code === changeTo)?.title;
+    const isCancellation = changeTo === 'free' || changeTo === 'free-uncapped';
+    if (!toPlanTitle && !isCancellation) {
+        return null;
+    }
+
     return {
         toCode: changeTo,
-        toPlanTitle: planTitleOf(changeTo, plans),
+        toPlanTitle: toPlanTitle ?? changeTo,
         at: formatBillingDate(changeAt),
-        detail: changeDetail({ from: plan.name, toCode: changeTo, toTitle: planTitleOf(changeTo, plans) })
+        detail: changeDetail({ from: plan.name, toCode: changeTo, toTitle: toPlanTitle ?? changeTo })
     };
 }
 

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { showsSpendHeadline, showsSummaryStrip } from './planVisibility.js';
+import { isLegacyPlan, showsSpendHeadline, showsSummaryStrip } from './planVisibility.js';
 import { buildSummaryState, SPEND_TOOLTIP } from './summaryState.js';
 
 import type { SummarySpend } from './summaryState.js';
@@ -139,6 +139,26 @@ describe('buildSummaryState headline', () => {
             expect(state.headline.tooltip).toBeUndefined();
             expect(state.plan).toBeNull();
         }
+    });
+});
+
+describe('isLegacyPlan', () => {
+    it('flags only the plans on the old usage model', () => {
+        for (const name of ['starter', 'growth', 'starter-legacy', 'scale-legacy', 'growth-legacy'] as const) {
+            expect(isLegacyPlan(planOf(name))).toBe(true);
+        }
+    });
+
+    // A bespoke contract isn't the same thing as an old usage model — Enterprise bills on the
+    // current metrics, so it gets the normal usage view rather than the legacy-plan banner.
+    it('does not flag current plans, including the custom-contract ones', () => {
+        for (const name of ['free', 'free-uncapped', 'starter-v2', 'growth-v2', 'startup-deal', 'enterprise', 'enterprise-cloud-hosted'] as const) {
+            expect(isLegacyPlan(planOf(name))).toBe(false);
+        }
+    });
+
+    it('does not flag anything before the plan loads', () => {
+        expect(isLegacyPlan(null)).toBe(false);
     });
 });
 

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { isBilledPlan, isLegacyPlan, showsSpendHeadline, showsSummaryStrip } from './planVisibility.js';
-import { buildSummaryState, SPEND_TOOLTIP } from './summaryState.js';
+import { buildSummaryState, pendingPlanChange, SPEND_TOOLTIP } from './summaryState.js';
 
 import type { SummarySpend } from './summaryState.js';
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
@@ -262,5 +262,21 @@ describe('buildSummaryState', () => {
     it('falls back to the plan code when the plan list has not loaded', () => {
         const state = buildSummaryState({ plan: planOf('growth-v2'), plans: undefined, paymentMethod: null, canManageBilling: true, now: NOW });
         expect(state.headline.value).toBe('growth-v2');
+    });
+});
+
+describe('pendingPlanChange without the plans list', () => {
+    const at = '2026-09-25T00:00:00.000Z';
+
+    it('says nothing rather than naming a raw Orb code', () => {
+        const plan = planOf('startup-deal', { orb_future_plan: 'growth-v2', orb_future_plan_at: at });
+        expect(pendingPlanChange({ plan, plans: undefined, now: NOW })).toBeNull();
+    });
+
+    it('still announces a cancellation, which names no destination', () => {
+        const plan = planOf('growth-v2', { orb_future_plan: 'free', orb_future_plan_at: at });
+        const change = pendingPlanChange({ plan, plans: undefined, now: NOW });
+        expect(change?.toCode).toBe('free');
+        expect(change?.detail).toBe('no further charges after this period.');
     });
 });

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -265,12 +265,17 @@ describe('buildSummaryState', () => {
     });
 });
 
-describe('pendingPlanChange without the plans list', () => {
+describe('pendingPlanChange guards', () => {
     const at = '2026-09-25T00:00:00.000Z';
 
     it('says nothing rather than naming a raw Orb code', () => {
         const plan = planOf('startup-deal', { orb_future_plan: 'growth-v2', orb_future_plan_at: at });
         expect(pendingPlanChange({ plan, plans: undefined, now: NOW })).toBeNull();
+    });
+
+    it('ignores a timestamp that does not parse', () => {
+        const plan = planOf('growth-v2', { orb_future_plan: 'starter-v2', orb_future_plan_at: 'not-a-date' });
+        expect(pendingPlanChange({ plan, plans, now: NOW })).toBeNull();
     });
 
     it('still announces a cancellation, which names no destination', () => {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -173,6 +173,7 @@ describe('buildSummaryState', () => {
         const state = build(planOf('startup-deal', { orb_future_plan: 'growth-v2', orb_future_plan_at: '2026-09-25T00:00:00.000Z' }));
         expect(state.date).toEqual({ label: 'CHANGES ON', value: 'September 25, 2026' });
         expect(state.change).toEqual({
+            toCode: 'growth-v2',
             toPlanTitle: 'Growth',
             at: 'September 25, 2026',
             detail: "your startup deal ends and you'll be charged at standard Growth pricing."
@@ -182,7 +183,7 @@ describe('buildSummaryState', () => {
     it('announces a downgrade the same way', () => {
         const state = build(planOf('growth-v2', { orb_future_plan: 'free', orb_future_plan_at: '2026-09-01T00:00:00.000Z' }));
         expect(state.date?.label).toBe('CHANGES ON');
-        expect(state.change).toEqual({ toPlanTitle: 'Free', at: 'September 1, 2026', detail: 'no further charges after this period.' });
+        expect(state.change).toEqual({ toCode: 'free', toPlanTitle: 'Free', at: 'September 1, 2026', detail: 'no further charges after this period.' });
     });
 
     it('ignores a change to the same plan — those are Orb-side repricings', () => {
@@ -206,7 +207,7 @@ describe('buildSummaryState', () => {
 
     it('adds no gloss to a paid-to-paid downgrade — the new plan name says it', () => {
         const state = build(planOf('growth-v2', { orb_future_plan: 'starter-v2', orb_future_plan_at: '2026-09-01T00:00:00.000Z' }));
-        expect(state.change).toEqual({ toPlanTitle: 'Starter', at: 'September 1, 2026', detail: null });
+        expect(state.change).toEqual({ toCode: 'starter-v2', toPlanTitle: 'Starter', at: 'September 1, 2026', detail: null });
     });
 
     it('falls back to the plan code when the plan list has not loaded', () => {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -149,8 +149,8 @@ describe('isLegacyPlan', () => {
         }
     });
 
-    // A bespoke contract isn't the same thing as an old usage model — Enterprise bills on the
-    // current metrics, so it gets the normal usage view rather than the legacy-plan banner.
+    // A bespoke contract isn't the same thing as an old usage model, so Enterprise gets the normal
+    // usage view rather than the legacy-plan banner.
     it('does not flag current plans, including the custom-contract ones', () => {
         for (const name of ['free', 'free-uncapped', 'starter-v2', 'growth-v2', 'startup-deal', 'enterprise', 'enterprise-cloud-hosted'] as const) {
             expect(isLegacyPlan(planOf(name))).toBe(false);

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isLegacyPlan, showsSpendHeadline, showsSummaryStrip } from './planVisibility.js';
+import { isBilledPlan, isLegacyPlan, showsSpendHeadline, showsSummaryStrip } from './planVisibility.js';
 import { buildSummaryState, SPEND_TOOLTIP } from './summaryState.js';
 
 import type { SummarySpend } from './summaryState.js';
@@ -159,6 +159,35 @@ describe('isLegacyPlan', () => {
 
     it('does not flag anything before the plan loads', () => {
         expect(isLegacyPlan(null)).toBe(false);
+    });
+});
+
+describe('isBilledPlan', () => {
+    it('excludes both free tiers, which have no invoices to link to', () => {
+        for (const name of ['free', 'free-uncapped'] as const) {
+            expect(isBilledPlan(planOf(name))).toBe(false);
+        }
+    });
+
+    it('includes every paid plan, current and legacy', () => {
+        for (const name of [
+            'starter-v2',
+            'growth-v2',
+            'enterprise',
+            'enterprise-cloud-hosted',
+            'startup-deal',
+            'starter',
+            'growth',
+            'starter-legacy',
+            'scale-legacy',
+            'growth-legacy'
+        ] as const) {
+            expect(isBilledPlan(planOf(name))).toBe(true);
+        }
+    });
+
+    it('is false before the plan loads, so no request fires', () => {
+        expect(isBilledPlan(null)).toBe(false);
     });
 });
 

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -24,19 +24,33 @@ export function formatLimit(limit: number) {
     return numberFormatter.format(limit);
 }
 
+// Below this, usage is shown in full. Production connection counts sit under 1,000 for 99.6% of
+// accounts, so abbreviating small figures would blur the numbers most customers actually look at.
+const USAGE_COMPACT_FROM = 10_000;
+
+// 3 significant digits, so an abbreviated figure never loses more than ~0.5% — the previous
+// divide-then-round approach dropped to a single significant digit just above each threshold
+// (1,022,107 rendered as "1M", 9,943 as "9K"). Lowercase `k` per the design; Intl gives "K".
+const compactFormatter = Intl.NumberFormat('en-US', { notation: 'compact', maximumSignificantDigits: 3 });
+
+/**
+ * A usage figure. These are billed quantities, so the format never rounds away a digit that changes
+ * what someone owes — anything under {@link USAGE_COMPACT_FROM} is exact, and above it keeps 3
+ * significant digits. Pair with {@link formatUsageExact} to offer the full number on hover.
+ *
+ * @example 46 -> 46
+ * @example 9943 -> 9,943
+ * @example 1022107 -> 1.02M
+ */
 export function formatUsage(usage: number) {
-    if (usage >= 1_000_000_000_000) {
-        return `${numberFormatter.format(usage / 1_000_000_000_000)}T`;
+    if (usage < USAGE_COMPACT_FROM) {
+        return numberFormatter.format(usage);
     }
-    if (usage >= 1_000_000_000) {
-        return `${numberFormatter.format(usage / 1_000_000_000)}B`;
-    }
-    if (usage >= 1_000_000) {
-        return `${numberFormatter.format(usage / 1_000_000)}M`;
-    }
-    if (usage >= 1000) {
-        return `${numberFormatter.format(usage / 1000)}K`;
-    }
+    return compactFormatter.format(usage).replace('K', 'k');
+}
+
+/** The unabbreviated figure, so an abbreviated cell can still be reconciled against an invoice. */
+export function formatUsageExact(usage: number) {
     return numberFormatter.format(usage);
 }
 

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -56,65 +56,36 @@ export function formatUsageExact(usage: number) {
     return numberFormatter.format(usage);
 }
 
-const MS_PER_SECOND = 1000;
-const MS_PER_MINUTE = 60 * MS_PER_SECOND;
-const MS_PER_HOUR = 60 * MS_PER_MINUTE;
-const oneDecimalFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 1 });
-
 /**
- * A duration held in milliseconds, shown in the unit the pricing page uses for the allowance
- * included in each plan (hours). Sub-hour values step down to minutes and seconds rather than
- * rendering as "0h": in production a quarter of accounts use under 6 minutes of compute in a month
- * and the smallest is a single second, while the largest exceeds 300,000 hours.
+ * The unit a metric is counted in, where the number alone doesn't say. Only compute carries one
+ * today: it's a raw millisecond figure, so "1.04M" on its own means nothing. The other metrics are
+ * counts of the thing their row is named after, so a unit would just repeat the label.
  *
- * @example 45000 -> 45s
- * @example 3240000 -> 54m
- * @example 5055834 -> 1.4h
- * @example 1140286209245 -> 316,746h
+ * `function_compute_gbms` is a misnomer kept for back-compat — the billable quantity behind it is
+ * `SUM(duration_ms)`, matching Orb's "Function compute time" (see `clickhouse.query.ts`).
  */
-export function formatDurationMs(ms: number): string {
-    if (ms <= 0) {
-        return '0h';
-    }
-    if (ms < MS_PER_SECOND) {
-        return '<1s';
-    }
-    if (ms < MS_PER_MINUTE) {
-        return `${Math.round(ms / MS_PER_SECOND)}s`;
-    }
-    if (ms < MS_PER_HOUR) {
-        return `${Math.round(ms / MS_PER_MINUTE)}m`;
-    }
-    const hours = ms / MS_PER_HOUR;
-    // A tenth of an hour is 6 minutes, which is meaningful at single-digit hours and noise past 100.
-    return `${hours < 100 ? oneDecimalFormatter.format(hours) : numberFormatter.format(hours)}h`;
+const METRIC_UNITS: Partial<Record<UsageMetric, string>> = {
+    function_compute_gbms: 'ms'
+};
+
+function withUnit(metric: UsageMetric, formatted: string): string {
+    const unit = METRIC_UNITS[metric];
+    return unit ? `${formatted} ${unit}` : formatted;
 }
 
-/**
- * Metrics whose value is a duration in milliseconds rather than a count. `function_compute_gbms` is
- * a misnomer kept for back-compat — the billable quantity behind it is `SUM(duration_ms)`, matching
- * Orb's "Function compute time" (see `clickhouse.query.ts`).
- */
-function isDurationMetric(metric: UsageMetric): boolean {
-    return metric === 'function_compute_gbms';
-}
-
-/** {@link formatUsage} or {@link formatDurationMs}, depending on what the metric measures. */
+/** {@link formatUsage}, plus the metric's unit where it has one. */
 export function formatMetricUsage(metric: UsageMetric, usage: number): string {
-    return isDurationMetric(metric) ? formatDurationMs(usage) : formatUsage(usage);
+    return withUnit(metric, formatUsage(usage));
 }
 
-/** {@link formatLimit} or {@link formatDurationMs}, depending on what the metric measures. */
+/** {@link formatLimit}, plus the metric's unit where it has one. */
 export function formatMetricLimit(metric: UsageMetric, limit: number): string {
-    return isDurationMetric(metric) ? formatDurationMs(limit) : formatLimit(limit);
+    return withUnit(metric, formatLimit(limit));
 }
 
 /** The unabbreviated figure for a metric, for the title on an abbreviated cell. */
 export function formatMetricExact(metric: UsageMetric, usage: number): string {
-    if (!isDurationMetric(metric)) {
-        return formatUsageExact(usage);
-    }
-    return `${oneDecimalFormatter.format(usage / MS_PER_HOUR)} hours`;
+    return withUnit(metric, formatUsageExact(usage));
 }
 
 /** Usage against a plan cap. `uncapped` = no limit; `near` starts at 70%; `over` at 100%. */

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -50,9 +50,12 @@ export function formatUsage(usage: number) {
     return compactFormatter.format(usage).replace('K', 'k');
 }
 
+// Records and connections are billed on a running average, so their totals arrive fractional.
+const exactFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });
+
 /** The unabbreviated figure, so an abbreviated cell can still be reconciled against an invoice. */
 export function formatUsageExact(usage: number) {
-    return numberFormatter.format(usage);
+    return exactFormatter.format(usage);
 }
 
 /** Usage against a plan cap. `uncapped` = no limit; `near` starts at 70%; `over` at 100%. */

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -1,12 +1,13 @@
 const numberFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 
 /**
- * Formats multiples of 1000 to K, M, B, or T.
- * @example 1000 -> 1K
- * @example 2000 -> 2K
+ * Formats exact multiples of 1000 to k, M, B, or T — lowercase `k` per the design, matching the
+ * abbreviation {@link formatUsage} produces so a used/limit pair doesn't mix "184k / 100K".
+ * @example 1000 -> 1k
+ * @example 2000 -> 2k
  * @example 2025 -> 2,025
  * @example 1000000 -> 1M
- * @example 1234000 -> 1,234K
+ * @example 1234000 -> 1,234k
  */
 export function formatLimit(limit: number) {
     if (limit >= 1_000_000_000_000 && limit % 1_000_000_000_000 === 0) {
@@ -19,7 +20,7 @@ export function formatLimit(limit: number) {
         return `${numberFormatter.format(limit / 1_000_000)}M`;
     }
     if (limit >= 1000 && limit % 1000 === 0) {
-        return `${numberFormatter.format(limit / 1000)}K`;
+        return `${numberFormatter.format(limit / 1000)}k`;
     }
     return numberFormatter.format(limit);
 }

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -1,5 +1,3 @@
-import type { UsageMetric } from '@nangohq/types';
-
 const numberFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 
 /**
@@ -54,38 +52,6 @@ export function formatUsage(usage: number) {
 /** The unabbreviated figure, so an abbreviated cell can still be reconciled against an invoice. */
 export function formatUsageExact(usage: number) {
     return numberFormatter.format(usage);
-}
-
-/**
- * The unit a metric is counted in, where the number alone doesn't say. Only compute carries one
- * today: it's a raw millisecond figure, so "1.04M" on its own means nothing. The other metrics are
- * counts of the thing their row is named after, so a unit would just repeat the label.
- *
- * `function_compute_gbms` is a misnomer kept for back-compat — the billable quantity behind it is
- * `SUM(duration_ms)`, matching Orb's "Function compute time" (see `clickhouse.query.ts`).
- */
-const METRIC_UNITS: Partial<Record<UsageMetric, string>> = {
-    function_compute_gbms: 'ms'
-};
-
-function withUnit(metric: UsageMetric, formatted: string): string {
-    const unit = METRIC_UNITS[metric];
-    return unit ? `${formatted} ${unit}` : formatted;
-}
-
-/** {@link formatUsage}, plus the metric's unit where it has one. */
-export function formatMetricUsage(metric: UsageMetric, usage: number): string {
-    return withUnit(metric, formatUsage(usage));
-}
-
-/** {@link formatLimit}, plus the metric's unit where it has one. */
-export function formatMetricLimit(metric: UsageMetric, limit: number): string {
-    return withUnit(metric, formatLimit(limit));
-}
-
-/** The unabbreviated figure for a metric, for the title on an abbreviated cell. */
-export function formatMetricExact(metric: UsageMetric, usage: number): string {
-    return withUnit(metric, formatUsageExact(usage));
 }
 
 /** Usage against a plan cap. `uncapped` = no limit; `near` starts at 70%; `over` at 100%. */

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -34,24 +34,25 @@ const USAGE_COMPACT_FROM = 10_000;
 // (1,022,107 rendered as "1M", 9,943 as "9K"). Lowercase `k` per the design; Intl gives "K".
 const compactFormatter = Intl.NumberFormat('en-US', { notation: 'compact', maximumSignificantDigits: 3 });
 
+// Records and connections are billed on a running average, so their totals arrive fractional.
+const exactFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });
+
 /**
  * A usage figure. These are billed quantities, so the format never rounds away a digit that changes
  * what someone owes — anything under {@link USAGE_COMPACT_FROM} is exact, and above it keeps 3
  * significant digits. Pair with {@link formatUsageExact} to offer the full number on hover.
  *
  * @example 46 -> 46
+ * @example 9.5 -> 9.5
  * @example 9943 -> 9,943
  * @example 1022107 -> 1.02M
  */
 export function formatUsage(usage: number) {
     if (usage < USAGE_COMPACT_FROM) {
-        return numberFormatter.format(usage);
+        return exactFormatter.format(usage);
     }
     return compactFormatter.format(usage).replace('K', 'k');
 }
-
-// Records and connections are billed on a running average, so their totals arrive fractional.
-const exactFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });
 
 /** The unabbreviated figure, so an abbreviated cell can still be reconciled against an invoice. */
 export function formatUsageExact(usage: number) {

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -1,3 +1,5 @@
+import type { UsageMetric } from '@nangohq/types';
+
 const numberFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 
 /**
@@ -52,6 +54,67 @@ export function formatUsage(usage: number) {
 /** The unabbreviated figure, so an abbreviated cell can still be reconciled against an invoice. */
 export function formatUsageExact(usage: number) {
     return numberFormatter.format(usage);
+}
+
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const oneDecimalFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 1 });
+
+/**
+ * A duration held in milliseconds, shown in the unit the pricing page uses for the allowance
+ * included in each plan (hours). Sub-hour values step down to minutes and seconds rather than
+ * rendering as "0h": in production a quarter of accounts use under 6 minutes of compute in a month
+ * and the smallest is a single second, while the largest exceeds 300,000 hours.
+ *
+ * @example 45000 -> 45s
+ * @example 3240000 -> 54m
+ * @example 5055834 -> 1.4h
+ * @example 1140286209245 -> 316,746h
+ */
+export function formatDurationMs(ms: number): string {
+    if (ms <= 0) {
+        return '0h';
+    }
+    if (ms < MS_PER_SECOND) {
+        return '<1s';
+    }
+    if (ms < MS_PER_MINUTE) {
+        return `${Math.round(ms / MS_PER_SECOND)}s`;
+    }
+    if (ms < MS_PER_HOUR) {
+        return `${Math.round(ms / MS_PER_MINUTE)}m`;
+    }
+    const hours = ms / MS_PER_HOUR;
+    // A tenth of an hour is 6 minutes, which is meaningful at single-digit hours and noise past 100.
+    return `${hours < 100 ? oneDecimalFormatter.format(hours) : numberFormatter.format(hours)}h`;
+}
+
+/**
+ * Metrics whose value is a duration in milliseconds rather than a count. `function_compute_gbms` is
+ * a misnomer kept for back-compat — the billable quantity behind it is `SUM(duration_ms)`, matching
+ * Orb's "Function compute time" (see `clickhouse.query.ts`).
+ */
+function isDurationMetric(metric: UsageMetric): boolean {
+    return metric === 'function_compute_gbms';
+}
+
+/** {@link formatUsage} or {@link formatDurationMs}, depending on what the metric measures. */
+export function formatMetricUsage(metric: UsageMetric, usage: number): string {
+    return isDurationMetric(metric) ? formatDurationMs(usage) : formatUsage(usage);
+}
+
+/** {@link formatLimit} or {@link formatDurationMs}, depending on what the metric measures. */
+export function formatMetricLimit(metric: UsageMetric, limit: number): string {
+    return isDurationMetric(metric) ? formatDurationMs(limit) : formatLimit(limit);
+}
+
+/** The unabbreviated figure for a metric, for the title on an abbreviated cell. */
+export function formatMetricExact(metric: UsageMetric, usage: number): string {
+    if (!isDurationMetric(metric)) {
+        return formatUsageExact(usage);
+    }
+    return `${oneDecimalFormatter.format(usage / MS_PER_HOUR)} hours`;
 }
 
 /** Usage against a plan cap. `uncapped` = no limit; `near` starts at 70%; `over` at 100%. */

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-    formatDurationMs,
     formatLimit,
+    formatMetricExact,
     formatMetricLimit,
     formatMetricUsage,
     formatUsage,
@@ -132,31 +132,16 @@ describe('formatUsageExact', () => {
     });
 });
 
-describe('formatDurationMs', () => {
-    // Production compute for a month ranges from a single second to over 300,000 hours, and 46% of
-    // accounts land under one hour — so the sub-hour bands matter as much as the huge ones.
-    it('steps down to minutes and seconds rather than rendering 0h', () => {
-        expect(formatDurationMs(0)).toBe('0h');
-        expect(formatDurationMs(500)).toBe('<1s');
-        expect(formatDurationMs(1080)).toBe('1s');
-        expect(formatDurationMs(45_000)).toBe('45s');
-        expect(formatDurationMs(180_000)).toBe('3m');
-        expect(formatDurationMs(3_240_000)).toBe('54m');
-    });
-
-    it('shows hours, dropping the decimal once it stops meaning anything', () => {
-        expect(formatDurationMs(5_055_834)).toBe('1.4h');
-        expect(formatDurationMs(50_000_000)).toBe('13.9h');
-        expect(formatDurationMs(574_358_502)).toBe('160h');
-        expect(formatDurationMs(1_140_286_209_245)).toBe('316,746h');
-    });
-});
-
 describe('formatMetricUsage / formatMetricLimit', () => {
-    it('treats compute as a duration and everything else as a count', () => {
-        expect(formatMetricUsage('function_compute_gbms', 5_055_834)).toBe('1.4h');
-        expect(formatMetricUsage('proxy', 5_055_834)).toBe('5.06M');
-        expect(formatMetricLimit('function_compute_gbms', 50_000_000)).toBe('13.9h');
+    // Compute is a raw millisecond figure, so the number alone says nothing; the other metrics are
+    // counts of the thing their row is named after, so a unit there would only repeat the label.
+    it('names the unit for compute and leaves counts bare', () => {
+        expect(formatMetricUsage('function_compute_gbms', 1_040_000)).toBe('1.04M ms');
+        expect(formatMetricLimit('function_compute_gbms', 50_000_000)).toBe('50M ms');
+        expect(formatMetricExact('function_compute_gbms', 1_040_000)).toBe('1,040,000 ms');
+
+        expect(formatMetricUsage('proxy', 1_022_107)).toBe('1.02M');
         expect(formatMetricLimit('proxy', 100_000)).toBe('100K');
+        expect(formatMetricUsage('function_executions', 2058)).toBe('2,058');
     });
 });

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -1,17 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-    formatLimit,
-    formatMetricExact,
-    formatMetricLimit,
-    formatMetricUsage,
-    formatUsage,
-    formatUsageExact,
-    getAggregateUsageState,
-    getUsageState,
-    getUsageStateTextColor,
-    NEAR_LIMIT_RATIO
-} from './usage.js';
+import { formatLimit, formatUsage, formatUsageExact, getAggregateUsageState, getUsageState, getUsageStateTextColor, NEAR_LIMIT_RATIO } from './usage.js';
 
 describe('getUsageState', () => {
     it('is uncapped when there is no limit', () => {
@@ -129,19 +118,5 @@ describe('formatUsageExact', () => {
     it('never abbreviates, so an abbreviated cell can be reconciled', () => {
         expect(formatUsageExact(1_022_107)).toBe('1,022,107');
         expect(formatUsageExact(46)).toBe('46');
-    });
-});
-
-describe('formatMetricUsage / formatMetricLimit', () => {
-    // Compute is a raw millisecond figure, so the number alone says nothing; the other metrics are
-    // counts of the thing their row is named after, so a unit there would only repeat the label.
-    it('names the unit for compute and leaves counts bare', () => {
-        expect(formatMetricUsage('function_compute_gbms', 1_040_000)).toBe('1.04M ms');
-        expect(formatMetricLimit('function_compute_gbms', 50_000_000)).toBe('50M ms');
-        expect(formatMetricExact('function_compute_gbms', 1_040_000)).toBe('1,040,000 ms');
-
-        expect(formatMetricUsage('proxy', 1_022_107)).toBe('1.02M');
-        expect(formatMetricLimit('proxy', 100_000)).toBe('100K');
-        expect(formatMetricUsage('function_executions', 2058)).toBe('2,058');
     });
 });

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -124,3 +124,10 @@ describe('formatUsageExact', () => {
         expect(formatUsageExact(50_072.5)).toBe('50,072.5');
     });
 });
+
+describe('formatUsage with a fractional total', () => {
+    it('does not round an average up to its own limit', () => {
+        // 9.5 of 10 connections must not read as 10 / 10.
+        expect(formatUsage(9.5)).toBe('9.5');
+    });
+});

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -119,4 +119,8 @@ describe('formatUsageExact', () => {
         expect(formatUsageExact(1_022_107)).toBe('1,022,107');
         expect(formatUsageExact(46)).toBe('46');
     });
+
+    it('keeps the decimals on an averaged metric', () => {
+        expect(formatUsageExact(50_072.5)).toBe('50,072.5');
+    });
 });

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatLimit, formatUsage, formatUsageExact, getAggregateUsageState, getUsageState, getUsageStateTextColor, NEAR_LIMIT_RATIO } from './usage.js';
+import {
+    formatDurationMs,
+    formatLimit,
+    formatMetricLimit,
+    formatMetricUsage,
+    formatUsage,
+    formatUsageExact,
+    getAggregateUsageState,
+    getUsageState,
+    getUsageStateTextColor,
+    NEAR_LIMIT_RATIO
+} from './usage.js';
 
 describe('getUsageState', () => {
     it('is uncapped when there is no limit', () => {
@@ -118,5 +129,34 @@ describe('formatUsageExact', () => {
     it('never abbreviates, so an abbreviated cell can be reconciled', () => {
         expect(formatUsageExact(1_022_107)).toBe('1,022,107');
         expect(formatUsageExact(46)).toBe('46');
+    });
+});
+
+describe('formatDurationMs', () => {
+    // Production compute for a month ranges from a single second to over 300,000 hours, and 46% of
+    // accounts land under one hour — so the sub-hour bands matter as much as the huge ones.
+    it('steps down to minutes and seconds rather than rendering 0h', () => {
+        expect(formatDurationMs(0)).toBe('0h');
+        expect(formatDurationMs(500)).toBe('<1s');
+        expect(formatDurationMs(1080)).toBe('1s');
+        expect(formatDurationMs(45_000)).toBe('45s');
+        expect(formatDurationMs(180_000)).toBe('3m');
+        expect(formatDurationMs(3_240_000)).toBe('54m');
+    });
+
+    it('shows hours, dropping the decimal once it stops meaning anything', () => {
+        expect(formatDurationMs(5_055_834)).toBe('1.4h');
+        expect(formatDurationMs(50_000_000)).toBe('13.9h');
+        expect(formatDurationMs(574_358_502)).toBe('160h');
+        expect(formatDurationMs(1_140_286_209_245)).toBe('316,746h');
+    });
+});
+
+describe('formatMetricUsage / formatMetricLimit', () => {
+    it('treats compute as a duration and everything else as a count', () => {
+        expect(formatMetricUsage('function_compute_gbms', 5_055_834)).toBe('1.4h');
+        expect(formatMetricUsage('proxy', 5_055_834)).toBe('5.06M');
+        expect(formatMetricLimit('function_compute_gbms', 50_000_000)).toBe('13.9h');
+        expect(formatMetricLimit('proxy', 100_000)).toBe('100K');
     });
 });

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -71,15 +71,15 @@ describe('getAggregateUsageState', () => {
 
 describe('formatLimit', () => {
     it('abbreviates exact multiples of 1000 as K/M/B/T', () => {
-        expect(formatLimit(1000)).toBe('1K');
-        expect(formatLimit(2000)).toBe('2K');
+        expect(formatLimit(1000)).toBe('1k');
+        expect(formatLimit(2000)).toBe('2k');
         expect(formatLimit(1_000_000)).toBe('1M');
         expect(formatLimit(1_000_000_000)).toBe('1B');
         expect(formatLimit(1_000_000_000_000)).toBe('1T');
     });
 
     it('uses the largest exact unit and keeps a grouped remainder', () => {
-        expect(formatLimit(1_234_000)).toBe('1,234K');
+        expect(formatLimit(1_234_000)).toBe('1,234k');
     });
 
     it('falls back to a grouped number when not an exact multiple', () => {

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatLimit, formatUsage, getAggregateUsageState, getUsageState, getUsageStateTextColor, NEAR_LIMIT_RATIO } from './usage.js';
+import { formatLimit, formatUsage, formatUsageExact, getAggregateUsageState, getUsageState, getUsageStateTextColor, NEAR_LIMIT_RATIO } from './usage.js';
 
 describe('getUsageState', () => {
     it('is uncapped when there is no limit', () => {
@@ -90,16 +90,33 @@ describe('formatLimit', () => {
 });
 
 describe('formatUsage', () => {
-    it('leaves values under 1000 as grouped numbers', () => {
+    it('shows anything under 10,000 in full', () => {
         expect(formatUsage(0)).toBe('0');
+        expect(formatUsage(46)).toBe('46');
         expect(formatUsage(999)).toBe('999');
+        expect(formatUsage(1046)).toBe('1,046');
+        expect(formatUsage(9999)).toBe('9,999');
     });
 
-    it('abbreviates any value at or above 1000 (rounded, no fraction)', () => {
-        expect(formatUsage(1000)).toBe('1K');
-        expect(formatUsage(1234)).toBe('1K');
-        expect(formatUsage(1_000_000)).toBe('1M');
-        expect(formatUsage(2_000_000_000)).toBe('2B');
-        expect(formatUsage(1_000_000_000_000)).toBe('1T');
+    it('abbreviates from 10,000 up, keeping 3 significant digits', () => {
+        expect(formatUsage(10_000)).toBe('10k');
+        expect(formatUsage(12_345)).toBe('12.3k');
+        expect(formatUsage(721_640)).toBe('722k');
+        expect(formatUsage(1_022_107)).toBe('1.02M');
+        expect(formatUsage(2_500_000_000)).toBe('2.5B');
+    });
+
+    // These are the values the previous divide-then-round formatter collapsed to a single
+    // significant digit — a real account 22k into its 1M proxy allowance read as "1M / 1M".
+    it('no longer hides usage just above a threshold', () => {
+        expect(formatUsage(9943)).toBe('9,943');
+        expect(formatUsage(1_499_999)).toBe('1.5M');
+    });
+});
+
+describe('formatUsageExact', () => {
+    it('never abbreviates, so an abbreviated cell can be reconciled', () => {
+        expect(formatUsageExact(1_022_107)).toBe('1,022,107');
+        expect(formatUsageExact(46)).toBe('46');
     });
 });


### PR DESCRIPTION
## Problem

Parts of the Billing & usage page had drifted from the latest designs, and several of the differences were correctness bugs rather than cosmetics — usage figures rounded past their real value, the legacy banner shown to Enterprise, and Free (uncapped) offered invoices it doesn't have.

## Solution

- No header action for either free tier; billed plans keep **All invoices**.
- **Scheduled plan change** moves out of the current plan's card to a full-width alert above the plan cards, with both surfaces sharing one `pendingPlanChange` rule.
<img width="1215" height="441" alt="image" src="https://github.com/user-attachments/assets/a5428dcc-ff55-414c-847d-71bfc6a54b86" />

- Legacy banner retitled to "Legacy plan", portal link moved to the action slot, and no longer shown to **Enterprise**.
<img width="1225" height="183" alt="image" src="https://github.com/user-attachments/assets/e587f548-39fc-4cb9-a1ec-651a0c88a24f" />

- Usage figures no longer round past their real value: exact under 10,000, then 3 significant digits (`1.02M`, not `1M`). Limits abbreviate to a matching lowercase `k`.
- Averaged metrics keep their decimals, so 9.5 of 10 connections no longer reads `10 / 10`.
- Compute time names its unit once, in the row label: `Function compute time (ms)`.
- Design system: `AlertButton` and the `link-*` buttons at `xs` drop the pill radius for the standard 2px, which only ever showed as a capsule focus ring.

Fixes [NAN-6644](https://linear.app/nango/issue/NAN-6644)

## Testing

`ts-build`, lint and `format:check` clean; 318 webapp unit tests pass.

Verified in the browser on a local stack with seeded ClickHouse data and against the remote dev API: both free tiers, paid `startup-deal`, legacy, scheduled downgrade and cancellation, the over-limit sidebar state, and the alert focus ring.
