### PR TITLE
fix(audit): stop one bad event from duplicating the ones batched with it

### DIFF
--- a/packages/audit/lib/store.integration.test.ts
+++ b/packages/audit/lib/store.integration.test.ts
@@ -212,4 +212,27 @@ describe('ClickhouseAuditStore.list deduplication', () => {
             await client.command({ query: `SYSTEM START MERGES ${database}.audit_trail_events` });
         }
     });
+
+    it('does not hand a copy back on the next page, since the cursor excludes the boundary row it shares a key with', async () => {
+        const newer = '55555555-5555-5555-5555-555555555555';
+        const older = '66666666-6666-6666-6666-666666666666';
+        await client.command({ query: `SYSTEM STOP MERGES ${database}.audit_trail_events` });
+        try {
+            await insertEvent({ id: newer, accountId: 10, occurredAt: at(4000) });
+            await insertEvent({ id: newer, accountId: 10, occurredAt: at(4000) });
+            await insertEvent({ id: older, accountId: 10, occurredAt: at(3000) });
+
+            // One per page, so the copy of `newer` can only be excluded by the cursor rather than by the
+            // in-page filter. Under a non-strict comparison it comes back as page two.
+            const first = (await store.list({ accountId: 10, limit: 1 })).unwrap();
+            expect(first.events.map((e) => e.id)).toEqual([newer]);
+            expect(first.nextCursor).not.toBeNull();
+
+            const second = (await store.list({ accountId: 10, limit: 1, before: first.nextCursor! })).unwrap();
+            expect(second.events.map((e) => e.id)).toEqual([older]);
+            expect(second.nextCursor).toBeNull();
+        } finally {
+            await client.command({ query: `SYSTEM START MERGES ${database}.audit_trail_events` });
+        }
+    });
 });

--- a/packages/audit/lib/store.integration.test.ts
+++ b/packages/audit/lib/store.integration.test.ts
@@ -222,6 +222,14 @@ describe('ClickhouseAuditStore.list deduplication', () => {
             await insertEvent({ id: newer, accountId: 10, occurredAt: at(4000) });
             await insertEvent({ id: older, accountId: 10, occurredAt: at(3000) });
 
+            // Without this the test degrades into a plain pagination check the moment anything collapses the
+            // copy before the read sees it.
+            const raw = await client.query({
+                query: `SELECT count() AS c FROM ${database}.audit_trail_events WHERE account_id = 10`,
+                format: 'JSONEachRow'
+            });
+            expect(Number((await raw.json<{ c: string | number }>())[0]!.c)).toBe(3);
+
             // One per page, so the copy of `newer` can only be excluded by the cursor rather than by the
             // in-page filter. Under a non-strict comparison it comes back as page two.
             const first = (await store.list({ accountId: 10, limit: 1 })).unwrap();

--- a/packages/audit/lib/store.ts
+++ b/packages/audit/lib/store.ts
@@ -97,6 +97,13 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
         }
     }
 
+    // Best effort at one row per event, not a guarantee: the pipeline is at-least-once by design, so a copy can appear, and ReplacingMergeTree only
+    // collapses it on merge. Until then the copies might sit in separate parts, and reconciling them server-side with FINAL or LIMIT 1 BY id reads far
+    // more rows than the query below can afford, so this read reconciles them instead —
+    // - in a page: copies share the ORDER BY key, so they arrive adjacent in the merged stream and the neighbour filter below cuts them
+    // - across pages: the cursor comparison is strict, so a copy of the boundary row is never fetched again
+    // Both key on the event id, so they only catch a redelivery of the same event; a re-emit carries a fresh id and reads as two. A thinned page is the
+    // only side effect, which is why `hasMore` keys off the raw count.
     async list({ accountId, limit, before, from, to, resources, actions }: ListAuditTrailEventsParams): Promise<Result<AuditTrailPage>> {
         const params: Record<string, unknown> = { account_id: accountId, limit: limit + 1 };
         const conditions = ['account_id = {account_id:Int64}'];
@@ -125,9 +132,8 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
             params['before_id'] = before.id;
         }
 
