### PR TITLE
fix(billing): filter overdue invoices by due date

### DIFF
--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -164,14 +164,19 @@ export class OrbClient implements BillingClient {
 
     async getOverdueInvoices(accountId: number): Promise<Result<BillingOverdueInvoices>> {
         try {
+            // A day of grace while Orb's own charge retries play out. Orb rejects a timestamp here and
+            // matches the given date inclusively.
+            const dueOnOrBefore = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
             // Pages are walked until a match: a page of fully-credited invoices doesn't end the search.
             for await (const invoice of this.orbSDK.invoices.list({
                 external_customer_id: String(accountId),
                 // `synced` is an issued invoice exported to external accounting — still owed.
                 status: ['issued', 'synced'],
-                // Orb takes a date, so this only matches invoices due before today: a day of grace
-                // while Orb's own charge retries play out, rather than warning within the hour.
-                'due_date[lt]': new Date().toISOString().slice(0, 10)
+                // Orb applies the date filter to whichever field `date_type` names and defaults that to
+                // `invoice_date`, where it matches every issued invoice, due or not.
+                date_type: 'due_date',
+                'due_date[lt]': dueOnOrBefore
             })) {
                 // Orb can't filter on the amount, and a fully-credited invoice is still `issued`.
                 if (Number(invoice.amount_due) > 0) {

--- a/packages/billing/lib/clients/orb/client.unit.test.ts
+++ b/packages/billing/lib/clients/orb/client.unit.test.ts
@@ -20,7 +20,7 @@ describe('OrbClient.getOverdueInvoices', () => {
         vi.setSystemTime(new Date('2026-07-14T15:00:00Z'));
     });
 
-    it('asks Orb only for outstanding invoices due before today', async () => {
+    it('asks Orb only for outstanding invoices due yesterday or earlier', async () => {
         const { client, list } = clientWith([]);
 
         await client.getOverdueInvoices(42);
@@ -28,8 +28,9 @@ describe('OrbClient.getOverdueInvoices', () => {
         expect(list).toHaveBeenCalledWith({
             external_customer_id: '42',
             status: ['issued', 'synced'],
+            date_type: 'due_date',
             // A date, not a timestamp — Orb documents this filter as `format: date`.
-            'due_date[lt]': '2026-07-14'
+            'due_date[lt]': '2026-07-13'
         });
     });
 


### PR DESCRIPTION
## Problem

The overdue-invoice alerts from #6845 flagged any issued, unpaid invoice as overdue, including ones still well inside their net terms.

`getOverdueInvoices` passed `due_date[lt]` without `date_type`. Orb applies that filter to whichever field `date_type` names and defaults it to `invoice_date`, which is on or before today for every issued invoice — so the filter matched everything. Orb accepts and validates the parameter (a timestamp value returns 400), it just applies it to the wrong column, and nothing in CI could catch it because the endpoint's integration tests mock the billing client.

## Solution

- Pass `date_type: 'due_date'` so the filter applies to the due date.
- Move the cutoff from today to yesterday: `due_date[lt]` includes the date it is given, so passing today flagged invoices due today, leaving no grace for Orb's own charge retries to land.
- Assert both in the unit test.

Follow-up to #6845 · [NAN-6232](https://linear.app/nango/issue/NAN-6232)

## Testing

Drove the real `OrbClient` against Orb test mode using purpose-built fixture customers. Unit tests 5/5.

| invoices on the customer (all issued, unpaid) | before | after |
| --- | --- | --- |
| due 6 weeks ago **and** due next week | true | true |
| due in 6 weeks only | **true** | false |
| due today only | **true** | false |
| no Orb customer at all | false | false |
