### PR TITLE
feat(server): mint and validate agent session tokens (NAN-6596)

### DIFF
--- a/packages/keystore/lib/db/migrations/20260819120000_add_agent_session_entity.ts
+++ b/packages/keystore/lib/db/migrations/20260819120000_add_agent_session_entity.ts
@@ -12,6 +12,4 @@ export async function up(knex: Knex): Promise<void> {
     await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} ADD COLUMN IF NOT EXISTS entity_uuid UUID;`);
 }
 
-export async function down(): Promise<void> {
-    // Postgres cannot remove enum values, and restoring NOT NULL would fail once agent_session keys exist.
-}
+export async function down(): Promise<void> {}

--- a/packages/keystore/lib/db/migrations/20260819120000_add_agent_session_entity.ts
+++ b/packages/keystore/lib/db/migrations/20260819120000_add_agent_session_entity.ts
@@ -10,6 +10,19 @@ export async function up(knex: Knex): Promise<void> {
     await knex.raw(`ALTER TYPE private_key_entity_types ADD VALUE IF NOT EXISTS 'agent_session';`);
     await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} ALTER COLUMN entity_id DROP NOT NULL;`);
     await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} ADD COLUMN IF NOT EXISTS entity_uuid UUID;`);
+    // NOT VALID then VALIDATE so existing rows are checked without blocking writes.
+    await knex.raw(`
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'private_keys_entity_ref_check' AND conrelid = '${PRIVATE_KEYS_TABLE}'::regclass
+            ) THEN
+                ALTER TABLE ${PRIVATE_KEYS_TABLE} ADD CONSTRAINT private_keys_entity_ref_check
+                    CHECK ((entity_id IS NULL) <> (entity_uuid IS NULL)) NOT VALID;
+            END IF;
+        END $$;
+    `);
+    await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} VALIDATE CONSTRAINT private_keys_entity_ref_check;`);
 }
 
 export async function down(): Promise<void> {}

--- a/packages/keystore/lib/db/migrations/20260819120000_add_agent_session_entity.ts
+++ b/packages/keystore/lib/db/migrations/20260819120000_add_agent_session_entity.ts
@@ -1,0 +1,17 @@
+import { PRIVATE_KEYS_TABLE } from '../../models/privatekeys.js';
+
+import type { Knex } from 'knex';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`ALTER TYPE private_key_entity_types ADD VALUE IF NOT EXISTS 'agent_session';`);
+    await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} ALTER COLUMN entity_id DROP NOT NULL;`);
+    await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} ADD COLUMN IF NOT EXISTS entity_uuid UUID;`);
+}
+
+export async function down(): Promise<void> {
+    // Postgres cannot remove enum values, and restoring NOT NULL would fail once agent_session keys exist.
+}

--- a/packages/keystore/lib/db/migrations/20260819120000_add_agent_session_entity.ts
+++ b/packages/keystore/lib/db/migrations/20260819120000_add_agent_session_entity.ts
@@ -10,19 +10,6 @@ export async function up(knex: Knex): Promise<void> {
     await knex.raw(`ALTER TYPE private_key_entity_types ADD VALUE IF NOT EXISTS 'agent_session';`);
     await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} ALTER COLUMN entity_id DROP NOT NULL;`);
     await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} ADD COLUMN IF NOT EXISTS entity_uuid UUID;`);
-    // NOT VALID then VALIDATE so existing rows are checked without blocking writes.
-    await knex.raw(`
-        DO $$ BEGIN
-            IF NOT EXISTS (
-                SELECT 1 FROM pg_constraint
-                WHERE conname = 'private_keys_entity_ref_check' AND conrelid = '${PRIVATE_KEYS_TABLE}'::regclass
-            ) THEN
-                ALTER TABLE ${PRIVATE_KEYS_TABLE} ADD CONSTRAINT private_keys_entity_ref_check
-                    CHECK ((entity_id IS NULL) <> (entity_uuid IS NULL)) NOT VALID;
-            END IF;
-        END $$;
-    `);
-    await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} VALIDATE CONSTRAINT private_keys_entity_ref_check;`);
 }
 
 export async function down(): Promise<void> {}

--- a/packages/keystore/lib/db/migrations/20260820090000_add_private_keys_entity_ref_check.ts
+++ b/packages/keystore/lib/db/migrations/20260820090000_add_private_keys_entity_ref_check.ts
@@ -1,0 +1,15 @@
+import { PRIVATE_KEYS_TABLE } from '../../models/privatekeys.js';
+
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${PRIVATE_KEYS_TABLE}
+        ADD CONSTRAINT private_keys_entity_ref_check
+        CHECK ((entity_id IS NULL) <> (entity_uuid IS NULL));
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} DROP CONSTRAINT IF EXISTS private_keys_entity_ref_check;`);
+}