-        // No FINAL and no `LIMIT 1 BY id`: both dedup server-side but defeat the short-circuit ORDER BY gets
-        // from the primary key prefix. Unbounded on a 5M-row account, rows read: 99K as written, 1.1M with
-        // LIMIT 1 BY, 5M with FINAL. Copies are dropped from the result set instead.
+        // No FINAL and no `LIMIT 1 BY id`: both dedup server-side but defeat the short-circuit ORDER BY gets from the primary key prefix. Rows read on
+        // a 5M-row account: 99K as written, 1.1M with LIMIT 1 BY, 5M with FINAL.
         // Cursor columns aliased so `occurred_at`/`id` in WHERE/ORDER BY still resolve to the real columns.
         const sql = `
             SELECT event, toString(id) AS cursor_id, toString(occurred_at) AS cursor_occurred_at
@@ -146,8 +152,6 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
             });
             const rows = await res.json<{ event: string; cursor_id: string; cursor_occurred_at: string }>();
 
-            // Copies share (account_id, occurred_at, id), so they are adjacent in this ordering. `hasMore`
-            // stays keyed off the raw count: a page thinned by more than the spare row is short, not final.
             const deduped = rows.filter((row, i) => i === 0 || row.cursor_id !== rows[i - 1]!.cursor_id);
 
             // Fetched limit+1: the extra row means there's another page — drop it and expose its cursor.

--- a/packages/metering/lib/processors/audit.ts
+++ b/packages/metering/lib/processors/audit.ts
@@ -123,24 +123,27 @@ export class AuditProcessor {
             return [];
         }
         if (getSubjectMessageAttribute(msg.Body, msg.MessageAttributes) !== SUBJECT) {
-            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'subject_mismatch' });
+            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'subject_mismatch', kind: 'envelope' });
             report(new Error('Audit consumer: message subject mismatch'), { messageId: msg.MessageId });
             return [];
         }
         const decoded = serde.deserialize<AuditRecordedEvent>(Buffer.from(unwrapSqsBody(msg.Body), 'base64'));
         if (decoded.isErr()) {
-            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'invalid_schema' });
+            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'invalid_schema', kind: 'envelope' });
             report(new Error('Audit consumer: failed to deserialize message'), { messageId: msg.MessageId });
             return [];
         }
         if (typeof decoded.value.payload?.event !== 'string') {
-            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'invalid_schema' });
+            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'invalid_schema', kind: 'envelope' });
             report(new Error('Audit consumer: message is not an audit envelope'), { messageId: msg.MessageId });
             return [];
         }
+        // `kind: event` is the alertable half: a real audit event that will never be stored, so a customer's
+        // trail has a hole. `kind: envelope` is a message that was never ours to store. Grouping by kind
+        // rather than by an enumeration of reasons keeps a monitor correct when a reason is added.
         const unstorable = unstorableReason(decoded.value.payload.event);
         if (unstorable) {
-            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: unstorable });
+            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: unstorable, kind: 'event' });
             report(new Error('Audit consumer: event cannot be stored'), { messageId: msg.MessageId, reason: unstorable });
             return [];
         }

--- a/packages/metering/lib/processors/audit.ts
+++ b/packages/metering/lib/processors/audit.ts
@@ -133,7 +133,6 @@ export class AuditProcessor {
             report(new Error('Audit consumer: failed to deserialize message'), { messageId: msg.MessageId });
             return [];
         }
-        // `deserialize` gives back whatever was serialised, so the type is an assertion rather than a check.
         if (typeof decoded.value.payload?.event !== 'string') {
             metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'invalid_schema' });
             report(new Error('Audit consumer: message is not an audit envelope'), { messageId: msg.MessageId });
@@ -176,18 +175,24 @@ const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
  * otherwise well-formed envelope. Kept as one function so the DLQ redrive can reuse it.
  */
 export function unstorableReason(event: string): 'invalid_json' | 'invalid_id' | 'invalid_account_id' | 'invalid_occurred_at' | null {
-    let parsed: Record<string, unknown>;
+    let parsed: unknown;
     try {
-        parsed = JSON.parse(event) as Record<string, unknown>;
+        parsed = JSON.parse(event);
     } catch {
         return 'invalid_json';
     }
-    const { id, accountId, occurredAt } = parsed;
+    // `null` parses without throwing, and destructuring it would throw out of the poll loop — taking the
+    // batch down, which is the failure this function exists to prevent.
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return 'invalid_json';
+    }
+    const { id, accountId, occurredAt } = parsed as Record<string, unknown>;
     if (typeof id !== 'string' || !UUID.test(id)) {
         return 'invalid_id';
     }
-    // Matches `CHECK JSONType(event, 'accountId') = 'Int64' AND account_id > 0`: an integer, and positive.
-    if (typeof accountId !== 'number' || !Number.isSafeInteger(accountId) || accountId <= 0) {
+    // Matches `CHECK JSONType(event, 'accountId') = 'Int64' AND account_id >= 0`: an integer, and not
+    // negative. Account 0 is seeded and is the one every no-auth request runs as, so it has to pass.
+    if (typeof accountId !== 'number' || !Number.isSafeInteger(accountId) || accountId < 0) {
         return 'invalid_account_id';
     }
     if (typeof occurredAt !== 'string' || Number.isNaN(Date.parse(occurredAt))) {

--- a/packages/metering/lib/processors/audit.ts
+++ b/packages/metering/lib/processors/audit.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 
 import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+import * as z from 'zod';
 
 import { getSubjectMessageAttribute, serde, unwrapSqsBody } from '@nangohq/pubsub';
 import { metrics, report } from '@nangohq/utils';
@@ -167,49 +168,44 @@ export class AuditProcessor {
     }
 }
 
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 /**
- * Why the table's constraints are mirrored here rather than left to the insert: a block is atomic, so one
- * unstorable row rejects the whole batch, and the redelivery that follows is re-batched with newly arrived
- * messages. That changes the message-id set the dedup token is derived from, so the token no longer
- * suppresses an attempt that had already been written — one bad event amplifies into duplicates of its
- * neighbours. These three fields are the table's ORDER BY keys, the only extracts that can fail on an
- * otherwise well-formed envelope. Kept as one function so the DLQ redrive can reuse it.
+ * The table refuses a row whose ORDER BY keys it cannot read, and a block insert is atomic, so one such row
+ * rejects the whole batch. The redelivery that follows is re-batched with newly arrived messages, which
+ * changes the message-id set the dedup token is derived from, so the token no longer suppresses an attempt
+ * that had already been written — one bad event amplifies into duplicates of its neighbours. These three
+ * fields are the keys, mirrored: `>= 0` and an integer for the `account_id` CHECK, a UUID for `toUUID`, and a
+ * real calendar date for `parseDateTime64BestEffort`. Kept as one function so the DLQ redrive can reuse it.
  */
-export function unstorableReason(event: string): 'invalid_json' | 'invalid_id' | 'invalid_account_id' | 'invalid_occurred_at' | null {
+const storableEvent = z.object({
+    id: z.uuid(),
+    accountId: z.number().int().nonnegative(),
+    // With the offset allowed: ClickHouse accepts one, and rejecting a storable event is the worse failure.
+    occurredAt: z.iso.datetime({ offset: true })
+});
+
+type UnstorableReason = 'invalid_json' | 'invalid_id' | 'invalid_account_id' | 'invalid_occurred_at';
+
+// The reason is a metric tag, so it names the field rather than quoting zod's message.
+const REASON_BY_FIELD: Record<string, UnstorableReason> = {
+    id: 'invalid_id',
+    accountId: 'invalid_account_id',
+    occurredAt: 'invalid_occurred_at'
+};
+
+export function unstorableReason(event: string): UnstorableReason | null {
     let parsed: unknown;
     try {
         parsed = JSON.parse(event);
     } catch {
         return 'invalid_json';
     }
-    // `null` parses without throwing, and destructuring it would throw out of the poll loop — taking the
-    // batch down, which is the failure this function exists to prevent.
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-        return 'invalid_json';
+    const result = storableEvent.safeParse(parsed);
+    if (result.success) {
+        return null;
     }
-    const { id, accountId, occurredAt } = parsed as Record<string, unknown>;
-    if (typeof id !== 'string' || !UUID.test(id)) {
-        return 'invalid_id';
-    }
-    // Matches `CHECK JSONType(event, 'accountId') = 'Int64' AND account_id >= 0`: an integer, and not
-    // negative. Account 0 is seeded and is the one every no-auth request runs as, so it has to pass.
-    if (typeof accountId !== 'number' || !Number.isSafeInteger(accountId) || accountId < 0) {
-        return 'invalid_account_id';
-    }
-    // `Date.parse` checks that the month is 1-12 and the day 1-31, but not the month's actual length, so
-    // 2026-02-30 parses and rolls over to March 2 while ClickHouse rejects it outright. The calendar day is
-    // therefore checked on its own, rather than against the parsed UTC day, which would differ - and falsely
-    // reject - whenever an offset moves the timestamp across midnight.
-    if (typeof occurredAt !== 'string' || Number.isNaN(Date.parse(occurredAt))) {
-        return 'invalid_occurred_at';
-    }
-    const day = /^(\d{4})-(\d{2})-(\d{2})/.exec(occurredAt);
-    if (!day || new Date(Date.UTC(Number(day[1]), Number(day[2]) - 1, Number(day[3]))).getUTCDate() !== Number(day[3])) {
-        return 'invalid_occurred_at';
-    }
-    return null;
+    // A blob that is not an object at all fails with an empty path — `null` parses without throwing.
+    const field = result.error.issues[0]?.path[0];
+    return (typeof field === 'string' ? REASON_BY_FIELD[field] : undefined) ?? 'invalid_json';
 }
 
 function nonIdentifyingFields(event: string): { eventId?: string | undefined; resource?: string | undefined; action?: string | undefined } {

--- a/packages/metering/lib/processors/audit.ts
+++ b/packages/metering/lib/processors/audit.ts
@@ -134,11 +134,15 @@ export class AuditProcessor {
             return [];
         }
         // `deserialize` gives back whatever was serialised, so the type is an assertion rather than a check.
-        // Only the envelope this code owns is verified — whether the event itself is storable is the table's
-        // constraints to decide, and duplicating them here would give them a second place to drift from.
         if (typeof decoded.value.payload?.event !== 'string') {
             metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'invalid_schema' });
             report(new Error('Audit consumer: message is not an audit envelope'), { messageId: msg.MessageId });
+            return [];
+        }
+        const unstorable = unstorableReason(decoded.value.payload.event);
+        if (unstorable) {
+            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: unstorable });
+            report(new Error('Audit consumer: event cannot be stored'), { messageId: msg.MessageId, reason: unstorable });
             return [];
         }
         const receiveCount = Number(msg.Attributes?.['ApproximateReceiveCount']);
@@ -159,6 +163,37 @@ export class AuditProcessor {
             report(new Error('Audit consumer delete failed', { cause: err }));
         }
     }
+}
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Why the table's constraints are mirrored here rather than left to the insert: a block is atomic, so one
+ * unstorable row rejects the whole batch, and the redelivery that follows is re-batched with newly arrived
+ * messages. That changes the message-id set the dedup token is derived from, so the token no longer
+ * suppresses an attempt that had already been written — one bad event amplifies into duplicates of its
+ * neighbours. These three fields are the table's ORDER BY keys, the only extracts that can fail on an
+ * otherwise well-formed envelope. Kept as one function so the DLQ redrive can reuse it.
+ */
+export function unstorableReason(event: string): 'invalid_json' | 'invalid_id' | 'invalid_account_id' | 'invalid_occurred_at' | null {
+    let parsed: Record<string, unknown>;
+    try {
+        parsed = JSON.parse(event) as Record<string, unknown>;
+    } catch {
+        return 'invalid_json';
+    }
+    const { id, accountId, occurredAt } = parsed;
+    if (typeof id !== 'string' || !UUID.test(id)) {
+        return 'invalid_id';
+    }
+    // Matches `CHECK JSONType(event, 'accountId') = 'Int64' AND account_id > 0`: an integer, and positive.
+    if (typeof accountId !== 'number' || !Number.isSafeInteger(accountId) || accountId <= 0) {
+        return 'invalid_account_id';
+    }
+    if (typeof occurredAt !== 'string' || Number.isNaN(Date.parse(occurredAt))) {
+        return 'invalid_occurred_at';
+    }
+    return null;
 }
 
 function nonIdentifyingFields(event: string): { eventId?: string | undefined; resource?: string | undefined; action?: string | undefined } {

--- a/packages/metering/lib/processors/audit.ts
+++ b/packages/metering/lib/processors/audit.ts
@@ -196,13 +196,14 @@ export function unstorableReason(event: string): 'invalid_json' | 'invalid_id' |
         return 'invalid_account_id';
     }
     // `Date.parse` checks that the month is 1-12 and the day 1-31, but not the month's actual length, so
-    // 2026-02-30 parses and rolls over to March 2 while ClickHouse rejects it outright. Comparing the day
-    // back catches the rollover without demanding a canonical format ClickHouse would have accepted anyway.
-    if (typeof occurredAt !== 'string') {
+    // 2026-02-30 parses and rolls over to March 2 while ClickHouse rejects it outright. The calendar day is
+    // therefore checked on its own, rather than against the parsed UTC day, which would differ - and falsely
+    // reject - whenever an offset moves the timestamp across midnight.
+    if (typeof occurredAt !== 'string' || Number.isNaN(Date.parse(occurredAt))) {
         return 'invalid_occurred_at';
     }
-    const occurred = new Date(occurredAt);
-    if (Number.isNaN(occurred.getTime()) || occurred.toISOString().slice(0, 10) !== occurredAt.slice(0, 10)) {
+    const day = /^(\d{4})-(\d{2})-(\d{2})/.exec(occurredAt);
+    if (!day || new Date(Date.UTC(Number(day[1]), Number(day[2]) - 1, Number(day[3]))).getUTCDate() !== Number(day[3])) {
         return 'invalid_occurred_at';
     }
     return null;

--- a/packages/metering/lib/processors/audit.ts
+++ b/packages/metering/lib/processors/audit.ts
@@ -195,7 +195,14 @@ export function unstorableReason(event: string): 'invalid_json' | 'invalid_id' |
     if (typeof accountId !== 'number' || !Number.isSafeInteger(accountId) || accountId < 0) {
         return 'invalid_account_id';
     }
-    if (typeof occurredAt !== 'string' || Number.isNaN(Date.parse(occurredAt))) {
+    // `Date.parse` checks that the month is 1-12 and the day 1-31, but not the month's actual length, so
+    // 2026-02-30 parses and rolls over to March 2 while ClickHouse rejects it outright. Comparing the day
+    // back catches the rollover without demanding a canonical format ClickHouse would have accepted anyway.
+    if (typeof occurredAt !== 'string') {
+        return 'invalid_occurred_at';
+    }
+    const occurred = new Date(occurredAt);
+    if (Number.isNaN(occurred.getTime()) || occurred.toISOString().slice(0, 10) !== occurredAt.slice(0, 10)) {
         return 'invalid_occurred_at';
     }
     return null;

--- a/packages/metering/lib/processors/audit.unit.test.ts
+++ b/packages/metering/lib/processors/audit.unit.test.ts
@@ -2,7 +2,7 @@ import { DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { serde } from '@nangohq/pubsub';
-import { Err, Ok } from '@nangohq/utils';
+import { Err, metrics, Ok } from '@nangohq/utils';
 
 import { AuditProcessor, unstorableReason } from './audit.js';
 
@@ -130,6 +130,17 @@ describe('AuditProcessor', () => {
         expect(records).toHaveLength(1);
         expect((JSON.parse(records[0]!.event) as { id: string }).id).toBe(uuid('good'));
         expect(deleted).toEqual(['handle-good']);
+    });
+
+    it('counts a dropped event apart from a message that was never ours, so a monitor can page on one', async () => {
+        const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        const recordMany = vi.fn().mockResolvedValue(Ok(undefined));
+        const wrongSubject = { ...auditMessage('x'), MessageAttributes: { subject: { DataType: 'String', StringValue: 'usage' } } };
+
+        await run([auditMessage('poison', { accountId: -1 }), wrongSubject], { recordMany });
+
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'invalid_account_id', kind: 'event' });
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'subject_mismatch', kind: 'envelope' });
     });
 
     it('skips a message published under another subject', async () => {

--- a/packages/metering/lib/processors/audit.unit.test.ts
+++ b/packages/metering/lib/processors/audit.unit.test.ts
@@ -12,12 +12,23 @@ import type { AuditRecordedEvent } from '@nangohq/types';
 
 const QUEUE_URL = 'https://sqs.us-west-2.amazonaws.com/1/audit-test-audit-test';
 
-function auditMessage(eventId: string) {
+const uuid = (seed: string) => `${seed.charCodeAt(0).toString(16).padStart(8, '0')}-0000-4000-8000-000000000000`;
+
+function auditMessage(eventId: string, overrides: Record<string, unknown> = {}) {
     const event = {
         idempotencyKey: `key-${eventId}`,
         subject: 'audit',
         type: 'audit.recorded',
-        payload: { event: JSON.stringify({ id: eventId, resource: 'connection', action: 'deleted', accountId: 42 }) },
+        payload: {
+            event: JSON.stringify({
+                id: uuid(eventId),
+                occurredAt: '2026-07-30T10:00:00.000Z',
+                resource: 'connection',
+                action: 'deleted',
+                accountId: 42,
+                ...overrides
+            })
+        },
         createdAt: new Date('2026-07-30T10:00:00.000Z')
     } satisfies AuditRecordedEvent;
 
@@ -80,7 +91,7 @@ describe('AuditProcessor', () => {
 
         expect(recordMany).toHaveBeenCalledTimes(1);
         const [records, opts] = recordMany.mock.calls[0] as [{ event: string }[], { dedupToken: string }];
-        expect(records.map((r) => (JSON.parse(r.event) as { id: string }).id)).toEqual(['a', 'b', 'c']);
+        expect(records.map((r) => (JSON.parse(r.event) as { id: string }).id)).toEqual([uuid('a'), uuid('b'), uuid('c')]);
         expect(opts.dedupToken).toMatch(/^[0-9a-f]{64}$/);
         expect(deleted.sort()).toEqual(['handle-a', 'handle-b', 'handle-c']);
     });
@@ -100,7 +111,24 @@ describe('AuditProcessor', () => {
 
         const [records] = recordMany.mock.calls[0] as [{ event: string }[]];
         expect(records).toHaveLength(1);
-        expect((JSON.parse(records[0]!.event) as { id: string }).id).toBe('good');
+        expect((JSON.parse(records[0]!.event) as { id: string }).id).toBe(uuid('good'));
+        expect(deleted).toEqual(['handle-good']);
+    });
+
+    it.each([
+        ['an account id the table would file under the wrong account', { accountId: 0 }],
+        ['an account id that is not an integer', { accountId: 1.5 }],
+        ['an unparseable occurredAt', { occurredAt: 'not-a-date' }],
+        ['an id that is not a uuid', { id: 'nope' }]
+    ])('keeps the batch alive when one event carries %s, leaving it for the DLQ', async (_case, overrides) => {
+        const recordMany = vi.fn().mockResolvedValue(Ok(undefined));
+        const { deleted } = await run([auditMessage('good'), auditMessage('poison', overrides)], { recordMany });
+
+        // The insert is atomic, so letting this row through would reject `good` too and redeliver it in a
+        // differently composed batch, past the dedup token that would have suppressed a re-write.
+        const [records] = recordMany.mock.calls[0] as [{ event: string }[]];
+        expect(records).toHaveLength(1);
+        expect((JSON.parse(records[0]!.event) as { id: string }).id).toBe(uuid('good'));
         expect(deleted).toEqual(['handle-good']);
     });
 

--- a/packages/metering/lib/processors/audit.unit.test.ts
+++ b/packages/metering/lib/processors/audit.unit.test.ts
@@ -233,6 +233,9 @@ describe('unstorableReason', () => {
         ['a fractional account id', 'invalid_account_id', event({ accountId: 1.5 })],
         ['an account id sent as a string', 'invalid_account_id', event({ accountId: '42' })],
         ['a missing id', 'invalid_id', event({ id: undefined })],
+        // `z.uuid()` checks the RFC version nibble, so this is stricter than `toUUID`, which would take it.
+        // Unreachable from `randomUUID`, and rejecting one message beats letting it fail a batch.
+        ['a uuid with no version', 'invalid_id', event({ id: '11111111-1111-0111-8111-111111111111' })],
         ['an unparseable occurredAt', 'invalid_occurred_at', event({ occurredAt: 'nope' })],
         // Rolls over to March 2 in JS but ClickHouse refuses it, which would fail the whole insert block.
         ['a day past the end of the month', 'invalid_occurred_at', event({ occurredAt: '2026-02-30T10:00:00.000Z' })],

--- a/packages/metering/lib/processors/audit.unit.test.ts
+++ b/packages/metering/lib/processors/audit.unit.test.ts
@@ -1,6 +1,7 @@
 import { DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { AuditClient } from '@nangohq/audit';
 import { serde } from '@nangohq/pubsub';
 import { Err, metrics, Ok } from '@nangohq/utils';
 
@@ -177,6 +178,40 @@ describe('AuditProcessor', () => {
 
         expect(recordMany).not.toHaveBeenCalled();
         expect(deleted).toEqual([]);
+    });
+});
+
+describe('unstorableReason contract with the emitter', () => {
+    // The guard is a hand-written mirror of the table, and its fixtures are hand-written too, so nothing
+    // otherwise stops a producer-side change from making every event unstorable - which would show up only
+    // as events piling into the DLQ. This runs what the emitter actually serialises through the guard.
+    it('accepts an event the emitter produced', async () => {
+        let captured = '';
+        const writer = {
+            record: (record: { event: string }) => {
+                captured = record.event;
+                return Promise.resolve(Ok(undefined));
+            }
+        };
+
+        (
+            await new AuditClient(writer, {} as never).record({
+                occurredAt: new Date().toISOString(),
+                accountId: 42,
+                environment: { id: 1, display: 'dev' },
+                actor: { type: 'user', id: '5', display: 'a@b.co' },
+                resource: 'connection',
+                action: 'deleted',
+                targets: [{ type: 'connection', id: '10' }],
+                context: { ip: '1.2.3.4' },
+                outcome: 'success'
+            })
+        ).unwrap();
+
+        // Covers the three fields the guard judges: the id `record()` stamps, the caller's ISO timestamp,
+        // and a numeric account id.
+        expect(captured).not.toBe('');
+        expect(unstorableReason(captured)).toBeNull();
     });
 });
 

--- a/packages/metering/lib/processors/audit.unit.test.ts
+++ b/packages/metering/lib/processors/audit.unit.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { serde } from '@nangohq/pubsub';
 import { Err, Ok } from '@nangohq/utils';
 
-import { AuditProcessor } from './audit.js';
+import { AuditProcessor, unstorableReason } from './audit.js';
 
 import type { SQSClient } from '@aws-sdk/client-sqs';
 import type { AuditBatchWriter } from '@nangohq/audit';
@@ -116,7 +116,7 @@ describe('AuditProcessor', () => {
     });
 
     it.each([
-        ['an account id the table would file under the wrong account', { accountId: 0 }],
+        ['a negative account id', { accountId: -1 }],
         ['an account id that is not an integer', { accountId: 1.5 }],
         ['an unparseable occurredAt', { occurredAt: 'not-a-date' }],
         ['an id that is not a uuid', { id: 'nope' }]
@@ -166,5 +166,28 @@ describe('AuditProcessor', () => {
 
         expect(recordMany).not.toHaveBeenCalled();
         expect(deleted).toEqual([]);
+    });
+});
+
+describe('unstorableReason', () => {
+    const event = (overrides: Record<string, unknown> = {}) =>
+        JSON.stringify({ id: uuid('a'), occurredAt: '2026-07-30T10:00:00.000Z', accountId: 42, ...overrides });
+
+    it('accepts account 0, the account every no-auth request runs as', () => {
+        expect(unstorableReason(event({ accountId: 0 }))).toBeNull();
+    });
+
+    it.each([
+        ['a well-formed event', event(), null],
+        ['a bare JSON null, which parses but cannot be destructured', 'null', 'invalid_json'],
+        ['a JSON array', '[]', 'invalid_json'],
+        ['unparseable JSON', '{', 'invalid_json'],
+        ['a negative account id', event({ accountId: -1 }), 'invalid_account_id'],
+        ['a fractional account id', event({ accountId: 1.5 }), 'invalid_account_id'],
+        ['an account id sent as a string', event({ accountId: '42' }), 'invalid_account_id'],
+        ['a missing id', event({ id: undefined }), 'invalid_id'],
+        ['an unparseable occurredAt', event({ occurredAt: 'nope' }), 'invalid_occurred_at']
+    ])('reports %s as %s', (_case, blob, expected) => {
+        expect(unstorableReason(blob)).toBe(expected);
     });
 });

--- a/packages/metering/lib/processors/audit.unit.test.ts
+++ b/packages/metering/lib/processors/audit.unit.test.ts
@@ -177,17 +177,23 @@ describe('unstorableReason', () => {
         expect(unstorableReason(event({ accountId: 0 }))).toBeNull();
     });
 
+    // Reason before blob, so the printf title reads as "reports X as invalid_account_id".
     it.each([
-        ['a well-formed event', event(), null],
-        ['a bare JSON null, which parses but cannot be destructured', 'null', 'invalid_json'],
-        ['a JSON array', '[]', 'invalid_json'],
-        ['unparseable JSON', '{', 'invalid_json'],
-        ['a negative account id', event({ accountId: -1 }), 'invalid_account_id'],
-        ['a fractional account id', event({ accountId: 1.5 }), 'invalid_account_id'],
-        ['an account id sent as a string', event({ accountId: '42' }), 'invalid_account_id'],
-        ['a missing id', event({ id: undefined }), 'invalid_id'],
-        ['an unparseable occurredAt', event({ occurredAt: 'nope' }), 'invalid_occurred_at']
-    ])('reports %s as %s', (_case, blob, expected) => {
+        ['a well-formed event', null, event()],
+        ['a bare JSON null, which parses but cannot be destructured', 'invalid_json', 'null'],
+        ['a JSON array', 'invalid_json', '[]'],
+        ['unparseable JSON', 'invalid_json', '{'],
+        ['a negative account id', 'invalid_account_id', event({ accountId: -1 })],
+        ['a fractional account id', 'invalid_account_id', event({ accountId: 1.5 })],
+        ['an account id sent as a string', 'invalid_account_id', event({ accountId: '42' })],
+        ['a missing id', 'invalid_id', event({ id: undefined })],
+        ['an unparseable occurredAt', 'invalid_occurred_at', event({ occurredAt: 'nope' })],
+        // Rolls over to March 2 in JS but ClickHouse refuses it, which would fail the whole insert block.
+        ['a day past the end of the month', 'invalid_occurred_at', event({ occurredAt: '2026-02-30T10:00:00.000Z' })],
+        ['a leap day in a non-leap year', 'invalid_occurred_at', event({ occurredAt: '2026-02-29T10:00:00.000Z' })],
+        ['a leap day in a leap year', null, event({ occurredAt: '2028-02-29T10:00:00.000Z' })],
+        ['a timestamp without milliseconds, which ClickHouse accepts', null, event({ occurredAt: '2026-01-15T10:00:00Z' })]
+    ])('reports %s as %s', (_case, expected, blob) => {
         expect(unstorableReason(blob)).toBe(expected);
     });
 });

--- a/packages/metering/lib/processors/audit.unit.test.ts
+++ b/packages/metering/lib/processors/audit.unit.test.ts
@@ -192,7 +192,10 @@ describe('unstorableReason', () => {
         ['a day past the end of the month', 'invalid_occurred_at', event({ occurredAt: '2026-02-30T10:00:00.000Z' })],
         ['a leap day in a non-leap year', 'invalid_occurred_at', event({ occurredAt: '2026-02-29T10:00:00.000Z' })],
         ['a leap day in a leap year', null, event({ occurredAt: '2028-02-29T10:00:00.000Z' })],
-        ['a timestamp without milliseconds, which ClickHouse accepts', null, event({ occurredAt: '2026-01-15T10:00:00Z' })]
+        ['a timestamp without milliseconds, which ClickHouse accepts', null, event({ occurredAt: '2026-01-15T10:00:00Z' })],
+        // An offset that moves the timestamp across midnight: the calendar day is still real, so it stays.
+        ['an offset timestamp whose UTC day differs', null, event({ occurredAt: '2026-01-01T00:30:00+01:00' })],
+        ['a month past 12', 'invalid_occurred_at', event({ occurredAt: '2026-13-01T10:00:00.000Z' })]
     ])('reports %s as %s', (_case, expected, blob) => {
         expect(unstorableReason(blob)).toBe(expected);
     });


### PR DESCRIPTION
Two halves of duplicate handling, found by tracing how a copy can reach a reader.

- **One unstorable event no longer takes its batch down.** A block insert is atomic, so a row the table refuses rejects the whole batch. Nothing is deleted, the messages redeliver, and SQS re-batches them with newly arrived ones — which changes the message-id set the dedup token is derived from, so the token stops suppressing an attempt that had already been written. One bad event amplifies into duplicates of its neighbours, for as many cycles as `maxReceiveCount` allows. The consumer now checks the three ORDER BY keys before an event can join a batch, and a rejected message follows the path the existing rejects take — left undeleted, so redrive carries it to the DLQ with its payload intact.
- **The read's cross-page duplicate suppression is now covered.** The existing dedup test pages once with no cursor, so the cursor's strict tuple comparison was never evaluated — loosening it to `<=` kept the suite green. The new case stores a copy of the newer of two events, pages one at a time, and asserts the copy never comes back.
- **The dedup reasoning is consolidated onto `list`**, where it was split across two comments that between them never said why the read reconciles copies at all, and left the cross-page half undocumented.

### Why the consumer now mirrors the table's constraints

This reverses a deliberate choice — the previous comment left storability to the table so the rules had one home. The price turned out to be batch-level collateral: a single event with a bad `accountId` blocks every event batched with it and churns the dedup token while doing so. The two now have to agree, so the account-id check mirrors the CHECK constraint exactly, including that the value must be an *integer* rather than merely positive. The checks live in one exported function so the DLQ redrive can reuse them.

### Where the validation lives

The checks mirror constraints the consumer does not own — the `account_id` CHECK and the two materialized extracts all live in this package's migrations. Longer term they belong to the writer, so `recordMany` refuses a row and reports it rather than the consumer knowing the table's rules. Left where it is deliberately: with one datastore there is nothing to abstract over, and self-hosted Postgres will bring a different set of constraints, so the shape of that interface is better decided with both in hand. It is one pure function with one caller, so the move is a rename and an import.

### Why the cursor is load-bearing

Suppression is split. Within a page, copies share the `ORDER BY` key, so they arrive adjacent in the merged stream and a neighbour filter cuts them. Across pages, `(occurred_at, id) < (before_ts, before_id)` excludes a copy of the boundary row because it shares both values. The second half exists for correct keyset pagination and suppresses duplicates as a side effect, so nothing signals what an edit would break — hence the test.

Both mechanisms key on the event id, so they catch a redelivery of the same event and not a re-emit, which arrives with a fresh id and reads as two events. Best effort, not exactly-once, now stated where it can be read.

## Test plan

- [x] 10 metering unit + 14 audit integration tests pass
- [x] Each new case verified red: the four rejection cases fail with the guard bypassed (the poison event's batch takes the good event with it), and the pagination case fails with the cursor loosened to `<=`
- [x] Fixtures corrected — they carried no `occurredAt` and used the seed string as the event id, so nothing in that suite was shaped like an event the emitters produce
- [x] Prettier, oxlint and `tsc` clean
- [ ] CI
