### PR TITLE
feat(runner): tighten runner egress networkpolicy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34824,6 +34824,7 @@
                 "@kubernetes/client-node": "1.4.0",
                 "@nangohq/data-ingestion": "file:../data-ingestion",
                 "@nangohq/database": "file:../database",
+                "@nangohq/egress": "file:../egress",
                 "@nangohq/feature-flags": "file:../feature-flags",
                 "@nangohq/fleet": "file:../fleet",
                 "@nangohq/kms": "file:../kms",

--- a/packages/egress/lib/egress.unit.test.ts
+++ b/packages/egress/lib/egress.unit.test.ts
@@ -13,8 +13,8 @@ import {
     resolveProxyBaseUrlOverrideDenylistForRunner
 } from './denylist.js';
 import { findOutboundUrlError, OutboundUrlError } from './errors.js';
-import { classifyBlockedIp } from './ip.js';
-import { resolvePolicyForOAuth, resolvePolicyForRunnerSync, resolvePolicyForServer } from './policy.js';
+import { classifyBlockedIp, ipv4ExceptCidrsForNetworkPolicy } from './ip.js';
+import { DEFAULT_OUTBOUND_URL_POLICY, resolvePolicyForOAuth, resolvePolicyForRunnerSync, resolvePolicyForServer } from './policy.js';
 import { absoluteUrlFromRedirectRequestOptions, createRedirectValidator } from './redirect.js';
 import { isBaseUrlOverrideDeniedByPolicy, validateOutboundUrlAsync, validateOutboundUrlSync } from './validate.js';
 
@@ -94,6 +94,42 @@ describe('egress IP classification', () => {
         expect(classifyBlockedIp('::ffff:127.0.0.1')).toBe('loopback');
         expect(classifyBlockedIp('::ffff:169.254.169.254')).toBe('link_local');
         expect(classifyBlockedIp('2606:4700:4700::1111')).toBeNull();
+    });
+});
+
+describe('ipv4ExceptCidrsForNetworkPolicy', () => {
+    it('excepts metadata, link-local, RFC1918, and CGNAT for the default runner policy', () => {
+        expect(ipv4ExceptCidrsForNetworkPolicy(DEFAULT_OUTBOUND_URL_POLICY)).toEqual([
+            '10.0.0.0/8',
+            '100.64.0.0/10',
+            '127.0.0.1/32',
+            '169.254.0.0/16',
+            '169.254.169.254/32',
+            '172.16.0.0/12',
+            '192.168.0.0/16'
+        ]);
+    });
+
+    it('drops RFC1918 and CGNAT when blockPrivateIps is false', () => {
+        const cidrs = ipv4ExceptCidrsForNetworkPolicy({
+            ...DEFAULT_OUTBOUND_URL_POLICY,
+            blockPrivateIps: false
+        });
+        expect(cidrs).not.toContain('10.0.0.0/8');
+        expect(cidrs).not.toContain('172.16.0.0/12');
+        expect(cidrs).not.toContain('192.168.0.0/16');
+        expect(cidrs).not.toContain('100.64.0.0/10');
+        expect(cidrs).toContain('169.254.169.254/32');
+        expect(cidrs).toContain('169.254.0.0/16');
+    });
+
+    it('drops link-local when blockLinkLocal is false', () => {
+        const cidrs = ipv4ExceptCidrsForNetworkPolicy({
+            ...DEFAULT_OUTBOUND_URL_POLICY,
+            blockLinkLocal: false
+        });
+        expect(cidrs).not.toContain('169.254.0.0/16');
+        expect(cidrs).toContain('169.254.169.254/32');
     });
 });
 

--- a/packages/egress/lib/ip.ts
+++ b/packages/egress/lib/ip.ts
@@ -229,3 +229,39 @@ export function isBlockedIpLiteral(hostname: string, options: { blockPrivateIps:
     }
     return null;
 }
+
+/** IPv4 CIDRs matching {@link classifyBlockedIpv4}. Used for Kubernetes NetworkPolicy `ipBlock.except`. */
+export const BLOCKED_IPV4_CIDRS = {
+    private: ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', '100.64.0.0/10'],
+    linkLocal: ['169.254.0.0/16'],
+    metadata: ['169.254.169.254/32']
+} as const;
+
+/**
+ * CIDRs to except from `0.0.0.0/0` so CNI enforcement matches the JS outbound policy.
+ * Always includes cloud-metadata; private and link-local ranges follow the policy flags.
+ * Denylist IPv4 literals are added as /32s so the hostname list and the except list cannot drift.
+ */
+export function ipv4ExceptCidrsForNetworkPolicy(policy: { blockPrivateIps: boolean; blockLinkLocal: boolean; denylist: Iterable<string> }): string[] {
+    const cidrs = new Set<string>(BLOCKED_IPV4_CIDRS.metadata);
+
+    if (policy.blockLinkLocal) {
+        for (const cidr of BLOCKED_IPV4_CIDRS.linkLocal) {
+            cidrs.add(cidr);
+        }
+    }
+    if (policy.blockPrivateIps) {
+        for (const cidr of BLOCKED_IPV4_CIDRS.private) {
+            cidrs.add(cidr);
+        }
+    }
+
+    for (const host of policy.denylist) {
+        const canonical = canonicalizeHostnameForDenylist(host);
+        if (net.isIP(canonical) === 4) {
+            cidrs.add(`${canonical}/32`);
+        }
+    }
+
+    return [...cidrs].sort();
+}

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -1,5 +1,6 @@
 import * as k8s from '@kubernetes/client-node';
 
+import { ipv4ExceptCidrsForNetworkPolicy, resolvePolicyForRunnerSync } from '@nangohq/egress';
 import { waitUntilHealthy } from '@nangohq/fleet';
 import { getJobsUrl, getPersistAPIUrl, getProvidersUrl } from '@nangohq/shared';
 import { Err, getInternalTlsEnv, getLogger, Ok } from '@nangohq/utils';
@@ -11,6 +12,32 @@ import type { Node, NodeProvider } from '@nangohq/fleet';
 import type { Result } from '@nangohq/utils';
 
 export const logger = getLogger('Kubernetes');
