### PR TITLE
feat(server): add agent session persistence (NAN-6593)

### DIFF
--- a/packages/database/lib/migrations/20260818173000_create_agent_sessions.cjs
+++ b/packages/database/lib/migrations/20260818173000_create_agent_sessions.cjs
@@ -1,0 +1,49 @@
+exports.config = { transaction: false };
+
+const table = 'agent_sessions';
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.raw(`
+        CREATE UNIQUE INDEX IF NOT EXISTS _nango_environments_account_id_id_unique_idx
+            ON _nango_environments (account_id, id);
+
+        CREATE TABLE IF NOT EXISTS ${table} (
+            id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            account_id INTEGER NOT NULL REFERENCES _nango_accounts(id) ON DELETE CASCADE,
+            environment_id INTEGER NOT NULL,
+            resolved_connections JSONB NOT NULL,
+            compiled_toolset JSONB NOT NULL,
+            meta_tools JSONB NOT NULL,
+            expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+            ended_at TIMESTAMP WITH TIME ZONE,
+            ended_reason TEXT CHECK (ended_reason IN ('terminated', 'expired')),
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            CONSTRAINT agent_sessions_end_state_check CHECK (
+                (ended_at IS NULL AND ended_reason IS NULL)
+                OR (ended_at IS NOT NULL AND ended_reason IS NOT NULL)
+            ),
+            CONSTRAINT agent_sessions_environment_account_fk
+                FOREIGN KEY (account_id, environment_id)
+                REFERENCES _nango_environments(account_id, id)
+                ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS agent_sessions_environment_id_idx
+            ON ${table} (environment_id);
+
+        CREATE INDEX IF NOT EXISTS agent_sessions_account_id_idx
+            ON ${table} (account_id);
+
+        CREATE INDEX IF NOT EXISTS agent_sessions_active_expiration_idx
+            ON ${table} (expires_at)
+            WHERE ended_at IS NULL;
+    `);
+};
+
+exports.down = async function () {
+    // Agent sessions are retained on rollback.
+};

--- a/packages/database/lib/migrations/20260818173000_create_agent_sessions.cjs
+++ b/packages/database/lib/migrations/20260818173000_create_agent_sessions.cjs
@@ -7,13 +7,10 @@ const table = 'agent_sessions';
  */
 exports.up = async function (knex) {
     await knex.schema.raw(`
-        CREATE UNIQUE INDEX IF NOT EXISTS _nango_environments_account_id_id_unique_idx
-            ON _nango_environments (account_id, id);
-
         CREATE TABLE IF NOT EXISTS ${table} (
             id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
             account_id INTEGER NOT NULL REFERENCES _nango_accounts(id) ON DELETE CASCADE,
-            environment_id INTEGER NOT NULL,
+            environment_id INTEGER NOT NULL REFERENCES _nango_environments(id) ON DELETE CASCADE,
             resolved_connections JSONB NOT NULL,
             compiled_toolset JSONB NOT NULL,
             meta_tools JSONB NOT NULL,
@@ -25,11 +22,7 @@ exports.up = async function (knex) {
             CONSTRAINT agent_sessions_end_state_check CHECK (
                 (ended_at IS NULL AND ended_reason IS NULL)
                 OR (ended_at IS NOT NULL AND ended_reason IS NOT NULL)
-            ),
-            CONSTRAINT agent_sessions_environment_account_fk
-                FOREIGN KEY (account_id, environment_id)
-                REFERENCES _nango_environments(account_id, id)
-                ON DELETE CASCADE
+            )
         );
 
         CREATE INDEX IF NOT EXISTS agent_sessions_environment_id_idx
@@ -44,6 +37,4 @@ exports.up = async function (knex) {
     `);
 };
 
-exports.down = async function () {
-    // Agent sessions are retained on rollback.
-};
+exports.down = async function () {};

