### PR TITLE
feat(server): track usage of the connections search param

### DIFF
--- a/packages/server/lib/controllers/connection/getConnections.ts
+++ b/packages/server/lib/controllers/connection/getConnections.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import { connectionService, connectionTagsSchema } from '@nangohq/shared';
-import { zodErrorToHTTP } from '@nangohq/utils';
+import { metrics, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionSimpleToPublicApi } from '../../formatters/connection.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
@@ -31,8 +31,12 @@ export const getPublicConnections = asyncWrapperWithEnvironment<GetPublicConnect
         return;
     }
 
-    const { environment } = res.locals;
+    const { account, environment } = res.locals;
     const queryParam = queryParamValues.data;
+
+    if (queryParam.search) {
+        metrics.increment(metrics.Types.CONNECTIONS_SEARCH_PARAM_USED, 1, { accountId: account.id });
+    }
 
     const connections = await connectionService.listConnections({
         environmentId: environment.id,

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -120,6 +120,7 @@ export enum Types {
     GET_RECORDS_RESPONSE_SIZE_BYTES = 'nango.server.getRecords.responseSizeBytes',
 
     CONNECTIONS_COUNT = 'nango.connections.count',
+    CONNECTIONS_SEARCH_PARAM_USED = 'nango.server.connections.searchParamUsed',
 
     RECORDS_TOTAL_COUNT = 'nango.records.total.count',
     RECORDS_TOTAL_SIZE_IN_BYTES = 'nango.records.total.sizeInBytes',


### PR DESCRIPTION
## Describe the problem and your solution

The `search` param on `GET /connections` is poorly documented and does an ILIKE wildcard search across a few columns under the hood — `_nango_connections.connection_id`, `end_users.display_name`, and `end_users.email`. Once `end_users` and the public-key auth method are removed, none of those columns will be supported anymore.

This adds a metric (`CONNECTIONS_SEARCH_PARAM_USED`) tracking usage of this param, tagged by account, so we know how much it's actually relied on before deciding what a redesigned search parameter should look like.

## Testing

- Extended the existing `should search connections` integration test to assert the metric fires with the right account tag.
- Added `should not track the search metric when search is not used` to confirm it stays silent otherwise.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

