### PR TITLE
feat(scheduler): support per-group task cap overrides

### DIFF
--- a/packages/scheduler/lib/db/migrations/20260818213000_group_overrides_add_task_cap.ts
+++ b/packages/scheduler/lib/db/migrations/20260818213000_group_overrides_add_task_cap.ts
@@ -1,0 +1,13 @@
+import { GROUP_OVERRIDES_TABLE } from '../../models/groupOverrides.js';
+
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${GROUP_OVERRIDES_TABLE}
+            ALTER COLUMN max_concurrency DROP NOT NULL,
+            ADD COLUMN IF NOT EXISTS task_cap INT CHECK (task_cap > 0)
+    `);
+}
+
+export async function down(): Promise<void> {}

--- a/packages/scheduler/lib/models/groupOverrides.ts
+++ b/packages/scheduler/lib/models/groupOverrides.ts
@@ -7,23 +7,35 @@ export const GROUP_OVERRIDES_TABLE = 'group_overrides';
 
 export interface GroupOverride {
     group_key: string;
-    max_concurrency: number;
+    max_concurrency: number | null;
+    task_cap: number | null;
     created_at?: Date;
     updated_at?: Date;
 }
 
+export interface GroupOverrideValues {
+    maxConcurrency: number | null;
+    taskCap: number | null;
+}
+
+type UpsertParams = { groupKey: string } & ({ maxConcurrency: number; taskCap?: number } | { maxConcurrency?: number; taskCap: number });
+
 /**
- * Set the max concurrency override for a group.
- * The value is stamped onto tasks when they are created, so an update only affects tasks created after it,
- * not ones already queued.
+ * Set one or more overrides for a group. Values omitted from an update are preserved.
+ * Max concurrency is stamped onto tasks when they are created, while the task cap is evaluated on every admission.
  */
-export async function upsert(db: knex.Knex, { groupKey, maxConcurrency }: { groupKey: string; maxConcurrency: number }): Promise<Result<void>> {
+export async function upsert(db: knex.Knex, { groupKey, maxConcurrency, taskCap }: UpsertParams): Promise<Result<void>> {
     try {
+        const update = {
+            ...(maxConcurrency !== undefined ? { max_concurrency: maxConcurrency } : {}),
+            ...(taskCap !== undefined ? { task_cap: taskCap } : {}),
+            updated_at: new Date()
+        };
         await db
             .from<GroupOverride>(GROUP_OVERRIDES_TABLE)
-            .insert({ group_key: groupKey, max_concurrency: maxConcurrency })
+            .insert({ group_key: groupKey, max_concurrency: maxConcurrency ?? null, task_cap: taskCap ?? null })
             .onConflict('group_key')
-            .merge({ max_concurrency: maxConcurrency, updated_at: new Date() });
+            .merge(update);
         return Ok(undefined);
     } catch (err) {
         return Err(new Error(`Error setting group override for '${groupKey}': ${stringifyError(err)}`));
@@ -42,13 +54,16 @@ export async function remove(db: knex.Knex, groupKey: string): Promise<Result<vo
 /**
  * Fetch the overrides for the given group keys as a map.
  */
-export async function getByGroupKeys(db: knex.Knex, groupKeys: string[]): Promise<Result<Map<string, number>>> {
+export async function getByGroupKeys(db: knex.Knex, groupKeys: string[]): Promise<Result<Map<string, GroupOverrideValues>>> {
     if (groupKeys.length === 0) {
         return Ok(new Map());
     }
     try {
-        const rows = await db.from<GroupOverride>(GROUP_OVERRIDES_TABLE).whereIn('group_key', groupKeys).select('group_key', 'max_concurrency');
-        return Ok(new Map(rows.map((r) => [r.group_key, r.max_concurrency])));
+        const rows = await db
+            .from<GroupOverride>(GROUP_OVERRIDES_TABLE)
+            .whereIn('group_key', groupKeys)
+            .select<Pick<GroupOverride, 'group_key' | 'max_concurrency' | 'task_cap'>[]>('group_key', 'max_concurrency', 'task_cap');
+        return Ok(new Map(rows.map((row) => [row.group_key, { maxConcurrency: row.max_concurrency, taskCap: row.task_cap }])));
     } catch (err) {
         return Err(new Error(`Error getting group overrides: ${stringifyError(err)}`));
     }

--- a/packages/scheduler/lib/models/groupOverrides.ts
+++ b/packages/scheduler/lib/models/groupOverrides.ts
@@ -18,10 +18,13 @@ export interface GroupOverrideValues {
     taskCap: number | null;
 }
 
-type UpsertParams = { groupKey: string } & ({ maxConcurrency: number; taskCap?: number } | { maxConcurrency?: number; taskCap: number });
+type UpsertParams = { groupKey: string } & (
+    | { maxConcurrency: number | null; taskCap?: number | null }
+    | { maxConcurrency?: number | null; taskCap: number | null }
+);
 
 /**
- * Set one or more overrides for a group. Values omitted from an update are preserved.
+ * Set one or more overrides for a group. Values omitted from an update are preserved, while null clears an override.
  * Max concurrency is stamped onto tasks when they are created, while the task cap is evaluated on every admission.
  */
 export async function upsert(db: knex.Knex, { groupKey, maxConcurrency, taskCap }: UpsertParams): Promise<Result<void>> {

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -90,6 +90,41 @@ describe('Task', () => {
         expect(res.created.map((t) => t.name).sort()).toEqual(['Also not capped', 'Not capped']);
         expect(res.discarded.map((d) => ({ name: d.props.name, reason: d.reason }))).toEqual([{ name: 'Capped', reason: 'capped' }]);
     });
+    it('should override the task cap independently for an existing group', async () => {
+        const groupKey = nanoid();
+        const defaultGroupKey = nanoid();
+        const groupMaxConcurrency = 5;
+        const initial = (
+            await tasks.create(
+                db,
+                [
+                    { ...props, groupKey, groupMaxConcurrency, name: 'Override 1' },
+                    { ...props, groupKey: defaultGroupKey, groupMaxConcurrency, name: 'Default 1' }
+                ],
+                { groupTaskCap: 1 }
+            )
+        ).unwrap();
+        expect(initial.created).toHaveLength(2);
+
+        (await groupOverrides.upsert(db, { groupKey, taskCap: 2 })).unwrap();
+        (await groupOverrides.upsert(db, { groupKey, maxConcurrency: 3 })).unwrap();
+
+        const res = (
+            await tasks.create(
+                db,
+                [
+                    { ...props, groupKey, groupMaxConcurrency, name: 'Override 2' },
+                    { ...props, groupKey, groupMaxConcurrency, name: 'Override capped' },
+                    { ...props, groupKey: defaultGroupKey, groupMaxConcurrency, name: 'Default capped' }
+                ],
+                { groupTaskCap: 1 }
+            )
+        ).unwrap();
+
+        expect(res.created.map((task) => task.name)).toEqual(['Override 2']);
+        expect(res.discarded.map((discarded) => discarded.props.name)).toEqual(['Override capped', 'Default capped']);
+        expect(res.created[0]?.groupMaxConcurrency).toBe(3);
+    });
     it('should error on unique-name collision', async () => {
         const name = `dup-${nanoid()}`;
         const first = await tasks.create(db, [{ ...props, name }]);

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -124,6 +124,10 @@ describe('Task', () => {
         expect(res.created.map((task) => task.name)).toEqual(['Override 2']);
         expect(res.discarded.map((discarded) => discarded.props.name)).toEqual(['Override capped', 'Default capped']);
         expect(res.created[0]?.groupMaxConcurrency).toBe(3);
+
+        (await groupOverrides.upsert(db, { groupKey, taskCap: null })).unwrap();
+        const afterClear = (await tasks.create(db, [{ ...props, groupKey, groupMaxConcurrency, name: 'Global cap' }], { groupTaskCap: 3 })).unwrap();
+        expect(afterClear.created[0]).toMatchObject({ name: 'Global cap', groupMaxConcurrency: 3 });
     });
     it('should error on unique-name collision', async () => {
         const name = `dup-${nanoid()}`;

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -165,7 +165,8 @@ export async function create(db: knex.Knex, taskProps: TaskProps[], opts: Create
                 candidatesPerGroup.set(props.groupKey, []);
             }
             const group = candidatesPerGroup.get(props.groupKey)!;
-            if (group.length < taskCap - (sizes.value.get(props.groupKey) ?? 0)) {
+            const remainingSlots = taskCap - (sizes.value.get(props.groupKey) ?? 0);
+            if (group.length < remainingSlots) {
                 group.push({
                     props,
                     task: {

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -159,16 +159,18 @@ export async function create(db: knex.Knex, taskProps: TaskProps[], opts: Create
         const candidatesPerGroup = new Map<string, { props: TaskProps; task: Task }[]>();
         const discarded: DiscardedTask[] = [];
         for (const props of taskProps) {
+            const override = overrides.value.get(props.groupKey);
+            const taskCap = override?.taskCap ?? groupTaskCap;
             if (!candidatesPerGroup.has(props.groupKey)) {
                 candidatesPerGroup.set(props.groupKey, []);
             }
             const group = candidatesPerGroup.get(props.groupKey)!;
-            if (group.length < groupTaskCap - (sizes.value.get(props.groupKey) ?? 0)) {
+            if (group.length < taskCap - (sizes.value.get(props.groupKey) ?? 0)) {
                 group.push({
                     props,
                     task: {
                         ...props,
-                        groupMaxConcurrency: overrides.value.get(props.groupKey) ?? props.groupMaxConcurrency,
+                        groupMaxConcurrency: override?.maxConcurrency ?? props.groupMaxConcurrency,
                         id: uuidv7(),
                         state: 'CREATED',
                         createdAt: now,


### PR DESCRIPTION
Allow scheduler groups to override the global queued/running task cap through `group_overrides.task_cap`. The cap is resolved on each admission, so an operator can raise it for a group that already has a backlog. Task cap and max concurrency overrides remain independent.

The migration makes `max_concurrency` nullable for cap-only rows and validates that task cap overrides are positive.

NAN-6528

## Test plan

- [x] `npm run ts-build`
- [x] `npm run test:integration -- packages/scheduler/lib/models/tasks.integration.test.ts`
- [x] `npm run lint`
- [x] Prettier check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

