### PR TITLE
fix(server): emit MCP schemas as JSON Schema 2020-12

### DIFF
--- a/packages/server/lib/controllers/mcp/connectSessions/create.ts
+++ b/packages/server/lib/controllers/mcp/connectSessions/create.ts
@@ -53,23 +53,20 @@ const commonCreateConnectSessionArguments = {
 };
 
 const createConnectSessionArgumentsSchema = z
-    .union([
-        z
-            .object({
-                ...commonCreateConnectSessionArguments,
-                end_user: endUserSchema,
-                tags: connectionTagsSchema.optional()
-            })
-            .strict(),
-        z
-            .object({
-                ...commonCreateConnectSessionArguments,
-                end_user: endUserSchema.optional(),
-                tags: connectionTagsSchema
-            })
-            .strict()
-    ])
+    .object({
+        ...commonCreateConnectSessionArguments,
+        end_user: endUserSchema.optional(),
+        tags: connectionTagsSchema.optional()
+    })
+    .strict()
     .superRefine((args, context) => {
+        if (!args.end_user && !args.tags) {
+            context.addIssue({
+                code: 'custom',
+                message: 'At least one of end_user or tags must be provided'
+            });
+        }
+
         for (const [integrationId, defaults] of Object.entries(args.integrations_config_defaults || {})) {
             if (defaults.connection_config && 'webhook_url' in defaults.connection_config) {
                 context.addIssue({
@@ -83,7 +80,8 @@ const createConnectSessionArgumentsSchema = z
 
 export const createConnectSessionTool = defineManagementMcpTool<typeof createConnectSessionArgumentsSchema, CreateConnectSessionOutput>({
     name: 'connect_session_create',
-    description: 'Create a Connect session for an end user in the authenticated Nango environment.',
+    description:
+        'Create a short-lived Connect session for authorizing an integration. Send the returned connect_link to the end user so they can complete OAuth or enter credentials. After authorization, use connections_list to find the resulting connection. At least one of end_user or tags must be provided.',
     inputSchema: createConnectSessionArgumentsSchema,
     outputSchema: createConnectSessionOutputSchema,
     requiredScopes: { every: ['environment:connect_sessions:write'] },

--- a/packages/server/lib/controllers/mcp/connectSessions/create.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/connectSessions/create.unit.test.ts
@@ -94,6 +94,18 @@ describe('createConnectSessionTool', () => {
         expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ endUser: null, tags: { team: 'platform' } }));
     });
 
+    it('requires an end user or tags', async () => {
+        const createSpy = vi.spyOn(connectSessionService, 'createConnectSession');
+
+        const result = await createConnectSessionTool.handler({ allowed_integrations: ['github'] }, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.message).toContain('arguments: At least one of end_user or tags must be provided');
+        }
+        expect(createSpy).not.toHaveBeenCalled();
+    });
+
     it('rejects invalid arguments before calling the service', async () => {
         const createSpy = vi.spyOn(connectSessionService, 'createConnectSession');
 

--- a/packages/server/lib/controllers/mcp/managementServer.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.ts
@@ -1,4 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { normalizeObjectSchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import * as z from 'zod/v4';
 
 import { hasApiKeyScope } from '@nangohq/utils';
 
@@ -16,7 +19,11 @@ import { handleMcpToolError, jsonStructuredContent } from './utils.js';
 
 import type { ManagementMcpContext, ManagementMcpRequiredScopes, ManagementMcpTool } from './managementTool.js';
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ApiKeyScope } from '@nangohq/types';
+
+const jsonSchema202012 = 'https://json-schema.org/draft/2020-12/schema';
+const emptyObjectJsonSchema: Tool['inputSchema'] = { type: 'object', properties: {} };
 
 const managementMcpTools: ManagementMcpTool[] = [
     createConnectSessionTool,
@@ -43,6 +50,7 @@ export function createManagementMcpServer(context: ManagementMcpContext, request
         }
     );
 
+    const listedTools: ManagementMcpTool[] = [];
     for (const toolDefinition of managementMcpTools) {
         // Need to cast because we have a different Zod version than the MCP SDK
         const config = {
@@ -68,10 +76,47 @@ export function createManagementMcpServer(context: ManagementMcpContext, request
             auditDeniedCallsForTool({ requestBody, context, tool: toolDefinition });
             // Disabled tools are omitted from tools/list and rejected by the SDK if called.
             registeredTool.disable();
+            continue;
         }
+
+        listedTools.push(toolDefinition);
     }
 
+    // MCP SDK 1.30 defaults Zod v4 conversion to draft-07 and does not expose a target option through registerTool.
+    // TODO(NAN-6651): Remove this tools/list override after the MCP SDK emits JSON Schema 2020-12.
+    server.server.setRequestHandler(ListToolsRequestSchema, () => ({
+        tools: listedTools.map(toListedTool)
+    }));
+
     return server;
+}
+
+function toListedTool(tool: ManagementMcpTool): Tool {
+    const inputSchema = toJsonSchema202012(tool.inputSchema, 'input') ?? emptyObjectJsonSchema;
+    const outputSchema = tool.outputSchema ? toJsonSchema202012(tool.outputSchema, 'output') : undefined;
+
+    return {
+        name: tool.name,
+        description: tool.description,
+        inputSchema,
+        ...(outputSchema ? { outputSchema } : {}),
+        ...(tool.annotations ? { annotations: tool.annotations } : {}),
+        execution: { taskSupport: 'forbidden' }
+    };
+}
+
+function toJsonSchema202012(schema: ManagementMcpTool['inputSchema'], io: 'input' | 'output'): Tool['inputSchema'] | undefined {
+    const objectSchema = normalizeObjectSchema(schema);
+    if (!objectSchema) {
+        return undefined;
+    }
+
+    const jsonSchema = z.toJSONSchema(objectSchema as z.ZodType, { target: 'draft-2020-12', io });
+    if (jsonSchema.type !== 'object' || jsonSchema.$schema !== jsonSchema202012) {
+        throw new Error(`Failed to generate a JSON Schema 2020-12 object for an MCP tool ${io} schema`);
+    }
+
+    return jsonSchema as Tool['inputSchema'];
 }
 
 function auditDeniedCallsForTool({ requestBody, context, tool }: { requestBody: unknown; context: ManagementMcpContext; tool: ManagementMcpTool }): void {

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -59,6 +59,22 @@ describe('createManagementMcpServer', () => {
         }
     });
 
+    it('advertises tool schemas using the default MCP JSON Schema dialect', async () => {
+        const { client, server } = await createTestClient(['environment:*']);
+
+        try {
+            const result = await client.listTools();
+
+            for (const tool of result.tools) {
+                expect(tool.inputSchema['$schema']).toBe('https://json-schema.org/draft/2020-12/schema');
+                expect(tool.outputSchema?.['$schema']).toBe('https://json-schema.org/draft/2020-12/schema');
+            }
+        } finally {
+            await client.close();
+            await server.close();
+        }
+    });
+
     it('exposes and authorizes non-idempotent Connect Session creation', async () => {
         const authorized = await createTestClient(['environment:connect_sessions:write']);
         try {


### PR DESCRIPTION
The Management MCP server now overrides `tools/list` schema serialization to emit JSON Schema 2020-12, avoiding Anthropic API rejection caused by the SDK's draft-07 default.

It preserves scope-based tool listing and tracks removal of the workaround under NAN-6651 once the upstream SDK fix lands. 

As a drive-by fix, changed connect session creation to no define the schema using zod's `oneOf` since that results in an empty object because it's not translated correctly to JSON schema in MCP SDK. Instead, it now advertises a root object schema that's less strict, but validates that `end_user` or `tags` is provided at runtime, and explains how to use the returned `connect_link`.

NAN-6653

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

