### PR TITLE
feat(webapp): show billed-this-month spend in the summary strip

### DIFF
--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -12,6 +12,7 @@ import type {
     BillingOverdueInvoices,
     BillingPlan,
     BillingSubscription,
+    BillingUpcomingInvoice,
     BillingUsageMetrics,
     DBTeam,
     GetBillingUsageOpts
@@ -91,6 +92,10 @@ export class Billing {
 
     async getOverdueInvoices(accountId: number): Promise<Result<BillingOverdueInvoices>> {
         return await this.client.getOverdueInvoices(accountId);
+    }
+
+    async getUpcomingInvoice(subscriptionId: string): Promise<Result<BillingUpcomingInvoice | null>> {
+        return await this.client.getUpcomingInvoice(subscriptionId);
     }
 
     async getUsage(subscriptionId: string, opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetrics>> {

--- a/packages/billing/lib/clients/noop/client.ts
+++ b/packages/billing/lib/clients/noop/client.ts
@@ -8,6 +8,7 @@ import type {
     BillingOverdueInvoices,
     BillingPlan,
     BillingSubscription,
+    BillingUpcomingInvoice,
     BillingUsageMetrics,
     DBTeam,
     GetBillingUsageOpts
@@ -65,6 +66,10 @@ export class NoopBillingClient implements BillingClient {
 
     getOverdueInvoices(_accountId: number): Promise<Result<BillingOverdueInvoices>> {
         return Promise.resolve(Ok({ hasOverdue: false }));
+    }
+
+    getUpcomingInvoice(_subscriptionId: string): Promise<Result<BillingUpcomingInvoice | null>> {
+        return Promise.resolve(Ok(null));
     }
 
     createSubscription(team: DBTeam, planExternalId: string): Promise<Result<BillingSubscription>> {

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -28,7 +28,7 @@ export function orbAmountToCents(amount: string): number | null {
 
     // Groups 2 and 3 are guaranteed by the pattern, but `noUncheckedIndexedAccess` can't see that.
     const whole = match[2] ?? '0';
-    // Some invoices carry more than two decimals; dropping them never overstates what's owed.
+    // Some invoices carry more than two decimals; the extra digits are dropped, not rounded.
     const fraction = match[3] ?? '';
     const cents = Number(whole) * 100 + Number(fraction.padEnd(2, '0').slice(0, 2));
     return match[1] === '-' ? -cents : cents;

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -21,8 +21,10 @@ function cutoverAppliesTo(eventTimestamp: Date): boolean {
  *
  * Parsed off the decimal string rather than `Number(x) * 100`, which is lossy: `Number('19.99') *
  * 100` is 1998.9999999999998. Orb also returns amounts with more than two decimals on some
- * invoices, so the extra digits are dropped rather than rounded — we never want to report more
- * owed than the invoice states. Returns null for anything that isn't a plain decimal.
+ * invoices, so the extra digits are dropped rather than rounded — on an amount owed that means we
+ * never overstate it. Truncation is toward zero, so the same guarantee doesn't hold for a negative
+ * amount; Orb clamps `amount_due` at zero, so that case isn't reachable from an invoice.
+ * Returns null for anything that isn't a plain decimal.
  */
 export function orbAmountToCents(amount: string): number | null {
     const match = /^(-?)(\d+)(?:\.(\d*))?$/.exec(amount.trim());

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -17,14 +17,8 @@ function cutoverAppliesTo(eventTimestamp: Date): boolean {
 }
 
 /**
- * Orb money as an integer number of cents.
- *
- * Parsed off the decimal string rather than `Number(x) * 100`, which is lossy: `Number('19.99') *
- * 100` is 1998.9999999999998. Orb also returns amounts with more than two decimals on some
- * invoices, so the extra digits are dropped rather than rounded — on an amount owed that means we
- * never overstate it. Truncation is toward zero, so the same guarantee doesn't hold for a negative
- * amount; Orb clamps `amount_due` at zero, so that case isn't reachable from an invoice.
- * Returns null for anything that isn't a plain decimal.
+ * Orb money as an integer number of cents, read off the decimal string rather than via
+ * `Number(x) * 100` — that is lossy, giving 1998.9999999999998 for '19.99' instead of 1999.
  */
 export function orbAmountToCents(amount: string): number | null {
     const match = /^(-?)(\d+)(?:\.(\d*))?$/.exec(amount.trim());
@@ -34,6 +28,7 @@ export function orbAmountToCents(amount: string): number | null {
 
     // Groups 2 and 3 are guaranteed by the pattern, but `noUncheckedIndexedAccess` can't see that.
     const whole = match[2] ?? '0';
+    // Some invoices carry more than two decimals; dropping them never overstates what's owed.
     const fraction = match[3] ?? '';
     const cents = Number(whole) * 100 + Number(fraction.padEnd(2, '0').slice(0, 2));
     return match[1] === '-' ? -cents : cents;

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -5,7 +5,7 @@ import { Err, Ok } from '@nangohq/utils';
 import { envs } from '../../envs.js';
 import { putOrbCustomerSchema } from './types.js';
 
-import type { BillingAddress, BillingCustomer, BillingEvent, BillingInvoicingDetails, Result, UsageMetric } from '@nangohq/types';
+import type { BillingAddress, BillingCustomer, BillingEvent, BillingInvoicingDetails, BillingUpcomingInvoice, Result, UsageMetric } from '@nangohq/types';
 import type Orb from 'orb-billing';
 
 // Keyed on the EVENT's timestamp, not the wall clock, so a batched or
@@ -14,6 +14,46 @@ import type Orb from 'orb-billing';
 // packages/utils.
 function cutoverAppliesTo(eventTimestamp: Date): boolean {
     return !!envs.BILLING_EVENTS_CUTOVER_AT && eventTimestamp >= new Date(envs.BILLING_EVENTS_CUTOVER_AT);
+}
+
+/**
+ * Orb money as an integer number of cents.
+ *
+ * Parsed off the decimal string rather than `Number(x) * 100`, which is lossy: `Number('19.99') *
+ * 100` is 1998.9999999999998. Orb also returns amounts with more than two decimals on some
+ * invoices, so the extra digits are dropped rather than rounded — we never want to report more
+ * owed than the invoice states. Returns null for anything that isn't a plain decimal.
+ */
+export function orbAmountToCents(amount: string): number | null {
+    const match = /^(-?)(\d+)(?:\.(\d*))?$/.exec(amount.trim());
+    if (!match) {
+        return null;
+    }
+
+    // Groups 2 and 3 are guaranteed by the pattern, but `noUncheckedIndexedAccess` can't see that.
+    const whole = match[2] ?? '0';
+    const fraction = match[3] ?? '';
+    const cents = Number(whole) * 100 + Number(fraction.padEnd(2, '0').slice(0, 2));
+    return match[1] === '-' ? -cents : cents;
+}
+
+/**
+ * The parts of an upcoming invoice the billing summary needs, or null when the amount can't be
+ * stated: an unparseable amount, or a currency that isn't ISO 4217. Orb returns the literal
+ * `credits` for credit-denominated invoices, which has no dollar meaning to show a customer.
+ */
+export function fromOrbUpcomingInvoice(invoice: { amount_due: string; currency: string }): BillingUpcomingInvoice | null {
+    const amountInCents = orbAmountToCents(invoice.amount_due);
+    if (amountInCents === null) {
+        return null;
+    }
+
+    const currency = invoice.currency.trim().toUpperCase();
+    if (!/^[A-Z]{3}$/.test(currency)) {
+        return null;
+    }
+
+    return { amountInCents, currency };
 }
 
 export function toOrbEvent(event: BillingEvent): Orb.Events.EventIngestParams.Event {

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { envs } from '../../envs.js';
-import { fromOrbAddress, fromOrbCustomer, orbMetricToUsageMetric, toOrbEvent, toOrbPutCustomerPayload } from './adapters.js';
+import {
+    fromOrbAddress,
+    fromOrbCustomer,
+    fromOrbUpcomingInvoice,
+    orbAmountToCents,
+    orbMetricToUsageMetric,
+    toOrbEvent,
+    toOrbPutCustomerPayload
+} from './adapters.js';
 
 import type { BillingEvent, BillingInvoicingDetails } from '@nangohq/types';
 import type Orb from 'orb-billing';
@@ -351,5 +359,66 @@ describe('orbMetricToUsageMetric', () => {
     it('is case-insensitive', () => {
         expect(orbMetricToUsageMetric('PROXY CALLS')).toBe('proxy');
         expect(orbMetricToUsageMetric('function logs')).toBe('function_logs');
+    });
+});
+describe('orbAmountToCents', () => {
+    it('parses a plain decimal amount to integer cents', () => {
+        expect(orbAmountToCents('0.00')).toBe(0);
+        expect(orbAmountToCents('0.07')).toBe(7);
+        expect(orbAmountToCents('149.00')).toBe(14900);
+        expect(orbAmountToCents('1284.30')).toBe(128430);
+    });
+
+    it('does not lose precision the way Number(x) * 100 does', () => {
+        // Number('19.99') * 100 is 1998.9999999999998, which is not a valid cent amount.
+        const cents = orbAmountToCents('19.99');
+        expect(cents).toBe(1999);
+        expect(Number.isInteger(cents)).toBe(true);
+    });
+
+    it('accepts amounts with no decimal part', () => {
+        expect(orbAmountToCents('100')).toBe(10000);
+    });
+
+    it('drops sub-cent precision rather than rounding up', () => {
+        expect(orbAmountToCents('19.9900000000')).toBe(1999);
+        expect(orbAmountToCents('19.999')).toBe(1999);
+        expect(orbAmountToCents('19.9')).toBe(1990);
+        expect(orbAmountToCents('19.')).toBe(1900);
+    });
+
+    it('handles negative amounts', () => {
+        expect(orbAmountToCents('-5.00')).toBe(-500);
+    });
+
+    it('returns null for anything that is not a plain decimal', () => {
+        expect(orbAmountToCents('')).toBeNull();
+        expect(orbAmountToCents('abc')).toBeNull();
+        expect(orbAmountToCents('1.2.3')).toBeNull();
+        expect(orbAmountToCents('1,284.30')).toBeNull();
+        expect(orbAmountToCents('$19.99')).toBeNull();
+    });
+});
+
+describe('fromOrbUpcomingInvoice', () => {
+    it('maps amount and currency', () => {
+        expect(fromOrbUpcomingInvoice({ amount_due: '1284.30', currency: 'USD' })).toEqual({ amountInCents: 128430, currency: 'USD' });
+    });
+
+    it('uppercases the currency', () => {
+        expect(fromOrbUpcomingInvoice({ amount_due: '10.00', currency: 'usd' })).toEqual({ amountInCents: 1000, currency: 'USD' });
+    });
+
+    it('passes through non-USD currencies', () => {
+        expect(fromOrbUpcomingInvoice({ amount_due: '10.00', currency: 'EUR' })).toEqual({ amountInCents: 1000, currency: 'EUR' });
+    });
+
+    it('returns null for a credit-denominated invoice', () => {
+        // Orb bills some customers in credits, which has no dollar meaning to show.
+        expect(fromOrbUpcomingInvoice({ amount_due: '10.00', currency: 'credits' })).toBeNull();
+    });
+
+    it('returns null for an unparseable amount', () => {
+        expect(fromOrbUpcomingInvoice({ amount_due: 'n/a', currency: 'USD' })).toBeNull();
     });
 });

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -414,7 +414,6 @@ describe('fromOrbUpcomingInvoice', () => {
     });
 
     it('returns null for a credit-denominated invoice', () => {
-        // Orb bills some customers in credits, which has no dollar meaning to show.
         expect(fromOrbUpcomingInvoice({ amount_due: '10.00', currency: 'credits' })).toBeNull();
     });
 

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -3,7 +3,7 @@ import Orb from 'orb-billing';
 import { Err, metrics, Ok, retry } from '@nangohq/utils';
 
 import { envs } from '../../envs.js';
-import { fromOrbCustomer, orbMetricToUsageMetric, toOrbEvent, toOrbPutCustomerPayload } from './adapters.js';
+import { fromOrbCustomer, fromOrbUpcomingInvoice, orbMetricToUsageMetric, toOrbEvent, toOrbPutCustomerPayload } from './adapters.js';
 
 import type {
     BillingClient,
@@ -12,6 +12,7 @@ import type {
     BillingInvoicingDetails,
     BillingOverdueInvoices,
     BillingSubscription,
+    BillingUpcomingInvoice,
     BillingUsageMetrics,
     DBTeam,
     GetBillingUsageOpts,
@@ -192,6 +193,32 @@ export class OrbClient implements BillingClient {
                 return Ok({ hasOverdue: false });
             }
             return Err(new Error('failed_to_get_overdue_invoices', { cause: err }));
+        }
+    }
+
+    async getUpcomingInvoice(subscriptionId: string): Promise<Result<BillingUpcomingInvoice | null>> {
+        try {
+            const invoice = await this.orbSDK.invoices.fetchUpcoming(
+                { subscription_id: subscriptionId },
+                {
+                    // https://docs.withorb.com/api-reference/cached-responses
+                    // Longer than getUsage's 60s: usage only syncs daily, and fetchUpcoming
+                    // recomputes a draft invoice server-side, so a short window buys nothing.
+                    headers: {
+                        'Orb-Cache-Control': 'cache',
+                        'Orb-Cache-Max-Age-Seconds': '300'
+                    }
+                }
+            );
+
+            return Ok(fromOrbUpcomingInvoice(invoice));
+        } catch (err) {
+            // No drafted invoice, or a subscription Orb doesn't know about — nothing to report,
+            // which the caller renders as "no figure" rather than as a failure.
+            if (isOrbNotFoundError(err)) {
+                return Ok(null);
+            }
+            return Err(new Error('failed_to_get_upcoming_invoice', { cause: err }));
         }
     }
 

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -213,8 +213,7 @@ export class OrbClient implements BillingClient {
 
             return Ok(fromOrbUpcomingInvoice(invoice));
         } catch (err) {
-            // No drafted invoice, or a subscription Orb doesn't know about — nothing to report,
-            // which the caller renders as "no figure" rather than as a failure.
+            // No drafted invoice, or a subscription Orb doesn't know about — absence, not failure.
             if (isOrbNotFoundError(err)) {
                 return Ok(null);
             }

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -213,8 +213,10 @@ export class OrbClient implements BillingClient {
 
             return Ok(fromOrbUpcomingInvoice(invoice));
         } catch (err) {
-            // No drafted invoice, or a subscription Orb doesn't know about — absence, not failure.
-            if (isOrbNotFoundError(err)) {
+            // No drafted invoice, a subscription Orb doesn't know about, or one that has ended:
+            // absence, not failure. A plan row keeps its `orb_subscription_id` after the
+            // subscription ends, so the ended case is reachable from ordinary data.
+            if (isOrbNotFoundError(err) || isOrbEndedSubscriptionError(err)) {
                 return Ok(null);
             }
             return Err(new Error('failed_to_get_upcoming_invoice', { cause: err }));
@@ -395,4 +397,14 @@ export class OrbClient implements BillingClient {
 
 function isOrbNotFoundError(err: unknown): err is InstanceType<typeof Orb.NotFoundError> {
     return err instanceof Orb.NotFoundError;
+}
+
+// Orb answers a fetchUpcoming for an ended subscription with a 400 rather than a 404, and the only
+// signal is the validation message. Matched narrowly so a genuinely malformed request still errors.
+function isOrbEndedSubscriptionError(err: unknown): boolean {
+    if (!(err instanceof Orb.BadRequestError)) {
+        return false;
+    }
+    const errors = (err.error as { validation_errors?: unknown } | undefined)?.validation_errors;
+    return Array.isArray(errors) && errors.some((e) => typeof e === 'string' && e.includes('status ended'));
 }

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -201,9 +201,6 @@ export class OrbClient implements BillingClient {
             const invoice = await this.orbSDK.invoices.fetchUpcoming(
                 { subscription_id: subscriptionId },
                 {
-                    // https://docs.withorb.com/api-reference/cached-responses
-                    // Longer than getUsage's 60s: usage only syncs daily, and fetchUpcoming
-                    // recomputes a draft invoice server-side, so a short window buys nothing.
                     headers: {
                         'Orb-Cache-Control': 'cache',
                         'Orb-Cache-Max-Age-Seconds': '300'
@@ -213,9 +210,6 @@ export class OrbClient implements BillingClient {
 
             return Ok(fromOrbUpcomingInvoice(invoice));
         } catch (err) {
-            // No drafted invoice, a subscription Orb doesn't know about, or one that has ended:
-            // absence, not failure. A plan row keeps its `orb_subscription_id` after the
-            // subscription ends, so the ended case is reachable from ordinary data.
             if (isOrbNotFoundError(err) || isOrbEndedSubscriptionError(err)) {
                 return Ok(null);
             }

--- a/packages/billing/lib/clients/orb/client.unit.test.ts
+++ b/packages/billing/lib/clients/orb/client.unit.test.ts
@@ -1,3 +1,4 @@
+import Orb from 'orb-billing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OrbClient } from './client.js';
@@ -59,5 +60,44 @@ describe('OrbClient.getOverdueInvoices', () => {
         const { client } = clientWith([]);
 
         expect((await client.getOverdueInvoices(42)).unwrap()).toStrictEqual({ hasOverdue: false });
+    });
+});
+
+/** Stubs `invoices.fetchUpcoming` so the error mapping can be exercised without Orb. */
+function clientRejecting(err: unknown) {
+    const client = new OrbClient();
+    const fetchUpcoming = vi.fn().mockRejectedValue(err);
+    (client as unknown as { orbSDK: { invoices: { fetchUpcoming: typeof fetchUpcoming } } }).orbSDK = { invoices: { fetchUpcoming } };
+    return client;
+}
+
+describe('OrbClient.getUpcomingInvoice', () => {
+    it('reports an ended subscription as no figure rather than a failure', async () => {
+        // Orb answers with a 400, not a 404, and a plan row keeps its subscription id after the
+        // subscription ends — so this is reachable from ordinary data, not a corrupted state.
+        const err = new Orb.BadRequestError(
+            400,
+            {
+                status: 400,
+                title: 'Request validation did not succeed.',
+                validation_errors: ['Unable to view upcoming invoice for subscription with status ended.']
+            },
+            'Request validation did not succeed.',
+            {}
+        );
+
+        expect((await clientRejecting(err).getUpcomingInvoice('sub_ended')).unwrap()).toBeNull();
+    });
+
+    it('still errors on a bad request that is not an ended subscription', async () => {
+        const err = new Orb.BadRequestError(400, { status: 400, validation_errors: ['subscription_id is not a valid id'] }, 'bad', {});
+
+        expect((await clientRejecting(err).getUpcomingInvoice('nope')).isErr()).toBe(true);
+    });
+
+    it('reports a missing subscription as no figure', async () => {
+        const err = new Orb.NotFoundError(404, { status: 404 }, 'not found', {});
+
+        expect((await clientRejecting(err).getUpcomingInvoice('sub_gone')).unwrap()).toBeNull();
     });
 });

--- a/packages/design-system/stories/SummaryStrip.stories.tsx
+++ b/packages/design-system/stories/SummaryStrip.stories.tsx
@@ -11,8 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
  * account's plan — these stories cover every state that decision can produce.
  *
  * Billed plans lead with the period's accrued spend and demote the plan name to its own slot; Free
- * leads with the plan name and has no spend to state. The spend headline is still behind a dev-tool
- * flag in the app, so customers currently see the `SpendUnavailable` shape on every plan.
+ * leads with the plan name.
  *
  * Legacy, enterprise and free-uncapped accounts (30 today) render no strip at all, so they have no
  * story: their terms are negotiated per customer or nothing is billable.
@@ -31,10 +30,7 @@ const editCard = (
     </IconButton>
 );
 
-/**
- * Starter and Growth: the period's accrued spend leads, the plan moves to a slot of its own, and the
- * card is editable inline. The tooltip explains what the figure includes and how fresh it is.
- */
+/** Starter and Growth: spend leads, the plan moves to its own slot, and the card is editable inline. */
 export const Paid: Story = {
     args: {
         headline: { label: 'CURRENT PERIOD SPEND', value: '$1,284.30', tooltip: SPEND_TOOLTIP },
@@ -44,10 +40,7 @@ export const Paid: Story = {
     }
 };
 
-/**
- * The spend read is slower than the plan, so only the figure is skeletoned — the label, the plan and
- * the date are already final, and nothing reflows when the number lands.
- */
+/** Spend resolves after the plan, so only the figure is skeletoned and nothing reflows when it lands. */
 export const SpendLoading: Story = {
     args: {
         headline: { label: 'CURRENT PERIOD SPEND', value: null, tooltip: SPEND_TOOLTIP },
@@ -57,10 +50,7 @@ export const SpendLoading: Story = {
     }
 };
 
-/**
- * The startup deal rates to $0.00 at any volume, so zero is the honest figure rather than a missing
- * one — it leads with spend like any other billed plan.
- */
+/** The startup deal rates to $0.00 at any volume, so zero is the figure rather than a missing one. */
 export const DealWithZeroSpend: Story = {
     args: {
         headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP },
@@ -70,9 +60,8 @@ export const DealWithZeroSpend: Story = {
 };
 
 /**
- * The Orb read failed, or had no invoice drafted yet. The strip falls back to the plan headline
- * rather than an error — a failed read isn't something the customer can act on. This is also what
- * every billed plan looks like while the headline is still behind its rollout flag.
+ * The Orb read failed or had nothing drafted. Falls back to the plan headline rather than an
+ * error — a failed read isn't something the customer can act on.
  */
 export const SpendUnavailable: Story = {
     args: {

--- a/packages/design-system/stories/SummaryStrip.stories.tsx
+++ b/packages/design-system/stories/SummaryStrip.stories.tsx
@@ -1,6 +1,7 @@
 import { Pencil } from 'lucide-react';
 
 import { SummaryStrip } from '@/pages/Team/Billing/components/SummaryStrip';
+import { SPEND_TOOLTIP } from '@/pages/Team/Billing/summaryState';
 import { IconButton } from '../src';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -8,6 +9,10 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 /**
  * The billing page's summary strip. Which slots appear is decided by `buildSummaryState` from the
  * account's plan — these stories cover every state that decision can produce.
+ *
+ * Billed plans lead with the period's accrued spend and demote the plan name to its own slot; Free
+ * leads with the plan name and has no spend to state. The spend headline is still behind a dev-tool
+ * flag in the app, so customers currently see the `SpendUnavailable` shape on every plan.
  *
  * Legacy, enterprise and free-uncapped accounts (30 today) render no strip at all, so they have no
  * story: their terms are negotiated per customer or nothing is billable.
@@ -26,10 +31,52 @@ const editCard = (
     </IconButton>
 );
 
-/** Starter and Growth: the billing period renews, and the card is editable inline. */
+/**
+ * Starter and Growth: the period's accrued spend leads, the plan moves to a slot of its own, and the
+ * card is editable inline. The tooltip explains what the figure includes and how fresh it is.
+ */
 export const Paid: Story = {
     args: {
-        planTitle: 'Growth',
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$1,284.30', tooltip: SPEND_TOOLTIP },
+        plan: { value: 'Growth' },
+        date: { label: 'RENEWS ON', value: 'September 1, 2026' },
+        payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
+    }
+};
+
+/**
+ * The spend read is slower than the plan, so only the figure is skeletoned — the label, the plan and
+ * the date are already final, and nothing reflows when the number lands.
+ */
+export const SpendLoading: Story = {
+    args: {
+        headline: { label: 'CURRENT PERIOD SPEND', value: null, tooltip: SPEND_TOOLTIP },
+        plan: { value: 'Growth' },
+        date: { label: 'RENEWS ON', value: 'September 1, 2026' },
+        payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
+    }
+};
+
+/**
+ * The startup deal rates to $0.00 at any volume, so zero is the honest figure rather than a missing
+ * one — it leads with spend like any other billed plan.
+ */
+export const DealWithZeroSpend: Story = {
+    args: {
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP },
+        plan: { value: 'Startup deal' },
+        payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
+    }
+};
+
+/**
+ * The Orb read failed, or had no invoice drafted yet. The strip falls back to the plan headline
+ * rather than an error — a failed read isn't something the customer can act on. This is also what
+ * every billed plan looks like while the headline is still behind its rollout flag.
+ */
+export const SpendUnavailable: Story = {
+    args: {
+        headline: { label: 'CURRENT PLAN', value: 'Growth' },
         date: { label: 'RENEWS ON', value: 'September 1, 2026' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
     }
@@ -42,7 +89,8 @@ export const Paid: Story = {
  */
 export const PaidWithoutCard: Story = {
     args: {
-        planTitle: 'Starter',
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$50.00', tooltip: SPEND_TOOLTIP },
+        plan: { value: 'Starter' },
         date: { label: 'RENEWS ON', value: 'September 1, 2026' }
     }
 };
@@ -50,7 +98,7 @@ export const PaidWithoutCard: Story = {
 /** Free shows when its caps reset, and never a payment method — even when a card is on file. */
 export const Free: Story = {
     args: {
-        planTitle: 'Free',
+        headline: { label: 'CURRENT PLAN', value: 'Free' },
         date: { label: 'LIMITS RESET', value: 'September 1, 2026' }
     }
 };
@@ -58,7 +106,8 @@ export const Free: Story = {
 /** A scheduled downgrade to Free: the plan isn't renewing, so the date is relabelled and explained. */
 export const Downgrading: Story = {
     args: {
-        planTitle: 'Starter',
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$50.00', tooltip: SPEND_TOOLTIP },
+        plan: { value: 'Starter' },
         date: { label: 'CHANGES ON', value: 'September 1, 2026' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
         change: { toPlanTitle: 'Free', at: 'September 1, 2026', detail: 'no further charges after this period.' }
@@ -68,7 +117,8 @@ export const Downgrading: Story = {
 /** A downgrade between paid plans, which needs no gloss — billing continues at the new plan's rate. */
 export const DowngradingToSmallerPlan: Story = {
     args: {
-        planTitle: 'Growth',
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$1,284.30', tooltip: SPEND_TOOLTIP },
+        plan: { value: 'Growth' },
         date: { label: 'CHANGES ON', value: 'September 1, 2026' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
         change: { toPlanTitle: 'Starter', at: 'September 1, 2026', detail: null }
@@ -78,7 +128,8 @@ export const DowngradingToSmallerPlan: Story = {
 /** A YC startup deal converting to Growth — same treatment, opposite direction. */
 export const DealConverting: Story = {
     args: {
-        planTitle: 'Startup deal',
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP },
+        plan: { value: 'Startup deal' },
         date: { label: 'CHANGES ON', value: 'September 25, 2026' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
         change: {
@@ -92,7 +143,8 @@ export const DealConverting: Story = {
 /** A deal with no conversion date stored yet — no date rather than a false renewal (NAN-6640). */
 export const DealWithoutDate: Story = {
     args: {
-        planTitle: 'Startup deal',
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP },
+        plan: { value: 'Startup deal' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
     }
 };
@@ -100,6 +152,6 @@ export const DealWithoutDate: Story = {
 /** While the plan resolves, nothing else can — the plan decides which slots exist. */
 export const Loading: Story = {
     args: {
-        planTitle: null
+        headline: null
     }
 };

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.integration.test.ts
@@ -131,13 +131,15 @@ describe(`GET ${route}`, () => {
             expect(res.json.error.code).toBe('server_error');
         });
 
-        it('should 500 when a spend plan has no linked subscription', async () => {
+        it('should report no figure when a spend plan has no linked subscription', async () => {
+            // Reachable before the Orb link exists, so it degrades rather than erroring.
             const { apiKey } = await seedPlan('starter-v2', { subscriptionId: null });
 
             const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
 
-            isError(res.json);
-            expect(res.res.status).toBe(500);
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+            expect(res.json.data).toStrictEqual({ amountInCents: null, currency: null });
             expect(getUpcomingInvoiceSpy).not.toHaveBeenCalled();
         });
     });

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.integration.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { billing } from '@nangohq/billing';
+import db from '@nangohq/database';
+import { seeders, updatePlan } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import { isError, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../utils/tests.js';
+
+const route = '/api/v1/plans/billing/upcoming-invoice';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+let getUpcomingInvoiceSpy: any;
+
+/** Seeds an account on `planName` with a linked Orb subscription, and returns its api key. */
+async function seedPlan(planName: string, { subscriptionId = 'orb_sub_123' }: { subscriptionId?: string | null } = {}) {
+    const seed = await seeders.seedAccountEnvAndUser();
+    await updatePlan(db.knex, { id: seed.plan.id, name: planName as any, orb_subscription_id: subscriptionId });
+    return seed;
+}
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+        getUpcomingInvoiceSpy = vi.spyOn(billing, 'getUpcomingInvoice');
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getUpcomingInvoiceSpy.mockResolvedValue(Ok({ amountInCents: 128430, currency: 'USD' }));
+    });
+
+    describe('Authentication & Authorization', () => {
+        it('should be protected', async () => {
+            const res = await api.fetch(route, { method: 'GET', query: { env: 'dev' } });
+
+            shouldBeProtected(res);
+        });
+
+        it('should enforce env query param', async () => {
+            const { apiKey } = await seeders.seedAccountEnvAndUser();
+            const res = await api.fetch(route, {
+                method: 'GET',
+                token: apiKey.secret,
+                // @ts-expect-error missing env on purpose
+                query: {}
+            });
+
+            shouldRequireQueryEnv(res);
+        });
+
+        it('should reject extra params in query', async () => {
+            const { apiKey } = await seeders.seedAccountEnvAndUser();
+            const res = await api.fetch(route, {
+                method: 'GET',
+                token: apiKey.secret,
+                // @ts-expect-error extra param on purpose
+                query: { env: 'dev', foo: 'bar' }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_query_params');
+        });
+    });
+
+    describe('Plan gating', () => {
+        it.each(['free', 'free-uncapped', 'enterprise'])('should not call Orb on %s', async (planName) => {
+            const { apiKey } = await seedPlan(planName);
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+            expect(res.json.data).toStrictEqual({ amountInCents: null, currency: null });
+            // The gate exists to keep a non-monthly plan's contract total off this endpoint, so
+            // "returned null" is not enough — the call must not happen at all.
+            expect(getUpcomingInvoiceSpy).not.toHaveBeenCalled();
+        });
+
+        it.each(['starter-v2', 'growth-v2', 'startup-deal'])('should return the upcoming amount on %s', async (planName) => {
+            const { apiKey } = await seedPlan(planName);
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+            expect(res.json.data).toStrictEqual({ amountInCents: 128430, currency: 'USD' });
+            expect(getUpcomingInvoiceSpy).toHaveBeenCalledWith('orb_sub_123');
+        });
+
+        it('should report zero rather than falling back — the startup deal really does bill $0.00', async () => {
+            const { apiKey } = await seedPlan('startup-deal');
+            getUpcomingInvoiceSpy.mockResolvedValue(Ok({ amountInCents: 0, currency: 'USD' }));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data).toStrictEqual({ amountInCents: 0, currency: 'USD' });
+        });
+    });
+
+    describe('Orb responses', () => {
+        it('should return null when Orb has no drafted invoice', async () => {
+            const { apiKey } = await seedPlan('starter-v2');
+            getUpcomingInvoiceSpy.mockResolvedValue(Ok(null));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data).toStrictEqual({ amountInCents: null, currency: null });
+        });
+
+        it('should 500 when the Orb read fails', async () => {
+            const { apiKey } = await seedPlan('starter-v2');
+            getUpcomingInvoiceSpy.mockResolvedValue(Err(new Error('failed_to_get_upcoming_invoice')));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isError(res.json);
+            expect(res.res.status).toBe(500);
+            expect(res.json.error.code).toBe('server_error');
+        });
+
+        it('should 500 when a spend plan has no linked subscription', async () => {
+            const { apiKey } = await seedPlan('starter-v2', { subscriptionId: null });
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isError(res.json);
+            expect(res.res.status).toBe(500);
+            expect(getUpcomingInvoiceSpy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.integration.test.ts
@@ -15,7 +15,12 @@ let getUpcomingInvoiceSpy: any;
 /** Seeds an account on `planName` with a linked Orb subscription, and returns its api key. */
 async function seedPlan(planName: string, { subscriptionId = 'orb_sub_123' }: { subscriptionId?: string | null } = {}) {
     const seed = await seeders.seedAccountEnvAndUser();
-    await updatePlan(db.knex, { id: seed.plan.id, name: planName as any, orb_subscription_id: subscriptionId });
+    // The whole suite asserts on plan gating, so a silently failed update would test the seeded
+    // default plan instead and pass for the wrong reason.
+    const updated = await updatePlan(db.knex, { id: seed.plan.id, name: planName as any, orb_subscription_id: subscriptionId });
+    if (updated.isErr()) {
+        throw updated.error;
+    }
     return seed;
 }
 

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
@@ -5,9 +5,9 @@ import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { DBPlan, GetUpcomingInvoice } from '@nangohq/types';
 
-// An allowlist rather than a denylist, and exhaustive so a new plan can't inherit a figure by
-// default: `amount_due` is the whole invoice, which on an annual contract is the contract total —
-// one enterprise account audited in Aug 2026 had $30,000 upcoming.
+// Monthly-billed plans only. `amount_due` is the whole upcoming invoice, so on an annual contract
+// it states the contract total rather than this period's charge — $30,000 on one enterprise account.
+// Exhaustive, so a new plan has to be classified rather than inheriting a figure.
 const SPEND_PLANS: Record<DBPlan['name'], boolean> = {
     'starter-v2': true,
     'growth-v2': true,
@@ -38,15 +38,11 @@ export const getUpcomingInvoice = asyncWrapper<GetUpcomingInvoice>(async (req, r
         return;
     }
 
-    // Against `true`, not truthiness: `plan.name` is a DB value, and one colliding with an
-    // Object.prototype key would otherwise read as allowed.
     if (SPEND_PLANS[plan.name] !== true) {
         res.status(200).send({ data: NO_SPEND });
         return;
     }
 
-    // No customer backfill unlike getBillingUsage — this is keyed by subscription, so there's no
-    // customer-keyed call to prepare for.
     if (!plan.orb_subscription_id) {
         report(new Error('billing_subscription_not_found', { cause: { accountId: plan.account_id, plan: plan.name } }));
         res.status(500).send({ error: { code: 'server_error', message: 'Billing subscription not found' } });

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
@@ -1,0 +1,56 @@
+import { billing } from '@nangohq/billing';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+
+import type { DBPlan, GetUpcomingInvoice } from '@nangohq/types';
+
+// An allowlist, deliberately inverted from NON_PAYING_PLANS in getOverdueInvoices: a plan added to
+// DBPlan['name'] should default to *not* reporting spend. A missing figure is a gap; a wrong one is
+// a support ticket.
+//
+// The reason is specific to this field. Orb's upcoming invoice states the whole invoice, which on a
+// long-term or annual contract is the contract total, not a month's charge — one enterprise account
+// audited in Aug 2026 had a $30,000 upcoming invoice. So only plans we've confirmed bill on a
+// monthly cycle belong here.
+const SPEND_PLANS: DBPlan['name'][] = ['starter-v2', 'growth-v2', 'startup-deal'];
+
+const NO_SPEND = { amountInCents: null, currency: null };
+
+export const getUpcomingInvoice = asyncWrapper<GetUpcomingInvoice>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const { plan } = res.locals;
+    if (!plan) {
+        res.status(400).send({ error: { code: 'feature_disabled' } });
+        return;
+    }
+
+    if (!SPEND_PLANS.includes(plan.name)) {
+        res.status(200).send({ data: NO_SPEND });
+        return;
+    }
+
+    // No customer backfill here, unlike getBillingUsage: the upcoming invoice is keyed by
+    // subscription, so there is no customer-keyed call to prepare for. A spend plan with no
+    // subscription is a real data inconsistency rather than a state to paper over.
+    if (!plan.orb_subscription_id) {
+        report(new Error('billing_subscription_not_found', { cause: { accountId: plan.account_id, plan: plan.name } }));
+        res.status(500).send({ error: { code: 'server_error', message: 'Billing subscription not found' } });
+        return;
+    }
+
+    const invoiceRes = await billing.getUpcomingInvoice(plan.orb_subscription_id);
+    if (invoiceRes.isErr()) {
+        report(invoiceRes.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to get upcoming invoice' } });
+        return;
+    }
+
+    const invoice = invoiceRes.value;
+    res.status(200).send({ data: invoice ? { amountInCents: invoice.amountInCents, currency: invoice.currency } : NO_SPEND });
+});

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
@@ -5,17 +5,9 @@ import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { DBPlan, GetUpcomingInvoice } from '@nangohq/types';
 
-// An allowlist, deliberately inverted from NON_PAYING_PLANS in getOverdueInvoices: a plan added to
-// DBPlan['name'] should default to *not* reporting spend. A missing figure is a gap; a wrong one is
-// a support ticket.
-//
-// The reason is specific to this field. Orb's upcoming invoice states the whole invoice, which on a
-// long-term or annual contract is the contract total, not a month's charge — one enterprise account
-// audited in Aug 2026 had a $30,000 upcoming invoice. So only plans we've confirmed bill on a
-// monthly cycle belong here.
-// Exhaustive over `DBPlan['name']`, mirroring the webapp's planVisibility maps: a plan added to
-// the type fails to compile here until it's been classified, so it can't inherit a figure by
-// default on either side.
+// An allowlist rather than a denylist, and exhaustive so a new plan can't inherit a figure by
+// default: `amount_due` is the whole invoice, which on an annual contract is the contract total —
+// one enterprise account audited in Aug 2026 had $30,000 upcoming.
 const SPEND_PLANS: Record<DBPlan['name'], boolean> = {
     'starter-v2': true,
     'growth-v2': true,
@@ -46,16 +38,15 @@ export const getUpcomingInvoice = asyncWrapper<GetUpcomingInvoice>(async (req, r
         return;
     }
 
-    // Compared against `true` rather than checked for truthiness: `plan.name` is a DB value, and
-    // an unlisted one that collides with an Object.prototype key would otherwise read as allowed.
+    // Against `true`, not truthiness: `plan.name` is a DB value, and one colliding with an
+    // Object.prototype key would otherwise read as allowed.
     if (SPEND_PLANS[plan.name] !== true) {
         res.status(200).send({ data: NO_SPEND });
         return;
     }
 
-    // No customer backfill here, unlike getBillingUsage: the upcoming invoice is keyed by
-    // subscription, so there is no customer-keyed call to prepare for. A spend plan with no
-    // subscription is a real data inconsistency rather than a state to paper over.
+    // No customer backfill unlike getBillingUsage — this is keyed by subscription, so there's no
+    // customer-keyed call to prepare for.
     if (!plan.orb_subscription_id) {
         report(new Error('billing_subscription_not_found', { cause: { accountId: plan.account_id, plan: plan.name } }));
         res.status(500).send({ error: { code: 'server_error', message: 'Billing subscription not found' } });

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
@@ -43,9 +43,10 @@ export const getUpcomingInvoice = asyncWrapper<GetUpcomingInvoice>(async (req, r
         return;
     }
 
+    // A spend plan can exist before its Orb subscription is linked — granted manually, or a
+    // deployment with billing switched off. No figure to state, not a failure.
     if (!plan.orb_subscription_id) {
-        report(new Error('billing_subscription_not_found', { cause: { accountId: plan.account_id, plan: plan.name } }));
-        res.status(500).send({ error: { code: 'server_error', message: 'Billing subscription not found' } });
+        res.status(200).send({ data: NO_SPEND });
         return;
     }
 

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
@@ -46,7 +46,9 @@ export const getUpcomingInvoice = asyncWrapper<GetUpcomingInvoice>(async (req, r
         return;
     }
 
-    if (!SPEND_PLANS[plan.name]) {
+    // Compared against `true` rather than checked for truthiness: `plan.name` is a DB value, and
+    // an unlisted one that collides with an Object.prototype key would otherwise read as allowed.
+    if (SPEND_PLANS[plan.name] !== true) {
         res.status(200).send({ data: NO_SPEND });
         return;
     }

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
@@ -13,7 +13,23 @@ import type { DBPlan, GetUpcomingInvoice } from '@nangohq/types';
 // long-term or annual contract is the contract total, not a month's charge — one enterprise account
 // audited in Aug 2026 had a $30,000 upcoming invoice. So only plans we've confirmed bill on a
 // monthly cycle belong here.
-const SPEND_PLANS: DBPlan['name'][] = ['starter-v2', 'growth-v2', 'startup-deal'];
+// Exhaustive over `DBPlan['name']`, mirroring the webapp's planVisibility maps: a plan added to
+// the type fails to compile here until it's been classified, so it can't inherit a figure by
+// default on either side.
+const SPEND_PLANS: Record<DBPlan['name'], boolean> = {
+    'starter-v2': true,
+    'growth-v2': true,
+    'startup-deal': true,
+    free: false,
+    'free-uncapped': false,
+    enterprise: false,
+    'enterprise-cloud-hosted': false,
+    starter: false,
+    growth: false,
+    'starter-legacy': false,
+    'scale-legacy': false,
+    'growth-legacy': false
+};
 
 const NO_SPEND = { amountInCents: null, currency: null };
 
@@ -30,7 +46,7 @@ export const getUpcomingInvoice = asyncWrapper<GetUpcomingInvoice>(async (req, r
         return;
     }
 
-    if (!SPEND_PLANS.includes(plan.name)) {
+    if (!SPEND_PLANS[plan.name]) {
         res.status(200).send({ data: NO_SPEND });
         return;
     }

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -103,6 +103,7 @@ import { getMeta } from './controllers/v1/meta/getMeta.js';
 import { postOrbWebhooks } from './controllers/v1/orb/postWebhooks.js';
 import { getPlainHmac } from './controllers/v1/plain/getHmac.js';
 import { getOverdueInvoices } from './controllers/v1/plans/billing/getOverdueInvoices.js';
+import { getUpcomingInvoice } from './controllers/v1/plans/billing/getUpcomingInvoice.js';
 import { putInvoicingDetails } from './controllers/v1/plans/billing/putInvoicingDetails.js';
 import { postPlanChange } from './controllers/v1/plans/change/postChange.js';
 import { getCurrentPlan } from './controllers/v1/plans/getCurrent.js';
@@ -287,6 +288,7 @@ web.route('/plans/billing-usage').get(webAuth, getBillingUsage);
 web.route('/plans/billing-usage/top-dimension-values').get(webAuth, getBillingUsageTopDimensionValues);
 web.route('/plans/billing/invoicing').put(webAuth, auditBillingDetailsChanged, can(p.canChangePlan), putInvoicingDetails);
 web.route('/plans/billing/overdue').get(webAuth, getOverdueInvoices);
+web.route('/plans/billing/upcoming-invoice').get(webAuth, can(p.canManageBilling), getUpcomingInvoice);
 web.route('/plans/change').post(webAuth, auditBillingPlanChanged, can(p.canChangePlan), postPlanChange);
 
 // Environments

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -288,7 +288,7 @@ web.route('/plans/billing-usage').get(webAuth, getBillingUsage);
 web.route('/plans/billing-usage/top-dimension-values').get(webAuth, getBillingUsageTopDimensionValues);
 web.route('/plans/billing/invoicing').put(webAuth, auditBillingDetailsChanged, can(p.canChangePlan), putInvoicingDetails);
 web.route('/plans/billing/overdue').get(webAuth, getOverdueInvoices);
-web.route('/plans/billing/upcoming-invoice').get(webAuth, can(p.canManageBilling), getUpcomingInvoice);
+web.route('/plans/billing/upcoming-invoice').get(webAuth, getUpcomingInvoice);
 web.route('/plans/change').post(webAuth, auditBillingPlanChanged, can(p.canChangePlan), postPlanChange);
 
 // Environments

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -125,6 +125,7 @@ import type {
     GetBillingUsage,
     GetBillingUsageTopDimensionValues,
     GetOverdueInvoices,
+    GetUpcomingInvoice,
     PostPlanChange,
     PostPlanExtendTrial,
     PutBillingInvoicingDetails
@@ -232,6 +233,7 @@ export type PrivateApiEndpoints =
     | GetOverdueInvoices
     | GetBillingUsage
     | GetBillingUsageTopDimensionValues
+    | GetUpcomingInvoice
     | GetUser
     | PatchUser
     | PutUserPassword

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -73,11 +73,7 @@ export interface BillingOverdueInvoices {
     hasOverdue: boolean;
 }
 
-/**
- * Orb's "upcoming" invoice for a subscription. Derived from `amount_due`, which is the *whole*
- * invoice — on an annual contract that's the contract total, not a month's charge, so only read
- * this for plans billed monthly.
- */
+/** Orb's upcoming invoice for a subscription — the whole invoice, not a month's slice of it. */
 export interface BillingUpcomingInvoice {
     amountInCents: number;
     /** ISO 4217, uppercased. Orb's `credits` is rejected upstream. */

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -10,6 +10,7 @@ export interface BillingClient {
     putCustomer: (accountId: number, invoicingDetails: BillingInvoicingDetails) => Promise<Result<BillingCustomer>>;
     getSubscription: (accountId: number) => Promise<Result<BillingSubscription | null>>;
     getOverdueInvoices: (accountId: number) => Promise<Result<BillingOverdueInvoices>>;
+    getUpcomingInvoice: (subscriptionId: string) => Promise<Result<BillingUpcomingInvoice | null>>;
     createSubscription: (team: DBTeam, planExternalId: string) => Promise<Result<BillingSubscription>>;
     getUsage: (subscriptionId: string, opts?: GetBillingUsageOpts) => Promise<Result<BillingUsageMetrics>>;
     upgrade: (opts: { subscriptionId: string; planExternalId: string }) => Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>>;
@@ -70,6 +71,21 @@ export interface BillingSubscription {
 
 export interface BillingOverdueInvoices {
     hasOverdue: boolean;
+}
+
+/**
+ * The subscription's in-progress invoice for the current billing period — what Orb calls the
+ * "upcoming" invoice. Amount is integer cents: Orb states amounts as decimal strings precisely so
+ * callers don't do float math, and cents matches `upgrade`'s `amountInCents`.
+ *
+ * Note `amount_due`, which this is derived from, is the *whole* invoice — on a long-term or annual
+ * contract that is the contract total, not a month's charge. Only read it for plans billed on a
+ * monthly cycle.
+ */
+export interface BillingUpcomingInvoice {
+    amountInCents: number;
+    /** ISO 4217, uppercased. Orb also returns the literal `credits`, which we reject upstream. */
+    currency: string;
 }
 
 export type CounterUsageMetric = Exclude<UsageMetric, 'records' | 'connections'>;

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -74,17 +74,13 @@ export interface BillingOverdueInvoices {
 }
 
 /**
- * The subscription's in-progress invoice for the current billing period — what Orb calls the
- * "upcoming" invoice. Amount is integer cents: Orb states amounts as decimal strings precisely so
- * callers don't do float math, and cents matches `upgrade`'s `amountInCents`.
- *
- * Note `amount_due`, which this is derived from, is the *whole* invoice — on a long-term or annual
- * contract that is the contract total, not a month's charge. Only read it for plans billed on a
- * monthly cycle.
+ * Orb's "upcoming" invoice for a subscription. Derived from `amount_due`, which is the *whole*
+ * invoice — on an annual contract that's the contract total, not a month's charge, so only read
+ * this for plans billed monthly.
  */
 export interface BillingUpcomingInvoice {
     amountInCents: number;
-    /** ISO 4217, uppercased. Orb also returns the literal `credits`, which we reject upstream. */
+    /** ISO 4217, uppercased. Orb's `credits` is rejected upstream. */
     currency: string;
 }
 

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -159,12 +159,8 @@ export type GetOverdueInvoices = ApiEndpoint<{
     };
 }>;
 
-// The subscription's in-progress invoice for the current billing period, backing the
-// "CURRENT PERIOD SPEND" headline on the billing summary strip. Only plans billed on a monthly
-// cycle reach Orb; everything else short-circuits to a null amount without a call.
-//
-// Null covers three cases the UI treats alike — the plan gets no spend figure, Orb has no drafted
-// invoice, or the amount wasn't stateable. All three mean "lead with the plan name instead".
+// Backs the "CURRENT PERIOD SPEND" headline on the billing summary strip. A null amount covers
+// every case the UI treats alike — plan not eligible, nothing drafted, amount not stateable.
 export type GetUpcomingInvoice = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
@@ -173,7 +169,6 @@ export type GetUpcomingInvoice = ApiEndpoint<{
     Success: {
         data: {
             amountInCents: number | null;
-            /** ISO 4217; null alongside a null amount. */
             currency: string | null;
         };
     };

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -159,8 +159,6 @@ export type GetOverdueInvoices = ApiEndpoint<{
     };
 }>;
 
-// A null amount is the single "no figure" signal, whatever the cause: plan not billed monthly,
-// nothing drafted yet, or an amount Orb didn't state in a usable currency.
 export type GetUpcomingInvoice = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -159,6 +159,26 @@ export type GetOverdueInvoices = ApiEndpoint<{
     };
 }>;
 
+// The subscription's in-progress invoice for the current billing period, backing the
+// "CURRENT PERIOD SPEND" headline on the billing summary strip. Only plans billed on a monthly
+// cycle reach Orb; everything else short-circuits to a null amount without a call.
+//
+// Null covers three cases the UI treats alike — the plan gets no spend figure, Orb has no drafted
+// invoice, or the amount wasn't stateable. All three mean "lead with the plan name instead".
+export type GetUpcomingInvoice = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
+    Method: 'GET';
+    Path: '/api/v1/plans/billing/upcoming-invoice';
+    Querystring: { env: string };
+    Success: {
+        data: {
+            amountInCents: number | null;
+            /** ISO 4217; null alongside a null amount. */
+            currency: string | null;
+        };
+    };
+}>;
+
 export type PutBillingInvoicingDetails = ApiEndpoint<{
     Audit: AuditPolicy<'billing', 'details_changed', 'account'>;
     Method: 'PUT';

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -159,8 +159,8 @@ export type GetOverdueInvoices = ApiEndpoint<{
     };
 }>;
 
-// Backs the "CURRENT PERIOD SPEND" headline on the billing summary strip. A null amount covers
-// every case the UI treats alike — plan not eligible, nothing drafted, amount not stateable.
+// A null amount is the single "no figure" signal, whatever the cause: plan not billed monthly,
+// nothing drafted yet, or an amount Orb didn't state in a usable currency.
 export type GetUpcomingInvoice = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';

--- a/packages/webapp/src/components/ui/Tooltip.tsx
+++ b/packages/webapp/src/components/ui/Tooltip.tsx
@@ -23,7 +23,7 @@ function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimiti
 }
 
 const tooltipContentVariants = cva(
-    'text-text-secondary animate-in fade-in-0 zoom-in-95 shadow-md data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-80 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-s leading-4 text-balance',
+    'text-text-secondary animate-in fade-in-0 zoom-in-95 shadow-md data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-80 w-fit max-w-sm origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-s leading-4 text-balance',
     {
         variants: {
             variant: {

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -5,10 +5,11 @@ import { IconButton } from '@nangohq/design-system';
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
+import { showsSpendHeadline } from '@/pages/Team/Billing/planVisibility';
 import { useStore } from '@/store';
 import { usePlanOverrideStore } from './planOverride';
 
-import type { UsageLimitOverride } from './planOverride';
+import type { SpendOverride, UsageLimitOverride } from './planOverride';
 import type { PlanDefinition } from '@nangohq/types';
 
 const REAL_PLAN_VALUE = '__real__';
@@ -16,6 +17,10 @@ const NO_SCHEDULED_CHANGE_VALUE = '__none__';
 const REAL_OVERDUE_VALUE = '__real_state__';
 const OVERDUE_VALUE = '__overdue__';
 const REAL_USAGE_VALUE = '__real_usage__';
+const REAL_SPEND_VALUE = '__real_spend__';
+const UNAVAILABLE_SPEND_VALUE = 'unavailable';
+// A base-only Starter bill, a mid-period Growth bill, and zero (what the startup deal really bills).
+const SPEND_PRESETS_IN_CENTS = [0, 5000, 128430];
 // Only these 3 self-serve tiers have a real downgrade/cancellation path — legacy and Enterprise
 // plans never schedule a change in practice, so they're not offered as scheduled-change targets.
 const MAIN_PLAN_ORDER: PlanDefinition['code'][] = ['free', 'starter-v2', 'growth-v2'];
@@ -36,11 +41,16 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
     const setOverdueOverride = usePlanOverrideStore((s) => s.setOverdueOverride);
     const usageLimitOverride = usePlanOverrideStore((s) => s.usageLimitOverride);
     const setUsageLimitOverride = usePlanOverrideStore((s) => s.setUsageLimitOverride);
+    const spendHeadlineEnabled = usePlanOverrideStore((s) => s.spendHeadlineEnabled);
+    const setSpendHeadlineEnabled = usePlanOverrideStore((s) => s.setSpendHeadlineEnabled);
+    const spendOverride = usePlanOverrideStore((s) => s.spendOverride);
+    const setSpendOverride = usePlanOverrideStore((s) => s.setSpendOverride);
 
     // Plan caps are enforced on Free only, so that simulator is offered there alone. Overdue invoices
     // aren't plan-specific — a downgraded account can still owe one — so that one is always offered.
     const { data: environmentData } = useCurrentPlan(env);
     const isFreePlan = environmentData?.plan?.name === 'free';
+    const leadsWithSpend = showsSpendHeadline(environmentData?.plan);
 
     // Several plans share a title — `starter` and `starter-legacy` are both "Starter (legacy)", as are
     // `growth` and `growth-legacy` — which makes them indistinguishable in the list. Append the code to
@@ -132,6 +142,54 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                         </SelectContent>
                     </Select>
                 </div>
+
+                {leadsWithSpend && (
+                    <div className="flex flex-col gap-3 border-t border-border-muted pt-4">
+                        <div className="flex flex-col gap-1.5">
+                            <span className="text-sm text-text-muted">Current period spend headline (unverified — hidden from customers)</span>
+                            <Select value={spendHeadlineEnabled ? 'on' : 'off'} onValueChange={(value) => setSpendHeadlineEnabled(value === 'on')}>
+                                <SelectTrigger className="w-full text-sm px-2.5 gap-2">
+                                    <SelectValue placeholder="Hidden" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="off">Hidden (plan name headline)</SelectItem>
+                                    <SelectItem value="on">Shown</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        {spendHeadlineEnabled && (
+                            <div className="flex flex-col gap-1.5">
+                                <span className="text-sm text-text-muted">Simulate spend (the local billing client returns none)</span>
+                                <Select
+                                    value={spendOverride === null ? REAL_SPEND_VALUE : String(spendOverride)}
+                                    onValueChange={(value) =>
+                                        setSpendOverride(
+                                            value === REAL_SPEND_VALUE
+                                                ? null
+                                                : value === UNAVAILABLE_SPEND_VALUE
+                                                  ? UNAVAILABLE_SPEND_VALUE
+                                                  : (Number(value) as SpendOverride)
+                                        )
+                                    }
+                                >
+                                    <SelectTrigger className="w-full text-sm px-2.5 gap-2">
+                                        <SelectValue placeholder="Real spend" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value={REAL_SPEND_VALUE}>Real spend (no override)</SelectItem>
+                                        {SPEND_PRESETS_IN_CENTS.map((cents) => (
+                                            <SelectItem key={cents} value={String(cents)}>
+                                                {(cents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
+                                            </SelectItem>
+                                        ))}
+                                        <SelectItem value={UNAVAILABLE_SPEND_VALUE}>Unavailable (falls back to plan name)</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        )}
+                    </div>
+                )}
 
                 {isFreePlan && (
                     <div className="flex flex-col gap-1.5 border-t border-border-muted pt-4">

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -19,7 +19,7 @@ const OVERDUE_VALUE = '__overdue__';
 const REAL_USAGE_VALUE = '__real_usage__';
 const REAL_SPEND_VALUE = '__real_spend__';
 const UNAVAILABLE_SPEND_VALUE = 'unavailable';
-// A base-only Starter bill, a mid-period Growth bill, and zero (what the startup deal really bills).
+// A base-only Starter bill, a mid-period Growth bill, and the startup deal's real zero.
 const SPEND_PRESETS_IN_CENTS = [0, 5000, 128430];
 // Only these 3 self-serve tiers have a real downgrade/cancellation path — legacy and Enterprise
 // plans never schedule a change in practice, so they're not offered as scheduled-change targets.

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -3,10 +3,13 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 import { LocalStorageKeys } from '@/utils/local-storage';
 
-import type { ApiPlan, GetOverdueInvoices, PlanDefinition } from '@nangohq/types';
+import type { ApiPlan, GetOverdueInvoices, GetUpcomingInvoice, PlanDefinition } from '@nangohq/types';
 
 /** Simulated aggregate usage state, matching what `getAggregateUsageState` can return. */
 export type UsageLimitOverride = 'near' | 'over';
+
+/** Simulated current-period spend: an amount in cents, or a failed read. */
+export type SpendOverride = number | 'unavailable';
 
 interface PlanOverrideState {
     /** The plan code to visually preview instead of the account's real plan, or `null` for the real plan. */
@@ -17,10 +20,20 @@ interface PlanOverrideState {
     overdueOverride: boolean;
     /** Plan-limit state to simulate, or `null` to use real usage. Free plan only. */
     usageLimitOverride: UsageLimitOverride | null;
+    /**
+     * Reveals the current-period spend headline on the summary strip. Off until the figure is
+     * verified against real Orb invoices — until then customers keep the plan-name headline and we
+     * never call the endpoint for them. Delete this flag once the headline ships to everyone.
+     */
+    spendHeadlineEnabled: boolean;
+    /** Spend to simulate, or `null` for the real Orb answer. Only meaningful with the flag on. */
+    spendOverride: SpendOverride | null;
     setOverride: (code: PlanDefinition['code'] | null) => void;
     setScheduledTarget: (code: PlanDefinition['code'] | null) => void;
     setOverdueOverride: (override: boolean) => void;
     setUsageLimitOverride: (override: UsageLimitOverride | null) => void;
+    setSpendHeadlineEnabled: (enabled: boolean) => void;
+    setSpendOverride: (override: SpendOverride | null) => void;
 }
 
 export const usePlanOverrideStore = create<PlanOverrideState>()(
@@ -30,12 +43,19 @@ export const usePlanOverrideStore = create<PlanOverrideState>()(
             scheduledTargetCode: null,
             overdueOverride: false,
             usageLimitOverride: null,
+            spendHeadlineEnabled: false,
+            spendOverride: null,
             // Reset the simulated states too — each is only valid for the plan it was picked against,
             // and the two are offered on opposite sides of the paid/free split.
-            setOverride: (overrideCode) => set({ overrideCode, scheduledTargetCode: null, overdueOverride: false, usageLimitOverride: null }),
+            // `spendHeadlineEnabled` is deliberately not reset: it's a rollout flag, not a
+            // simulated state, so it shouldn't switch itself off every time you preview a plan.
+            setOverride: (overrideCode) =>
+                set({ overrideCode, scheduledTargetCode: null, overdueOverride: false, usageLimitOverride: null, spendOverride: null }),
             setScheduledTarget: (scheduledTargetCode) => set({ scheduledTargetCode }),
             setOverdueOverride: (overdueOverride) => set({ overdueOverride }),
-            setUsageLimitOverride: (usageLimitOverride) => set({ usageLimitOverride })
+            setUsageLimitOverride: (usageLimitOverride) => set({ usageLimitOverride }),
+            setSpendHeadlineEnabled: (spendHeadlineEnabled) => set({ spendHeadlineEnabled }),
+            setSpendOverride: (spendOverride) => set({ spendOverride })
         }),
         {
             name: LocalStorageKeys.DevPlanOverride,
@@ -58,6 +78,18 @@ export function buildOverdueOverride(realPortalUrl?: string | null): GetOverdueI
             portalUrl: realPortalUrl ?? null
         }
     };
+}
+
+/**
+ * Stands in for the real upcoming-invoice response when the dev-tool override is on, for visual QA
+ * only. `'unavailable'` produces the null amount the strip renders as a fallback to the plan name,
+ * which is also what a failed Orb read looks like from here.
+ */
+export function buildSpendOverride(override: SpendOverride): GetUpcomingInvoice['Success'] {
+    if (override === 'unavailable') {
+        return { data: { amountInCents: null, currency: null } };
+    }
+    return { data: { amountInCents: override, currency: 'USD' } };
 }
 
 /** Overlays a dev-tool plan override (and optional simulated scheduled change) onto a real plan, for visual QA only. */

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -8,7 +8,6 @@ import type { ApiPlan, GetOverdueInvoices, GetUpcomingInvoice, PlanDefinition } 
 /** Simulated aggregate usage state, matching what `getAggregateUsageState` can return. */
 export type UsageLimitOverride = 'near' | 'over';
 
-/** Simulated current-period spend: an amount in cents, or a failed read. */
 export type SpendOverride = number | 'unavailable';
 
 interface PlanOverrideState {
@@ -21,12 +20,11 @@ interface PlanOverrideState {
     /** Plan-limit state to simulate, or `null` to use real usage. Free plan only. */
     usageLimitOverride: UsageLimitOverride | null;
     /**
-     * Reveals the current-period spend headline on the summary strip. Off until the figure is
-     * verified against real Orb invoices — until then customers keep the plan-name headline and we
-     * never call the endpoint for them. Delete this flag once the headline ships to everyone.
+     * Reveals the current-period spend headline. Off until the figure is verified against real Orb
+     * invoices; delete this flag once it ships to everyone.
      */
     spendHeadlineEnabled: boolean;
-    /** Spend to simulate, or `null` for the real Orb answer. Only meaningful with the flag on. */
+    /** Spend to simulate. Only meaningful with the flag on. */
     spendOverride: SpendOverride | null;
     setOverride: (code: PlanDefinition['code'] | null) => void;
     setScheduledTarget: (code: PlanDefinition['code'] | null) => void;
@@ -47,8 +45,8 @@ export const usePlanOverrideStore = create<PlanOverrideState>()(
             spendOverride: null,
             // Reset the simulated states too — each is only valid for the plan it was picked against,
             // and the two are offered on opposite sides of the paid/free split.
-            // `spendHeadlineEnabled` is deliberately not reset: it's a rollout flag, not a
-            // simulated state, so it shouldn't switch itself off every time you preview a plan.
+            // `spendHeadlineEnabled` is deliberately not reset — it's a rollout flag, not a
+            // simulated state scoped to the previewed plan.
             setOverride: (overrideCode) =>
                 set({ overrideCode, scheduledTargetCode: null, overdueOverride: false, usageLimitOverride: null, spendOverride: null }),
             setScheduledTarget: (scheduledTargetCode) => set({ scheduledTargetCode }),
@@ -80,11 +78,7 @@ export function buildOverdueOverride(realPortalUrl?: string | null): GetOverdueI
     };
 }
 
-/**
- * Stands in for the real upcoming-invoice response when the dev-tool override is on, for visual QA
- * only. `'unavailable'` produces the null amount the strip renders as a fallback to the plan name,
- * which is also what a failed Orb read looks like from here.
- */
+/** Stands in for the real upcoming-invoice response when the override is on, for visual QA only. */
 export function buildSpendOverride(override: SpendOverride): GetUpcomingInvoice['Success'] {
     if (override === 'unavailable') {
         return { data: { amountInCents: null, currency: null } };

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -190,7 +190,7 @@ const UPCOMING_INVOICE_STALE_TIME = 60 * 60 * 1000; // 1h
 
 /**
  * The current period's accrued spend, backing the summary strip headline. `enabled` is the
- * caller's call — a rollout flag, the plan and the permission all have to agree before we ask.
+ * caller's call — the rollout flag and the plan both have to agree before we ask.
  */
 export function useApiGetUpcomingInvoice(env: string, plan?: { name: string } | null, options?: { enabled?: boolean }) {
     const planName = plan?.name;

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -182,6 +182,12 @@ export function useApiGetOverdueInvoices(env: string, plan?: { name: string } | 
 
 export const GetUpcomingInvoiceQueryKey = ['plans', 'billing', 'upcoming-invoice'];
 
+// The billing cycle is the UTC calendar month, so `YYYY-MM` identifies the period the figure
+// belongs to. Used as part of the cache key rather than to display anything.
+function currentBillingPeriod(): string {
+    return new Date().toISOString().slice(0, 7);
+}
+
 // Orb only recomputes the draft invoice as the daily usage sync lands, and the tooltip says as much
 // ("up to 24 hours behind"), so a short window would spend requests on a number that hasn't moved.
 const UPCOMING_INVOICE_STALE_TIME = 60 * 60 * 1000; // 1h
@@ -202,8 +208,9 @@ export function useApiGetUpcomingInvoice(env: string, plan?: { name: string } | 
         staleTime: UPCOMING_INVOICE_STALE_TIME,
         // planName is in the key so switching plan in-session doesn't briefly show the previous
         // plan's figure; the override is in it so toggling takes effect rather than waiting out
-        // the stale window above.
-        queryKey: [...GetUpcomingInvoiceQueryKey, env, planName, spendOverride],
+        // the stale window above. The UTC period is in it too, so a page left open across the
+        // month boundary can't keep presenting last period's total as this one's.
+        queryKey: [...GetUpcomingInvoiceQueryKey, env, planName, currentBillingPeriod(), spendOverride],
         queryFn: async (): Promise<GetUpcomingInvoice['Success']> => {
             if (spendOverride !== null) {
                 return buildSpendOverride(spendOverride);

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -198,7 +198,7 @@ export function useApiGetUpcomingInvoice(env: string, plan?: { name: string } | 
     // see the populated states outside a real paid account.
     const spendOverride = usePlanOverrideStore((s) => s.spendOverride);
     return useQuery<GetUpcomingInvoice['Success'], APIError>({
-        enabled: Boolean(env) && (options?.enabled ?? true),
+        enabled: Boolean(env) && (options?.enabled ?? false),
         staleTime: UPCOMING_INVOICE_STALE_TIME,
         // Everything that changes the answer is in the key, including the UTC month: nearly every
         // subscription bills on the calendar month, so this rotates when their period does.

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 
 import { permissions } from '@nangohq/authz';
 
-import { applyPlanOverride, buildOverdueOverride, usePlanOverrideStore } from '../features/planOverride';
+import { applyPlanOverride, buildOverdueOverride, buildSpendOverride, usePlanOverrideStore } from '../features/planOverride';
 import { APIError, apiFetch } from '../utils/api';
 import { globalEnv } from '../utils/env';
 import { useEnvironment } from './useEnvironment';
@@ -18,6 +18,7 @@ import type {
     GetOverdueInvoices,
     GetPlan,
     GetPlans,
+    GetUpcomingInvoice,
     GetUsage,
     PostPlanChange,
     PostPlanExtendTrial,
@@ -170,6 +171,49 @@ export function useApiGetOverdueInvoices(env: string, plan?: { name: string } | 
             });
 
             const json = (await res.json()) as GetOverdueInvoices['Reply'];
+            if (res.status !== 200 || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        }
+    });
+}
+
+export const GetUpcomingInvoiceQueryKey = ['plans', 'billing', 'upcoming-invoice'];
+
+// Orb only recomputes the draft invoice as the daily usage sync lands, and the tooltip says as much
+// ("up to 24 hours behind"), so a short window would spend requests on a number that hasn't moved.
+const UPCOMING_INVOICE_STALE_TIME = 60 * 60 * 1000; // 1h
+
+/**
+ * The current period's accrued spend, backing the summary strip headline.
+ *
+ * `enabled` is the caller's call rather than derived here: the headline is behind a rollout flag as
+ * well as a plan and permission check, and all three have to agree before we make the request.
+ */
+export function useApiGetUpcomingInvoice(env: string, plan?: { name: string } | null, options?: { enabled?: boolean }) {
+    const planName = plan?.name;
+    // Dev-tool override (planOverride.ts) — the local/noop billing client returns no invoice, so
+    // this is the only way to see the populated states outside a real paid account.
+    const spendOverride = usePlanOverrideStore((s) => s.spendOverride);
+    return useQuery<GetUpcomingInvoice['Success'], APIError>({
+        enabled: Boolean(env) && (options?.enabled ?? true),
+        staleTime: UPCOMING_INVOICE_STALE_TIME,
+        // planName is in the key so switching plan in-session doesn't briefly show the previous
+        // plan's figure; the override is in it so toggling takes effect rather than waiting out
+        // the stale window above.
+        queryKey: [...GetUpcomingInvoiceQueryKey, env, planName, spendOverride],
+        queryFn: async (): Promise<GetUpcomingInvoice['Success']> => {
+            if (spendOverride !== null) {
+                return buildSpendOverride(spendOverride);
+            }
+
+            const res = await apiFetch(`/api/v1/plans/billing/upcoming-invoice?env=${env}`, {
+                method: 'GET'
+            });
+
+            const json = (await res.json()) as GetUpcomingInvoice['Reply'];
             if (res.status !== 200 || 'error' in json) {
                 throw new APIError({ res, json });
             }

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -182,13 +182,10 @@ export function useApiGetOverdueInvoices(env: string, plan?: { name: string } | 
 
 export const GetUpcomingInvoiceQueryKey = ['plans', 'billing', 'upcoming-invoice'];
 
-// The billing cycle is the UTC calendar month, so `YYYY-MM` identifies the period. Cache key only.
 function currentBillingPeriod(): string {
     return new Date().toISOString().slice(0, 7);
 }
 
-// Orb only recomputes the draft invoice as the daily usage sync lands, so a shorter window would
-// spend requests on a number that hasn't moved.
 const UPCOMING_INVOICE_STALE_TIME = 60 * 60 * 1000; // 1h
 
 /**

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -200,8 +200,8 @@ export function useApiGetUpcomingInvoice(env: string, plan?: { name: string } | 
     return useQuery<GetUpcomingInvoice['Success'], APIError>({
         enabled: Boolean(env) && (options?.enabled ?? true),
         staleTime: UPCOMING_INVOICE_STALE_TIME,
-        // Everything that changes the answer is in the key — the period especially, so a page left
-        // open across the month boundary can't keep showing last period's total.
+        // Everything that changes the answer is in the key, including the UTC month: nearly every
+        // subscription bills on the calendar month, so this rotates when their period does.
         queryKey: [...GetUpcomingInvoiceQueryKey, env, planName, currentBillingPeriod(), spendOverride],
         queryFn: async (): Promise<GetUpcomingInvoice['Success']> => {
             if (spendOverride !== null) {

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -182,34 +182,29 @@ export function useApiGetOverdueInvoices(env: string, plan?: { name: string } | 
 
 export const GetUpcomingInvoiceQueryKey = ['plans', 'billing', 'upcoming-invoice'];
 
-// The billing cycle is the UTC calendar month, so `YYYY-MM` identifies the period the figure
-// belongs to. Used as part of the cache key rather than to display anything.
+// The billing cycle is the UTC calendar month, so `YYYY-MM` identifies the period. Cache key only.
 function currentBillingPeriod(): string {
     return new Date().toISOString().slice(0, 7);
 }
 
-// Orb only recomputes the draft invoice as the daily usage sync lands, and the tooltip says as much
-// ("up to 24 hours behind"), so a short window would spend requests on a number that hasn't moved.
+// Orb only recomputes the draft invoice as the daily usage sync lands, so a shorter window would
+// spend requests on a number that hasn't moved.
 const UPCOMING_INVOICE_STALE_TIME = 60 * 60 * 1000; // 1h
 
 /**
- * The current period's accrued spend, backing the summary strip headline.
- *
- * `enabled` is the caller's call rather than derived here: the headline is behind a rollout flag as
- * well as a plan and permission check, and all three have to agree before we make the request.
+ * The current period's accrued spend, backing the summary strip headline. `enabled` is the
+ * caller's call — a rollout flag, the plan and the permission all have to agree before we ask.
  */
 export function useApiGetUpcomingInvoice(env: string, plan?: { name: string } | null, options?: { enabled?: boolean }) {
     const planName = plan?.name;
-    // Dev-tool override (planOverride.ts) — the local/noop billing client returns no invoice, so
-    // this is the only way to see the populated states outside a real paid account.
+    // Dev-tool override — the noop billing client returns no invoice, so this is the only way to
+    // see the populated states outside a real paid account.
     const spendOverride = usePlanOverrideStore((s) => s.spendOverride);
     return useQuery<GetUpcomingInvoice['Success'], APIError>({
         enabled: Boolean(env) && (options?.enabled ?? true),
         staleTime: UPCOMING_INVOICE_STALE_TIME,
-        // planName is in the key so switching plan in-session doesn't briefly show the previous
-        // plan's figure; the override is in it so toggling takes effect rather than waiting out
-        // the stale window above. The UTC period is in it too, so a page left open across the
-        // month boundary can't keep presenting last period's total as this one's.
+        // Everything that changes the answer is in the key — the period especially, so a page left
+        // open across the month boundary can't keep showing last period's total.
         queryKey: [...GetUpcomingInvoiceQueryKey, env, planName, currentBillingPeriod(), spendOverride],
         queryFn: async (): Promise<GetUpcomingInvoice['Success']> => {
             if (spendOverride !== null) {

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -38,12 +38,13 @@ export const Summary: React.FC = () => {
         if (!spendEnabled) {
             return null;
         }
-        // `isPending` stays true forever on a disabled or failed query, so pair it with the error
-        // flag — otherwise a failed read skeletons the headline instead of falling back.
+        // React Query keeps the last successful data when a refetch fails, so the error flag has to
+        // clear the amount as well as the pending state — otherwise a failed refresh leaves a stale
+        // figure on screen, which is worse than no figure at all.
         return {
             pending: isSpendPending && !didSpendFail,
-            amountInCents: upcoming?.data.amountInCents ?? null,
-            currency: upcoming?.data.currency ?? null
+            amountInCents: didSpendFail ? null : (upcoming?.data.amountInCents ?? null),
+            currency: didSpendFail ? null : (upcoming?.data.currency ?? null)
         };
     }, [spendEnabled, isSpendPending, didSpendFail, upcoming]);
 

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -30,7 +30,7 @@ export const Summary: React.FC = () => {
 
     // Behind a dev-tool flag until the figure is reconciled against real Orb invoices (NAN-6246).
     const spendHeadlineEnabled = usePlanOverrideStore((s) => s.spendHeadlineEnabled);
-    const spendEnabled = spendHeadlineEnabled && canManageBilling && showsSpendHeadline(plan);
+    const spendEnabled = spendHeadlineEnabled && showsSpendHeadline(plan);
     const { data: upcoming, isPending: isSpendPending, isError: didSpendFail } = useApiGetUpcomingInvoice(env, plan, { enabled: spendEnabled });
     const spend = useMemo(() => {
         if (!spendEnabled) {

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -4,11 +4,12 @@ import { useMemo } from 'react';
 import { permissions } from '@nangohq/authz';
 import { IconButton } from '@nangohq/design-system';
 
+import { usePlanOverrideStore } from '@/features/planOverride';
 import { usePermissions } from '@/hooks/usePermissions';
-import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
+import { useApiGetPlans, useApiGetUpcomingInvoice, useCurrentPlan } from '@/hooks/usePlan';
 import { useStripePaymentMethods } from '@/hooks/useStripe';
 import { useStore } from '@/store';
-import { showsSummaryStrip } from '../planVisibility';
+import { showsSpendHeadline, showsSummaryStrip } from '../planVisibility';
 import { buildSummaryState } from '../summaryState';
 import { PaymentMethodDialog } from './PaymentMethodDialog';
 import { SummaryStrip } from './SummaryStrip';
@@ -27,12 +28,31 @@ export const Summary: React.FC = () => {
     const { data: paymentMethods } = useStripePaymentMethods(env);
     const paymentMethod = paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
 
+    // Behind a dev-tool flag until the figure is reconciled against real Orb invoices (NAN-6246).
+    // With it off this is `false`, `spend` stays null, and the strip renders exactly as it did
+    // before — including making no request.
+    const spendHeadlineEnabled = usePlanOverrideStore((s) => s.spendHeadlineEnabled);
+    const spendEnabled = spendHeadlineEnabled && canManageBilling && showsSpendHeadline(plan);
+    const { data: upcoming, isPending: isSpendPending, isError: didSpendFail } = useApiGetUpcomingInvoice(env, plan, { enabled: spendEnabled });
+    const spend = useMemo(() => {
+        if (!spendEnabled) {
+            return null;
+        }
+        // `isPending` stays true forever on a disabled or failed query, so pair it with the error
+        // flag — otherwise a failed read skeletons the headline instead of falling back.
+        return {
+            pending: isSpendPending && !didSpendFail,
+            amountInCents: upcoming?.data.amountInCents ?? null,
+            currency: upcoming?.data.currency ?? null
+        };
+    }, [spendEnabled, isSpendPending, didSpendFail, upcoming]);
+
     const state = useMemo(() => {
         if (!plan || arePlansPending) {
             return null;
         }
-        return buildSummaryState({ plan, plans: plansList?.data, paymentMethod, canManageBilling, now: new Date() });
-    }, [plan, plansList, arePlansPending, paymentMethod, canManageBilling]);
+        return buildSummaryState({ plan, plans: plansList?.data, paymentMethod, canManageBilling, spend, now: new Date() });
+    }, [plan, plansList, arePlansPending, paymentMethod, canManageBilling, spend]);
 
     // Legacy, enterprise and free-uncapped accounts get no strip at all — their terms are negotiated
     // per customer or nothing is billable, so every field would be empty or untrue.
@@ -44,7 +64,8 @@ export const Summary: React.FC = () => {
         <div className="flex flex-col gap-4">
             <h3 className="text-text-strong text-body-medium-medium">Summary</h3>
             <SummaryStrip
-                planTitle={state?.planTitle ?? null}
+                headline={state?.headline ?? null}
+                plan={state?.plan}
                 date={state?.date}
                 payment={
                     state?.payment && {

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -29,8 +29,6 @@ export const Summary: React.FC = () => {
     const paymentMethod = paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
 
     // Behind a dev-tool flag until the figure is reconciled against real Orb invoices (NAN-6246).
-    // With it off this is `false`, `spend` stays null, and the strip renders exactly as it did
-    // before — including making no request.
     const spendHeadlineEnabled = usePlanOverrideStore((s) => s.spendHeadlineEnabled);
     const spendEnabled = spendHeadlineEnabled && canManageBilling && showsSpendHeadline(plan);
     const { data: upcoming, isPending: isSpendPending, isError: didSpendFail } = useApiGetUpcomingInvoice(env, plan, { enabled: spendEnabled });
@@ -39,8 +37,7 @@ export const Summary: React.FC = () => {
             return null;
         }
         // React Query keeps the last successful data when a refetch fails, so the error flag has to
-        // clear the amount as well as the pending state — otherwise a failed refresh leaves a stale
-        // figure on screen, which is worse than no figure at all.
+        // clear the amount too, or a failed refresh leaves a stale figure on screen.
         return {
             pending: isSpendPending && !didSpendFail,
             amountInCents: didSpendFail ? null : (upcoming?.data.amountInCents ?? null),

--- a/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
@@ -1,10 +1,15 @@
+import { CircleHelp } from 'lucide-react';
+
 import { Card } from '@nangohq/design-system';
 
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { Skeleton } from '@/components/ui/Skeleton';
 
 export interface SummaryStripProps {
     /** Null renders a skeleton — the plan decides which other slots appear, so nothing else can resolve first. */
-    planTitle: string | null;
+    headline: { label: string; value: string | null; tooltip?: string } | null;
+    /** Only set when the headline is spend, so the plan name still has somewhere to live. */
+    plan?: { value: string } | null;
     date?: { label: string; value: string } | null;
     /** Omitted whenever there's no card to show — Free, no card on file, or no billing permission. */
     payment?: { card: { brand?: string | null; last4: string }; action?: React.ReactNode } | null;
@@ -12,30 +17,40 @@ export interface SummaryStripProps {
     change?: { toPlanTitle: string; at: string; detail: string | null } | null;
 }
 
+const SummaryLabel: React.FC<{ label: string; tooltip?: string }> = ({ label, tooltip }) => (
+    <div className="flex items-center gap-1.5">
+        <span className="type-text-regular-xs text-text-disabled">{label}</span>
+        {/* Smaller than InfoTooltip's default 16px, which is sized against a body-large heading. */}
+        {tooltip && (
+            <InfoTooltip side="top" align="start" icon={<CircleHelp className="size-3.5" />}>
+                {tooltip}
+            </InfoTooltip>
+        )}
+    </div>
+);
+
 const SummaryItem: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
     <div className="flex flex-col gap-1">
-        <span className="type-text-regular-xs text-text-disabled">{label}</span>
+        <SummaryLabel label={label} />
         <div className="flex items-center gap-1.5 h-5 type-text-regular-sm text-text-default">{children}</div>
     </div>
 );
 
 /**
- * Presentational billing summary strip: current plan, a date whose meaning depends on the plan, and
- * the card on file. Pure — every decision about which slots appear is made by `buildSummaryState`.
- *
- * The design leads paid plans with a current-period spend figure instead of the plan name; that
- * figure needs an Orb spend read our backend doesn't have yet (NAN-6246), so the plan holds the
- * headline until then.
+ * Presentational billing summary strip: a headline that is either the period's spend or the plan
+ * name, a date whose meaning depends on the plan, and the card on file. Pure — every decision about
+ * which slots appear is made by `buildSummaryState`.
  */
-export const SummaryStrip: React.FC<SummaryStripProps> = ({ planTitle, date, payment, change }) => (
+export const SummaryStrip: React.FC<SummaryStripProps> = ({ headline, plan, date, payment, change }) => (
     <Card>
         <div className="p-4 flex items-start justify-between gap-8">
             <div className="flex flex-col gap-1">
-                <span className="type-text-regular-xs text-text-disabled">CURRENT PLAN</span>
-                <span className="type-heading-lg text-text-strong">{planTitle ?? <Skeleton className="w-24 h-7" />}</span>
+                <SummaryLabel label={headline?.label ?? 'CURRENT PLAN'} tooltip={headline?.tooltip} />
+                <span className="type-heading-lg text-text-strong">{headline?.value ?? <Skeleton className="w-32 h-7" />}</span>
             </div>
             {/* 62px is the gap between the items in the design, off the spacing scale. */}
             <div className="flex items-start justify-end gap-[62px]">
+                {plan && <SummaryItem label="PLAN">{plan.value}</SummaryItem>}
                 {date && <SummaryItem label={date.label}>{date.value}</SummaryItem>}
                 {payment && (
                     <SummaryItem label="PAYMENT METHOD">

--- a/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
@@ -1,5 +1,3 @@
-import { CircleHelp } from 'lucide-react';
-
 import { Card } from '@nangohq/design-system';
 
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
@@ -20,9 +18,8 @@ export interface SummaryStripProps {
 const SummaryLabel: React.FC<{ label: string; tooltip?: string }> = ({ label, tooltip }) => (
     <div className="flex items-center gap-1.5">
         <span className="type-text-regular-xs text-text-disabled">{label}</span>
-        {/* Smaller than InfoTooltip's default 16px, which is sized against a body-large heading. */}
         {tooltip && (
-            <InfoTooltip side="top" align="start" icon={<CircleHelp className="size-3.5" />}>
+            <InfoTooltip side="top" align="start">
                 {tooltip}
             </InfoTooltip>
         )}

--- a/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
@@ -6,7 +6,6 @@ import { Skeleton } from '@/components/ui/Skeleton';
 export interface SummaryStripProps {
     /** Null renders a skeleton — the plan decides which other slots appear, so nothing else can resolve first. */
     headline: { label: string; value: string | null; tooltip?: string } | null;
-    /** Only set when the headline is spend, so the plan name still has somewhere to live. */
     plan?: { value: string } | null;
     date?: { label: string; value: string } | null;
     /** Omitted whenever there's no card to show — Free, no card on file, or no billing permission. */
@@ -34,9 +33,8 @@ const SummaryItem: React.FC<{ label: string; children: React.ReactNode }> = ({ l
 );
 
 /**
- * Presentational billing summary strip: a headline that is either the period's spend or the plan
- * name, a date whose meaning depends on the plan, and the card on file. Pure — every decision about
- * which slots appear is made by `buildSummaryState`.
+ * Presentational billing summary strip. Pure — every decision about which slots appear, and what
+ * the headline says, is made by `buildSummaryState`.
  */
 export const SummaryStrip: React.FC<SummaryStripProps> = ({ headline, plan, date, payment, change }) => (
     <Card>

--- a/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/SummaryStrip.tsx
@@ -40,7 +40,7 @@ export const SummaryStrip: React.FC<SummaryStripProps> = ({ headline, plan, date
     <Card>
         <div className="p-4 flex items-start justify-between gap-8">
             <div className="flex flex-col gap-1">
-                <SummaryLabel label={headline?.label ?? 'CURRENT PLAN'} tooltip={headline?.tooltip} />
+                {headline ? <SummaryLabel label={headline.label} tooltip={headline.tooltip} /> : <Skeleton className="w-32 h-4" />}
                 <span className="type-heading-lg text-text-strong">{headline?.value ?? <Skeleton className="w-32 h-7" />}</span>
             </div>
             {/* 62px is the gap between the items in the design, off the spacing scale. */}

--- a/packages/webapp/src/pages/Team/Billing/money.ts
+++ b/packages/webapp/src/pages/Team/Billing/money.ts
@@ -1,12 +1,7 @@
 /**
- * `$1,234.56` from an integer cent amount, or null when it can't be formatted.
- *
- * Cents in, because that's what the API carries: Orb states amounts as decimal strings and the
- * server parses them to integer cents so no float math happens on the way here. Rendered in the
- * invoice's own currency so a non-USD contract isn't silently labelled in dollars.
- *
- * Null for a missing or non-ISO currency — Orb bills some customers in `credits`, which has no
- * symbol to show — so the caller can fall back rather than invent one.
+ * `$1,234.56` from an integer cent amount, in the invoice's own currency. Null for a missing or
+ * non-ISO currency — Orb bills some customers in `credits` — so callers fall back rather than
+ * invent a symbol.
  */
 export function formatMoneyFromCents(amountInCents: number, currency: string | null): string | null {
     if (!Number.isFinite(amountInCents)) {
@@ -18,7 +13,6 @@ export function formatMoneyFromCents(amountInCents: number, currency: string | n
         return null;
     }
 
-    // No fraction-digit overrides: Intl already uses each currency's own precision, so USD keeps
-    // its cents while a zero-decimal currency like JPY doesn't gain a meaningless ".00".
+    // No fraction-digit overrides: Intl uses each currency's own precision, so JPY doesn't gain a ".00".
     return new Intl.NumberFormat('en-US', { style: 'currency', currency: code }).format(amountInCents / 100);
 }

--- a/packages/webapp/src/pages/Team/Billing/money.ts
+++ b/packages/webapp/src/pages/Team/Billing/money.ts
@@ -18,10 +18,7 @@ export function formatMoneyFromCents(amountInCents: number, currency: string | n
         return null;
     }
 
-    return new Intl.NumberFormat('en-US', {
-        style: 'currency',
-        currency: code,
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-    }).format(amountInCents / 100);
+    // No fraction-digit overrides: Intl already uses each currency's own precision, so USD keeps
+    // its cents while a zero-decimal currency like JPY doesn't gain a meaningless ".00".
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: code }).format(amountInCents / 100);
 }

--- a/packages/webapp/src/pages/Team/Billing/money.ts
+++ b/packages/webapp/src/pages/Team/Billing/money.ts
@@ -1,0 +1,27 @@
+/**
+ * `$1,234.56` from an integer cent amount, or null when it can't be formatted.
+ *
+ * Cents in, because that's what the API carries: Orb states amounts as decimal strings and the
+ * server parses them to integer cents so no float math happens on the way here. Rendered in the
+ * invoice's own currency so a non-USD contract isn't silently labelled in dollars.
+ *
+ * Null for a missing or non-ISO currency — Orb bills some customers in `credits`, which has no
+ * symbol to show — so the caller can fall back rather than invent one.
+ */
+export function formatMoneyFromCents(amountInCents: number, currency: string | null): string | null {
+    if (!Number.isFinite(amountInCents)) {
+        return null;
+    }
+
+    const code = currency?.trim().toUpperCase();
+    if (!code || !/^[A-Z]{3}$/.test(code)) {
+        return null;
+    }
+
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: code,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    }).format(amountInCents / 100);
+}

--- a/packages/webapp/src/pages/Team/Billing/money.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/money.unit.test.ts
@@ -24,12 +24,11 @@ describe('formatMoneyFromCents', () => {
     });
 
     it("uses each currency's own precision rather than forcing cents", () => {
-        // JPY has no minor unit, so a ".00" would be meaningless there.
+        // JPY has no minor unit.
         expect(formatMoneyFromCents(128400, 'JPY')).toBe('¥1,284');
     });
 
     it('returns null for a currency with no dollar meaning', () => {
-        // Orb bills some customers in credits.
         expect(formatMoneyFromCents(1000, 'credits')).toBeNull();
         expect(formatMoneyFromCents(1000, null)).toBeNull();
         expect(formatMoneyFromCents(1000, '')).toBeNull();

--- a/packages/webapp/src/pages/Team/Billing/money.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/money.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatMoneyFromCents } from './money.js';
+
+describe('formatMoneyFromCents', () => {
+    it('formats whole and fractional dollar amounts', () => {
+        expect(formatMoneyFromCents(0, 'USD')).toBe('$0.00');
+        expect(formatMoneyFromCents(7, 'USD')).toBe('$0.07');
+        expect(formatMoneyFromCents(14900, 'USD')).toBe('$149.00');
+    });
+
+    it('groups thousands', () => {
+        expect(formatMoneyFromCents(128430, 'USD')).toBe('$1,284.30');
+        expect(formatMoneyFromCents(123456789, 'USD')).toBe('$1,234,567.89');
+    });
+
+    it('normalises the currency code', () => {
+        expect(formatMoneyFromCents(128430, 'usd')).toBe('$1,284.30');
+        expect(formatMoneyFromCents(128430, ' USD ')).toBe('$1,284.30');
+    });
+
+    it('renders non-USD currencies in their own symbol', () => {
+        expect(formatMoneyFromCents(128430, 'EUR')).toBe('€1,284.30');
+    });
+
+    it('returns null for a currency with no dollar meaning', () => {
+        // Orb bills some customers in credits.
+        expect(formatMoneyFromCents(1000, 'credits')).toBeNull();
+        expect(formatMoneyFromCents(1000, null)).toBeNull();
+        expect(formatMoneyFromCents(1000, '')).toBeNull();
+    });
+
+    it('returns null for a non-finite amount', () => {
+        expect(formatMoneyFromCents(NaN, 'USD')).toBeNull();
+        expect(formatMoneyFromCents(Infinity, 'USD')).toBeNull();
+    });
+});

--- a/packages/webapp/src/pages/Team/Billing/money.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/money.unit.test.ts
@@ -23,6 +23,11 @@ describe('formatMoneyFromCents', () => {
         expect(formatMoneyFromCents(128430, 'EUR')).toBe('€1,284.30');
     });
 
+    it("uses each currency's own precision rather than forcing cents", () => {
+        // JPY has no minor unit, so a ".00" would be meaningless there.
+        expect(formatMoneyFromCents(128400, 'JPY')).toBe('¥1,284');
+    });
+
     it('returns null for a currency with no dollar meaning', () => {
         // Orb bills some customers in credits.
         expect(formatMoneyFromCents(1000, 'credits')).toBeNull();

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -40,14 +40,8 @@ const SHOWS_SUMMARY_STRIP: Record<DBPlan['name'], boolean> = {
     'growth-legacy': false
 };
 
-// Plans whose strip leads with a spend figure instead of the plan name. Narrower again than
-// SHOWS_SUMMARY_STRIP: `free` renders a strip but never accrues a charge, so a $0.00 headline would
-// be noise. The startup deal does lead with spend — it rates to $0.00 at any volume, and $0.00 is
-// the honest answer there rather than a missing one.
-//
-// Mirrors SPEND_PLANS in the server's getUpcomingInvoice controller. The server is authoritative —
-// it returns a null amount regardless — so drift costs at most a wasted request; this map only
-// decides whether we bother asking. Exhaustive over `DBPlan['name']` like the maps above.
+// Plans that lead with spend instead of the plan name — the startup deal included, since its
+// $0.00 is a real answer rather than a gap. The server decides for real; this only saves a request.
 const SHOWS_SPEND_HEADLINE: Record<DBPlan['name'], boolean> = {
     'starter-v2': true,
     'growth-v2': true,

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -40,6 +40,29 @@ const SHOWS_SUMMARY_STRIP: Record<DBPlan['name'], boolean> = {
     'growth-legacy': false
 };
 
+// Plans whose strip leads with a spend figure instead of the plan name. Narrower again than
+// SHOWS_SUMMARY_STRIP: `free` renders a strip but never accrues a charge, so a $0.00 headline would
+// be noise. The startup deal does lead with spend — it rates to $0.00 at any volume, and $0.00 is
+// the honest answer there rather than a missing one.
+//
+// Mirrors SPEND_PLANS in the server's getUpcomingInvoice controller. The server is authoritative —
+// it returns a null amount regardless — so drift costs at most a wasted request; this map only
+// decides whether we bother asking. Exhaustive over `DBPlan['name']` like the maps above.
+const SHOWS_SPEND_HEADLINE: Record<DBPlan['name'], boolean> = {
+    'starter-v2': true,
+    'growth-v2': true,
+    'startup-deal': true,
+    free: false,
+    'free-uncapped': false,
+    enterprise: false,
+    'enterprise-cloud-hosted': false,
+    starter: false,
+    growth: false,
+    'starter-legacy': false,
+    'scale-legacy': false,
+    'growth-legacy': false
+};
+
 export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {
     if (!plan) {
         return false;
@@ -52,4 +75,11 @@ export function isLegacyPlan(plan: ApiPlan | null | undefined): boolean {
         return false;
     }
     return !PLAN_IS_CURRENT[plan.name];
+}
+/** Whether the strip leads with current-period spend rather than the plan name. */
+export function showsSpendHeadline(plan: ApiPlan | null | undefined): boolean {
+    if (!plan) {
+        return false;
+    }
+    return SHOWS_SPEND_HEADLINE[plan.name];
 }

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -5,7 +5,7 @@ import { showsSpendHeadline } from './planVisibility';
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
 export const SPEND_TOOLTIP =
-    "Your base fee plus any usage beyond your plan's included quota. Any account credit is applied when the invoice is issued. Usage syncs daily, so this can be up to 24 hours behind.";
+    "Next month's base fee plus this period's usage beyond your plan's included quota. Any account credit is applied when the invoice is issued. Usage syncs daily, so this can be up to 24 hours behind.";
 
 export interface SummaryStripHeadline {
     label: string;

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -5,7 +5,7 @@ import { showsSpendHeadline } from './planVisibility';
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
 export const SPEND_TOOLTIP =
-    "Includes your base fee plus any usage beyond your plan's included quota, less any account credit. Usage syncs daily, so this can be up to 24 hours behind.";
+    "Your base fee plus any usage beyond your plan's included quota. Any account credit is already applied. Usage syncs daily, so this can be up to 24 hours behind.";
 
 export interface SummaryStripHeadline {
     label: string;

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -1,9 +1,39 @@
 import { formatBillingDate, nextUsageResetDate } from './billingPeriod';
+import { formatMoneyFromCents } from './money';
+import { showsSpendHeadline } from './planVisibility';
 
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
+export const SPEND_TOOLTIP =
+    "Includes your base fee plus any usage beyond your plan's included quota, less any account credit. Usage syncs daily, so this can be up to 24 hours behind.";
+
+export interface SummaryStripHeadline {
+    label: string;
+    /** Null while the value is still resolving — the strip skeletons it in place. */
+    value: string | null;
+    /** Info tooltip beside the label. Only the spend headline carries one. */
+    tooltip?: string;
+}
+
+/**
+ * Current-period spend as the caller's query holds it. A null `amountInCents` covers both "Orb had
+ * nothing to report" and "the read failed" — the strip treats them alike, falling back to the plan
+ * name rather than showing a figure it can't stand behind.
+ */
+export interface SummarySpend {
+    pending: boolean;
+    amountInCents: number | null;
+    currency: string | null;
+}
+
 export interface SummaryStripState {
-    planTitle: string;
+    /**
+     * The lead figure. Plans billed on a monthly cycle lead with the period's accrued spend;
+     * everyone else leads with the plan name, because on Free there is never a charge to state.
+     */
+    headline: SummaryStripHeadline;
+    /** The plan name, demoted to a slot when spend leads. Null when the plan IS the headline. */
+    plan: { value: string } | null;
     /** Omitted when no date can be stated truthfully — e.g. a deal whose conversion date we don't hold. */
     date: { label: string; value: string } | null;
     /** Null hides the slot entirely — Free, no card on file, or a viewer who can't manage billing. */
@@ -30,6 +60,43 @@ function changeDetail({ from, toCode, toTitle }: { from: string; toCode: string;
 }
 
 /**
+/**
+ * The lead slot, and whether the plan name gets demoted to a slot of its own beside it.
+ *
+ * Falls back to the plan name whenever spend can't be stated — the plan doesn't get a figure, the
+ * read failed, or Orb had nothing drafted. Deliberately does NOT special-case zero: the startup
+ * deal rates to $0.00 at any volume, so $0.00 is the answer rather than a missing one.
+ */
+function buildHeadline({
+    plan,
+    planTitle,
+    spend
+}: {
+    plan: ApiPlan;
+    planTitle: string;
+    spend: SummarySpend | null;
+}): Pick<SummaryStripState, 'headline' | 'plan'> {
+    const asPlan = { headline: { label: 'CURRENT PLAN', value: planTitle }, plan: null };
+    if (!spend || !showsSpendHeadline(plan)) {
+        return asPlan;
+    }
+
+    const spendSlots = (value: string | null) => ({
+        headline: { label: 'CURRENT PERIOD SPEND', value, tooltip: SPEND_TOOLTIP },
+        plan: { value: planTitle }
+    });
+
+    if (spend.pending) {
+        // The label is decidable from the plan alone, so it renders final while only the figure
+        // resolves — no reflow, and nothing claims the plan name is the headline in the meantime.
+        return spendSlots(null);
+    }
+
+    const formatted = spend.amountInCents === null ? null : formatMoneyFromCents(spend.amountInCents, spend.currency);
+    return formatted === null ? asPlan : spendSlots(formatted);
+}
+
+/**
  * Everything the strip shows, derived in one place so the rules are testable without React.
  *
  * The date slot carries three different meanings, which is why it isn't a single "reset" value:
@@ -41,12 +108,15 @@ export function buildSummaryState({
     plans,
     paymentMethod,
     canManageBilling,
+    spend,
     now
 }: {
     plan: ApiPlan;
     plans: PlanDefinition[] | undefined;
     paymentMethod: StripePaymentMethod | null;
     canManageBilling: boolean;
+    /** Null when the caller isn't reading spend at all — the strip then leads with the plan name. */
+    spend?: SummarySpend | null;
     now: Date;
 }): SummaryStripState {
     const planTitle = planTitleOf(plan.name, plans);
@@ -78,7 +148,7 @@ export function buildSummaryState({
     }
 
     return {
-        planTitle,
+        ...buildHeadline({ plan, planTitle, spend: spend ?? null }),
         date,
         // Free never shows a payment method, even when a card is on file. Nor does an account with
         // no card — the slot is dropped rather than dashed, and the billing section below is where

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -5,7 +5,7 @@ import { showsSpendHeadline } from './planVisibility';
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
 export const SPEND_TOOLTIP =
-    "Your base fee plus any usage beyond your plan's included quota. Any account credit is already applied. Usage syncs daily, so this can be up to 24 hours behind.";
+    "Your base fee plus any usage beyond your plan's included quota. Any account credit is applied when the invoice is issued. Usage syncs daily, so this can be up to 24 hours behind.";
 
 export interface SummaryStripHeadline {
     label: string;

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -15,11 +15,7 @@ export interface SummaryStripHeadline {
     tooltip?: string;
 }
 
-/**
- * Current-period spend as the caller's query holds it. A null `amountInCents` covers both "Orb had
- * nothing to report" and "the read failed" — the strip treats them alike, falling back to the plan
- * name rather than showing a figure it can't stand behind.
- */
+/** Current-period spend as the caller's query holds it. A null amount means "no figure to show". */
 export interface SummarySpend {
     pending: boolean;
     amountInCents: number | null;
@@ -27,10 +23,6 @@ export interface SummarySpend {
 }
 
 export interface SummaryStripState {
-    /**
-     * The lead figure. Plans billed on a monthly cycle lead with the period's accrued spend;
-     * everyone else leads with the plan name, because on Free there is never a charge to state.
-     */
     headline: SummaryStripHeadline;
     /** The plan name, demoted to a slot when spend leads. Null when the plan IS the headline. */
     plan: { value: string } | null;
@@ -61,11 +53,8 @@ function changeDetail({ from, toCode, toTitle }: { from: string; toCode: string;
 
 /**
 /**
- * The lead slot, and whether the plan name gets demoted to a slot of its own beside it.
- *
- * Falls back to the plan name whenever spend can't be stated — the plan doesn't get a figure, the
- * read failed, or Orb had nothing drafted. Deliberately does NOT special-case zero: the startup
- * deal rates to $0.00 at any volume, so $0.00 is the answer rather than a missing one.
+ * The lead slot, falling back to the plan name whenever spend can't be stated. Zero is
+ * deliberately not special-cased — the startup deal really does bill $0.00.
  */
 function buildHeadline({
     plan,
@@ -87,8 +76,7 @@ function buildHeadline({
     });
 
     if (spend.pending) {
-        // The label is decidable from the plan alone, so it renders final while only the figure
-        // resolves — no reflow, and nothing claims the plan name is the headline in the meantime.
+        // The label needs only the plan, so it renders final while the figure resolves — no reflow.
         return spendSlots(null);
     }
 
@@ -115,7 +103,6 @@ export function buildSummaryState({
     plans: PlanDefinition[] | undefined;
     paymentMethod: StripePaymentMethod | null;
     canManageBilling: boolean;
-    /** Null when the caller isn't reading spend at all — the strip then leads with the plan name. */
     spend?: SummarySpend | null;
     now: Date;
 }): SummaryStripState {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -52,7 +52,6 @@ function changeDetail({ from, toCode, toTitle }: { from: string; toCode: string;
 }
 
 /**
-/**
  * The lead slot, falling back to the plan name whenever spend can't be stated. Zero is
  * deliberately not special-cased — the startup deal really does bill $0.00.
  */

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -102,7 +102,6 @@ describe('buildSummaryState headline', () => {
     it('shows the label with no value while the read is in flight', () => {
         const state = build(planOf('starter-v2'), { spend: { pending: true, amountInCents: null, currency: null } });
         expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: null, tooltip: SPEND_TOOLTIP });
-        // The plan slot is already final, so only the figure moves when it lands.
         expect(state.plan).toEqual({ value: 'Starter' });
     });
 
@@ -121,7 +120,6 @@ describe('buildSummaryState headline', () => {
     });
 
     it('falls back to the plan name when the currency has no symbol to show', () => {
-        // Orb bills some customers in credits.
         const state = build(planOf('growth-v2'), { spend: spendOf(128430, 'credits') });
         expect(state.headline).toEqual({ label: 'CURRENT PLAN', value: 'Growth' });
     });
@@ -133,8 +131,8 @@ describe('buildSummaryState headline', () => {
     });
 
     it('renders exactly as before when spend is not being read at all', () => {
-        // The rollout flag reaches this function as `spend: null`. Off has to be indistinguishable
-        // from the pre-spend strip, or shipping it dark isn't actually dark.
+        // The rollout flag reaches this function as `spend: null`, and off has to be
+        // indistinguishable from the pre-spend strip.
         for (const name of ['starter-v2', 'growth-v2', 'startup-deal'] as const) {
             const state = build(planOf(name), { spend: null });
             expect(state.headline.label).toBe('CURRENT PLAN');

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { showsSummaryStrip } from './planVisibility.js';
-import { buildSummaryState } from './summaryState.js';
+import { showsSpendHeadline, showsSummaryStrip } from './planVisibility.js';
+import { buildSummaryState, SPEND_TOOLTIP } from './summaryState.js';
 
+import type { SummarySpend } from './summaryState.js';
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
 const NOW = new Date('2026-08-17T10:00:00Z');
@@ -19,14 +20,20 @@ const card: StripePaymentMethod = { id: 'pm_1', brand: 'visa', last4: '4242', ex
 function planOf(name: ApiPlan['name'], overrides: Partial<ApiPlan> = {}): ApiPlan {
     return { name, orb_future_plan: null, orb_future_plan_at: null, ...overrides } as ApiPlan;
 }
-function build(plan: ApiPlan, opts: { paymentMethod?: StripePaymentMethod | null; canManageBilling?: boolean } = {}) {
+function build(plan: ApiPlan, opts: { paymentMethod?: StripePaymentMethod | null; canManageBilling?: boolean; spend?: SummarySpend | null } = {}) {
     return buildSummaryState({
         plan,
         plans,
         paymentMethod: opts.paymentMethod ?? null,
         canManageBilling: opts.canManageBilling ?? true,
+        spend: opts.spend ?? null,
         now: NOW
     });
+}
+
+/** A resolved spend read, as `Summary` would hand it over. */
+function spendOf(amountInCents: number | null, currency: string | null = 'USD'): SummarySpend {
+    return { pending: false, amountInCents, currency };
 }
 
 describe('showsSummaryStrip', () => {
@@ -56,10 +63,91 @@ describe('showsSummaryStrip', () => {
     });
 });
 
+describe('showsSpendHeadline', () => {
+    it('leads with spend on the plans billed monthly', () => {
+        for (const name of ['starter-v2', 'growth-v2', 'startup-deal'] as const) {
+            expect(showsSpendHeadline(planOf(name))).toBe(true);
+        }
+    });
+
+    it('keeps the plan headline everywhere else', () => {
+        for (const name of [
+            'free',
+            'free-uncapped',
+            'enterprise',
+            'enterprise-cloud-hosted',
+            'starter',
+            'growth',
+            'starter-legacy',
+            'scale-legacy',
+            'growth-legacy'
+        ] as const) {
+            expect(showsSpendHeadline(planOf(name))).toBe(false);
+        }
+    });
+
+    it('handles a missing plan', () => {
+        expect(showsSpendHeadline(null)).toBe(false);
+        expect(showsSpendHeadline(undefined)).toBe(false);
+    });
+});
+
+describe('buildSummaryState headline', () => {
+    it('leads with the formatted spend and demotes the plan to its own slot', () => {
+        const state = build(planOf('growth-v2'), { spend: spendOf(128430) });
+        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: '$1,284.30', tooltip: SPEND_TOOLTIP });
+        expect(state.plan).toEqual({ value: 'Growth' });
+    });
+
+    it('shows the label with no value while the read is in flight', () => {
+        const state = build(planOf('starter-v2'), { spend: { pending: true, amountInCents: null, currency: null } });
+        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: null, tooltip: SPEND_TOOLTIP });
+        // The plan slot is already final, so only the figure moves when it lands.
+        expect(state.plan).toEqual({ value: 'Starter' });
+    });
+
+    it('reports $0.00 on the startup deal rather than treating it as missing', () => {
+        // The deal rates to $0.00 at any volume, so zero is the answer, not a gap.
+        const state = build(planOf('startup-deal'), { spend: spendOf(0) });
+        expect(state.headline.value).toBe('$0.00');
+        expect(state.plan).toEqual({ value: 'Startup deal' });
+    });
+
+    it('falls back to the plan name when the read failed or Orb had nothing', () => {
+        const state = build(planOf('growth-v2'), { spend: spendOf(null, null) });
+        expect(state.headline).toEqual({ label: 'CURRENT PLAN', value: 'Growth' });
+        expect(state.headline.tooltip).toBeUndefined();
+        expect(state.plan).toBeNull();
+    });
+
+    it('falls back to the plan name when the currency has no symbol to show', () => {
+        // Orb bills some customers in credits.
+        const state = build(planOf('growth-v2'), { spend: spendOf(128430, 'credits') });
+        expect(state.headline).toEqual({ label: 'CURRENT PLAN', value: 'Growth' });
+    });
+
+    it('never leads with spend on Free, even if a figure is handed over', () => {
+        const state = build(planOf('free'), { spend: spendOf(128430) });
+        expect(state.headline).toEqual({ label: 'CURRENT PLAN', value: 'Free' });
+        expect(state.plan).toBeNull();
+    });
+
+    it('renders exactly as before when spend is not being read at all', () => {
+        // The rollout flag reaches this function as `spend: null`. Off has to be indistinguishable
+        // from the pre-spend strip, or shipping it dark isn't actually dark.
+        for (const name of ['starter-v2', 'growth-v2', 'startup-deal'] as const) {
+            const state = build(planOf(name), { spend: null });
+            expect(state.headline.label).toBe('CURRENT PLAN');
+            expect(state.headline.tooltip).toBeUndefined();
+            expect(state.plan).toBeNull();
+        }
+    });
+});
+
 describe('buildSummaryState', () => {
     it('shows Free the caps reset and never a payment method, even with a card', () => {
         const state = build(planOf('free'), { paymentMethod: card });
-        expect(state.planTitle).toBe('Free');
+        expect(state.headline).toEqual({ label: 'CURRENT PLAN', value: 'Free' });
         expect(state.date).toEqual({ label: 'LIMITS RESET', value: 'September 1, 2026' });
         expect(state.payment).toBeNull();
     });
@@ -125,6 +213,6 @@ describe('buildSummaryState', () => {
 
     it('falls back to the plan code when the plan list has not loaded', () => {
         const state = buildSummaryState({ plan: planOf('growth-v2'), plans: undefined, paymentMethod: null, canManageBilling: true, now: NOW });
-        expect(state.planTitle).toBe('growth-v2');
+        expect(state.headline.value).toBe('growth-v2');
     });
 });


### PR DESCRIPTION
## Problem

The billing summary strip leads with the plan name; the design leads billed plans with what will actually be invoiced. Every dollar lives in Orb, so the backend had no way to read that figure.

## Solution

- New `getUpcomingInvoice` on the billing client, exposed as `GET /api/v1/plans/billing/upcoming-invoice`. Visible to every user, not just billing admins.
- `starter-v2`, `growth-v2` and `startup-deal` lead with `CURRENT PERIOD SPEND`, demoting the plan name to its own slot. Free keeps the plan headline, and any plan falls back to it when spend can't be stated.
- Plans are allowlisted server-side, not denylisted: `amount_due` states a whole annual contract on non-monthly plans, so a plan added later must default to no figure.

**Ships dark** behind a dev-tool flag — customers see today's strip unchanged and their browsers make no request. Flipping it on is gated on reconciling the figure against real invoices.

Fixes [NAN-6246](https://linear.app/nango/issue/NAN-6246) · stacked on #7139

## Testing

Verified end to end against live Orb test mode, not mocks: Growth $500.00, Starter $50.00, the deal $0.00. Flag-off renders identically to before and issues no request. 398 unit and 38 integration tests.

Real Orb surfaced two things the mocked tests structurally couldn't — an ended subscription returns `400` rather than `404`, and account credit isn't applied until the invoice is issued. Both fixed; evidence is on the ticket.

Also carries one unrelated fix: tooltips had no `max-width`, so long content ran the full viewport width.

## Follow-ups

- Enable the headline for customers: flip the flag, delete it and the dev-tool rows.
- `upgrade()` in `orb/client.ts` does `Number(amount_due) * 100`, producing fractional cents toward a Stripe PaymentIntent. `orbAmountToCents` is a one-line retrofit.

