### PR TITLE
feat(audit): retain audit events for a year, not 90 days (NAN-6485)

### DIFF
--- a/packages/audit/lib/store.ts
+++ b/packages/audit/lib/store.ts
@@ -10,7 +10,7 @@ import type { Result } from '@nangohq/utils';
 
 const logger = getLogger('audit');
 
-const AUDIT_RETENTION_DAYS = 90;
+const AUDIT_RETENTION_DAYS = 365;
 const READ_QUERY_MAX_EXECUTION_SECONDS = 30;
 
 export interface AuditTrailCursor {

--- a/packages/audit/lib/store.unit.test.ts
+++ b/packages/audit/lib/store.unit.test.ts
@@ -31,7 +31,7 @@ describe('ClickhouseAuditStore.record', () => {
     it('inserts the record verbatim with the retention tier', async () => {
         const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
         const insert = vi.fn().mockResolvedValue({});
-        const store = new ClickhouseAuditStore({ insert } as unknown as ClickHouseClient, 90);
+        const store = new ClickhouseAuditStore({ insert } as unknown as ClickHouseClient);
 
         const result = await store.record(record);
 
@@ -40,7 +40,7 @@ describe('ClickhouseAuditStore.record', () => {
         const arg = insert.mock.calls[0]![0] as { table: string; format: string; values: { event: string; retention_days: number }[] };
         expect(arg.table).toBe('audit_trail_events');
         expect(arg.format).toBe('JSONEachRow');
-        expect(arg.values).toEqual([{ event: record.event, retention_days: 90 }]);
+        expect(arg.values).toEqual([{ event: record.event, retention_days: 365 }]);
 
         expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'true' });
     });


### PR DESCRIPTION
- **Audit events are retained for a year instead of 90 days.** The first deliverable promises a year, and `retention_days` is stamped on every row at write time and sits in the ClickHouse partition key — so events already written keep 90 and cannot be extended. Every day the old value stayed cost history we had promised.

Two things worth knowing about the reach:

- Existing rows are not rewritten. The year starts from this deploy, and everything written so far is test data.
- The stamp happens in the **metering consumer**, not the server, so this takes effect on a metering deploy.

Nothing pinned the default before: every unit test constructed `ClickhouseAuditStore` with an explicit `90`, so the constant was free to drift. The single-record test now omits the argument and asserts the default; the batch test still passes one so the override stays covered.

This is the fixed value the first deliverable asks for. Per-account retention — a value on the plan, resolved and cached in the consumer, with deliberate behaviour on lookup failure — is separate and unstarted.

## Test plan

- [x] 25 audit tests pass, `ts-build` clean, lint 0
- [x] Reverting the constant reds exactly the one test that now asserts the default
- [ ] After the metering deploy: confirm new rows land with `retention_days = 365`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Increased the default audit record retention period from 90 days to 365 days.
  * Audit records will now remain available for up to one year when no custom retention period is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->