--- a/packages/keystore/lib/db/migrations/20260820090000_add_private_keys_entity_ref_check.ts
+++ b/packages/keystore/lib/db/migrations/20260820090000_add_private_keys_entity_ref_check.ts
@@ -10,6 +10,4 @@ export async function up(knex: Knex): Promise<void> {
     `);
 }
 
-export async function down(knex: Knex): Promise<void> {
-    await knex.raw(`ALTER TABLE ${PRIVATE_KEYS_TABLE} DROP CONSTRAINT IF EXISTS private_keys_entity_ref_check;`);
-}
+export async function down(): Promise<void> {}

--- a/packages/keystore/lib/db/migrations/20260820090000_add_private_keys_entity_ref_check.ts
+++ b/packages/keystore/lib/db/migrations/20260820090000_add_private_keys_entity_ref_check.ts
@@ -6,7 +6,12 @@ export async function up(knex: Knex): Promise<void> {
     await knex.raw(`
         ALTER TABLE ${PRIVATE_KEYS_TABLE}
         ADD CONSTRAINT private_keys_entity_ref_check
-        CHECK ((entity_id IS NULL) <> (entity_uuid IS NULL));
+        CHECK (
+            CASE WHEN entity_type = 'agent_session'
+                THEN entity_id IS NULL AND entity_uuid IS NOT NULL
+                ELSE entity_id IS NOT NULL AND entity_uuid IS NULL
+            END
+        );
     `);
 }
 

--- a/packages/keystore/lib/models/privatekeys.integration.test.ts
+++ b/packages/keystore/lib/models/privatekeys.integration.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { afterAll, describe, expect, it } from 'vitest';
 
 import { testDb } from '../db/helpers.test.js';
@@ -118,6 +120,31 @@ describe('PrivateKey', async () => {
         const [keyValue] = createKey.unwrap();
         const getKey = await getPrivateKey(db, keyValue);
         expect(getKey.isErr()).toBe(true);
+    });
+
+    it('should be created and retrieved for a uuid entity', async () => {
+        const entityUuid = randomUUID();
+        const createKey = await createPrivateKey(
+            db,
+            {
+                displayName: '',
+                entityType: 'agent_session',
+                entityUuid,
+                accountId: 1,
+                environmentId: 1,
+                ttlInMs: 10_000
+            },
+            { onlyStoreHash: true }
+        );
+
+        const [keyValue] = createKey.unwrap();
+        expect(keyValue).toMatch(/^nango_agent_session_[a-f0-9]{64}$/);
+
+        const key = (await getPrivateKey(db, keyValue)).unwrap();
+        expect(key.entityType).toBe('agent_session');
+        expect(key.entityUuid).toBe(entityUuid);
+        expect(key.entityId).toBe(null);
+        expect(key.encrypted).toBe(null);
     });
 
     it('should be created and retrieved with only hash stored', async () => {

--- a/packages/keystore/lib/models/privatekeys.ts
+++ b/packages/keystore/lib/models/privatekeys.ts
@@ -4,7 +4,7 @@ import { Err, Ok } from '@nangohq/utils';
 
 import { getEncryption, hashValue } from '../utils/encryption.js';
 
-import type { EntityType, PrivateKey } from '@nangohq/types';
+import type { EntityType, PrivateKey, PrivateKeyEntityRef } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type knex from 'knex';
 
@@ -32,7 +32,8 @@ interface DbPrivateKey {
     readonly expires_at: Date | null;
     readonly last_access_at: Date | null;
     readonly entity_type: EntityType;
-    readonly entity_id: number;
+    readonly entity_id: number | null;
+    readonly entity_uuid: string | null;
 }
 type DbInsertPrivateKey = Omit<DbPrivateKey, 'id' | 'created_at' | 'last_access_at'>;
 
@@ -49,7 +50,8 @@ const PrivateKeyMapper = {
             expires_at: key.expiresAt,
             last_access_at: key.lastAccessAt,
             entity_type: key.entityType,
-            entity_id: key.entityId
+            entity_id: key.entityId,
+            entity_uuid: key.entityUuid
         };
     },
     from: (dbKey: DbPrivateKey): PrivateKey => {
@@ -64,23 +66,18 @@ const PrivateKeyMapper = {
             expiresAt: dbKey.expires_at,
             lastAccessAt: dbKey.last_access_at,
             entityType: dbKey.entity_type,
-            entityId: dbKey.entity_id
+            entityId: dbKey.entity_id,
+            entityUuid: dbKey.entity_uuid
         };
     }
 };
 
 export async function createPrivateKey(
     db: knex.Knex,
-    {
-        displayName,
-        entityType,
-        entityId,
-        accountId,
-        environmentId,
-        ttlInMs
-    }: Pick<PrivateKey, 'displayName' | 'entityType' | 'entityId' | 'accountId' | 'environmentId'> & { ttlInMs?: number },
+    params: Pick<PrivateKey, 'displayName' | 'accountId' | 'environmentId'> & PrivateKeyEntityRef & { ttlInMs?: number },
     options: { onlyStoreHash: boolean } = { onlyStoreHash: false }
 ): Promise<Result<[string, PrivateKey], PrivateKeyError>> {
+    const { displayName, entityType, accountId, environmentId, ttlInMs } = params;
     const now = new Date();
     const random = crypto.randomBytes(32).toString('hex');
     const keyValue = `nango_${entityType}_${random}`;
@@ -93,7 +90,8 @@ export async function createPrivateKey(
         hash,
         expires_at: ttlInMs ? new Date(now.getTime() + ttlInMs) : null,
         entity_type: entityType,
-        entity_id: entityId
+        entity_id: 'entityId' in params ? params.entityId : null,
+        entity_uuid: 'entityUuid' in params ? params.entityUuid : null
     };
     const [dbKey] = await db.into(PRIVATE_KEYS_TABLE).insert(key).returning('*');
     if (!dbKey) {

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -83,6 +83,8 @@ export const envSchema = z
     .max(255);
 export const connectSessionTokenPrefix = 'nango_connect_session_';
 export const connectSessionTokenSchema = z.string().regex(new RegExp(`^${connectSessionTokenPrefix}[a-f0-9]{64}$`));
+export const agentSessionTokenPrefix = 'nango_agent_session_';
+export const agentSessionTokenSchema = z.string().regex(new RegExp(`^${agentSessionTokenPrefix}[a-f0-9]{64}$`));
 export const modelSchema = z
     .string()
     .regex(/^[A-Z][a-zA-Z0-9_-]+$/)

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -19,11 +19,12 @@ import {
 } from '@nangohq/utils';
 
 import { envs } from '../env.js';
-import { connectSessionTokenPrefix, connectSessionTokenSchema } from '../helpers/validation.js';
+import { agentSessionTokenSchema, connectSessionTokenPrefix, connectSessionTokenSchema } from '../helpers/validation.js';
+import * as agentSessionService from '../services/agentSession.service.js';
 import * as connectSessionService from '../services/connectSession.service.js';
 
 import type { RequestLocals } from '../utils/express.js';
-import type { ApiKeyContext, ApiKeyPrincipal, ConnectSession, DBAPISecret, DBEnvironment, DBPlan, DBTeam, InternalEndUser } from '@nangohq/types';
+import type { AgentSession, ApiKeyContext, ApiKeyPrincipal, ConnectSession, DBAPISecret, DBEnvironment, DBPlan, DBTeam, InternalEndUser } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { NextFunction, Request, Response } from 'express';
 
@@ -318,6 +319,94 @@ export class AccessMiddleware {
             return;
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_CONNECT_SESSION, Date.now() - start);
+            span.finish();
+        }
+    }
+
+    private async validateAgentSessionToken(token: string): Promise<
+        Result<{
+            account: DBTeam;
+            environment: DBEnvironment;
+            secret: DBAPISecret;
+            agentSession: AgentSession;
+            plan: DBPlan | null;
+        }>
+    > {
+        const parsedToken = agentSessionTokenSchema.safeParse(token);
+        if (!parsedToken.success) {
+            return Err('invalid_agent_session_token_format');
+        }
+
+        const getAgentSession = await agentSessionService.getAgentSessionByToken(db.knex, token);
+        if (getAgentSession.isErr()) {
+            return Err('unknown_agent_session_token');
+        }
+
+        // Checked on the session rather than trusted to the credential's own expiry, so the
+        // planned switch to session-scoped customer keys does not change what gets rejected.
+        const agentSession = getAgentSession.value;
+        if (agentSession.endedAt !== null || agentSession.expiresAt.getTime() <= Date.now()) {
+            return Err('agent_session_ended');
+        }
+
+        const accountContext = await accountService.getAccountContext({ environmentId: agentSession.environmentId });
+        if (!accountContext) {
+            return Err('unknown_account');
+        }
+
+        if (flagHasPlan && !accountContext.plan) {
+            return Err('plan_not_found');
+        }
+
+        return Ok({
+            account: accountContext.account,
+            environment: accountContext.environment,
+            secret: accountContext.secret,
+            agentSession,
+            plan: accountContext.plan
+        });
+    }
+
+    async agentSessionAuth(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
+        const active = tracer.scope().active();
+        const span = tracer.startSpan('agentSessionAuth', {
+            childOf: active!
+        });
+
+        const start = Date.now();
+        try {
+            const authorizationHeader = req.get('authorization');
+            if (!authorizationHeader) {
+                errorManager.errRes(res, 'missing_auth_header');
+                return;
+            }
+
+            const token = authorizationHeader.split('Bearer ').pop();
+            if (!token) {
+                errorManager.errRes(res, 'malformed_auth_header');
+                return;
+            }
+
+            const result = await this.validateAgentSessionToken(token);
+            if (result.isErr()) {
+                errorManager.errRes(res, result.error.message);
+                return;
+            }
+
+            res.locals['authType'] = 'agentSession';
+            res.locals['account'] = result.value.account;
+            res.locals['environment'] = result.value.environment;
+            res.locals['agentSession'] = result.value.agentSession;
+            res.locals['plan'] = result.value.plan;
+            tagTraceUser(result.value);
+            next();
+        } catch (err) {
+            logger.error(`failed_get_env_by_agent_session ${stringifyError(err)}`);
+            span.setTag('error', err);
+            errorManager.errRes(res, 'unknown_account');
+            return;
+        } finally {
+            metrics.duration(metrics.Types.AUTH_GET_ENV_BY_AGENT_SESSION, Date.now() - start);
             span.finish();
         }
     }

--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -3,9 +3,17 @@ import { randomUUID } from 'node:crypto';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
+import * as keystore from '@nangohq/keystore';
 import { seeders } from '@nangohq/shared';
 
-import { createAgentSession, getAgentSession, listExpiredAgentSessions, terminateAgentSession } from './agentSession.service.js';
+import {
+    createAgentSession,
+    createAgentSessionToken,
+    getAgentSession,
+    getAgentSessionByToken,
+    listExpiredAgentSessions,
+    terminateAgentSession
+} from './agentSession.service.js';
 
 import type { AgentSession, AgentSessionCompiledToolset, AgentSessionResolvedConnections, DBEnvironment, DBTeam } from '@nangohq/types';
 
@@ -17,6 +25,7 @@ describe('agentSession service', () => {
 
     beforeAll(async () => {
         await multipleMigrations();
+        await keystore.migrate(db.knex);
     });
 
     beforeEach(async () => {
@@ -157,6 +166,70 @@ describe('agentSession service', () => {
         ).unwrap();
         expect(retried.endedAt).toStrictEqual(terminated.endedAt);
         expect(retried.endedReason).toBe('terminated');
+    });
+
+    it('mints a token that resolves back to the session', async () => {
+        const expiresAt = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000);
+        const session = await createSession({ account, environment, expiresAt });
+
+        const minted = (await createAgentSessionToken(db.knex, session)).unwrap();
+        expect(minted.token).toMatch(/^nango_agent_session_[a-f0-9]{64}$/);
+        expect(Math.abs(minted.expiresAt.getTime() - expiresAt.getTime())).toBeLessThan(5_000);
+
+        const resolved = (await getAgentSessionByToken(db.knex, minted.token)).unwrap();
+        expect(resolved).toStrictEqual(session);
+    });
+
+    it('rejects an unknown token', async () => {
+        const result = await getAgentSessionByToken(db.knex, `nango_agent_session_${'a'.repeat(64)}`);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.code).toBe('not_found');
+        }
+    });
+
+    it('rejects a token minted for another entity type', async () => {
+        const [token] = (
+            await keystore.createPrivateKey(db.knex, {
+                displayName: '',
+                entityType: 'connect_session',
+                entityId: 1,
+                accountId: account.id,
+                environmentId: environment.id
+            })
+        ).unwrap();
+
+        const result = await getAgentSessionByToken(db.knex, token);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.code).toBe('not_found');
+        }
+    });
+
+    it('refuses to mint a token for an expired session', async () => {
+        const session = await createSession({ account, environment, expiresAt: new Date(Date.now() - 60_000) });
+
+        const result = await createAgentSessionToken(db.knex, session);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.code).toBe('token_creation_failed');
+        }
+    });
+
+    it('stops resolving the token once it expires', async () => {
+        const session = await createSession({ account, environment, expiresAt: new Date(Date.now() + 20) });
+        const minted = (await createAgentSessionToken(db.knex, session)).unwrap();
+
+        await new Promise((resolve) => setTimeout(resolve, 40));
+
+        const result = await getAgentSessionByToken(db.knex, minted.token);
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.code).toBe('not_found');
+        }
     });
 
     it('lists active expired sessions in expiration order and honors the limit', async () => {

--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -220,10 +220,10 @@ describe('agentSession service', () => {
     });
 
     it('stops resolving the token once it expires', async () => {
-        const session = await createSession({ account, environment, expiresAt: new Date(Date.now() + 20) });
+        const session = await createSession({ account, environment, expiresAt: new Date(Date.now() + 300) });
         const minted = (await createAgentSessionToken(db.knex, session)).unwrap();
 
-        await new Promise((resolve) => setTimeout(resolve, 40));
+        await new Promise((resolve) => setTimeout(resolve, 400));
 
         const result = await getAgentSessionByToken(db.knex, minted.token);
         expect(result.isErr()).toBe(true);

--- a/packages/server/lib/services/agentSession.service.ts
+++ b/packages/server/lib/services/agentSession.service.ts
@@ -1,3 +1,4 @@
+import * as keystore from '@nangohq/keystore';
 import { Err, Ok } from '@nangohq/utils';
 
 import type { Knex } from '@nangohq/database';
@@ -39,7 +40,7 @@ export interface CreateAgentSessionParams {
 
 export type ExpiredAgentSession = Pick<AgentSession, 'id' | 'accountId' | 'environmentId' | 'expiresAt'>;
 
-type AgentSessionErrorCode = 'not_found' | 'creation_failed';
+type AgentSessionErrorCode = 'not_found' | 'creation_failed' | 'token_creation_failed';
 
 export class AgentSessionError extends Error {
     public readonly code: AgentSessionErrorCode;
@@ -114,6 +115,74 @@ export async function terminateAgentSession(
     return getAgentSession(db, { id, accountId, environmentId });
 }
 
+// Agent session tokens are minted through the keystore for now. Once the unified authz project
+// lands (RFC: user-level grants and unified authz) they become customer keys with grants scoped
+// to the environment and session, so every mint and resolve detail must stay behind
+// createAgentSessionToken and getAgentSessionByToken to keep that switch local.
+export async function createAgentSessionToken(db: Knex, session: AgentSession): Promise<Result<{ token: string; expiresAt: Date }, AgentSessionError>> {
+    const ttlInMs = session.expiresAt.getTime() - Date.now();
+    if (ttlInMs <= 0) {
+        return Err(
+            new AgentSessionError({
+                code: 'token_creation_failed',
+                message: 'Agent session is already expired',
+                payload: { id: session.id }
+            })
+        );
+    }
+
+    // The token is handed out once at creation, so only its hash is stored.
+    const privateKey = await keystore.createPrivateKey(
+        db,
+        {
+            displayName: '',
+            accountId: session.accountId,
+            environmentId: session.environmentId,
+            entityType: 'agent_session',
+            entityUuid: session.id,
+            ttlInMs
+        },
+        { onlyStoreHash: true }
+    );
+    if (privateKey.isErr()) {
+        return Err(
+            new AgentSessionError({
+                code: 'token_creation_failed',
+                message: 'Failed to create agent session token',
+                payload: { id: session.id },
+                cause: privateKey.error
+            })
+        );
+    }
+
+    const [token, storedKey] = privateKey.value;
+    if (!storedKey.expiresAt) {
+        return Err(
+            new AgentSessionError({
+                code: 'token_creation_failed',
+                message: 'Failed to create agent session token',
+                payload: { id: session.id }
+            })
+        );
+    }
+
+    return Ok({ token, expiresAt: storedKey.expiresAt });
+}
+
+export async function getAgentSessionByToken(db: Knex, token: string): Promise<Result<AgentSession, AgentSessionError>> {
+    const privateKey = await keystore.getPrivateKey(db, token);
+    if (privateKey.isErr()) {
+        return Err(tokenNotFoundError(token));
+    }
+
+    const key = privateKey.value;
+    if (key.entityType !== 'agent_session' || key.entityUuid === null) {
+        return Err(tokenNotFoundError(token));
+    }
+
+    return getAgentSession(db, { id: key.entityUuid, accountId: key.accountId, environmentId: key.environmentId });
+}
+
 export async function listExpiredAgentSessions(db: Knex, { limit }: { limit: number }): Promise<ExpiredAgentSession[]> {
     const sessions = await db<DBAgentSession>(AGENT_SESSIONS_TABLE)
         .select('id', 'account_id', 'environment_id', 'expires_at')
@@ -139,6 +208,14 @@ function notFoundError({ id, accountId, environmentId }: { id: string; accountId
         code: 'not_found',
         message: `Agent session '${id}' not found`,
         payload: { id, accountId, environmentId }
+    });
+}
+
+function tokenNotFoundError(token: string): AgentSessionError {
+    return new AgentSessionError({
+        code: 'not_found',
+        message: 'Token not found',
+        payload: { token: `${token.substring(0, 32)}...` }
     });
 }
 

--- a/packages/server/lib/services/agentSession.service.ts
+++ b/packages/server/lib/services/agentSession.service.ts
@@ -131,42 +131,33 @@ export async function createAgentSessionToken(db: Knex, session: AgentSession): 
         );
     }
 
-    // The token is handed out once at creation, so only its hash is stored.
-    const privateKey = await keystore.createPrivateKey(
-        db,
-        {
-            displayName: '',
-            accountId: session.accountId,
-            environmentId: session.environmentId,
-            entityType: 'agent_session',
-            entityUuid: session.id,
-            ttlInMs
-        },
-        { onlyStoreHash: true }
-    );
-    if (privateKey.isErr()) {
-        return Err(
-            new AgentSessionError({
-                code: 'token_creation_failed',
-                message: 'Failed to create agent session token',
-                payload: { id: session.id },
-                cause: privateKey.error
-            })
+    try {
+        // The token is handed out once at creation, so only its hash is stored.
+        const privateKey = await keystore.createPrivateKey(
+            db,
+            {
+                displayName: '',
+                accountId: session.accountId,
+                environmentId: session.environmentId,
+                entityType: 'agent_session',
+                entityUuid: session.id,
+                ttlInMs
+            },
+            { onlyStoreHash: true }
         );
-    }
+        if (privateKey.isErr()) {
+            return Err(tokenCreationFailedError(session.id, privateKey.error));
+        }
 
-    const [token, storedKey] = privateKey.value;
-    if (!storedKey.expiresAt) {
-        return Err(
-            new AgentSessionError({
-                code: 'token_creation_failed',
-                message: 'Failed to create agent session token',
-                payload: { id: session.id }
-            })
-        );
-    }
+        const [token, storedKey] = privateKey.value;
+        if (!storedKey.expiresAt) {
+            return Err(tokenCreationFailedError(session.id));
+        }
 
-    return Ok({ token, expiresAt: storedKey.expiresAt });
+        return Ok({ token, expiresAt: storedKey.expiresAt });
+    } catch (err) {
+        return Err(tokenCreationFailedError(session.id, err));
+    }
 }
 
 export async function getAgentSessionByToken(db: Knex, token: string): Promise<Result<AgentSession, AgentSessionError>> {
@@ -208,6 +199,15 @@ function notFoundError({ id, accountId, environmentId }: { id: string; accountId
         code: 'not_found',
         message: `Agent session '${id}' not found`,
         payload: { id, accountId, environmentId }
+    });
+}
+
+function tokenCreationFailedError(sessionId: string, cause?: unknown): AgentSessionError {
+    return new AgentSessionError({
+        code: 'token_creation_failed',
+        message: 'Failed to create agent session token',
+        payload: { id: sessionId },
+        cause
     });
 }
 

--- a/packages/server/lib/services/connectSession.service.ts
+++ b/packages/server/lib/services/connectSession.service.ts
@@ -410,6 +410,10 @@ export async function getConnectSessionByToken(db: Knex, token: string): Promise
     }
 
     const privateKey = getSession.value;
+    if (privateKey.entityType !== 'connect_session' || privateKey.entityId === null) {
+        return Err(new ConnectSessionError({ code: 'not_found', message: `Token not found`, payload: { token: `${token.substring(0, 32)}...` } }));
+    }
+
     const session = await getConnectSession(db, { id: privateKey.entityId, accountId: privateKey.accountId, environmentId: privateKey.environmentId });
     if (session.isErr()) {
         return Err(session.error);

--- a/packages/server/lib/utils/express.ts
+++ b/packages/server/lib/utils/express.ts
@@ -1,4 +1,4 @@
-import type { ApiKeyPrincipal, ConnectSession, DBAPISecret, DBEnvironment, DBPlan, DBTeam, DBUser, InternalEndUser } from '@nangohq/types';
+import type { AgentSession, ApiKeyPrincipal, ConnectSession, DBAPISecret, DBEnvironment, DBPlan, DBTeam, DBUser, InternalEndUser } from '@nangohq/types';
 
 // Types are historically loose so we need to fix them at some point
 // export type RequestLocals =
@@ -23,13 +23,15 @@ import type { ApiKeyPrincipal, ConnectSession, DBAPISecret, DBEnvironment, DBPla
 
 export interface RequestLocals {
     // Set by every auth path.
-    authType: 'secretKey' | 'publicKey' | 'basic' | 'adminKey' | 'none' | 'session' | 'connectSession';
+    authType: 'secretKey' | 'publicKey' | 'basic' | 'adminKey' | 'none' | 'session' | 'connectSession' | 'agentSession';
     account: DBTeam;
     plan: DBPlan | null;
 
-    // Asserted, not guaranteed: `connectSession` is only set by connect-session auth and `user` only
-    // by session auth. Enough handlers read them unguarded that narrowing them is its own change.
+    // Asserted, not guaranteed: `connectSession` is only set by connect-session auth, `agentSession` only
+    // by agent-session auth and `user` only by session auth. Enough handlers read them unguarded that
+    // narrowing them is its own change.
     connectSession: ConnectSession;
+    agentSession: AgentSession;
     user: DBUser;
 
     // Set only by some auth paths, so a handler must check before use.

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -93,6 +93,21 @@ export class NangoError extends NangoInternalError {
                 this.message = 'Authentication failed. The provided connect session token does not match any account.';
                 break;
 
+            case 'invalid_agent_session_token_format':
+                this.status = 401;
+                this.message = 'Authentication failed. The provided agent session token is not following correct format: nango_agent_session_RANDOM';
+                break;
+
+            case 'unknown_agent_session_token':
+                this.status = 401;
+                this.message = 'Authentication failed. The provided agent session token does not match any account.';
+                break;
+
+            case 'agent_session_ended':
+                this.status = 401;
+                this.message = 'Authentication failed. The agent session has ended or expired. Create a new session to continue.';
+                break;
+
             case 'only_nango_cloud':
                 this.status = 401;
                 this.message = 'This endpoint is only available for Nango Cloud.';

--- a/packages/types/lib/keystore/index.ts
+++ b/packages/types/lib/keystore/index.ts
@@ -1,4 +1,7 @@
-export type EntityType = 'connect_session' | 'connection' | 'environment';
+export type EntityType = 'connect_session' | 'connection' | 'environment' | 'agent_session';
+
+// Agent sessions have a UUID primary key, every other entity an integer id.
+export type PrivateKeyEntityRef = { entityType: Exclude<EntityType, 'agent_session'>; entityId: number } | { entityType: 'agent_session'; entityUuid: string };
 
 export interface PrivateKey {
     readonly id: number;
@@ -11,5 +14,6 @@ export interface PrivateKey {
     readonly expiresAt: Date | null;
     readonly lastAccessAt: Date | null;
     readonly entityType: EntityType;
-    readonly entityId: number;
+    readonly entityId: number | null;
+    readonly entityUuid: string | null;
 }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -8,6 +8,7 @@ export enum Types {
     AUTH_SECRET_KEY_HASH_CACHE = 'nango.auth.secretKeyHashCache',
     AUTH_SHADOW_CACHE = 'nango.auth.shadowCache',
     AUTH_CONTEXT_CACHE = 'nango.auth.contextCache',
+    AUTH_GET_ENV_BY_AGENT_SESSION = 'nango.auth.getEnvByAgentSession',
     AUTH_GET_ENV_BY_CONNECT_SESSION = 'nango.auth.getEnvByConnectSession',
     AUTH_GET_ENV_BY_SECRET_KEY = 'nango.auth.getEnvBySecretKey',
     AUTH_GET_ENV_BY_SECRET_KEY_SOURCE = 'nango.auth.getEnvBySecretKey.source',


### PR DESCRIPTION
NAN-6596

Agent sessions need a credential of their own until the unified authz project lands. This reuses the keystore's hashed private key minting from connect sessions, with the session's expiry as the token TTL and only the hash stored since the token is handed out once at creation.

Tokens look like `nango_agent_session_` plus 64 hex chars. The new `agentSessionAuth` middleware resolves a bearer token to account, environment and session, and rejects ended or expired sessions. Nothing routes through it yet, that comes with the MCP endpoint (NAN-6600).

Non-obvious decisions:

- `private_keys.entity_id` was integer only and agent session ids are uuids, so the keystore gains a nullable `entity_uuid` column and `createPrivateKey` takes a discriminated entity ref. Existing callers are unchanged.
- Ended and expired are checked on the session row in the middleware, not just left to the keystore TTL. Per the authz RFC these tokens will later become customer keys with grants scoped to env and session, so all mint and resolve logic sits behind `createAgentSessionToken` and `getAgentSessionByToken` to keep that switch local.

Test plan:

- [x] keystore mints and resolves a uuid entity key, hash only
- [x] token resolves back to its session, unknown and cross entity tokens are rejected
- [x] minting refuses an already expired session, resolution stops at token expiry
- [x] connect session token path unaffected (getSession, postUnauthenticated suites)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

