### PR TITLE
feat(functions): add logging/tracking to POST /functions/invocations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,30 +72,6 @@
                 "url": "https://github.com/sponsors/philsturgeon"
             }
         },
-        "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
         "node_modules/@apidevtools/openapi-schemas": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -16,7 +16,7 @@ export interface AdditionalOperationData {
     environment?: { id: number; name: string } | undefined;
     connection?: { id: number; name: string } | undefined;
     integration?: { id: number; name: string; provider: string } | undefined;
-    syncConfig?: { id: number; name: string } | undefined; // TODO: rename to script or something similar because it also apply to actions and on-events scripts
+    syncConfig?: { id: number; name: string } | undefined; // TODO: rename to functions or something similar because it also apply to legacy syncs/actions/on-events scripts but also to functions
     meta?: MessageRow['meta'];
 }
 
@@ -99,8 +99,8 @@ export function createCursor({ sort }: Pick<estypes.SearchHit, 'sort'>): string 
     return Buffer.from(JSON.stringify(sort)).toString('base64');
 }
 
-export function parseCursor(str: string): any[] {
-    return JSON.parse(Buffer.from(str, 'base64').toString('utf8'));
+export function parseCursor(str: string): unknown[] {
+    return JSON.parse(Buffer.from(str, 'base64').toString('utf8')) as unknown[];
 }
 
 export const operationTypeToMessage: Record<ConcatOperationList, string> = {
@@ -129,5 +129,6 @@ export const operationTypeToMessage: Record<ConcatOperationList, string> = {
     'webhook:connection_refresh': 'Token refresh webhooks',
     'events:post_connection_creation': 'Event-based executions',
     'events:pre_connection_deletion': 'Event-based executions',
-    'events:validate_connection': 'Event-based executions'
+    'events:validate_connection': 'Event-based executions',
+    'function:invoke': 'Function invoked'
 };

--- a/packages/server/lib/controllers/functions/postInvocation.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.ts
@@ -1,8 +1,10 @@
+import tracer from 'dd-trace';
 import { z } from 'zod';
 
 import db from '@nangohq/database';
+import { logContextGetter, OtlpSpan } from '@nangohq/logs';
 import { connectionService, functionConfigService, validateFunctionInput } from '@nangohq/shared';
-import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { report, requireEmptyQuery, truncateJson, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema, scriptNameSchema } from '../../helpers/validation.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
@@ -71,21 +73,51 @@ export const postFunctionInvocation = asyncWrapperWithEnvironment<PostFunctionIn
         return;
     }
 
-    const { currentVersion } = functionRes.value[0];
+    const { currentVersion, integration, config } = functionRes.value[0];
 
     if (!supportInvocation(currentVersion, body.invocation_type)) {
         res.status(400).send({ error: { code: 'invalid_invocation', message: `Function '${body.name}' is not invokable with ${body.invocation_type}` } });
         return;
     }
 
-    const validation = validateFunctionInput(currentVersion, body.input);
+    const { input, ...rest } = body;
+
+    const validation = validateFunctionInput(currentVersion, input);
 
     if (validation.isErr()) {
         res.status(400).send({ error: { code: 'validation_error', message: validation.error.message, errors: validation.error.validationErrors } });
         return;
     }
 
-    res.status(501).send({ error: { code: 'not_implemented', message: 'Function invocation is not implemented yet' } });
+    return tracer.trace('server.function.invocation', async (span) => {
+        span.addTags(rest);
+
+        const timeoutMs =
+            rest.invocation_type === 'wait'
+                ? 2 * 60 * 1000 // 2 minutes for synchronous invocations
+                : 24 * 60 * 60 * 1000; // 24 hours for asynchronous invocations
+        const connection = connectionRes.response!;
+
+        const logCtx = await logContextGetter.create(
+            { operation: { type: 'function', action: 'invoke' }, expiresAt: new Date(Date.now() + timeoutMs).toISOString() },
+            {
+                account: res.locals.account,
+                environment: res.locals.environment,
+                integration: { id: integration.id, name: integration.unique_key, provider: integration.provider },
+                connection: { id: connection.id, name: connection.connection_id },
+                syncConfig: { id: currentVersion.id, name: config.name },
+                meta: {
+                    invocation_type: rest.invocation_type,
+                    ...(rest.options ? { options: rest.options } : {}),
+                    ...(input ? { input: truncateJson(input) } : {})
+                }
+            }
+        );
+        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
+        void logCtx.success();
+        res.status(501).send({ error: { code: 'not_implemented', message: 'Function invocation is not implemented yet' } });
+    });
 });
 
 function supportInvocation(version: DBFunctionConfigVersion, invocationType: FunctionInvocationType): boolean {

--- a/packages/server/lib/controllers/functions/postInvocation.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.ts
@@ -115,7 +115,7 @@ export const postFunctionInvocation = asyncWrapperWithEnvironment<PostFunctionIn
         );
         logCtx.attachSpan(new OtlpSpan(logCtx.operation));
 
