### PR TITLE
fix(auth): bind invitation signup tokens to invited email

### DIFF
--- a/packages/server/lib/controllers/v1/account/managed/auth.ts
+++ b/packages/server/lib/controllers/v1/account/managed/auth.ts
@@ -1,6 +1,6 @@
 import db from '@nangohq/database';
-import { acceptInvitation, accountService, expirePreviousInvitations, getInvitation, userService } from '@nangohq/shared';
-import { basePublicUrl, flagHasUsage, nanoid, normalizeEmail, report } from '@nangohq/utils';
+import { acceptInvitation, accountService, expirePreviousInvitations, getInvitation, userService, validateInvitation } from '@nangohq/shared';
+import { basePublicUrl, flagHasUsage, nanoid, report } from '@nangohq/utils';
 
 import { envs } from '../../../../env.js';
 import { linkBillingCustomer, linkBillingFreeSubscription } from '../../../../utils/billing.js';
@@ -120,11 +120,12 @@ export async function finalizeManagedAuthentication({
     const state = parseManagedAuthState(encodedState || '');
     let invitation: DBInvitation | null = null;
     if (state?.token) {
-        invitation = await getInvitation(state.token);
-        if (!invitation || normalizeEmail(invitation.email) !== normalizeEmail(authorizedUser.email)) {
-            res.status(400).send({ error: { code: 'not_found', message: 'Invitation does not exist or is expired' } });
+        const validatedInvitation = validateInvitation(await getInvitation(state.token), authorizedUser.email);
+        if (validatedInvitation.isErr()) {
+            res.status(400).send({ error: { code: validatedInvitation.error.code, message: validatedInvitation.error.message } });
             return;
         }
+        invitation = validatedInvitation.value;
     }
 
     let isNewTeam = true;

--- a/packages/server/lib/controllers/v1/account/signup.ts
+++ b/packages/server/lib/controllers/v1/account/signup.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { acceptInvitation, accountService, getInvitation, pbkdf2, userService } from '@nangohq/shared';
-import { flagHasUsage, PBKDF2_ITERATIONS, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { flagHasUsage, normalizeEmail, PBKDF2_ITERATIONS, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envs } from '../../../env.js';
 import { sendVerificationEmail } from '../../../helpers/email.js';
@@ -72,19 +72,21 @@ export const signup = asyncWrapper<PostSignup>(async (req, res) => {
     let invitationRole: Role = envs.DEFAULT_USER_ROLE;
     if (token) {
         // Invitation signup
-        const validToken = await getInvitation(token);
-        if (!validToken) {
+        const invitation = await getInvitation(token);
+        const isEnterpriseAdminInvitation =
+            invitation?.email === '' && invitation.account_id === 0 && invitation.invited_by === 0 && invitation.token === '' && invitation.accepted;
+        if (!invitation || (!isEnterpriseAdminInvitation && normalizeEmail(invitation.email) !== normalizeEmail(email))) {
             res.status(400).send({ error: { code: 'invalid_invite_token', message: 'The token used was found to be invalid.' } });
             return;
         }
 
-        account = await accountService.getAccountById(db.knex, validToken.account_id);
+        account = await accountService.getAccountById(db.knex, invitation.account_id);
         if (!account) {
             res.status(500).send({ error: { code: 'server_error', message: 'Failed to get team' } });
             return;
         }
 
-        invitationRole = validToken.role;
+        invitationRole = invitation.role;
         await acceptInvitation(token);
     } else {
         if (!envs.AUTH_ALLOW_SIGNUP) {

--- a/packages/server/lib/controllers/v1/account/signup.ts
+++ b/packages/server/lib/controllers/v1/account/signup.ts
@@ -3,8 +3,8 @@ import crypto from 'crypto';
 import * as z from 'zod';
 
 import db from '@nangohq/database';
-import { acceptInvitation, accountService, getInvitation, pbkdf2, userService } from '@nangohq/shared';
-import { flagHasUsage, normalizeEmail, PBKDF2_ITERATIONS, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { acceptInvitation, accountService, getInvitation, pbkdf2, userService, validateInvitation } from '@nangohq/shared';
+import { flagHasUsage, PBKDF2_ITERATIONS, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envs } from '../../../env.js';
 import { sendVerificationEmail } from '../../../helpers/email.js';
@@ -72,21 +72,19 @@ export const signup = asyncWrapper<PostSignup>(async (req, res) => {
     let invitationRole: Role = envs.DEFAULT_USER_ROLE;
     if (token) {
         // Invitation signup
-        const invitation = await getInvitation(token);
-        const isEnterpriseAdminInvitation =
-            invitation?.email === '' && invitation.account_id === 0 && invitation.invited_by === 0 && invitation.token === '' && invitation.accepted;
-        if (!invitation || (!isEnterpriseAdminInvitation && normalizeEmail(invitation.email) !== normalizeEmail(email))) {
-            res.status(400).send({ error: { code: 'invalid_invite_token', message: 'The token used was found to be invalid.' } });
+        const invitation = validateInvitation(await getInvitation(token), email);
+        if (invitation.isErr()) {
+            res.status(400).send({ error: { code: invitation.error.code, message: invitation.error.message } });
             return;
         }
 
-        account = await accountService.getAccountById(db.knex, invitation.account_id);
+        account = await accountService.getAccountById(db.knex, invitation.value.account_id);
         if (!account) {
             res.status(500).send({ error: { code: 'server_error', message: 'Failed to get team' } });
             return;
         }
 
-        invitationRole = invitation.role;
+        invitationRole = invitation.value.role;
         await acceptInvitation(token);
     } else {
         if (!envs.AUTH_ALLOW_SIGNUP) {

--- a/packages/server/lib/controllers/v1/account/signup.unit.test.ts
+++ b/packages/server/lib/controllers/v1/account/signup.unit.test.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { roles } from '@nangohq/utils';
+import { Err, Ok, roles } from '@nangohq/utils';
 
 import { envs } from '../../../env.js';
 import { signup } from './signup.js';
@@ -10,19 +10,29 @@ import { signup } from './signup.js';
 import type * as NangoUtils from '@nangohq/utils';
 import type { Request, Response } from 'express';
 
-const { mockAcceptInvitation, mockGetInvitation, mockGetPlan, mockGetAccountById, mockGetUserByEmail, mockPbkdf2, mockCreateUser, mockSendVerificationEmail } =
-    vi.hoisted(() => {
-        return {
-            mockAcceptInvitation: vi.fn(),
-            mockGetInvitation: vi.fn(),
-            mockGetPlan: vi.fn(),
-            mockGetAccountById: vi.fn(),
-            mockGetUserByEmail: vi.fn(),
-            mockPbkdf2: vi.fn(),
-            mockCreateUser: vi.fn(),
-            mockSendVerificationEmail: vi.fn()
-        };
-    });
+const {
+    mockAcceptInvitation,
+    mockGetInvitation,
+    mockGetPlan,
+    mockGetAccountById,
+    mockGetUserByEmail,
+    mockPbkdf2,
+    mockCreateUser,
+    mockSendVerificationEmail,
+    mockValidateInvitation
+} = vi.hoisted(() => {
+    return {
+        mockAcceptInvitation: vi.fn(),
+        mockGetInvitation: vi.fn(),
+        mockGetPlan: vi.fn(),
+        mockGetAccountById: vi.fn(),
+        mockGetUserByEmail: vi.fn(),
+        mockPbkdf2: vi.fn(),
+        mockCreateUser: vi.fn(),
+        mockSendVerificationEmail: vi.fn(),
+        mockValidateInvitation: vi.fn()
+    };
+});
 
 vi.mock('@nangohq/database', () => ({
     default: { knex: {} }
@@ -36,6 +46,7 @@ vi.mock('@nangohq/shared', () => ({
     getInvitation: mockGetInvitation,
     getPlan: mockGetPlan,
     pbkdf2: mockPbkdf2,
+    validateInvitation: mockValidateInvitation,
     userService: {
         getUserByEmail: mockGetUserByEmail,
         createUser: mockCreateUser
@@ -69,6 +80,12 @@ describe('signup', () => {
         mockGetAccountById.mockResolvedValue({ id: 7 });
         mockGetUserByEmail.mockResolvedValue(null);
         mockCreateUser.mockResolvedValue({ uuid: crypto.randomUUID(), id: 11, account_id: 7, role: nonDefaultRole });
+        mockValidateInvitation.mockImplementation((invitation: { email: string } | null, expectedEmail: string) => {
+            if (!invitation || invitation.email.toLowerCase() !== expectedEmail.toLowerCase()) {
+                return Err(Object.assign(new Error('Invitation does not exist or is expired'), { code: 'not_found' }));
+            }
+            return Ok(invitation);
+        });
     });
 
     it('preserves the invited role at signup when plan mode is disabled', async () => {
@@ -153,7 +170,7 @@ describe('signup', () => {
         await signup(req, res, vi.fn());
 
         expect(status).toHaveBeenCalledWith(400);
-        expect(send).toHaveBeenCalledWith({ error: { code: 'invalid_invite_token', message: 'The token used was found to be invalid.' } });
+        expect(send).toHaveBeenCalledWith({ error: { code: 'not_found', message: 'Invitation does not exist or is expired' } });
         expect(mockGetAccountById).not.toHaveBeenCalled();
         expect(mockAcceptInvitation).not.toHaveBeenCalled();
         expect(mockPbkdf2).not.toHaveBeenCalled();
@@ -173,6 +190,7 @@ describe('signup', () => {
             accepted: true,
             role: 'administrator'
         });
+        mockValidateInvitation.mockImplementation((invitation) => Ok(invitation));
         mockGetAccountById.mockResolvedValue({ id: 0 });
         const login = vi.fn((_user: unknown, callback: (err?: Error) => void) => callback());
         const req = {

--- a/packages/server/lib/controllers/v1/account/signup.unit.test.ts
+++ b/packages/server/lib/controllers/v1/account/signup.unit.test.ts
@@ -77,7 +77,7 @@ describe('signup', () => {
 
         mockGetInvitation.mockResolvedValue({
             token: invitationToken,
-            email,
+            email: 'Invitee@Example.com',
             account_id: 7,
             role: nonDefaultRole
         });
@@ -120,5 +120,76 @@ describe('signup', () => {
 
         expect(payload?.data.verified).toBe(true);
         expect(typeof payload?.data.uuid).toBe('string');
+    });
+
+    it('rejects an invitation used with a different email without consuming it', async () => {
+        const invitationToken = crypto.randomUUID();
+        const invitedEmail = 'invitee@example.com';
+        const submittedEmail = 'attacker@example.com';
+
+        mockGetInvitation.mockResolvedValue({
+            token: invitationToken,
+            email: invitedEmail,
+            account_id: 7,
+            role: nonDefaultRole
+        });
+
+        const login = vi.fn();
+        const req = {
+            body: { email: submittedEmail, name: 'Attacker', password: 'Password123!', token: invitationToken },
+            query: {},
+            route: { path: '/api/v1/account/signup' },
+            originalUrl: '/api/v1/account/signup',
+            header: vi.fn(),
+            login
+        } as unknown as Request;
+        const status = vi.fn().mockReturnThis();
+        const send = vi.fn().mockReturnThis();
+        const res = {
+            status,
+            send
+        } as unknown as Response;
+
+        await signup(req, res, vi.fn());
+
+        expect(status).toHaveBeenCalledWith(400);
+        expect(send).toHaveBeenCalledWith({ error: { code: 'invalid_invite_token', message: 'The token used was found to be invalid.' } });
+        expect(mockGetAccountById).not.toHaveBeenCalled();
+        expect(mockAcceptInvitation).not.toHaveBeenCalled();
+        expect(mockPbkdf2).not.toHaveBeenCalled();
+        expect(mockCreateUser).not.toHaveBeenCalled();
+        expect(login).not.toHaveBeenCalled();
+    });
+
+    it('allows enterprise admin signup with its synthetic invitation', async () => {
+        const invitationToken = crypto.randomUUID();
+        const email = 'admin@example.com';
+
+        mockGetInvitation.mockResolvedValue({
+            token: '',
+            email: '',
+            account_id: 0,
+            invited_by: 0,
+            accepted: true,
+            role: 'administrator'
+        });
+        mockGetAccountById.mockResolvedValue({ id: 0 });
+        const login = vi.fn((_user: unknown, callback: (err?: Error) => void) => callback());
+        const req = {
+            body: { email, name: 'Admin', password: 'Password123!', token: invitationToken },
+            query: {},
+            route: { path: '/api/v1/account/signup' },
+            originalUrl: '/api/v1/account/signup',
+            header: vi.fn(),
+            login
+        } as unknown as Request;
+        const status = vi.fn().mockReturnThis();
+        const send = vi.fn().mockReturnThis();
+        const res = { status, send } as unknown as Response;
+
+        await signup(req, res, vi.fn());
+
+        expect(mockCreateUser).toHaveBeenCalledWith(expect.objectContaining({ email, account_id: 0, email_verified: true, role: 'administrator' }));
+        expect(status).toHaveBeenCalledWith(200);
     });
 });

--- a/packages/server/lib/controllers/v1/invite/acceptInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/acceptInvite.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
-import { acceptInvitation, getInvitation, userService } from '@nangohq/shared';
-import { normalizeEmail, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { acceptInvitation, getInvitation, userService, validateInvitation } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
@@ -30,14 +30,14 @@ export const acceptInvite = asyncWrapper<AcceptInvite>(async (req, res) => {
 
     const { user } = res.locals;
     const data: AcceptInvite['Params'] = val.data;
-    const invitation = await getInvitation(data.id);
-    if (!invitation || normalizeEmail(invitation.email) !== normalizeEmail(user.email)) {
-        res.status(400).send({ error: { code: 'not_found', message: 'Invitation does not exist or is expired' } });
+    const invitation = validateInvitation(await getInvitation(data.id), user.email);
+    if (invitation.isErr()) {
+        res.status(400).send({ error: { code: invitation.error.code, message: invitation.error.message } });
         return;
     }
 
     await acceptInvitation(data.id);
-    const updated = await userService.update({ id: user.id, account_id: invitation.account_id, role: invitation.role });
+    const updated = await userService.update({ id: user.id, account_id: invitation.value.account_id, role: invitation.value.role });
     if (!updated) {
         res.status(500).send({ error: { code: 'server_error', message: 'failed to update user team' } });
         return;

--- a/packages/server/lib/controllers/v1/invite/acceptInvite.unit.test.ts
+++ b/packages/server/lib/controllers/v1/invite/acceptInvite.unit.test.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { roles } from '@nangohq/utils';
+import { Ok, roles } from '@nangohq/utils';
 
 import { envs } from '../../../env.js';
 import { acceptInvite } from './acceptInvite.js';
@@ -10,12 +10,13 @@ import { acceptInvite } from './acceptInvite.js';
 import type * as NangoUtils from '@nangohq/utils';
 import type { Request, Response } from 'express';
 
-const { mockAcceptInvitation, mockGetInvitation, mockGetPlan, mockUpdateUser } = vi.hoisted(() => {
+const { mockAcceptInvitation, mockGetInvitation, mockGetPlan, mockUpdateUser, mockValidateInvitation } = vi.hoisted(() => {
     return {
         mockAcceptInvitation: vi.fn(),
         mockGetInvitation: vi.fn(),
         mockGetPlan: vi.fn(),
-        mockUpdateUser: vi.fn()
+        mockUpdateUser: vi.fn(),
+        mockValidateInvitation: vi.fn()
     };
 });
 
@@ -27,6 +28,7 @@ vi.mock('@nangohq/shared', () => ({
     acceptInvitation: mockAcceptInvitation,
     getInvitation: mockGetInvitation,
     getPlan: mockGetPlan,
+    validateInvitation: mockValidateInvitation,
     userService: {
         update: mockUpdateUser
     }
@@ -52,6 +54,7 @@ describe('acceptInvite', () => {
         vi.clearAllMocks();
         mockAcceptInvitation.mockResolvedValue(undefined);
         mockUpdateUser.mockResolvedValue({ id: 2, account_id: 3, role: nonDefaultRole });
+        mockValidateInvitation.mockImplementation((invitation) => Ok(invitation));
     });
 
     it('preserves the invited role when plan mode is disabled', async () => {

--- a/packages/server/lib/controllers/v1/invite/declineInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/declineInvite.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 
-import { declineInvitation, getInvitation } from '@nangohq/shared';
+import { declineInvitation, getInvitation, validateInvitation } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -30,9 +30,9 @@ export const declineInvite = asyncWrapper<DeclineInvite>(async (req, res) => {
 
     const { user } = res.locals;
     const data: DeclineInvite['Params'] = val.data;
-    const invitation = await getInvitation(data.id);
-    if (!invitation || invitation.email !== user.email) {
-        res.status(400).send({ error: { code: 'not_found', message: 'Invitation does not exist or is expired' } });
+    const invitation = validateInvitation(await getInvitation(data.id), user.email);
+    if (invitation.isErr()) {
+        res.status(400).send({ error: { code: invitation.error.code, message: invitation.error.message } });
         return;
     }
 

--- a/packages/shared/lib/services/invitations.ts
+++ b/packages/shared/lib/services/invitations.ts
@@ -1,10 +1,10 @@
 import * as uuid from 'uuid';
 
 import db from '@nangohq/database';
-import { isEnterprise, normalizeEmail } from '@nangohq/utils';
+import { Err, isEnterprise, normalizeEmail, Ok } from '@nangohq/utils';
 
 import type { Knex } from '@nangohq/database';
-import type { DBInvitation } from '@nangohq/types';
+import type { DBInvitation, Result } from '@nangohq/types';
 
 const INVITE_EMAIL_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
 
@@ -123,4 +123,24 @@ export async function deleteExpiredInvitations({ limit, olderThan }: { limit: nu
             sub.select('id').from<DBInvitation>('_nango_invited_users').where('expires_at', '<=', dateThreshold.toISOString()).limit(limit);
         })
         .delete();
+}
+
+export function isEnterpriseAdminInvitation(invitation: DBInvitation) {
+    return invitation.email === '' && invitation.account_id === 0 && invitation.invited_by === 0 && invitation.token === '' && invitation.accepted;
+}
+
+export class InvitationNotFoundError extends Error {
+    public readonly code = 'not_found';
+
+    constructor() {
+        super('Invitation does not exist or is expired');
+    }
+}
+
+export function validateInvitation(invitation: DBInvitation | null, expectedEmail: string): Result<DBInvitation, InvitationNotFoundError> {
+    if (!invitation || (!isEnterpriseAdminInvitation(invitation) && normalizeEmail(invitation.email) !== normalizeEmail(expectedEmail))) {
+        return Err(new InvitationNotFoundError());
+    }
+
+    return Ok(invitation);
 }

--- a/packages/shared/lib/services/invitations.ts
+++ b/packages/shared/lib/services/invitations.ts
@@ -7,6 +7,32 @@ import type { Knex } from '@nangohq/database';
 import type { DBInvitation, Result } from '@nangohq/types';
 
 const INVITE_EMAIL_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
+const UNIX_EPOCH = new Date(0);
+
+// NOTE: enterprise invitations using `NANGO_ADMIN_INVITE_TOKEN` as an invitation
+// token generate a special synthetic invitation object, that is used to bypass
+// the invitation validation constraints:
+export const enterpriseAdminInvite: DBInvitation = {
+    id: 1,
+    email: '',
+    name: '',
+    account_id: 0,
+    invited_by: 0,
+    token: '',
+    expires_at: UNIX_EPOCH,
+    accepted: true,
+    created_at: UNIX_EPOCH,
+    updated_at: UNIX_EPOCH,
+    role: 'administrator'
+};
+
+export function isEnterpriseAdminInvitation(invitation: DBInvitation) {
+    return invitation === enterpriseAdminInvite;
+}
+
+function isAdminInviteToken(token: string): boolean {
+    return process.env['NANGO_ADMIN_INVITE_TOKEN'] === token;
+}
 
 export async function expirePreviousInvitations({ email, accountId, trx }: { email: string; accountId: number; trx: Knex }) {
     const result = await trx
@@ -85,24 +111,11 @@ export async function declineInvitation(token: string) {
 }
 
 export async function getInvitation(token: string): Promise<DBInvitation | null> {
-    const now = new Date();
-
-    if (isEnterprise && process.env['NANGO_ADMIN_INVITE_TOKEN'] === token) {
-        return {
-            id: 1,
-            email: '',
-            name: '',
-            account_id: 0,
-            invited_by: 0,
-            token: '',
-            expires_at: now,
-            accepted: true,
-            created_at: now,
-            updated_at: now,
-            role: 'administrator'
-        };
+    if (isEnterprise && isAdminInviteToken(token)) {
+        return enterpriseAdminInvite;
     }
 
+    const now = new Date();
     const result = await db.knex
         .select('*')
         .from<DBInvitation>(`_nango_invited_users`)
@@ -125,10 +138,6 @@ export async function deleteExpiredInvitations({ limit, olderThan }: { limit: nu
         .delete();
 }
 
-export function isEnterpriseAdminInvitation(invitation: DBInvitation) {
-    return invitation.email === '' && invitation.account_id === 0 && invitation.invited_by === 0 && invitation.token === '' && invitation.accepted;
-}
-
 export class InvitationNotFoundError extends Error {
     public readonly code = 'not_found';
 
@@ -138,9 +147,13 @@ export class InvitationNotFoundError extends Error {
 }
 
 export function validateInvitation(invitation: DBInvitation | null, expectedEmail: string): Result<DBInvitation, InvitationNotFoundError> {
-    if (!invitation || (!isEnterpriseAdminInvitation(invitation) && normalizeEmail(invitation.email) !== normalizeEmail(expectedEmail))) {
+    if (!invitation) {
         return Err(new InvitationNotFoundError());
     }
 
-    return Ok(invitation);
+    if (isEnterpriseAdminInvitation(invitation) || normalizeEmail(invitation.email) === normalizeEmail(expectedEmail)) {
+        return Ok(invitation);
+    }
+
+    return Err(new InvitationNotFoundError());
 }

--- a/packages/shared/lib/services/invitations.unit.test.ts
+++ b/packages/shared/lib/services/invitations.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { validateInvitation } from './invitations.js';
+import { enterpriseAdminInvite, validateInvitation } from './invitations.js';
 
 import type { DBInvitation } from '@nangohq/types';
 
@@ -41,9 +41,21 @@ describe('validateInvitation', () => {
         }
     });
 
-    it('accepts the synthetic enterprise administrator invitation for any email', () => {
-        const result = validateInvitation(invitation({ email: '', account_id: 0, invited_by: 0, token: '', accepted: true }), 'admin@example.com');
+    it('accepts the shared enterprise administrator invitation for any email', () => {
+        const result = validateInvitation(enterpriseAdminInvite, 'admin@example.com');
 
         expect(result.isOk()).toBe(true);
+    });
+
+    it('does not accept a persisted invitation that resembles the enterprise administrator invitation', () => {
+        const persistedInvitation: DBInvitation = {
+            ...enterpriseAdminInvite,
+            expires_at: new Date(enterpriseAdminInvite.expires_at),
+            created_at: new Date(enterpriseAdminInvite.created_at),
+            updated_at: new Date(enterpriseAdminInvite.updated_at)
+        };
+        const result = validateInvitation(persistedInvitation, 'admin@example.com');
+
+        expect(result.isErr()).toBe(true);
     });
 });

--- a/packages/shared/lib/services/invitations.unit.test.ts
+++ b/packages/shared/lib/services/invitations.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateInvitation } from './invitations.js';
+
+import type { DBInvitation } from '@nangohq/types';
+
+function invitation(overrides: Partial<DBInvitation> = {}): DBInvitation {
+    const now = new Date();
+    return {
+        id: 1,
+        email: 'invitee@example.com',
+        name: 'Invitee',
+        account_id: 1,
+        invited_by: 1,
+        token: 'invite-token',
+        expires_at: now,
+        accepted: false,
+        created_at: now,
+        updated_at: now,
+        role: 'administrator',
+        ...overrides
+    };
+}
+
+describe('validateInvitation', () => {
+    it('accepts a case-insensitive email match', () => {
+        const result = validateInvitation(invitation(), 'Invitee@Example.com');
+
+        expect(result.isOk()).toBe(true);
+    });
+
+    it.each([
+        ['the invitation is missing', null],
+        ['the invitation email does not match', invitation()]
+    ])('returns a standard not-found error when %s', (_, invalidInvitation) => {
+        const result = validateInvitation(invalidInvitation, 'other@example.com');
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({ code: 'not_found', message: 'Invitation does not exist or is expired' });
+        }
+    });
+
+    it('accepts the synthetic enterprise administrator invitation for any email', () => {
+        const result = validateInvitation(invitation({ email: '', account_id: 0, invited_by: 0, token: '', accepted: true }), 'admin@example.com');
+
+        expect(result.isOk()).toBe(true);
+    });
+});

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -55,7 +55,7 @@ export type PostSignup = ApiEndpoint<{
         | ApiError<'error_creating_user'>
         | ApiError<'user_already_exists'>
         | ApiError<'error_creating_account'>
-        | ApiError<'invalid_invite_token'>
+        | ApiError<'not_found'>
         | ApiError<'email_not_verified'>;
     Success: {
         data: {


### PR DESCRIPTION
Validate that the email submitted during invitation signup matches the invitation’s email after normalization. Reject mismatches before consuming the token or creating an auto-verified account.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