--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -1,0 +1,194 @@
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { createAgentSession, getAgentSession, listExpiredAgentSessions, terminateAgentSession } from './agentSession.service.js';
+
+import type { AgentSession, AgentSessionCompiledToolset, AgentSessionResolvedConnections, DBEnvironment, DBTeam } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+const table = 'agent_sessions';
+
+describe('agentSession service', () => {
+    let account: DBTeam;
+    let environment: DBEnvironment;
+
+    beforeAll(async () => {
+        await db.knex.raw('CREATE SCHEMA IF NOT EXISTS ??', [db.schema()]);
+        await db.knex.migrate.latest({ directory: path.resolve('packages/database/lib/migrations') });
+    });
+
+    beforeEach(async () => {
+        await db.knex(table).delete();
+        const seed = await seeders.seedAccountEnvAndUser();
+        account = seed.account;
+        environment = seed.env;
+    });
+
+    it('creates and retrieves an immutable session snapshot', async () => {
+        const expiresAt = new Date(Date.now() + 60_000);
+        const resolvedConnections = {
+            github: { connectionId: 'github-connection', tags: { endUser: 'customer-1' } },
+            slack: null
+        } satisfies AgentSessionResolvedConnections;
+        const compiledToolset = {
+            github: { pinned: ['create_issue'], searchable: ['get_issue'] },
+            slack: { pinned: [], searchable: ['send_message'] }
+        } satisfies AgentSessionCompiledToolset;
+
+        const created = unwrap(
+            await createAgentSession(db.knex, {
+                accountId: account.id,
+                environmentId: environment.id,
+                resolvedConnections,
+                compiledToolset,
+                metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+                expiresAt
+            })
+        );
+
+        expect(created).toMatchObject({
+            accountId: account.id,
+            environmentId: environment.id,
+            resolvedConnections,
+            compiledToolset,
+            metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+            expiresAt,
+            endedAt: null,
+            endedReason: null
+        });
+        expect(created.id).toMatch(/^[0-9a-f-]{36}$/i);
+        expect(created.createdAt).toBeInstanceOf(Date);
+        expect(created.updatedAt).toBeInstanceOf(Date);
+
+        const retrieved = unwrap(
+            await getAgentSession(db.knex, {
+                id: created.id,
+                accountId: account.id,
+                environmentId: environment.id
+            })
+        );
+        expect(retrieved).toStrictEqual(created);
+    });
+
+    it('scopes session retrieval to the account and environment', async () => {
+        const session = await createSession({ account, environment });
+        const other = await seeders.seedAccountEnvAndUser();
+
+        const wrongTenant = await getAgentSession(db.knex, {
+            id: session.id,
+            accountId: other.account.id,
+            environmentId: other.env.id
+        });
+        const unknown = await getAgentSession(db.knex, {
+            id: randomUUID(),
+            accountId: account.id,
+            environmentId: environment.id
+        });
+
+        expect(wrongTenant.isErr()).toBe(true);
+        expect(unknown.isErr()).toBe(true);
+        if (wrongTenant.isErr()) {
+            expect(wrongTenant.error.code).toBe('not_found');
+        }
+        if (unknown.isErr()) {
+            expect(unknown.error.code).toBe('not_found');
+        }
+    });
+
+    it('rejects an environment owned by another account', async () => {
+        const other = await seeders.seedAccountEnvAndUser();
+
+        await expect(
+            createAgentSession(db.knex, {
+                accountId: account.id,
+                environmentId: other.env.id,
+                resolvedConnections: {},
+                compiledToolset: {},
+                metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+                expiresAt: new Date(Date.now() + 60_000)
+            })
+        ).rejects.toMatchObject({ code: '23503' });
+    });
+
+    it('terminates a session idempotently without replacing its terminal state', async () => {
+        const session = await createSession({ account, environment });
+
+        const terminated = unwrap(
+            await terminateAgentSession(db.knex, {
+                id: session.id,
+                accountId: account.id,
+                environmentId: environment.id,
+                reason: 'terminated'
+            })
+        );
+        expect(terminated.endedAt).toBeInstanceOf(Date);
+        expect(terminated.endedReason).toBe('terminated');
+
+        const retried = unwrap(
+            await terminateAgentSession(db.knex, {
+                id: session.id,
+                accountId: account.id,
+                environmentId: environment.id,
+                reason: 'expired'
+            })
+        );
+        expect(retried.endedAt).toStrictEqual(terminated.endedAt);
+        expect(retried.endedReason).toBe('terminated');
+    });
+
+    it('lists active expired sessions in expiration order and honors the limit', async () => {
+        const expiredOld = await createSession({ account, environment, expiresAt: new Date(Date.now() - 3 * 60 * 60 * 1000) });
+        const expiredEnded = await createSession({ account, environment, expiresAt: new Date(Date.now() - 2 * 60 * 60 * 1000) });
+        const expiredRecent = await createSession({ account, environment, expiresAt: new Date(Date.now() - 60 * 60 * 1000) });
+        const active = await createSession({ account, environment, expiresAt: new Date(Date.now() + 60 * 60 * 1000) });
+        unwrap(
+            await terminateAgentSession(db.knex, {
+                id: expiredEnded.id,
+                accountId: account.id,
+                environmentId: environment.id,
+                reason: 'expired'
+            })
+        );
+
+        const limited = await listExpiredAgentSessions(db.knex, { limit: 1 });
+        expect(limited.map(({ id }) => id)).toStrictEqual([expiredOld.id]);
+
+        const expired = await listExpiredAgentSessions(db.knex, { limit: 10 });
+        expect(expired.map(({ id }) => id)).toStrictEqual([expiredOld.id, expiredRecent.id]);
+        expect(expired.map(({ id }) => id)).not.toContain(expiredEnded.id);
+        expect(expired.map(({ id }) => id)).not.toContain(active.id);
+    });
+});
+
+async function createSession({
+    account,
+    environment,
+    expiresAt = new Date(Date.now() + 60_000)
+}: {
+    account: DBTeam;
+    environment: DBEnvironment;
+    expiresAt?: Date;
+}): Promise<AgentSession> {
+    return unwrap(
+        await createAgentSession(db.knex, {
+            accountId: account.id,
+            environmentId: environment.id,
+            resolvedConnections: {},
+            compiledToolset: {},
+            metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+            expiresAt
+        })
+    );
+}
+
+function unwrap<T>(result: Result<T>): T {
+    if (result.isErr()) {
+        throw result.error;
+    }
+    return result.value;
+}