-        void logCtx.success();
+        void logCtx.failed();
         res.status(501).send({ error: { code: 'not_implemented', message: 'Function invocation is not implemented yet' } });
     });
 });

--- a/packages/shared/lib/services/functions/models/functions.integration.test.ts
+++ b/packages/shared/lib/services/functions/models/functions.integration.test.ts
@@ -61,7 +61,7 @@ describe(search, () => {
 
         expect(functions).toHaveLength(1);
         expect(functions[0]).toMatchObject({
-            integration: { id: firstIntegration.id, unique_key: firstIntegration.unique_key },
+            integration: { id: firstIntegration.id, unique_key: firstIntegration.unique_key, provider: firstIntegration.provider },
             config: { nango_config_id: firstIntegration.id, name: 'firstFunction' },
             currentVersion: { version: 'first-version' }
         });
@@ -107,7 +107,7 @@ describe(search, () => {
 
         expect(functions).toHaveLength(1);
         expect(functions[0]).toMatchObject({
-            integration: { id: github.id, unique_key: github.unique_key },
+            integration: { id: github.id, unique_key: github.unique_key, provider: github.provider },
             config: { nango_config_id: github.id, name: config.name },
             currentVersion: { version: config.version.version }
         });

--- a/packages/shared/lib/services/functions/models/functions.ts
+++ b/packages/shared/lib/services/functions/models/functions.ts
@@ -42,11 +42,12 @@ const VERSION_COLUMNS = {
     deleted_at: true
 } satisfies Record<keyof DBFunctionConfigVersion, true>;
 
-type FunctionIntegration = Pick<DBIntegrationDecrypted, 'id' | 'unique_key'> & { id: number };
+type FunctionIntegration = Pick<DBIntegrationDecrypted, 'id' | 'unique_key' | 'provider'> & { id: number };
 
 const INTEGRATION_COLUMNS = {
     id: true,
-    unique_key: true
+    unique_key: true,
+    provider: true
 } satisfies Record<keyof FunctionIntegration, true>;
 
 const CONFIG_PREFIX = 'config_';
@@ -78,7 +79,7 @@ type Prefixed<T, Prefix extends string> = {
     [K in keyof T as `${Prefix}${Extract<K, string>}`]: T[K];
 };
 
-type JoinedFunctionConfigRow = Prefixed<DBFunctionConfig, typeof CONFIG_PREFIX> &
+type SearchFunctionConfigRow = Prefixed<DBFunctionConfig, typeof CONFIG_PREFIX> &
     Prefixed<DBFunctionConfigVersion, typeof VERSION_PREFIX> &
     Prefixed<FunctionIntegration, typeof INTEGRATION_PREFIX>;
 
@@ -99,7 +100,7 @@ export async function search(
                 this.on('integration.id', 'config.nango_config_id').andOn('integration.environment_id', 'config.environment_id');
             })
             .leftJoin({ version: VERSIONS_TABLE }, 'version.id', 'config.current_version_id')
-            .select<JoinedFunctionConfigRow[]>([
+            .select<SearchFunctionConfigRow[]>([
                 ...aliasedColumns<FunctionIntegration>('integration', INTEGRATION_COLUMNS, INTEGRATION_PREFIX),
                 ...aliasedColumns<DBFunctionConfig>('config', CONFIG_COLUMNS, CONFIG_PREFIX),
                 ...aliasedColumns<DBFunctionConfigVersion>('version', VERSION_COLUMNS, VERSION_PREFIX)
@@ -152,18 +153,27 @@ export async function upsert(
     try {
         const upserted = await db.transaction(async (trx) => {
             // insert and returns new function config or return the existing one
-            const [config] = await trx(CONFIGS_TABLE)
-                .insert({
-                    environment_id: environmentId,
-                    nango_config_id: trx
+            const [config] = await trx
+                .with('integration', (qb) =>
+                    qb
                         .from<DBIntegrationDecrypted>(INTEGRATIONS_TABLE)
-                        .select('id')
-                        .where({ environment_id: environmentId, unique_key: integrationId, deleted: false }),
-                    name
-                })
-                .onConflict(trx.raw('(nango_config_id, name) WHERE deleted_at IS NULL'))
-                .merge(['nango_config_id'])
-                .returning<DBFunctionConfig[]>('*');
+                        .select('id', 'provider')
+                        .where({ environment_id: environmentId, unique_key: integrationId, deleted: false })
+                )
+                .with(
+                    'upserted',
+                    trx.raw(
+                        `INSERT INTO ?? (environment_id, nango_config_id, name)
+                             SELECT ?, integration.id, ? FROM integration
+                             ON CONFLICT (nango_config_id, name) WHERE deleted_at IS NULL
+                             DO UPDATE SET nango_config_id = EXCLUDED.nango_config_id
+                             RETURNING *`,
+                        [CONFIGS_TABLE, environmentId, name]
+                    )
+                )
+                .select<(DBFunctionConfig & { provider: string })[]>('upserted.*', 'integration.provider')
+                .from('upserted')
+                .join('integration', 'integration.id', 'upserted.nango_config_id');
 
             if (!config) {
                 throw new Error('failed_to_upsert_function_config', { cause: { integrationId } });
@@ -190,7 +200,7 @@ export async function upsert(
                 .returning<DBFunctionConfig[]>('*');
 
             return {
-                integration: { id: config.nango_config_id, unique_key: integrationId },
+                integration: { id: config.nango_config_id, unique_key: integrationId, provider: config.provider },
                 config: updatedConfig ?? config,
                 currentVersion
             };

--- a/packages/shared/lib/services/functions/reconcile.unit.test.ts
+++ b/packages/shared/lib/services/functions/reconcile.unit.test.ts
@@ -37,7 +37,7 @@ function deployedFunction({
     const now = new Date('2026-01-01T00:00:00.000Z');
     const versionId = id * 10;
     return {
-        integration: { id: nangoConfigId, unique_key: artifact.integrationId },
+        integration: { id: nangoConfigId, unique_key: artifact.integrationId, provider: 'github' },
         config: {
             id,
             nango_config_id: nangoConfigId,

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -25,6 +25,10 @@ export type OperationState = 'waiting' | 'running' | 'success' | 'failed' | 'tim
 /**
  * Operations
  */
+export interface OperationFunction {
+    type: 'function';
+    action: 'invoke';
+}
 export interface OperationSync {
     type: 'sync';
     action: 'pause' | 'unpause' | 'run' | 'request_run' | 'request_run_full' | 'cancel' | 'init' | 'create_variant' | 'delete_variant';
@@ -61,7 +65,9 @@ export interface OperationDeploy {
     type: 'deploy';
     action: 'prebuilt' | 'custom';
 }
+
 export type OperationList =
+    | OperationFunction
     | OperationSync
     | OperationProxy
     | OperationAction

--- a/packages/webapp/src/pages/Logs/constants.tsx
+++ b/packages/webapp/src/pages/Logs/constants.tsx
@@ -151,7 +151,12 @@ export const typesOptions: FilterOption<SearchOperationsType>[] = [
     { value: 'action', label: 'Action' },
     { value: 'events', label: 'Event-based execution' },
     { value: 'proxy', label: 'Proxy' },
-    { value: 'deploy', label: 'Deploy' }
+    { value: 'deploy', label: 'Deploy' },
+    {
+        value: 'function',
+        label: 'Function',
+        children: [{ label: 'Function invoked', value: 'function:invoke' }]
+    }
 ];
 export const typesList = Object.keys({
     'action:run': null,
@@ -180,6 +185,7 @@ export const typesList = Object.keys({
     'webhook:forward': null,
     'webhook:incoming': null,
     'webhook:sync': null,
+    'function:invoke': null,
     action: null,
     admin: null,
     all: null,
@@ -188,5 +194,6 @@ export const typesList = Object.keys({
     events: null,
     proxy: null,
     sync: null,
-    webhook: null
+    webhook: null,
+    function: null
 } satisfies Record<SearchOperationsType, null>) as SearchOperationsType[];


### PR DESCRIPTION
Adding logging and tracing to POST /functions/invocations.
The endpoint is still not executing anything and anyway the CLI doesn't allow deploying functions with a trigger yet.
This is the first PR of an incoming stacks to add function invocation.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added log filtering for function invocations.
  * Function invocation events now appear as a distinct operation type in logs.
  * Function integration results now include provider information.

* **Bug Fixes**
  * Improved function invocation diagnostics with structured context, tracing, and truncated log data.
  * Strengthened cursor parsing type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->