### PR TITLE
feat(usage): add v2 function execution aggregates

### DIFF
--- a/packages/usage/lib/clickhouse/migrations/20260818000011_create_daily_function_executions_v2.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260818000011_create_daily_function_executions_v2.ts
@@ -1,0 +1,51 @@
+export const sql = [
+    `
+    CREATE TABLE IF NOT EXISTS {database:Identifier}.daily_function_executions_v2
+    (
+        day              Date,
+        account_id       Int64,
+        environment_id   Int64,
+        integration_id   LowCardinality(String),
+        connection_id    String,
+        function_name    String,
+        function_type    LowCardinality(String),
+        success          Bool,
+        runtime          LowCardinality(String),
+        value            Int64,
+        duration_ms      UInt64,
+        duration_seconds UInt64,
+        compute_gbms     Float64,
+        compute_gbs      Float64,
+        custom_logs      UInt64,
+        proxy_calls      UInt64
+    )
+    ENGINE = SummingMergeTree()
+    PARTITION BY toYYYYMM(day)
+    ORDER BY (account_id, day, environment_id, integration_id, connection_id, function_type, function_name, success, runtime)
+    TTL day + INTERVAL 24 MONTH
+    `,
+    `
+    CREATE MATERIALIZED VIEW IF NOT EXISTS {database:Identifier}.daily_function_executions_v2_mv
+    TO {database:Identifier}.daily_function_executions_v2 AS
+    SELECT
+        toDate(ts)                                                              AS day,
+        account_id,
+        attributes.environmentId::Int64                                         AS environment_id,
+        attributes.integrationId::String                                        AS integration_id,
+        attributes.connectionId::String                                         AS connection_id,
+        attributes.functionName::String                                         AS function_name,
+        attributes.type::String                                                 AS function_type,
+        attributes.success::Bool                                                AS success,
+        attributes.runtime::String                                              AS runtime,
+        sum(value)                                                              AS value,
+        sum(coalesce(attributes.telemetryBag.durationMs::Nullable(UInt64), 0))  AS duration_ms,
+        sum(toUInt64(ceil(coalesce(attributes.telemetryBag.durationMs::Nullable(UInt64), 0) / 1000.0))) AS duration_seconds,
+        sum(coalesce(attributes.telemetryBag.durationMs::Nullable(UInt64), 0) * coalesce(attributes.telemetryBag.memoryGb::Nullable(Float64), 0.0)) AS compute_gbms,
+        sum(ceil(coalesce(attributes.telemetryBag.durationMs::Nullable(UInt64), 0) / 1000.0) * coalesce(attributes.telemetryBag.memoryGb::Nullable(Float64), 0.0)) AS compute_gbs,
+        sum(coalesce(attributes.telemetryBag.customLogs::Nullable(UInt64), 0))  AS custom_logs,
+        sum(coalesce(attributes.telemetryBag.proxyCalls::Nullable(UInt64), 0))  AS proxy_calls
+    FROM {database:Identifier}.raw_events
+    WHERE type = 'usage.function_executions'
+    GROUP BY day, account_id, environment_id, integration_id, connection_id, function_type, function_name, success, runtime
+    `
+];


### PR DESCRIPTION

Create a new daily_function_executions_v2 ClickHouse table and materialized view.

The v2 removes the explicit SummingMergeTree column definition so that any numeric columns not part of a primary or sorting key, are automatically aggregated. This should make the table more flexible to column accretion over time.

Both are computed before aggregation, avoiding incorrect rounding of already-summed durations. The migration is DDL-only; historical backfill and reader cutover will follow separately.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

