### PR TITLE
feat(billing): show overdue alert to all members

### DIFF
--- a/packages/server/lib/controllers/v1/plans/billing/getOverdueInvoices.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getOverdueInvoices.ts
@@ -1,6 +1,8 @@
+import { permissions } from '@nangohq/authz';
 import { billing } from '@nangohq/billing';
 import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { resolve } from '../../../../authz/resolve.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { GetOverdueInvoices } from '@nangohq/types';
@@ -33,10 +35,11 @@ export const getOverdueInvoices = asyncWrapper<GetOverdueInvoices>(async (req, r
         return;
     }
 
-    // Only fetch the customer for the portal CTA when there's actually something overdue.
-    // A failure here costs the CTA, not the warning, so report it and carry on with a null URL.
+    // Everyone gets `hasOverdue`, but the Orb portal link grants access by possession, so it's only
+    // returned to members who can manage billing — others get a null URL. Fetch the customer only when
+    // something is overdue and the caller can act on it; a failure here costs the CTA, not the warning.
     let portalUrl: string | null = null;
-    if (overdueRes.value.hasOverdue) {
+    if (overdueRes.value.hasOverdue && (await resolve(res.locals, permissions.canManageBilling))) {
         const customerRes = await billing.getCustomer(account.id);
         if (customerRes.isErr()) {
             report(customerRes.error);

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -286,7 +286,7 @@ web.route('/plans/usage').get(webAuth, getUsage);
 web.route('/plans/billing-usage').get(webAuth, getBillingUsage);
 web.route('/plans/billing-usage/top-dimension-values').get(webAuth, getBillingUsageTopDimensionValues);
 web.route('/plans/billing/invoicing').put(webAuth, auditBillingDetailsChanged, can(p.canChangePlan), putInvoicingDetails);
-web.route('/plans/billing/overdue').get(webAuth, can(p.canManageBilling), getOverdueInvoices);
+web.route('/plans/billing/overdue').get(webAuth, getOverdueInvoices);
 web.route('/plans/change').post(webAuth, auditBillingPlanChanged, can(p.canChangePlan), postPlanChange);
 
 // Environments

--- a/packages/webapp/src/features/Billing/OverdueInvoiceAlert.tsx
+++ b/packages/webapp/src/features/Billing/OverdueInvoiceAlert.tsx
@@ -6,17 +6,20 @@ import type { AlertProps } from '@nangohq/design-system';
 
 interface OverdueInvoiceAlertProps {
     size?: AlertProps['size'];
+    canManageBilling: boolean;
     /** Actions differ per context: the Billing page opens the Stripe dialog, the sidebar links to it. */
     children?: React.ReactNode;
 }
 
-export function OverdueInvoiceAlert({ size = 'compact', children }: OverdueInvoiceAlertProps) {
+export function OverdueInvoiceAlert({ size = 'compact', canManageBilling, children }: OverdueInvoiceAlertProps) {
     return (
         <Alert variant="danger" size={size}>
             <CircleAlert />
             <AlertTitle>Invoice(s) overdue</AlertTitle>
-            <AlertDescription>Edit payment method to avoid interruption.</AlertDescription>
-            {children && <AlertActions>{children}</AlertActions>}
+            <AlertDescription>
+                {canManageBilling ? 'Edit payment method to avoid interruption.' : 'Reach out to your admin to update the payment method.'}
+            </AlertDescription>
+            {canManageBilling && children && <AlertActions>{children}</AlertActions>}
         </Alert>
     );
 }

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -1,13 +1,10 @@
 import { keepPreviousData, queryOptions, useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
-import { permissions } from '@nangohq/authz';
-
 import { applyPlanOverride, buildOverdueOverride, usePlanOverrideStore } from '../features/planOverride';
 import { APIError, apiFetch } from '../utils/api';
 import { globalEnv } from '../utils/env';
 import { useEnvironment } from './useEnvironment';
-import { usePermissions } from './usePermissions';
 
 import type {
     ApiPlan,
@@ -147,14 +144,10 @@ const OVERDUE_INVOICES_POLL_INTERVAL = 60 * 1000; // 1min
 export function useApiGetOverdueInvoices(env: string, plan?: { name: string } | null, realPortalUrl?: string | null) {
     const planName = plan?.name;
     const overdueOverride = usePlanOverrideStore((s) => s.overdueOverride);
-    // The endpoint is billing-manager only, so don't ask on behalf of anyone else.
-    const { can } = usePermissions();
-    const canManageBilling = can(permissions.canManageBilling);
-    const allowed = canManageBilling || overdueOverride;
-    const query = useQuery<GetOverdueInvoices['Success'], APIError>({
-        // Not gated on the plan: an account that downgraded to free can still owe an invoice. The
-        // override never calls the endpoint, so it doesn't need the permission the endpoint does.
-        enabled: Boolean(env) && allowed,
+    return useQuery<GetOverdueInvoices['Success'], APIError>({
+        // Fetched for every member, not just billing managers — the overdue warning shows to all. Not
+        // gated on the plan either: a downgraded account can still owe an invoice.
+        enabled: Boolean(env),
         staleTime: OVERDUE_INVOICES_STALE_TIME,
         // Only while something is overdue: Orb retries a failed charge asynchronously, and nothing else
         // refetches this (window-focus refetching is off), so the alert would otherwise outlive payment.
@@ -177,10 +170,6 @@ export function useApiGetOverdueInvoices(env: string, plan?: { name: string } | 
             return json;
         }
     });
-
-    // `enabled: false` stops fetching but keeps serving the cache, so a mid-session permission
-    // loss would still render the last overdue result.
-    return useMemo(() => (allowed ? query : { ...query, data: undefined }), [query, allowed]);
 }
 
 export const GetBillingUsageQueryKey = ['plans', 'billing-usage'];

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -1,10 +1,13 @@
 import { keepPreviousData, queryOptions, useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
+import { permissions } from '@nangohq/authz';
+
 import { applyPlanOverride, buildOverdueOverride, usePlanOverrideStore } from '../features/planOverride';
 import { APIError, apiFetch } from '../utils/api';
 import { globalEnv } from '../utils/env';
 import { useEnvironment } from './useEnvironment';
+import { usePermissions } from './usePermissions';
 
 import type {
     ApiPlan,
@@ -144,6 +147,10 @@ const OVERDUE_INVOICES_POLL_INTERVAL = 60 * 1000; // 1min
 export function useApiGetOverdueInvoices(env: string, plan?: { name: string } | null, realPortalUrl?: string | null) {
     const planName = plan?.name;
     const overdueOverride = usePlanOverrideStore((s) => s.overdueOverride);
+    // Only used to key the cache: `portalUrl` is returned to billing managers only, so a mid-session
+    // permission change must not serve the other role's cached response.
+    const { can } = usePermissions();
+    const canManageBilling = can(permissions.canManageBilling);
     return useQuery<GetOverdueInvoices['Success'], APIError>({
         // Fetched for every member, not just billing managers — the overdue warning shows to all. Not
         // gated on the plan either: a downgraded account can still owe an invoice.
@@ -152,7 +159,7 @@ export function useApiGetOverdueInvoices(env: string, plan?: { name: string } | 
         // Only while something is overdue: Orb retries a failed charge asynchronously, and nothing else
         // refetches this (window-focus refetching is off), so the alert would otherwise outlive payment.
         refetchInterval: (query) => (query.state.data?.data.hasOverdue ? OVERDUE_INVOICES_POLL_INTERVAL : false),
-        queryKey: [...GetOverdueInvoicesQueryKey, env, planName, overdueOverride, overdueOverride ? realPortalUrl : null],
+        queryKey: [...GetOverdueInvoicesQueryKey, env, planName, canManageBilling, overdueOverride, overdueOverride ? realPortalUrl : null],
         queryFn: async (): Promise<GetOverdueInvoices['Success']> => {
             if (overdueOverride) {
                 return buildOverdueOverride(realPortalUrl);

--- a/packages/webapp/src/layout/AppSidebar/index.tsx
+++ b/packages/webapp/src/layout/AppSidebar/index.tsx
@@ -2,6 +2,8 @@ import { ArrowUpRight, BarChart3, Blocks, Cog, List, Plug, Sprout, X } from 'luc
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { AlertButtonLink } from '@/components/ui/AlertButtonLink';
 import {
     Sidebar,
@@ -17,6 +19,7 @@ import {
 } from '@/components/ui/Sidebar';
 import { OverdueInvoiceAlert } from '@/features/Billing/OverdueInvoiceAlert';
 import { useMeta } from '@/hooks/useMeta';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useApiGetOverdueInvoices, useCurrentPlan } from '@/hooks/usePlan';
 import { apiPatchUser } from '@/hooks/useUser';
 import { useStore } from '@/store';
@@ -69,6 +72,8 @@ export const AppSidebar: React.FC = () => {
     // just adds noise and surfaces upgrade/downgrade inconsistencies (NAN-5959).
     const showUsageAlert = plan?.name === 'free';
 
+    const { can } = usePermissions();
+    const canManageBilling = can(permissions.canManageBilling);
     const { data: overdue } = useApiGetOverdueInvoices(env, plan);
     const showOverdueAlert = Boolean(overdue?.data.hasOverdue);
 
@@ -111,7 +116,7 @@ export const AppSidebar: React.FC = () => {
             <SidebarFooter className="p-0">
                 {showOverdueAlert && (
                     <div className="px-2.5 mb-4">
-                        <OverdueInvoiceAlert>
+                        <OverdueInvoiceAlert canManageBilling={canManageBilling}>
                             <AlertButtonLink
                                 to="/team/billing#payment-and-invoices"
                                 onClick={() => track('web:usage:edit_payment_method_clicked', { source: 'sidebar' })}

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -1,11 +1,13 @@
 import { ArrowUpRight, ExternalLink, Info } from 'lucide-react';
 import { useMemo } from 'react';
 
+import { permissions } from '@nangohq/authz';
 import { Alert, AlertButton, AlertDescription, AlertTitle, Button } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { AlertButtonLink } from '@/components/ui/AlertButtonLink';
 import { OverdueInvoiceAlert } from '@/features/Billing/OverdueInvoiceAlert';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useApiGetBillingUsage, useApiGetOverdueInvoices, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
@@ -42,10 +44,12 @@ export const Usage: React.FC = () => {
     // billing running-average, matching what each row's drill-in chart also requests.
     const { data: usage, isLoading, error: usageError } = useApiGetBillingUsage(env, timeframe, { avgPerDay: true, enabled: plan != null && !isFree });
     const { data: overdue } = useApiGetOverdueInvoices(env, plan, usage?.data.customer.portalUrl);
+    const { can } = usePermissions();
+    const canManageBilling = can(permissions.canManageBilling);
 
     // Kept out of the usageError branch below so a usage outage can't hide a payment warning.
     const overdueBanner = overdue?.data.hasOverdue && (
-        <OverdueInvoiceAlert size="wide">
+        <OverdueInvoiceAlert size="wide" canManageBilling={canManageBilling}>
             {overdue.data.portalUrl && (
                 <AlertButtonLink
                     to={overdue.data.portalUrl}


### PR DESCRIPTION
## Problem

The overdue-invoice warning (sidebar card + Billing page banner) was gated to billing managers, so a non-admin never learned the account had an overdue invoice. Product ([Figma thread](https://www.figma.com/design/UPhGLAHKgFxGfnb7vwJ6YK/Nango-%E2%80%94-Product?node-id=574-45571)) wants the warning visible to everyone — anyone on the team can nudge whoever owns billing.

## Solution

- Open `GET /plans/billing/overdue` to any authenticated member (drop the `canManageBilling` route gate); return `hasOverdue` to all.
- Keep the payment action admin-only: the Orb portal link grants access by possession, so the endpoint returns `portalUrl` only to members who can manage billing (checked in-handler via `resolve`).
- `OverdueInvoiceAlert` now branches on `canManageBilling`: admins get "Edit payment method to avoid interruption." + the CTAs; non-admins get "Reach out to your admin to update the payment method." and no action.
- `useApiGetOverdueInvoices` fetches for every member (removed the permission gate and cache masking).

Note: this differs from Robin's suggestion of showing the CTA *disabled* — since the portal link is access-by-possession, we don't send it to non-admins at all and swap the copy instead. Fixes [NAN-6232](https://linear.app/nango/issue/NAN-6232).

## Testing

- Endpoint integration tests pass (9/9); `ts-build` and lint clean.
- Browser-verified both states via the dev overdue override: admin sees the CTA + "Edit payment method…"; non-admin sees "Reach out to your admin…" with no CTA and no `portalUrl` in the response.
