### PR TITLE
fix(providers): disable PKCE for facebook

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -7982,6 +7982,7 @@ facebook:
         - marketing
         - social
     auth_mode: OAUTH2
+    disable_pkce: true
     authorization_url: https://www.facebook.com/v22.0/dialog/oauth
     token_url: https://graph.facebook.com/v22.0/oauth/access_token
     proxy:


### PR DESCRIPTION
### Problem

Nango defaults PKCE on for `auth_mode: OAUTH2`, but Meta's OAuth dialog accepts `code_challenge` / `code_challenge_method` on the authorization request and silently discards them. The token exchange then sends a `code_verifier` that Meta has no challenge to verify against, and the connection fails at the final step:

```json
{
  "message": "code_verifier param is provided without a code_challenge in authorization request.",
  "type": "OAuthException"
}
```

This affects `facebook` and `meta-marketing-api` (which is `alias: facebook`, so it inherits the same behaviour).

### What I verified

- The authorization request Nango builds **does** include `code_challenge=...&code_challenge_method=S256` — captured from the 302 off `/oauth/connect/{integration}`. Meta still reports no challenge at exchange time.
- Not version-specific: `v22.0` and `v26.0` behave identically.
- Not fixable from the Meta app config. Facebook Login is enabled and the redirect URI is allowlisted (the token endpoint returns `Invalid verification code format` rather than a redirect error), and neither the App Dashboard nor the Graph API exposes any PKCE-related setting. Toggling "Native or desktop app" makes no difference.

### Prior art

better-auth hit the identical error and fixed it the same way, by dropping the challenge from the Facebook authorization URL: https://github.com/better-auth/better-auth/pull/189

### Change

```yaml
 facebook:
     auth_mode: OAUTH2
+    disable_pkce: true
     authorization_url: https://www.facebook.com/v22.0/dialog/oauth
```

Happy to test against a real Meta app once this is on Cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