+
+function toV1LabelSelector(selector: {
+    matchLabels?: Record<string, string> | undefined;
+    matchExpressions?:
+        | {
+              key: string;
+              operator: string;
+              values?: string[] | undefined;
+          }[]
+        | undefined;
+}): k8s.V1LabelSelector {
+    const out: k8s.V1LabelSelector = {};
+    if (selector.matchLabels) {
+        out.matchLabels = selector.matchLabels;
+    }
+    if (selector.matchExpressions) {
+        out.matchExpressions = selector.matchExpressions.map((expr) => {
+            const requirement: k8s.V1LabelSelectorRequirement = { key: expr.key, operator: expr.operator };
+            if (expr.values) {
+                requirement.values = expr.values;
+            }
+            return requirement;
+        });
+    }
+    return out;
+}
 
 export function getTlsSecretName(serviceName: string): string {
     return `${serviceName}-internal-tls`;
@@ -515,26 +542,7 @@ class Kubernetes {
             spec: {
                 podSelector: {},
                 policyTypes: ['Egress'],
-                egress: [
-                    {
-                        to: [
-                            {
-                                namespaceSelector: {
-                                    matchLabels: { name: this.jobsNamespace }
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        to: [
-                            {
-                                ipBlock: {
-                                    cidr: '0.0.0.0/0'
-                                }
-                            }
-                        ]
-                    }
-                ]
+                egress: this.buildRunnerEgressRules()
             }
         };
         try {
@@ -550,6 +558,62 @@ class Kubernetes {
         }
 
         return Ok(undefined);
+    }
+
+    private buildRunnerEgressRules(): k8s.V1NetworkPolicyEgressRule[] {
+        const nangoPodSelector = toV1LabelSelector(envs.RUNNER_EGRESS_NANGO_POD_SELECTOR);
+        const outboundPolicy = resolvePolicyForRunnerSync({
+            proxyBaseUrlOverrideEnabled: String(envs.NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED),
+            proxyBaseUrlOverrideDenylistRaw:
+                envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST.length > 0 ? JSON.stringify(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST) : undefined,
+            outboundUrlPolicy: envs.NANGO_OUTBOUND_URL_POLICY ?? undefined
+        });
+        const exceptCidrs = ipv4ExceptCidrsForNetworkPolicy(outboundPolicy);
+        const dnsPorts: k8s.V1NetworkPolicyPort[] = [
+            { protocol: 'UDP', port: 53 },
+            { protocol: 'TCP', port: 53 }
+        ];
+
+        return [
+            {
+                to: [
+                    {
+                        namespaceSelector: {
+                            matchLabels: { 'kubernetes.io/metadata.name': this.jobsNamespace }
+                        },
+                        podSelector: nangoPodSelector
+                    }
+                ],
+                ports: [{ protocol: 'TCP', port: 80 }]
+            },
+            {
+                to: [
+                    {
+                        namespaceSelector: {
+                            matchLabels: { 'kubernetes.io/metadata.name': 'kube-system' }
+                        },
+                        podSelector: {
+                            matchExpressions: [{ key: 'k8s-app', operator: 'In', values: ['kube-dns', 'coredns'] }]
+                        }
+                    }
+                ],
+                ports: dnsPorts
+            },
+            {
+                to: [{ ipBlock: { cidr: '169.254.20.10/32' } }],
+                ports: dnsPorts
+            },
+            {
+                to: [
+                    {
+                        ipBlock: {
+                            cidr: '0.0.0.0/0',
+                            except: exceptCidrs
+                        }
+                    }
+                ]
+            }
+        ];
     }
 
     private async deleteNetworkPolicies(namespace: string, nodeId: number): Promise<void> {

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -589,7 +589,7 @@ class Kubernetes {
                         podSelector: nangoPodSelector
                     }
                 ],
-                ports: [{ protocol: 'TCP', port: 80 }]
+                ports: envs.RUNNER_EGRESS_NANGO_PORTS.map((port) => ({ protocol: 'TCP', port }))
             },
             {
                 to: [

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -100,6 +100,11 @@ class Kubernetes {
         return false;
     }
 
+    /** Label on the jobs namespace. Ingress and egress must use the same key or one side will not match. */
+    private jobsNamespaceMatchLabels(): { name: string } {
+        return { name: this.jobsNamespace };
+    }
+
     static getInstance(): Kubernetes {
         if (!Kubernetes.instance) {
             Kubernetes.instance = new Kubernetes();
@@ -516,7 +521,7 @@ class Kubernetes {
                         _from: [
                             {
                                 namespaceSelector: {
-                                    matchLabels: { name: this.jobsNamespace }
+                                    matchLabels: this.jobsNamespaceMatchLabels()
                                 }
                             }
                         ]
@@ -579,7 +584,7 @@ class Kubernetes {
                 to: [
                     {
                         namespaceSelector: {
-                            matchLabels: { 'kubernetes.io/metadata.name': this.jobsNamespace }
+                            matchLabels: this.jobsNamespaceMatchLabels()
                         },
                         podSelector: nangoPodSelector
                     }

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -105,6 +105,11 @@ class Kubernetes {
         return { name: this.jobsNamespace };
     }
 
+    /** Same `app` label as the runner Deployment / Service — do not use `{}` (whole namespace). */
+    private runnerPodSelector(name: string): k8s.V1LabelSelector {
+        return { matchLabels: { app: name } };
+    }
+
     static getInstance(): Kubernetes {
         if (!Kubernetes.instance) {
             Kubernetes.instance = new Kubernetes();
@@ -160,7 +165,7 @@ class Kubernetes {
         }
 
         // Create network policies
-        const networkPoliciesResult = await this.createNetworkPolicies(namespace, node.id);
+        const networkPoliciesResult = await this.createNetworkPolicies(namespace, node.id, name);
         if (networkPoliciesResult.isErr()) {
             return networkPoliciesResult;
         }
@@ -493,7 +498,7 @@ class Kubernetes {
         return Ok(undefined);
     }
 
-    private async createNetworkPolicies(namespace: string, nodeId: number): Promise<Result<void>> {
+    private async createNetworkPolicies(namespace: string, nodeId: number, name: string): Promise<Result<void>> {
         const denyAll: k8s.V1NetworkPolicy = {
             metadata: { name: `default-deny-${nodeId}` },
             spec: {
@@ -545,7 +550,7 @@ class Kubernetes {
         const allowEgressToNangoAndInternet: k8s.V1NetworkPolicy = {
             metadata: { name: `allow-egress-to-nango-and-internet-${nodeId}` },
             spec: {
-                podSelector: {},
+                podSelector: this.runnerPodSelector(name),
                 policyTypes: ['Egress'],
                 egress: this.buildRunnerEgressRules()
             }

--- a/packages/jobs/lib/runner/kubernetes.unit.test.ts
+++ b/packages/jobs/lib/runner/kubernetes.unit.test.ts
@@ -353,6 +353,17 @@ describe('runner NetworkPolicy egress', () => {
         });
     });
 
+    it('should apply egress only to the runner pod, not the whole namespace', async () => {
+        const res = await kubernetesNodeProvider.start(node);
+        expect(res.isOk()).toBe(true);
+
+        expect(policyByName('allow-egress-to-nango-and-internet-1').spec.podSelector).toEqual({
+            matchLabels: { app: 'account-7-1' }
+        });
+        expect(policyByName('default-deny-1').spec.podSelector).toEqual({});
+        expect(policyByName('allow-from-nango-1').spec.podSelector).toEqual({});
+    });
+
     it('should allow egress to persist, jobs, and server on port 80 only', async () => {
         const res = await kubernetesNodeProvider.start(node);
         expect(res.isOk()).toBe(true);

--- a/packages/jobs/lib/runner/kubernetes.unit.test.ts
+++ b/packages/jobs/lib/runner/kubernetes.unit.test.ts
@@ -362,7 +362,7 @@ describe('runner NetworkPolicy egress', () => {
             to: [
                 {
                     namespaceSelector: {
-                        matchLabels: { 'kubernetes.io/metadata.name': 'nango' }
+                        matchLabels: { name: 'nango' }
                     },
                     podSelector: {
                         matchExpressions: [{ key: 'app.kubernetes.io/component', operator: 'In', values: ['persist', 'jobs', 'server'] }]
@@ -393,9 +393,11 @@ describe('runner NetworkPolicy egress', () => {
         const spec = JSON.stringify(policyByName('allow-egress-to-nango-and-internet-1').spec.egress);
         expect(spec).not.toContain('orchestrator');
         expect(spec).not.toContain('datadog');
-        expect(spec).not.toContain('"matchLabels":{"name":"nango"}');
         const nangoRule = policyByName('allow-egress-to-nango-and-internet-1').spec.egress.find((rule: { ports?: { port: number }[] }) =>
             rule.ports?.some((p) => p.port === 80)
+        );
+        expect(nangoRule.to[0].namespaceSelector.matchLabels).toEqual(
+            policyByName('allow-from-nango-1').spec.ingress[0]._from[0].namespaceSelector.matchLabels
         );
         expect(nangoRule.to[0].podSelector).not.toEqual({});
         expect(nangoRule.to[0].podSelector.matchLabels).toBeUndefined();

--- a/packages/jobs/lib/runner/kubernetes.unit.test.ts
+++ b/packages/jobs/lib/runner/kubernetes.unit.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DEFAULT_OUTBOUND_URL_POLICY, ipv4ExceptCidrsForNetworkPolicy } from '@nangohq/egress';
+
 import { getTlsEnvVars, getTlsSecretName, kubernetesNodeProvider } from './kubernetes.js';
 
 import type { Node } from '@nangohq/fleet';
 
-vi.mock('../env.js', () => ({
-    envs: {
+const { getInternalTlsEnvMock, k8sMock, mockEnvs, defaultRunnerEnvs } = vi.hoisted(() => {
+    const defaultRunnerEnvs = {
         NODE_ENV: 'test',
         NANGO_CLOUD: false,
         RUNNER_NAMESPACE: 'runners',
@@ -14,8 +16,11 @@ vi.mock('../env.js', () => ({
         NANGO_RUNNER_URL_SCHEME: 'http',
         RUNNER_DO_NOT_DISRUPT: false,
         NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED: false,
-        NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST: [],
-        NANGO_OUTBOUND_URL_POLICY: null,
+        NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST: [] as string[],
+        NANGO_OUTBOUND_URL_POLICY: null as { blockPrivateIps?: boolean; blockLinkLocal?: boolean } | null,
+        RUNNER_EGRESS_NANGO_POD_SELECTOR: {
+            matchExpressions: [{ key: 'app.kubernetes.io/component', operator: 'In', values: ['persist', 'jobs', 'server'] }]
+        } as { matchLabels?: Record<string, string>; matchExpressions?: { key: string; operator: string; values?: string[] }[] },
         PROVIDERS_RELOAD_INTERVAL: 60_000,
         RUNNER_MAX_REQUEST_CPU: 2000,
         RUNNER_MAX_REQUEST_MEMORY: 4096,
@@ -23,7 +28,22 @@ vi.mock('../env.js', () => ({
         RUNNER_MIN_REQUEST_MEMORY: 512,
         RUNNER_REQUEST_CPU_MULTIPLIER: 1.4,
         RUNNER_REQUEST_MEMORY_MULTIPLIER: 1.4
-    }
+    };
+    return {
+        getInternalTlsEnvMock: vi.fn<() => Record<string, string>>(() => ({})),
+        k8sMock: {
+            calls: [] as { method: string; body?: any; name?: string }[],
+            errors: new Map<string, { reason: string }>(),
+            /** Fail replaceNamespacedSecret only when setting ownerReferences (the link step). */
+            failLink: false
+        },
+        defaultRunnerEnvs,
+        mockEnvs: { ...defaultRunnerEnvs }
+    };
+});
+
+vi.mock('../env.js', () => ({
+    envs: mockEnvs
 }));
 
 vi.mock('@nangohq/shared', () => ({
@@ -46,16 +66,6 @@ const tlsEnv = {
     NANGO_INTERNAL_TLS_CA: '-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----',
     NANGO_INTERNAL_TLS_KEY_PASSPHRASE: 'secret'
 };
-
-const { getInternalTlsEnvMock, k8sMock } = vi.hoisted(() => ({
-    getInternalTlsEnvMock: vi.fn<() => Record<string, string>>(() => ({})),
-    k8sMock: {
-        calls: [] as { method: string; body?: any; name?: string }[],
-        errors: new Map<string, { reason: string }>(),
-        /** Fail replaceNamespacedSecret only when setting ownerReferences (the link step). */
-        failLink: false
-    }
-}));
 
 vi.mock('@nangohq/utils', async (importOriginal) => {
     const actual = await importOriginal();
@@ -160,6 +170,7 @@ describe('runner TLS secret lifecycle', () => {
         k8sMock.calls = [];
         k8sMock.errors.clear();
         k8sMock.failLink = false;
+        Object.assign(mockEnvs, defaultRunnerEnvs);
         getInternalTlsEnvMock.mockReturnValue(tlsEnv);
     });
 
@@ -291,5 +302,154 @@ describe('runner TLS secret lifecycle', () => {
 
         const res = await kubernetesNodeProvider.terminate(node);
         expect(res.isOk()).toBe(true);
+    });
+});
+
+describe('runner NetworkPolicy egress', () => {
+    beforeEach(() => {
+        k8sMock.calls = [];
+        k8sMock.errors.clear();
+        k8sMock.failLink = false;
+        Object.assign(mockEnvs, defaultRunnerEnvs);
+        getInternalTlsEnvMock.mockReturnValue({});
+    });
+
+    function policyByName(name: string) {
+        return k8sMock.calls.find((call) => call.method === 'createNamespacedNetworkPolicy' && call.body?.metadata?.name === name)?.body;
+    }
+
+    it('should leave default-deny ingress unchanged', async () => {
+        const res = await kubernetesNodeProvider.start(node);
+        expect(res.isOk()).toBe(true);
+
+        expect(policyByName('default-deny-1')).toEqual({
+            metadata: { name: 'default-deny-1' },
+            spec: {
+                podSelector: {},
+                policyTypes: ['Ingress']
+            }
+        });
+    });
+
+    it('should leave allow-from-nango ingress unchanged', async () => {
+        const res = await kubernetesNodeProvider.start(node);
+        expect(res.isOk()).toBe(true);
+
+        expect(policyByName('allow-from-nango-1').spec).toEqual({
+            podSelector: {},
+            ingress: [
+                {
+                    _from: [
+                        {
+                            namespaceSelector: {
+                                matchLabels: { name: 'nango' }
+                            }
+                        }
+                    ]
+                }
+            ],
+            policyTypes: ['Ingress']
+        });
+    });
+
+    it('should allow egress to persist, jobs, and server on port 80 only', async () => {
+        const res = await kubernetesNodeProvider.start(node);
+        expect(res.isOk()).toBe(true);
+
+        const egress = policyByName('allow-egress-to-nango-and-internet-1').spec.egress;
+        const nangoRule = egress.find((rule: { ports?: { port: number }[] }) => rule.ports?.some((p) => p.port === 80));
+        expect(nangoRule).toEqual({
+            to: [
+                {
+                    namespaceSelector: {
+                        matchLabels: { 'kubernetes.io/metadata.name': 'nango' }
+                    },
+                    podSelector: {
+                        matchExpressions: [{ key: 'app.kubernetes.io/component', operator: 'In', values: ['persist', 'jobs', 'server'] }]
+                    }
+                }
+            ],
+            ports: [{ protocol: 'TCP', port: 80 }]
+        });
+    });
+
+    it('should use RUNNER_EGRESS_NANGO_POD_SELECTOR when set', async () => {
+        mockEnvs.RUNNER_EGRESS_NANGO_POD_SELECTOR = {
+            matchExpressions: [{ key: 'app', operator: 'In', values: ['persist', 'jobs', 'nango-server'] }]
+        };
+
+        const res = await kubernetesNodeProvider.start(node);
+        expect(res.isOk()).toBe(true);
+
+        const egress = policyByName('allow-egress-to-nango-and-internet-1').spec.egress;
+        const nangoRule = egress.find((rule: { ports?: { port: number }[] }) => rule.ports?.some((p) => p.port === 80));
+        expect(nangoRule.to[0].podSelector).toEqual(mockEnvs.RUNNER_EGRESS_NANGO_POD_SELECTOR);
+    });
+
+    it('should not select orchestrator, Datadog, or the whole nango namespace', async () => {
+        const res = await kubernetesNodeProvider.start(node);
+        expect(res.isOk()).toBe(true);
+
+        const spec = JSON.stringify(policyByName('allow-egress-to-nango-and-internet-1').spec.egress);
+        expect(spec).not.toContain('orchestrator');
+        expect(spec).not.toContain('datadog');
+        expect(spec).not.toContain('"matchLabels":{"name":"nango"}');
+        const nangoRule = policyByName('allow-egress-to-nango-and-internet-1').spec.egress.find((rule: { ports?: { port: number }[] }) =>
+            rule.ports?.some((p) => p.port === 80)
+        );
+        expect(nangoRule.to[0].podSelector).not.toEqual({});
+        expect(nangoRule.to[0].podSelector.matchLabels).toBeUndefined();
+    });
+
+    it('should allow DNS to kube-system CoreDNS and NodeLocal DNSCache', async () => {
+        const res = await kubernetesNodeProvider.start(node);
+        expect(res.isOk()).toBe(true);
+
+        const egress = policyByName('allow-egress-to-nango-and-internet-1').spec.egress;
+        expect(egress).toContainEqual({
+            to: [
+                {
+                    namespaceSelector: {
+                        matchLabels: { 'kubernetes.io/metadata.name': 'kube-system' }
+                    },
+                    podSelector: {
+                        matchExpressions: [{ key: 'k8s-app', operator: 'In', values: ['kube-dns', 'coredns'] }]
+                    }
+                }
+            ],
+            ports: [
+                { protocol: 'UDP', port: 53 },
+                { protocol: 'TCP', port: 53 }
+            ]
+        });
+        expect(egress).toContainEqual({
+            to: [{ ipBlock: { cidr: '169.254.20.10/32' } }],
+            ports: [
+                { protocol: 'UDP', port: 53 },
+                { protocol: 'TCP', port: 53 }
+            ]
+        });
+    });
+
+    it('should except the default runner outbound CIDRs from 0.0.0.0/0', async () => {
+        const res = await kubernetesNodeProvider.start(node);
+        expect(res.isOk()).toBe(true);
+
+        const egress = policyByName('allow-egress-to-nango-and-internet-1').spec.egress;
+        const internetRule = egress.find((rule: { to?: { ipBlock?: { cidr: string } }[] }) => rule.to?.[0]?.ipBlock?.cidr === '0.0.0.0/0');
+        expect(internetRule.to[0].ipBlock.except).toEqual(ipv4ExceptCidrsForNetworkPolicy(DEFAULT_OUTBOUND_URL_POLICY));
+    });
+
+    it('should drop RFC1918 excepts when blockPrivateIps is false', async () => {
+        mockEnvs.NANGO_OUTBOUND_URL_POLICY = { blockPrivateIps: false };
+
+        const res = await kubernetesNodeProvider.start(node);
+        expect(res.isOk()).toBe(true);
+
+        const egress = policyByName('allow-egress-to-nango-and-internet-1').spec.egress;
+        const internetRule = egress.find((rule: { to?: { ipBlock?: { cidr: string } }[] }) => rule.to?.[0]?.ipBlock?.cidr === '0.0.0.0/0');
+        expect(internetRule.to[0].ipBlock.except).not.toContain('10.0.0.0/8');
+        expect(internetRule.to[0].ipBlock.except).toContain('169.254.169.254/32');
+        expect(internetRule.to[0].ipBlock.except).toContain('169.254.0.0/16');
     });
 });

--- a/packages/jobs/lib/runner/kubernetes.unit.test.ts
+++ b/packages/jobs/lib/runner/kubernetes.unit.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DEFAULT_OUTBOUND_URL_POLICY, ipv4ExceptCidrsForNetworkPolicy } from '@nangohq/egress';
-
 import { getTlsEnvVars, getTlsSecretName, kubernetesNodeProvider } from './kubernetes.js';
 
 import type { Node } from '@nangohq/fleet';
@@ -465,7 +463,15 @@ describe('runner NetworkPolicy egress', () => {
 
         const egress = policyByName('allow-egress-to-nango-and-internet-1').spec.egress;
         const internetRule = egress.find((rule: { to?: { ipBlock?: { cidr: string } }[] }) => rule.to?.[0]?.ipBlock?.cidr === '0.0.0.0/0');
-        expect(internetRule.to[0].ipBlock.except).toEqual(ipv4ExceptCidrsForNetworkPolicy(DEFAULT_OUTBOUND_URL_POLICY));
+        expect(internetRule.to[0].ipBlock.except).toEqual([
+            '10.0.0.0/8',
+            '100.64.0.0/10',
+            '127.0.0.1/32',
+            '169.254.0.0/16',
+            '169.254.169.254/32',
+            '172.16.0.0/12',
+            '192.168.0.0/16'
+        ]);
     });
 
     it('should drop RFC1918 excepts when blockPrivateIps is false', async () => {

--- a/packages/jobs/lib/runner/kubernetes.unit.test.ts
+++ b/packages/jobs/lib/runner/kubernetes.unit.test.ts
@@ -21,6 +21,7 @@ const { getInternalTlsEnvMock, k8sMock, mockEnvs, defaultRunnerEnvs } = vi.hoist
         RUNNER_EGRESS_NANGO_POD_SELECTOR: {
             matchExpressions: [{ key: 'app.kubernetes.io/component', operator: 'In', values: ['persist', 'jobs', 'server'] }]
         } as { matchLabels?: Record<string, string>; matchExpressions?: { key: string; operator: string; values?: string[] }[] },
+        RUNNER_EGRESS_NANGO_PORTS: [80],
         PROVIDERS_RELOAD_INTERVAL: 60_000,
         RUNNER_MAX_REQUEST_CPU: 2000,
         RUNNER_MAX_REQUEST_MEMORY: 4096,
@@ -384,6 +385,20 @@ describe('runner NetworkPolicy egress', () => {
         const egress = policyByName('allow-egress-to-nango-and-internet-1').spec.egress;
         const nangoRule = egress.find((rule: { ports?: { port: number }[] }) => rule.ports?.some((p) => p.port === 80));
         expect(nangoRule.to[0].podSelector).toEqual(mockEnvs.RUNNER_EGRESS_NANGO_POD_SELECTOR);
+    });
+
+    it('should use RUNNER_EGRESS_NANGO_PORTS when set', async () => {
+        mockEnvs.RUNNER_EGRESS_NANGO_PORTS = [80, 443];
+
+        const res = await kubernetesNodeProvider.start(node);
+        expect(res.isOk()).toBe(true);
+
+        const egress = policyByName('allow-egress-to-nango-and-internet-1').spec.egress;
+        const nangoRule = egress.find((rule: { ports?: { port: number }[] }) => rule.ports?.some((p) => p.port === 443));
+        expect(nangoRule.ports).toEqual([
+            { protocol: 'TCP', port: 80 },
+            { protocol: 'TCP', port: 443 }
+        ]);
     });
 
     it('should not select orchestrator, Datadog, or the whole nango namespace', async () => {

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -23,6 +23,7 @@
         "@kubernetes/client-node": "1.4.0",
         "@nangohq/data-ingestion": "file:../data-ingestion",
         "@nangohq/database": "file:../database",
+        "@nangohq/egress": "file:../egress",
         "@nangohq/feature-flags": "file:../feature-flags",
         "@nangohq/fleet": "file:../fleet",
         "@nangohq/kms": "file:../kms",

--- a/packages/jobs/tsconfig.json
+++ b/packages/jobs/tsconfig.json
@@ -12,6 +12,9 @@
             "path": "../database"
         },
         {
+            "path": "../egress"
+        },
+        {
             "path": "../feature-flags"
         },
         {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -58,11 +58,26 @@ const runnerEgressNangoPodSelectorSchema = z
                 matchLabels: z.record(z.string(), z.string()).optional(),
                 matchExpressions: z
                     .array(
-                        z.object({
-                            key: z.string(),
-                            operator: z.enum(['In', 'NotIn', 'Exists', 'DoesNotExist']),
-                            values: z.array(z.string()).optional()
-                        })
+                        z
+                            .object({
+                                key: z.string(),
+                                operator: z.enum(['In', 'NotIn', 'Exists', 'DoesNotExist']),
+                                values: z.array(z.string()).optional()
+                            })
+                            .strict()
+                            .refine(
+                                (expr) => {
+                                    const hasValues = expr.values !== undefined && expr.values.length > 0;
+                                    if (expr.operator === 'In' || expr.operator === 'NotIn') {
+                                        return hasValues;
+                                    }
+                                    return !hasValues;
+                                },
+                                {
+                                    message:
+                                        'RUNNER_EGRESS_NANGO_POD_SELECTOR matchExpressions require values for In/NotIn and must omit values for Exists/DoesNotExist'
+                                }
+                            )
                     )
                     .optional()
             })

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -9,6 +9,35 @@ export const DEFAULT_RUNNER_EGRESS_NANGO_POD_SELECTOR = {
     matchExpressions: [{ key: 'app.kubernetes.io/component', operator: 'In' as const, values: ['persist', 'jobs', 'server'] }]
 };
 
+export const DEFAULT_RUNNER_EGRESS_NANGO_PORTS = [80];
+
+const runnerEgressNangoPortsSchema = z
+    .string()
+    .optional()
+    .transform((s, ctx) => {
+        if (s === undefined || s.trim() === '') {
+            return [...DEFAULT_RUNNER_EGRESS_NANGO_PORTS];
+        }
+        const ports = new Set<number>();
+        for (const part of s.split(',')) {
+            const trimmed = part.trim();
+            if (trimmed === '') {
+                continue;
+            }
+            const port = Number(trimmed);
+            if (!Number.isInteger(port) || port < 1 || port > 65535) {
+                ctx.addIssue(`Invalid port in RUNNER_EGRESS_NANGO_PORTS: ${part}`);
+                return z.NEVER;
+            }
+            ports.add(port);
+        }
+        if (ports.size === 0) {
+            ctx.addIssue('RUNNER_EGRESS_NANGO_PORTS must include at least one port');
+            return z.NEVER;
+        }
+        return [...ports].sort((a, b) => a - b);
+    });
+
 const runnerEgressNangoPodSelectorSchema = z
     .string()
     .optional()
@@ -332,6 +361,7 @@ const ENVS_SHAPE = z.object({
     RUNNER_MEMORY_WARNING_THRESHOLD: z.coerce.number().optional().default(85),
     RUNNER_NAMESPACE: z.string().optional().default('nango'),
     RUNNER_EGRESS_NANGO_POD_SELECTOR: runnerEgressNangoPodSelectorSchema,
+    RUNNER_EGRESS_NANGO_PORTS: runnerEgressNangoPortsSchema,
     RUNNER_HTTP_LOG_SAMPLE_PCT: z.coerce.number().optional(),
     NAMESPACE_PER_RUNNER: z.stringbool().optional().default(false),
     RUNNER_CLIENT_HEADERS_TIMEOUT_MS: z.coerce.number().optional().default(10_000),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -11,6 +11,41 @@ export const DEFAULT_RUNNER_EGRESS_NANGO_POD_SELECTOR = {
 
 export const DEFAULT_RUNNER_EGRESS_NANGO_PORTS = [80];
 
+/** Kubernetes qualified name: 1–63 chars, alphanumeric, with `-`, `_`, `.` in the middle. */
+const K8S_LABEL_NAME = /^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$/;
+/** DNS-1123 subdomain used as an optional label-key prefix (max 253). */
+const K8S_DNS1123_SUBDOMAIN = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+
+function isK8sLabelName(name: string): boolean {
+    return name.length >= 1 && name.length <= 63 && K8S_LABEL_NAME.test(name);
+}
+
+/** Kubernetes label key: `[prefix/]name`. Prefix is a DNS-1123 subdomain. */
+function isK8sLabelKey(key: string): boolean {
+    const parts = key.split('/');
+    if (parts.length === 1) {
+        return isK8sLabelName(parts[0]!);
+    }
+    const prefix = parts[0];
+    const name = parts[1];
+    if (parts.length !== 2 || prefix === undefined || name === undefined) {
+        return false;
+    }
+    return prefix.length >= 1 && prefix.length <= 253 && K8S_DNS1123_SUBDOMAIN.test(prefix) && isK8sLabelName(name);
+}
+
+/** Kubernetes label value: empty or a qualified name, max 63 chars. */
+function isK8sLabelValue(value: string): boolean {
+    return value.length <= 63 && (value === '' || K8S_LABEL_NAME.test(value));
+}
+
+const k8sLabelKeySchema = z.string().refine(isK8sLabelKey, {
+    message: 'RUNNER_EGRESS_NANGO_POD_SELECTOR contains an invalid Kubernetes label key'
+});
+const k8sLabelValueSchema = z.string().refine(isK8sLabelValue, {
+    message: 'RUNNER_EGRESS_NANGO_POD_SELECTOR contains an invalid Kubernetes label value'
+});
+
 const runnerEgressNangoPortsSchema = z
     .string()
     .optional()
@@ -55,14 +90,19 @@ const runnerEgressNangoPodSelectorSchema = z
     .pipe(
         z
             .object({
-                matchLabels: z.record(z.string(), z.string()).optional(),
+                matchLabels: z
+                    .record(z.string(), k8sLabelValueSchema)
+                    .refine((labels) => Object.keys(labels).every(isK8sLabelKey), {
+                        message: 'RUNNER_EGRESS_NANGO_POD_SELECTOR contains an invalid Kubernetes label key'
+                    })
+                    .optional(),
                 matchExpressions: z
                     .array(
                         z
                             .object({
-                                key: z.string(),
+                                key: k8sLabelKeySchema,
                                 operator: z.enum(['In', 'NotIn', 'Exists', 'DoesNotExist']),
-                                values: z.array(z.string()).optional()
+                                values: z.array(k8sLabelValueSchema).optional()
                             })
                             .strict()
                             .refine(

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -15,9 +15,19 @@ export const DEFAULT_RUNNER_EGRESS_NANGO_PORTS = [80];
 const K8S_LABEL_NAME = /^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$/;
 /** DNS-1123 subdomain used as an optional label-key prefix (max 253). */
 const K8S_DNS1123_SUBDOMAIN = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+const DNS1123_LABEL_MAX_LENGTH = 63;
+const DNS1123_SUBDOMAIN_MAX_LENGTH = 253;
 
 function isK8sLabelName(name: string): boolean {
     return name.length >= 1 && name.length <= 63 && K8S_LABEL_NAME.test(name);
+}
+
+/** RFC 1123 subdomain: total ≤253, each label ≤63. The regex alone does not cap per-label length. */
+function isK8sDns1123Subdomain(prefix: string): boolean {
+    if (prefix.length < 1 || prefix.length > DNS1123_SUBDOMAIN_MAX_LENGTH || !K8S_DNS1123_SUBDOMAIN.test(prefix)) {
+        return false;
+    }
+    return prefix.split('.').every((label) => label.length <= DNS1123_LABEL_MAX_LENGTH);
 }
 
 /** Kubernetes label key: `[prefix/]name`. Prefix is a DNS-1123 subdomain. */
@@ -31,7 +41,7 @@ function isK8sLabelKey(key: string): boolean {
     if (parts.length !== 2 || prefix === undefined || name === undefined) {
         return false;
     }
-    return prefix.length >= 1 && prefix.length <= 253 && K8S_DNS1123_SUBDOMAIN.test(prefix) && isK8sLabelName(name);
+    return isK8sDns1123Subdomain(prefix) && isK8sLabelName(name);
 }
 
 /** Kubernetes label value: empty or a qualified name, max 63 chars. */

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -5,6 +5,49 @@ import { roles } from '../roles.js';
 
 const PUBSUB_SUBJECTS = ['user', 'usage', 'team', 'lambda_keep_warm', 'audit'] as const;
 
+export const DEFAULT_RUNNER_EGRESS_NANGO_POD_SELECTOR = {
+    matchExpressions: [{ key: 'app.kubernetes.io/component', operator: 'In' as const, values: ['persist', 'jobs', 'server'] }]
+};
+
+const runnerEgressNangoPodSelectorSchema = z
+    .string()
+    .optional()
+    .transform((s, ctx) => {
+        if (s === undefined || s.trim() === '') {
+            return structuredClone(DEFAULT_RUNNER_EGRESS_NANGO_POD_SELECTOR);
+        }
+        try {
+            return JSON.parse(s) as unknown;
+        } catch {
+            ctx.addIssue(`Invalid JSON in RUNNER_EGRESS_NANGO_POD_SELECTOR`);
+            return z.NEVER;
+        }
+    })
+    .pipe(
+        z
+            .object({
+                matchLabels: z.record(z.string(), z.string()).optional(),
+                matchExpressions: z
+                    .array(
+                        z.object({
+                            key: z.string(),
+                            operator: z.enum(['In', 'NotIn', 'Exists', 'DoesNotExist']),
+                            values: z.array(z.string()).optional()
+                        })
+                    )
+                    .optional()
+            })
+            .strict()
+            .refine(
+                (sel) => {
+                    const hasLabels = sel.matchLabels !== undefined && Object.keys(sel.matchLabels).length > 0;
+                    const hasExpressions = sel.matchExpressions !== undefined && sel.matchExpressions.length > 0;
+                    return hasLabels || hasExpressions;
+                },
+                { message: 'RUNNER_EGRESS_NANGO_POD_SELECTOR must select specific pods (empty selector is not allowed)' }
+            )
+    );
+
 function outboundUrlPolicySchema(varName: string) {
     return z
         .string()
@@ -288,6 +331,7 @@ const ENVS_SHAPE = z.object({
     RUNNER_URL: z.url().optional(),
     RUNNER_MEMORY_WARNING_THRESHOLD: z.coerce.number().optional().default(85),
     RUNNER_NAMESPACE: z.string().optional().default('nango'),
+    RUNNER_EGRESS_NANGO_POD_SELECTOR: runnerEgressNangoPodSelectorSchema,
     RUNNER_HTTP_LOG_SAMPLE_PCT: z.coerce.number().optional(),
     NAMESPACE_PER_RUNNER: z.stringbool().optional().default(false),
     RUNNER_CLIENT_HEADERS_TIMEOUT_MS: z.coerce.number().optional().default(10_000),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -297,6 +297,44 @@ describe('parse', () => {
         }).toThrow(/must omit values for Exists\/DoesNotExist/);
     });
 
+    it('should throw on an empty label key in RUNNER_EGRESS_NANGO_POD_SELECTOR', () => {
+        expect(() => {
+            parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify({ matchLabels: { '': 'persist' } }) });
+        }).toThrow(/invalid Kubernetes label key/);
+    });
+
+    it('should throw on a syntactically invalid label key in RUNNER_EGRESS_NANGO_POD_SELECTOR', () => {
+        expect(() => {
+            parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify({ matchLabels: { '-app': 'persist' } }) });
+        }).toThrow(/invalid Kubernetes label key/);
+    });
+
+    it('should throw on a syntactically invalid label value in RUNNER_EGRESS_NANGO_POD_SELECTOR', () => {
+        expect(() => {
+            parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify({ matchLabels: { app: 'persist!' } }) });
+        }).toThrow(/invalid Kubernetes label value/);
+    });
+
+    it('should throw on an invalid matchExpression key in RUNNER_EGRESS_NANGO_POD_SELECTOR', () => {
+        expect(() => {
+            parseEnvs(ENVS, {
+                RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify({
+                    matchExpressions: [{ key: 'not a key', operator: 'In', values: ['persist'] }]
+                })
+            });
+        }).toThrow(/invalid Kubernetes label key/);
+    });
+
+    it('should throw on an invalid matchExpression value in RUNNER_EGRESS_NANGO_POD_SELECTOR', () => {
+        expect(() => {
+            parseEnvs(ENVS, {
+                RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify({
+                    matchExpressions: [{ key: 'app', operator: 'In', values: ['persist!'] }]
+                })
+            });
+        }).toThrow(/invalid Kubernetes label value/);
+    });
+
     it('should default RUNNER_EGRESS_NANGO_PORTS to 80', () => {
         const res = parseEnvs(ENVS, {});
         expect(res.RUNNER_EGRESS_NANGO_PORTS).toEqual([80]);

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -271,6 +271,32 @@ describe('parse', () => {
         }).toThrow('Invalid JSON in RUNNER_EGRESS_NANGO_POD_SELECTOR');
     });
 
+    it('should parse Exists without values', () => {
+        const selector = { matchExpressions: [{ key: 'app.kubernetes.io/component', operator: 'Exists' }] };
+        const res = parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify(selector) });
+        expect(res.RUNNER_EGRESS_NANGO_POD_SELECTOR).toEqual(selector);
+    });
+
+    it('should throw when In/NotIn is missing values', () => {
+        expect(() => {
+            parseEnvs(ENVS, {
+                RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify({
+                    matchExpressions: [{ key: 'app.kubernetes.io/component', operator: 'In' }]
+                })
+            });
+        }).toThrow(/require values for In\/NotIn/);
+    });
+
+    it('should throw when Exists/DoesNotExist includes values', () => {
+        expect(() => {
+            parseEnvs(ENVS, {
+                RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify({
+                    matchExpressions: [{ key: 'app.kubernetes.io/component', operator: 'Exists', values: ['persist'] }]
+                })
+            });
+        }).toThrow(/must omit values for Exists\/DoesNotExist/);
+    });
+
     it('should default RUNNER_EGRESS_NANGO_PORTS to 80', () => {
         const res = parseEnvs(ENVS, {});
         expect(res.RUNNER_EGRESS_NANGO_PORTS).toEqual([80]);

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -271,6 +271,28 @@ describe('parse', () => {
         }).toThrow('Invalid JSON in RUNNER_EGRESS_NANGO_POD_SELECTOR');
     });
 
+    it('should default RUNNER_EGRESS_NANGO_PORTS to 80', () => {
+        const res = parseEnvs(ENVS, {});
+        expect(res.RUNNER_EGRESS_NANGO_PORTS).toEqual([80]);
+    });
+
+    it('should parse a comma-separated RUNNER_EGRESS_NANGO_PORTS list', () => {
+        const res = parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_PORTS: '443, 80, 443' });
+        expect(res.RUNNER_EGRESS_NANGO_PORTS).toEqual([80, 443]);
+    });
+
+    it('should throw on an empty RUNNER_EGRESS_NANGO_PORTS list', () => {
+        expect(() => {
+            parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_PORTS: ',' });
+        }).toThrow(/at least one port/);
+    });
+
+    it('should throw on an invalid port in RUNNER_EGRESS_NANGO_PORTS', () => {
+        expect(() => {
+            parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_PORTS: '80,not-a-port' });
+        }).toThrow('Invalid port in RUNNER_EGRESS_NANGO_PORTS');
+    });
+
     it('should default NANGO_LOGS_PROVIDER to elasticsearch', () => {
         const res = parseEnvs(ENVS, {});
         expect(res.NANGO_LOGS_PROVIDER).toBe('elasticsearch');

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -246,6 +246,31 @@ describe('parse', () => {
         }).toThrow();
     });
 
+    it('should default RUNNER_EGRESS_NANGO_POD_SELECTOR to persist, jobs, and server', () => {
+        const res = parseEnvs(ENVS, {});
+        expect(res.RUNNER_EGRESS_NANGO_POD_SELECTOR).toEqual({
+            matchExpressions: [{ key: 'app.kubernetes.io/component', operator: 'In', values: ['persist', 'jobs', 'server'] }]
+        });
+    });
+
+    it('should parse a valid RUNNER_EGRESS_NANGO_POD_SELECTOR', () => {
+        const selector = { matchLabels: { app: 'persist' } };
+        const res = parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify(selector) });
+        expect(res.RUNNER_EGRESS_NANGO_POD_SELECTOR).toEqual(selector);
+    });
+
+    it('should throw on an empty RUNNER_EGRESS_NANGO_POD_SELECTOR', () => {
+        expect(() => {
+            parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify({}) });
+        }).toThrow(/empty selector is not allowed/);
+    });
+
+    it('should throw on invalid JSON in RUNNER_EGRESS_NANGO_POD_SELECTOR', () => {
+        expect(() => {
+            parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_POD_SELECTOR: 'not-json' });
+        }).toThrow('Invalid JSON in RUNNER_EGRESS_NANGO_POD_SELECTOR');
+    });
+
     it('should default NANGO_LOGS_PROVIDER to elasticsearch', () => {
         const res = parseEnvs(ENVS, {});
         expect(res.NANGO_LOGS_PROVIDER).toBe('elasticsearch');

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -309,6 +309,20 @@ describe('parse', () => {
         }).toThrow(/invalid Kubernetes label key/);
     });
 
+    it('should parse a label key whose DNS prefix segments are 63 characters', () => {
+        const segment = 'a'.repeat(63);
+        const selector = { matchLabels: { [`${segment}.io/app`]: 'persist' } };
+        const res = parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify(selector) });
+        expect(res.RUNNER_EGRESS_NANGO_POD_SELECTOR).toEqual(selector);
+    });
+
+    it('should throw when a label-key prefix has a DNS segment longer than 63 characters', () => {
+        const segment = 'a'.repeat(64);
+        expect(() => {
+            parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify({ matchLabels: { [`${segment}.io/app`]: 'persist' } }) });
+        }).toThrow(/invalid Kubernetes label key/);
+    });
+
     it('should throw on a syntactically invalid label value in RUNNER_EGRESS_NANGO_POD_SELECTOR', () => {
         expect(() => {
             parseEnvs(ENVS, { RUNNER_EGRESS_NANGO_POD_SELECTOR: JSON.stringify({ matchLabels: { app: 'persist!' } }) });


### PR DESCRIPTION
## Summary

Tighten runner NetworkPolicy egress so a runner cannot reach the orchestrator or private/metadata ranges, while still reaching persist, jobs, server, DNS, and the public internet.

- Allow nango internals only to pods matching `RUNNER_EGRESS_NANGO_POD_SELECTOR` (default: `app.kubernetes.io/component` in persist, jobs, server) on TCP 80
- Use the same jobs-namespace label as ingress (`name`) so both sides match
- Allow DNS to kube-system CoreDNS/kube-dns and NodeLocal DNSCache (`169.254.20.10`)
- Except RFC1918, CGNAT, link-local, and cloud-metadata from `0.0.0.0/0`, derived from `NANGO_OUTBOUND_URL_POLICY` via `@nangohq/egress` so JS and CNI stay aligned

Create-only policies (no in-place replace). Ingress unchanged. Datadog stays on UDS, not a network peer.