--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -1,9 +1,8 @@
 import { randomUUID } from 'node:crypto';
-import path from 'node:path';
 
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
-import db from '@nangohq/database';
+import db, { multipleMigrations } from '@nangohq/database';
 import { seeders } from '@nangohq/shared';
 
 import { createAgentSession, getAgentSession, listExpiredAgentSessions, terminateAgentSession } from './agentSession.service.js';
@@ -18,8 +17,7 @@ describe('agentSession service', () => {
     let environment: DBEnvironment;
 
     beforeAll(async () => {
-        await db.knex.raw('CREATE SCHEMA IF NOT EXISTS ??', [db.schema()]);
-        await db.knex.migrate.latest({ directory: path.resolve('packages/database/lib/migrations') });
+        await multipleMigrations();
     });
 
     beforeEach(async () => {
@@ -103,16 +101,19 @@ describe('agentSession service', () => {
     it('rejects an environment owned by another account', async () => {
         const other = await seeders.seedAccountEnvAndUser();
 
-        await expect(
-            createAgentSession(db.knex, {
-                accountId: account.id,
-                environmentId: other.env.id,
-                resolvedConnections: {},
-                compiledToolset: {},
-                metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
-                expiresAt: new Date(Date.now() + 60_000)
-            })
-        ).rejects.toMatchObject({ code: '23503' });
+        const result = await createAgentSession(db.knex, {
+            accountId: account.id,
+            environmentId: other.env.id,
+            resolvedConnections: {},
+            compiledToolset: {},
+            metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.code).toBe('creation_failed');
+        }
     });
 
     it('terminates a session idempotently without replacing its terminal state', async () => {

--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -8,7 +8,6 @@ import { seeders } from '@nangohq/shared';
 import { createAgentSession, getAgentSession, listExpiredAgentSessions, terminateAgentSession } from './agentSession.service.js';
 
 import type { AgentSession, AgentSessionCompiledToolset, AgentSessionResolvedConnections, DBEnvironment, DBTeam } from '@nangohq/types';
-import type { Result } from '@nangohq/utils';
 
 const table = 'agent_sessions';
 
@@ -38,7 +37,7 @@ describe('agentSession service', () => {
             slack: { pinned: [], searchable: ['send_message'] }
         } satisfies AgentSessionCompiledToolset;
 
-        const created = unwrap(
+        const created = (
             await createAgentSession(db.knex, {
                 accountId: account.id,
                 environmentId: environment.id,
@@ -47,7 +46,7 @@ describe('agentSession service', () => {
                 metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
                 expiresAt
             })
-        );
+        ).unwrap();
 
         expect(created).toMatchObject({
             accountId: account.id,
@@ -63,13 +62,13 @@ describe('agentSession service', () => {
         expect(created.createdAt).toBeInstanceOf(Date);
         expect(created.updatedAt).toBeInstanceOf(Date);
 
-        const retrieved = unwrap(
+        const retrieved = (
             await getAgentSession(db.knex, {
                 id: created.id,
                 accountId: account.id,
                 environmentId: environment.id
             })
-        );
+        ).unwrap();
         expect(retrieved).toStrictEqual(created);
     });
 
@@ -116,28 +115,46 @@ describe('agentSession service', () => {
         }
     });
 
+    it('rejects a soft-deleted environment', async () => {
+        await db.knex('_nango_environments').where({ id: environment.id }).update({ deleted: true, deleted_at: new Date() });
+
+        const result = await createAgentSession(db.knex, {
+            accountId: account.id,
+            environmentId: environment.id,
+            resolvedConnections: {},
+            compiledToolset: {},
+            metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.code).toBe('creation_failed');
+        }
+    });
+
     it('terminates a session idempotently without replacing its terminal state', async () => {
         const session = await createSession({ account, environment });
 
-        const terminated = unwrap(
+        const terminated = (
             await terminateAgentSession(db.knex, {
                 id: session.id,
                 accountId: account.id,
                 environmentId: environment.id,
                 reason: 'terminated'
             })
-        );
+        ).unwrap();
         expect(terminated.endedAt).toBeInstanceOf(Date);
         expect(terminated.endedReason).toBe('terminated');
 
-        const retried = unwrap(
+        const retried = (
             await terminateAgentSession(db.knex, {
                 id: session.id,
                 accountId: account.id,
                 environmentId: environment.id,
                 reason: 'expired'
             })
-        );
+        ).unwrap();
         expect(retried.endedAt).toStrictEqual(terminated.endedAt);
         expect(retried.endedReason).toBe('terminated');
     });
@@ -147,14 +164,14 @@ describe('agentSession service', () => {
         const expiredEnded = await createSession({ account, environment, expiresAt: new Date(Date.now() - 2 * 60 * 60 * 1000) });
         const expiredRecent = await createSession({ account, environment, expiresAt: new Date(Date.now() - 60 * 60 * 1000) });
         const active = await createSession({ account, environment, expiresAt: new Date(Date.now() + 60 * 60 * 1000) });
-        unwrap(
+        (
             await terminateAgentSession(db.knex, {
                 id: expiredEnded.id,
                 accountId: account.id,
                 environmentId: environment.id,
                 reason: 'expired'
             })
-        );
+        ).unwrap();
 
         const limited = await listExpiredAgentSessions(db.knex, { limit: 1 });
         expect(limited.map(({ id }) => id)).toStrictEqual([expiredOld.id]);
@@ -175,7 +192,7 @@ async function createSession({
     environment: DBEnvironment;
     expiresAt?: Date;
 }): Promise<AgentSession> {
-    return unwrap(
+    return (
         await createAgentSession(db.knex, {
             accountId: account.id,
             environmentId: environment.id,
@@ -184,12 +201,5 @@ async function createSession({
             metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
             expiresAt
         })
-    );
-}
-
-function unwrap<T>(result: Result<T>): T {
-    if (result.isErr()) {
-        throw result.error;
-    }
-    return result.value;
+    ).unwrap();
 }

--- a/packages/server/lib/services/agentSession.service.ts
+++ b/packages/server/lib/services/agentSession.service.ts
@@ -11,6 +11,12 @@ import type {
 import type { Result } from '@nangohq/utils';
 
 const AGENT_SESSIONS_TABLE = 'agent_sessions';
+const ENVIRONMENTS_TABLE = '_nango_environments';
+
+interface DBEnvironmentOwner {
+    readonly id: number;
+    readonly account_id: number;
+}
 
 export interface DBAgentSession {
     readonly id: string;
@@ -35,14 +41,16 @@ export interface CreateAgentSessionParams {
     expiresAt: Date;
 }
 
+export type ExpiredAgentSession = Pick<AgentSession, 'id' | 'accountId' | 'environmentId' | 'expiresAt'>;
+
 type AgentSessionErrorCode = 'not_found' | 'creation_failed';
 
 export class AgentSessionError extends Error {
     public readonly code: AgentSessionErrorCode;
     public readonly payload: Record<string, unknown>;
 
-    constructor({ code, message, payload }: { code: AgentSessionErrorCode; message: string; payload?: Record<string, unknown> }) {
-        super(message);
+    constructor({ code, message, payload, cause }: { code: AgentSessionErrorCode; message: string; payload?: Record<string, unknown>; cause?: unknown }) {
+        super(message, { cause });
         this.name = 'AgentSessionError';
         this.code = code;
         this.payload = payload ?? {};
@@ -50,28 +58,34 @@ export class AgentSessionError extends Error {
 }
 
 export async function createAgentSession(db: Knex, params: CreateAgentSessionParams): Promise<Result<AgentSession, AgentSessionError>> {
-    const [session] = await db<DBAgentSession>(AGENT_SESSIONS_TABLE)
-        .insert({
-            account_id: params.accountId,
-            environment_id: params.environmentId,
-            resolved_connections: jsonb(db, params.resolvedConnections),
-            compiled_toolset: jsonb(db, params.compiledToolset),
-            meta_tools: jsonb(db, params.metaTools),
-            expires_at: params.expiresAt
-        })
-        .returning('*');
+    try {
+        const environment = await db<DBEnvironmentOwner>(ENVIRONMENTS_TABLE)
+            .select('id')
+            .where({ id: params.environmentId, account_id: params.accountId })
+            .first();
+        if (!environment) {
+            return Err(creationFailedError(params));
+        }
 
-    if (!session) {
-        return Err(
-            new AgentSessionError({
-                code: 'creation_failed',
-                message: 'Failed to create agent session',
-                payload: { accountId: params.accountId, environmentId: params.environmentId }
+        const [session] = await db<DBAgentSession>(AGENT_SESSIONS_TABLE)
+            .insert({
+                account_id: params.accountId,
+                environment_id: params.environmentId,
+                resolved_connections: jsonb(db, params.resolvedConnections),
+                compiled_toolset: jsonb(db, params.compiledToolset),
+                meta_tools: jsonb(db, params.metaTools),
+                expires_at: params.expiresAt
             })
-        );
-    }
+            .returning('*');
 
-    return Ok(toAgentSession(session));
+        if (!session) {
+            throw new Error('Agent session insert returned no row');
+        }
+
+        return Ok(toAgentSession(session));
+    } catch (err) {
+        return Err(creationFailedError(params, err));
+    }
 }
 
 export async function getAgentSession(
@@ -104,14 +118,20 @@ export async function terminateAgentSession(
     return getAgentSession(db, { id, accountId, environmentId });
 }
 
-export async function listExpiredAgentSessions(db: Knex, { limit }: { limit: number }): Promise<AgentSession[]> {
+export async function listExpiredAgentSessions(db: Knex, { limit }: { limit: number }): Promise<ExpiredAgentSession[]> {
     const sessions = await db<DBAgentSession>(AGENT_SESSIONS_TABLE)
+        .select('id', 'account_id', 'environment_id', 'expires_at')
         .whereNull('ended_at')
         .where('expires_at', '<=', db.fn.now())
         .orderBy('expires_at', 'asc')
         .limit(limit);
 
-    return sessions.map(toAgentSession);
+    return sessions.map((session) => ({
+        id: session.id,
+        accountId: session.account_id,
+        environmentId: session.environment_id,
+        expiresAt: session.expires_at
+    }));
 }
 
 function jsonb(db: Knex, value: object): Knex.Raw {
@@ -123,6 +143,15 @@ function notFoundError({ id, accountId, environmentId }: { id: string; accountId
         code: 'not_found',
         message: `Agent session '${id}' not found`,
         payload: { id, accountId, environmentId }
+    });
+}
+
+function creationFailedError(params: CreateAgentSessionParams, cause?: unknown): AgentSessionError {
+    return new AgentSessionError({
+        code: 'creation_failed',
+        message: 'Failed to create agent session',
+        payload: { accountId: params.accountId, environmentId: params.environmentId },
+        cause
     });
 }
 

--- a/packages/server/lib/services/agentSession.service.ts
+++ b/packages/server/lib/services/agentSession.service.ts
@@ -6,17 +6,13 @@ import type {
     AgentSessionCompiledToolset,
     AgentSessionEndedReason,
     AgentSessionMetaTools,
-    AgentSessionResolvedConnections
+    AgentSessionResolvedConnections,
+    DBEnvironment
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 const AGENT_SESSIONS_TABLE = 'agent_sessions';
 const ENVIRONMENTS_TABLE = '_nango_environments';
-
-interface DBEnvironmentOwner {
-    readonly id: number;
-    readonly account_id: number;
-}
 
 export interface DBAgentSession {
     readonly id: string;
@@ -59,9 +55,9 @@ export class AgentSessionError extends Error {
 
 export async function createAgentSession(db: Knex, params: CreateAgentSessionParams): Promise<Result<AgentSession, AgentSessionError>> {
     try {
-        const environment = await db<DBEnvironmentOwner>(ENVIRONMENTS_TABLE)
+        const environment = await db<Pick<DBEnvironment, 'id' | 'account_id' | 'deleted'>>(ENVIRONMENTS_TABLE)
             .select('id')
-            .where({ id: params.environmentId, account_id: params.accountId })
+            .where({ id: params.environmentId, account_id: params.accountId, deleted: false })
             .first();
         if (!environment) {
             return Err(creationFailedError(params));

--- a/packages/server/lib/services/agentSession.service.ts
+++ b/packages/server/lib/services/agentSession.service.ts
@@ -1,0 +1,143 @@
+import { Err, Ok } from '@nangohq/utils';
+
+import type { Knex } from '@nangohq/database';
+import type {
+    AgentSession,
+    AgentSessionCompiledToolset,
+    AgentSessionEndedReason,
+    AgentSessionMetaTools,
+    AgentSessionResolvedConnections
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+const AGENT_SESSIONS_TABLE = 'agent_sessions';
+
+export interface DBAgentSession {
+    readonly id: string;
+    readonly environment_id: number;
+    readonly account_id: number;
+    readonly resolved_connections: AgentSessionResolvedConnections;
+    readonly compiled_toolset: AgentSessionCompiledToolset;
+    readonly meta_tools: AgentSessionMetaTools;
+    readonly expires_at: Date;
+    readonly ended_at: Date | null;
+    readonly ended_reason: AgentSessionEndedReason | null;
+    readonly created_at: Date;
+    readonly updated_at: Date;
+}
+
+export interface CreateAgentSessionParams {
+    accountId: number;
+    environmentId: number;
+    resolvedConnections: AgentSessionResolvedConnections;
+    compiledToolset: AgentSessionCompiledToolset;
+    metaTools: AgentSessionMetaTools;
+    expiresAt: Date;
+}
+
+type AgentSessionErrorCode = 'not_found' | 'creation_failed';
+
+export class AgentSessionError extends Error {
+    public readonly code: AgentSessionErrorCode;
+    public readonly payload: Record<string, unknown>;
+
+    constructor({ code, message, payload }: { code: AgentSessionErrorCode; message: string; payload?: Record<string, unknown> }) {
+        super(message);
+        this.name = 'AgentSessionError';
+        this.code = code;
+        this.payload = payload ?? {};
+    }
+}
+
+export async function createAgentSession(db: Knex, params: CreateAgentSessionParams): Promise<Result<AgentSession, AgentSessionError>> {
+    const [session] = await db<DBAgentSession>(AGENT_SESSIONS_TABLE)
+        .insert({
+            account_id: params.accountId,
+            environment_id: params.environmentId,
+            resolved_connections: jsonb(db, params.resolvedConnections),
+            compiled_toolset: jsonb(db, params.compiledToolset),
+            meta_tools: jsonb(db, params.metaTools),
+            expires_at: params.expiresAt
+        })
+        .returning('*');
+
+    if (!session) {
+        return Err(
+            new AgentSessionError({
+                code: 'creation_failed',
+                message: 'Failed to create agent session',
+                payload: { accountId: params.accountId, environmentId: params.environmentId }
+            })
+        );
+    }
+
+    return Ok(toAgentSession(session));
+}
+
+export async function getAgentSession(
+    db: Knex,
+    { id, accountId, environmentId }: { id: string; accountId: number; environmentId: number }
+): Promise<Result<AgentSession, AgentSessionError>> {
+    const session = await db<DBAgentSession>(AGENT_SESSIONS_TABLE).where({ id, account_id: accountId, environment_id: environmentId }).first();
+
+    if (!session) {
+        return Err(notFoundError({ id, accountId, environmentId }));
+    }
+
+    return Ok(toAgentSession(session));
+}
+
+export async function terminateAgentSession(
+    db: Knex,
+    { id, accountId, environmentId, reason }: { id: string; accountId: number; environmentId: number; reason: AgentSessionEndedReason }
+): Promise<Result<AgentSession, AgentSessionError>> {
+    const [session] = await db<DBAgentSession>(AGENT_SESSIONS_TABLE)
+        .where({ id, account_id: accountId, environment_id: environmentId })
+        .whereNull('ended_at')
+        .update({ ended_at: db.fn.now(), ended_reason: reason, updated_at: db.fn.now() })
+        .returning('*');
+
+    if (session) {
+        return Ok(toAgentSession(session));
+    }
+
+    return getAgentSession(db, { id, accountId, environmentId });
+}
+
+export async function listExpiredAgentSessions(db: Knex, { limit }: { limit: number }): Promise<AgentSession[]> {
+    const sessions = await db<DBAgentSession>(AGENT_SESSIONS_TABLE)
+        .whereNull('ended_at')
+        .where('expires_at', '<=', db.fn.now())
+        .orderBy('expires_at', 'asc')
+        .limit(limit);
+
+    return sessions.map(toAgentSession);
+}
+
+function jsonb(db: Knex, value: object): Knex.Raw {
+    return db.raw('?::jsonb', [JSON.stringify(value)]);
+}
+
+function notFoundError({ id, accountId, environmentId }: { id: string; accountId: number; environmentId: number }): AgentSessionError {
+    return new AgentSessionError({
+        code: 'not_found',
+        message: `Agent session '${id}' not found`,
+        payload: { id, accountId, environmentId }
+    });
+}
+
+function toAgentSession(session: DBAgentSession): AgentSession {
+    return {
+        id: session.id,
+        environmentId: session.environment_id,
+        accountId: session.account_id,
+        resolvedConnections: session.resolved_connections,
+        compiledToolset: session.compiled_toolset,
+        metaTools: session.meta_tools,
+        expiresAt: session.expires_at,
+        endedAt: session.ended_at,
+        endedReason: session.ended_reason,
+        createdAt: session.created_at,
+        updatedAt: session.updated_at
+    };
+}

--- a/packages/types/lib/agent/session.ts
+++ b/packages/types/lib/agent/session.ts
@@ -1,0 +1,26 @@
+import type { JsonObject } from 'type-fest';
+
+export type AgentSessionResolvedConnections = JsonObject;
+export type AgentSessionCompiledToolset = JsonObject;
+
+export interface AgentSessionMetaTools {
+    readonly nangoProxy: boolean;
+    readonly nangoSearch: boolean;
+    readonly nangoExecute: boolean;
+}
+
+export type AgentSessionEndedReason = 'terminated' | 'expired';
+
+export interface AgentSession {
+    readonly id: string;
+    readonly environmentId: number;
+    readonly accountId: number;
+    readonly resolvedConnections: AgentSessionResolvedConnections;
+    readonly compiledToolset: AgentSessionCompiledToolset;
+    readonly metaTools: AgentSessionMetaTools;
+    readonly expiresAt: Date;
+    readonly endedAt: Date | null;
+    readonly endedReason: AgentSessionEndedReason | null;
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
+}

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -13,6 +13,7 @@ export type * from './logs/messages.js';
 export type * from './keystore/index.js';
 
 export type * from './action/api.js';
+export type * from './agent/session.js';
 export type * from './admin/http.api.js';
 export type * from './account/api.js';
 export type * from './account/context.js';


### PR DESCRIPTION
NAN-6593

Adds the persistence foundation for immutable agent sessions. The table stores resolved connection and compiled toolset snapshots, while the service validates account and environment ownership and indexes active expiry.

## Database fields

| Field | Type | Purpose |
| --- | --- | --- |
| `id` | UUID | Database-generated session identifier |
| `account_id` | INTEGER | Owning account, deleted with the account |
| `environment_id` | INTEGER | Owning environment, deleted with the environment |
| `resolved_connections` | JSONB | Connection selected per integration when the session is created |
| `compiled_toolset` | JSONB | Complete reachable toolset, including pinned and searchable tools |
| `meta_tools` | JSONB | Resolved per-session meta-tool capability flags |
| `expires_at` | TIMESTAMPTZ | Time after which the session must be expired |
| `ended_at` | TIMESTAMPTZ, nullable | Time the session was first terminated or expired |
| `ended_reason` | TEXT, nullable | Terminal reason: `terminated` or `expired` |
| `created_at` | TIMESTAMPTZ | Creation time |
| `updated_at` | TIMESTAMPTZ | Last persistence update time |

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->