### PR TITLE
feat(mcp): add functions list tool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -15843,3 +15843,4 @@ Use these slugs to construct provider-specific docs URLs only when needed.
 - [Pricing](https://nango.dev/pricing): Plans and pricing for Nango Cloud.
 - [Talk to the team](https://nango.dev/demo): Book a call with Nango for sales, onboarding, or technical questions.
 - [Community Slack](https://nango.dev/slack): Get help, share feedback, and connect with other Nango developers.
+

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -12972,6 +12972,14 @@ The tool accepts JSON and UTF-8 text responses up to 5 MB (5,000,000 bytes). Uns
 | --------------- | ----------------------------------------------------------------- | ---------------------- |
 | `proxy_request` | Make an authenticated request through the Nango requests proxy. | `environment:proxy`    |
 
+### Functions
+
+Use the Functions tools to inspect functions deployed to an integration in the authenticated Nango environment.
+
+| Tool             | Description                                                                    | Required API key scope        |
+| ---------------- | ------------------------------------------------------------------------------ | ----------------------------- |
+| `functions_list` | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+
 ### Logs
 
 Use the Logs tools to find activity in the authenticated Nango environment and inspect the messages for a specific operation.
@@ -15835,4 +15843,3 @@ Use these slugs to construct provider-specific docs URLs only when needed.
 - [Pricing](https://nango.dev/pricing): Plans and pricing for Nango Cloud.
 - [Talk to the team](https://nango.dev/demo): Book a call with Nango for sales, onboarding, or technical questions.
 - [Community Slack](https://nango.dev/slack): Get help, share feedback, and connect with other Nango developers.
-

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -15762,3 +15762,4 @@ Use these slugs to construct provider-specific docs URLs only when needed.
 - [Pricing](https://nango.dev/pricing): Plans and pricing for Nango Cloud.
 - [Talk to the team](https://nango.dev/demo): Book a call with Nango for sales, onboarding, or technical questions.
 - [Community Slack](https://nango.dev/slack): Get help, share feedback, and connect with other Nango developers.
+

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -12893,6 +12893,14 @@ The tool accepts JSON and UTF-8 text responses up to 5 MB (5,000,000 bytes). Uns
 | --------------- | ----------------------------------------------------------------- | ---------------------- |
 | `proxy_request` | Make an authenticated request through the Nango requests proxy. | `environment:proxy`    |
 
+### Functions
+
+Use the Functions tools to inspect functions deployed to an integration in the authenticated Nango environment.
+
+| Tool             | Description                                                                    | Required API key scope        |
+| ---------------- | ------------------------------------------------------------------------------ | ----------------------------- |
+| `functions_list` | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+
 ### Logs
 
 Use the Logs tools to find activity in the authenticated Nango environment and inspect the messages for a specific operation.
@@ -15754,4 +15762,3 @@ Use these slugs to construct provider-specific docs URLs only when needed.
 - [Pricing](https://nango.dev/pricing): Plans and pricing for Nango Cloud.
 - [Talk to the team](https://nango.dev/demo): Book a call with Nango for sales, onboarding, or technical questions.
 - [Community Slack](https://nango.dev/slack): Get help, share feedback, and connect with other Nango developers.
-

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -74,6 +74,14 @@ The tool accepts JSON and UTF-8 text responses up to 5 MB (5,000,000 bytes). Uns
 | --------------- | ----------------------------------------------------------------- | ---------------------- |
 | `proxy_request` | Make an authenticated request through the Nango requests proxy. | `environment:proxy`    |
 
+### Functions
+
+Use the Functions tools to inspect functions deployed to an integration in the authenticated Nango environment.
+
+| Tool             | Description                                                                    | Required API key scope        |
+| ---------------- | ------------------------------------------------------------------------------ | ----------------------------- |
+| `functions_list` | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+
 ### Logs
 
 Use the Logs tools to find activity in the authenticated Nango environment and inspect the messages for a specific operation.

--- a/packages/server/lib/controllers/mcp/functions/errors.ts
+++ b/packages/server/lib/controllers/mcp/functions/errors.ts
@@ -1,0 +1,26 @@
+import { getLogger } from '@nangohq/utils';
+
+import { InternalMcpError, PublicMcpError } from '../utils.js';
+
+import type { ListFunctionsError } from '@nangohq/shared';
+
+const logger = getLogger('Server.MCP.Functions');
+
+export function listFunctionsServiceErrorToMcp(error: ListFunctionsError): Error {
+    const code = error.code;
+    switch (code) {
+        case 'integration_not_found':
+            return new PublicMcpError(error.message);
+        case 'list_failed':
+            return error;
+        default: {
+            const exhaustiveCheck: never = code;
+            return unexpectedListFunctionsServiceError(exhaustiveCheck);
+        }
+    }
+}
+
+function unexpectedListFunctionsServiceError(code: never): InternalMcpError {
+    logger.error('Unexpected ListFunctionsError code while listing functions', { code });
+    return new InternalMcpError();
+}

--- a/packages/server/lib/controllers/mcp/functions/errors.ts
+++ b/packages/server/lib/controllers/mcp/functions/errors.ts
@@ -11,16 +11,14 @@ export function listFunctionsServiceErrorToMcp(error: ListFunctionsError): Error
     switch (code) {
         case 'integration_not_found':
             return new PublicMcpError(error.message);
-        case 'list_failed':
-            return error;
+        case 'list_failed': {
+            logger.error('Failed to list functions', { err: error });
+            return new InternalMcpError();
+        }
         default: {
             const exhaustiveCheck: never = code;
-            return unexpectedListFunctionsServiceError(exhaustiveCheck);
+            logger.error('Unexpected ListFunctionsError code while listing functions', { code: exhaustiveCheck });
+            return new InternalMcpError();
         }
     }
-}
-
-function unexpectedListFunctionsServiceError(code: never): InternalMcpError {
-    logger.error('Unexpected ListFunctionsError code while listing functions', { code });
-    return new InternalMcpError();
 }

--- a/packages/server/lib/controllers/mcp/functions/list.ts
+++ b/packages/server/lib/controllers/mcp/functions/list.ts
@@ -1,0 +1,34 @@
+import { legacyFunctionService } from '@nangohq/shared';
+
+import { defineManagementMcpTool } from '../managementTool.js';
+import { listFunctionsServiceErrorToMcp } from './errors.js';
+import { listFunctionsArgumentsSchema, listFunctionsOutputSchema } from './schema.js';
+
+import type { ListFunctionsOutput } from './schema.js';
+
+export const listFunctionsTool = defineManagementMcpTool<typeof listFunctionsArgumentsSchema, ListFunctionsOutput>({
+    name: 'functions_list',
+    description: 'List and filter functions deployed to an integration in the authenticated Nango environment.',
+    inputSchema: listFunctionsArgumentsSchema,
+    outputSchema: listFunctionsOutputSchema,
+    annotations: { readOnlyHint: true },
+    requiredScopes: { every: ['environment:functions:list'] },
+    audit: { kind: 'no-audit', reason: 'read-only' },
+    async handler({ args, environment }) {
+        const result = await legacyFunctionService.listFunctions({
+            environmentId: environment.id,
+            providerConfigKey: args.integration_id,
+            type: args.type,
+            search: args.search,
+            limit: args.limit,
+            offset: args.page * args.limit
+        });
+
+        return result
+            .map(({ rows, total }) => ({
+                data: rows,
+                pagination: { total, page: args.page, limit: args.limit }
+            }))
+            .mapError((error) => listFunctionsServiceErrorToMcp(error));
+    }
+});

--- a/packages/server/lib/controllers/mcp/functions/list.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/functions/list.unit.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { legacyFunctionService } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
-import { PublicMcpError } from '../utils.js';
+import { InternalMcpError, PublicMcpError } from '../utils.js';
 import { listFunctionsTool } from './list.js';
 
 import type { ManagementMcpContext } from '../managementTool.js';
@@ -105,7 +105,7 @@ describe('listFunctionsTool', () => {
         }
     });
 
-    it('preserves internal listing errors for the MCP error boundary', async () => {
+    it('maps internal listing failures to an internal MCP error', async () => {
         const error = new legacyFunctionService.ListFunctionsError({ code: 'list_failed', message: 'Failed to list functions' });
         vi.spyOn(legacyFunctionService, 'listFunctions').mockResolvedValue(Err(error));
 
@@ -113,7 +113,7 @@ describe('listFunctionsTool', () => {
 
         expect(result.isErr()).toBe(true);
         if (result.isErr()) {
-            expect(result.error).toBe(error);
+            expect(result.error).toBeInstanceOf(InternalMcpError);
         }
     });
 });

--- a/packages/server/lib/controllers/mcp/functions/list.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/functions/list.unit.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { legacyFunctionService } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import { PublicMcpError } from '../utils.js';
+import { listFunctionsTool } from './list.js';
+
+import type { ManagementMcpContext } from '../managementTool.js';
+import type { DeployedNangoFunction } from '@nangohq/types';
+
+describe('listFunctionsTool', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('maps integration filters and pagination to the legacy function service', async () => {
+        const listSpy = vi.spyOn(legacyFunctionService, 'listFunctions').mockResolvedValue(Ok({ rows: [functionFixture], total: 25 }));
+
+        const result = await listFunctionsTool.handler(
+            {
+                integration_id: 'github',
+                type: 'action',
+                search: 'issue',
+                page: 2,
+                limit: 10
+            },
+            context
+        );
+
+        expect(listSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            providerConfigKey: 'github',
+            type: 'action',
+            search: 'issue',
+            limit: 10,
+            offset: 20
+        });
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({
+                data: [functionFixture],
+                pagination: { total: 25, page: 2, limit: 10 }
+            });
+        }
+    });
+
+    it('applies the public endpoint pagination defaults', async () => {
+        const listSpy = vi.spyOn(legacyFunctionService, 'listFunctions').mockResolvedValue(Ok({ rows: [], total: 0 }));
+
+        const result = await listFunctionsTool.handler({ integration_id: 'github' }, context);
+
+        expect(listSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            providerConfigKey: 'github',
+            type: undefined,
+            search: undefined,
+            limit: 20,
+            offset: 0
+        });
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value.pagination).toStrictEqual({ total: 0, page: 0, limit: 20 });
+        }
+    });
+
+    it.each([
+        { name: 'missing integration ID', args: {} },
+        { name: 'unknown argument', args: { integration_id: 'github', unexpected: true } },
+        { name: 'string page', args: { integration_id: 'github', page: '1' } },
+        { name: 'negative page', args: { integration_id: 'github', page: -1 } },
+        { name: 'zero limit', args: { integration_id: 'github', limit: 0 } },
+        { name: 'oversized limit', args: { integration_id: 'github', limit: 101 } },
+        { name: 'invalid type', args: { integration_id: 'github', type: 'webhook' } },
+        { name: 'blank search', args: { integration_id: 'github', search: ' ' } }
+    ])('rejects $name before calling the function service', async ({ args }) => {
+        const listSpy = vi.spyOn(legacyFunctionService, 'listFunctions');
+
+        const result = await listFunctionsTool.handler(args, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toContain('Invalid functions_list arguments:');
+        }
+        expect(listSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns a public error when the integration does not exist', async () => {
+        vi.spyOn(legacyFunctionService, 'listFunctions').mockResolvedValue(
+            Err(
+                new legacyFunctionService.ListFunctionsError({
+                    code: 'integration_not_found',
+                    message: 'Integration does not exist'
+                })
+            )
+        );
+
+        const result = await listFunctionsTool.handler({ integration_id: 'missing' }, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toBe('Integration does not exist');
+        }
+    });
+
+    it('preserves internal listing errors for the MCP error boundary', async () => {
+        const error = new legacyFunctionService.ListFunctionsError({ code: 'list_failed', message: 'Failed to list functions' });
+        vi.spyOn(legacyFunctionService, 'listFunctions').mockResolvedValue(Err(error));
+
+        const result = await listFunctionsTool.handler({ integration_id: 'github' }, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBe(error);
+        }
+    });
+});
+
+const context = {
+    account: {},
+    environment: { id: 42 },
+    grantedScopes: ['environment:functions:list']
+} as ManagementMcpContext;
+
+const functionFixture: DeployedNangoFunction = {
+    id: 1,
+    name: 'create-issue',
+    type: 'action',
+    description: 'Create an issue',
+    scopes: ['repo'],
+    returns: ['Issue'],
+    json_schema: null,
+    enabled: true,
+    last_deployed: '2026-01-01T00:00:00.000Z',
+    source: 'repo'
+};

--- a/packages/server/lib/controllers/mcp/functions/schema.ts
+++ b/packages/server/lib/controllers/mcp/functions/schema.ts
@@ -2,8 +2,6 @@ import * as z from 'zod/v4';
 
 import { functionTypeSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
 
-import type { FunctionListSuccess } from '@nangohq/types';
-
 export const listFunctionsArgumentsSchema = z
     .object({
         integration_id: providerConfigKeySchema.min(1),
@@ -24,13 +22,15 @@ const deployedFunctionBaseSchema = {
     source: z.enum(['catalog', 'standalone', 'repo'])
 };
 
+const jsonSchemaSchema: z.ZodType<object> = z.looseObject({});
+
 const deployedSyncFunctionSchema = z
     .object({
         ...deployedFunctionBaseSchema,
         type: z.literal('sync'),
         input: z.string().optional(),
         returns: z.array(z.string()),
-        json_schema: z.looseObject({}).nullable(),
+        json_schema: jsonSchemaSchema.nullable(),
         runs: z.string().nullable(),
         auto_start: z.boolean(),
         track_deletes: z.boolean()
@@ -43,7 +43,7 @@ const deployedActionFunctionSchema = z
         type: z.literal('action'),
         input: z.string().optional(),
         returns: z.array(z.string()),
-        json_schema: z.looseObject({}).nullable()
+        json_schema: jsonSchemaSchema.nullable()
     })
     .strict();
 
@@ -70,4 +70,4 @@ export const listFunctionsOutputSchema = z
     })
     .strict();
 
-export type ListFunctionsOutput = FunctionListSuccess;
+export type ListFunctionsOutput = z.infer<typeof listFunctionsOutputSchema>;

--- a/packages/server/lib/controllers/mcp/functions/schema.ts
+++ b/packages/server/lib/controllers/mcp/functions/schema.ts
@@ -1,0 +1,73 @@
+import * as z from 'zod/v4';
+
+import { functionTypeSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
+
+import type { FunctionListSuccess } from '@nangohq/types';
+
+export const listFunctionsArgumentsSchema = z
+    .object({
+        integration_id: providerConfigKeySchema.min(1),
+        type: functionTypeSchema.optional(),
+        search: z.string().trim().min(1).max(255).optional(),
+        page: z.number().int().min(0).optional().default(0),
+        limit: z.number().int().min(1).max(100).optional().default(20)
+    })
+    .strict();
+
+const deployedFunctionBaseSchema = {
+    id: z.number().int(),
+    name: z.string(),
+    description: z.string().optional(),
+    scopes: z.array(z.string()).optional(),
+    enabled: z.boolean(),
+    last_deployed: z.iso.datetime(),
+    source: z.enum(['catalog', 'standalone', 'repo'])
+};
+
+const deployedSyncFunctionSchema = z
+    .object({
+        ...deployedFunctionBaseSchema,
+        type: z.literal('sync'),
+        input: z.string().optional(),
+        returns: z.array(z.string()),
+        json_schema: z.looseObject({}).nullable(),
+        runs: z.string().nullable(),
+        auto_start: z.boolean(),
+        track_deletes: z.boolean()
+    })
+    .strict();
+
+const deployedActionFunctionSchema = z
+    .object({
+        ...deployedFunctionBaseSchema,
+        type: z.literal('action'),
+        input: z.string().optional(),
+        returns: z.array(z.string()),
+        json_schema: z.looseObject({}).nullable()
+    })
+    .strict();
+
+const deployedOnEventFunctionSchema = z
+    .object({
+        ...deployedFunctionBaseSchema,
+        type: z.literal('on-event'),
+        event: z.enum(['post-connection-creation', 'pre-connection-deletion', 'validate-connection'])
+    })
+    .strict();
+
+export const deployedFunctionSchema = z.discriminatedUnion('type', [deployedSyncFunctionSchema, deployedActionFunctionSchema, deployedOnEventFunctionSchema]);
+
+export const listFunctionsOutputSchema = z
+    .object({
+        data: z.array(deployedFunctionSchema),
+        pagination: z
+            .object({
+                total: z.number().int().min(0),
+                page: z.number().int().min(0),
+                limit: z.number().int().min(1).max(100)
+            })
+            .strict()
+    })
+    .strict();
+
+export type ListFunctionsOutput = FunctionListSuccess;

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -170,6 +170,7 @@ describe('POST /mcp management server', () => {
             'connections_list',
             'connections_get',
             'proxy_request',
+            'functions_list',
             'logs_list_operations',
             'logs_get_operation'
         ]);
@@ -187,6 +188,7 @@ describe('POST /mcp management server', () => {
             'connections_list',
             'connections_get',
             'proxy_request',
+            'functions_list',
             'logs_list_operations',
             'logs_get_operation'
         ];
@@ -274,6 +276,93 @@ describe('POST /mcp management server', () => {
 
         expect(res.status).toBe(200);
         expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['integrations_list']);
+    });
+
+    it('lists the functions tool with functions:list scope', async () => {
+        const { secret } = await createKeyWithScopes(['environment:functions:list']);
+        const res = await mcpPost({
+            token: secret,
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools).toHaveLength(1);
+        expect(res.json.result.tools[0]).toMatchObject({
+            name: 'functions_list',
+            annotations: { readOnlyHint: true }
+        });
+    });
+
+    it('lists filtered functions for an integration', async () => {
+        const { secret, env } = await createKeyWithScopes(['environment:functions:list']);
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+        if (!integration.id) {
+            throw new Error('Integration seed has no ID');
+        }
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id,
+            sync_name: 'create-issue',
+            type: 'action'
+        });
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id,
+            sync_name: 'sync-issues',
+            type: 'sync'
+        });
+
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'functions_list',
+                    arguments: { integration_id: 'github', type: 'action', search: 'issue', page: 0, limit: 1 }
+                }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        expect(parseToolText(res)).toStrictEqual(res.json.result.structuredContent);
+        expect(res.json.result.structuredContent.pagination).toStrictEqual({ total: 1, page: 0, limit: 1 });
+        expect(res.json.result.structuredContent.data).toHaveLength(1);
+        expect(res.json.result.structuredContent.data[0]).toMatchObject({ name: 'create-issue', type: 'action' });
+    });
+
+    it('returns public errors for invalid function arguments and missing integrations', async () => {
+        const { secret } = await createKeyWithScopes(['environment:functions:list']);
+
+        const invalid = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: { name: 'functions_list', arguments: { integration_id: 'github', limit: 0 } }
+            }
+        });
+        expect(invalid.json.result).toMatchObject({ isError: true });
+        expect(invalid.json.result.content[0].text).toContain('Invalid arguments for tool functions_list');
+
+        const missing = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 2,
+                method: 'tools/call',
+                params: { name: 'functions_list', arguments: { integration_id: 'missing' } }
+            }
+        });
+        expect(missing.json.result).toStrictEqual({
+            content: [{ type: 'text', text: 'Integration does not exist' }],
+            isError: true
+        });
     });
 
     it.each(['environment:connections:list', 'environment:connections:list_credentials'] as const)('lists the connections tool with %s', async (scope) => {

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -314,6 +314,13 @@ describe('POST /mcp management server', () => {
             sync_name: 'sync-issues',
             type: 'sync'
         });
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id,
+            sync_name: 'create-user',
+            type: 'action'
+        });
 
         const res = await mcpPost({
             token: secret,

--- a/packages/server/lib/controllers/mcp/managementServer.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.ts
@@ -9,6 +9,7 @@ import { recordManagementMcpAudit } from './audit.js';
 import { getConnectionsTool } from './connections/get.js';
 import { listConnectionsTool } from './connections/list.js';
 import { createConnectSessionTool } from './connectSessions/create.js';
+import { listFunctionsTool } from './functions/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { deleteIntegrationsTool } from './integrations/delete.js';
 import { getIntegrationsTool } from './integrations/get.js';
@@ -37,6 +38,7 @@ const managementMcpTools: ManagementMcpTool[] = [
     listConnectionsTool,
     getConnectionsTool,
     proxyRequestTool,
+    listFunctionsTool,
     listLogOperationsTool,
     getLogOperationTool
 ];

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -9,6 +9,7 @@ import { audit } from '../../audit.js';
 import { getConnectionsTool } from './connections/get.js';
 import { listConnectionsTool } from './connections/list.js';
 import { createConnectSessionTool } from './connectSessions/create.js';
+import { listFunctionsTool } from './functions/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { deleteIntegrationsTool } from './integrations/delete.js';
 import { updateIntegrationsTool } from './integrations/update.js';
@@ -60,6 +61,7 @@ describe('createManagementMcpServer', () => {
                     name: 'proxy_request',
                     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
                 },
+                { name: 'functions_list', annotations: { readOnlyHint: true } },
                 { name: 'logs_list_operations', annotations: { readOnlyHint: true } },
                 { name: 'logs_get_operation', annotations: { readOnlyHint: true } }
             ]);
@@ -477,6 +479,76 @@ describe('createManagementMcpServer', () => {
                 isError: true
             });
         } finally {
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it.each(['environment:functions:list', 'environment:functions:*'])('exposes the read-only functions list tool with %s', async (scope) => {
+        const { client, server } = await createTestClient([scope]);
+
+        try {
+            const result = await client.listTools();
+
+            expect(result.tools).toHaveLength(1);
+            expect(result.tools[0]).toMatchObject({
+                name: 'functions_list',
+                annotations: { readOnlyHint: true }
+            });
+        } finally {
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('authorizes function listing before invoking the tool', async () => {
+        const handlerSpy = vi.spyOn(listFunctionsTool, 'handler');
+        const { client, server } = await createTestClient(['environment:mcp']);
+
+        try {
+            const result = await client.callTool({ name: 'functions_list', arguments: { integration_id: 'github' } });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: 'MCP error -32602: Tool functions_list disabled' }],
+                isError: true
+            });
+            expect(handlerSpy).not.toHaveBeenCalled();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('returns function lists as JSON text and structured content', async () => {
+        const response = {
+            data: [
+                {
+                    id: 1,
+                    name: 'create-issue',
+                    type: 'action' as const,
+                    returns: ['Issue'],
+                    json_schema: null,
+                    enabled: true,
+                    last_deployed: '2026-01-01T00:00:00.000Z',
+                    source: 'repo' as const
+                }
+            ],
+            pagination: { total: 1, page: 0, limit: 20 }
+        };
+        const handlerSpy = vi.spyOn(listFunctionsTool, 'handler').mockResolvedValueOnce(Ok(response));
+        const { client, server } = await createTestClient(['environment:functions:list']);
+
+        try {
+            const result = await client.callTool({ name: 'functions_list', arguments: { integration_id: 'github' } });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],
+                structuredContent: response
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
             await client.close();
             await server.close();
         }

--- a/packages/server/lib/controllers/shared/integrations/functions/listFunctions.ts
+++ b/packages/server/lib/controllers/shared/integrations/functions/listFunctions.ts
@@ -1,4 +1,4 @@
-import { configService, legacyFunctionService } from '@nangohq/shared';
+import { legacyFunctionService } from '@nangohq/shared';
 import { report } from '@nangohq/utils';
 
 import type { RequestLocalsWithEnvironment } from '../../../../utils/express.js';
@@ -22,12 +22,6 @@ export async function handleListIntegrationFunctions({
     page: number;
     limit: number;
 }): Promise<void> {
-    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
-    if (!integration) {
-        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
-        return;
-    }
-
     const fnResult = await legacyFunctionService.listFunctions({
         environmentId: environment.id,
         providerConfigKey,
@@ -38,9 +32,22 @@ export async function handleListIntegrationFunctions({
     });
 
     if (fnResult.isErr()) {
-        report(fnResult.error);
-        res.status(500).send({ error: { code: 'server_error', message: 'Failed to list functions' } });
-        return;
+        const code = fnResult.error.code;
+        switch (code) {
+            case 'integration_not_found':
+                res.status(404).send({ error: { code: 'not_found', message: fnResult.error.message } });
+                return;
+            case 'list_failed':
+                report(fnResult.error);
+                res.status(500).send({ error: { code: 'server_error', message: 'Failed to list functions' } });
+                return;
+            default: {
+                const exhaustiveCheck: never = code;
+                report(new Error('unexpected_list_functions_error', { cause: exhaustiveCheck }));
+                res.status(500).send({ error: { code: 'server_error', message: 'Failed to list functions' } });
+                return;
+            }
+        }
     }
 
     const { rows, total } = fnResult.value;

--- a/packages/shared/lib/services/functions/index.ts
+++ b/packages/shared/lib/services/functions/index.ts
@@ -1,6 +1,7 @@
 export { deployBundle, prepareDeploymentBundle } from './deploy.js';
 export type { DeploymentBundleError, DeploymentBundlePreparationError } from './deploy.js';
 export * as legacyFunctionService from './legacy/index.js';
+export type { ListFunctionsError, ListFunctionsErrorCode } from './legacy/service.js';
 export * as functionConfigService from './models/functions.js';
 export { reconcile } from './reconcile.js';
 export type { DeploymentBundleReconciliation } from './reconcile.js';

--- a/packages/shared/lib/services/functions/legacy/index.ts
+++ b/packages/shared/lib/services/functions/legacy/index.ts
@@ -1,3 +1,4 @@
 // Legacy unification over `_nango_sync_configs` and `on_event_scripts`.
-export { getFunction, listFunctions } from './service.js';
+export { getFunction, ListFunctionsError, listFunctions } from './service.js';
+export type { ListFunctionsErrorCode } from './service.js';
 export { findActiveDeployedMeta } from './models/functions.js';

--- a/packages/shared/lib/services/functions/legacy/service.ts
+++ b/packages/shared/lib/services/functions/legacy/service.ts
@@ -40,8 +40,8 @@ export async function listFunctions({
     offset: number;
 }): Promise<Result<{ rows: DeployedNangoFunction[]; total: number }, ListFunctionsError>> {
     try {
-        const integration = await configService.getProviderConfig(providerConfigKey, environmentId);
-        if (!integration) {
+        const integrationId = await configService.getIdByProviderConfigKey(environmentId, providerConfigKey);
+        if (!integrationId) {
             return Err(
                 new ListFunctionsError({
                     code: 'integration_not_found',

--- a/packages/shared/lib/services/functions/legacy/service.ts
+++ b/packages/shared/lib/services/functions/legacy/service.ts
@@ -1,10 +1,23 @@
 import { Err, Ok } from '@nangohq/utils';
 
+import configService from '../../config.service.js';
 import { toDeployedNangoFunction } from './mappers.js';
 import * as functionsModel from './models/functions.js';
 
 import type { DeployedNangoFunction, FunctionType } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+
+export type ListFunctionsErrorCode = 'integration_not_found' | 'list_failed';
+
+export class ListFunctionsError extends Error {
+    public readonly code: ListFunctionsErrorCode;
+
+    constructor({ code, message, cause }: { code: ListFunctionsErrorCode; message: string; cause?: unknown }) {
+        super(message, { cause });
+        this.name = 'ListFunctionsError';
+        this.code = code;
+    }
+}
 
 /**
  * Lists active deployed functions for a single integration across syncs,
@@ -25,22 +38,32 @@ export async function listFunctions({
     search: string | undefined;
     limit: number;
     offset: number;
-}): Promise<Result<{ rows: DeployedNangoFunction[]; total: number }>> {
+}): Promise<Result<{ rows: DeployedNangoFunction[]; total: number }, ListFunctionsError>> {
     try {
+        const integration = await configService.getProviderConfig(providerConfigKey, environmentId);
+        if (!integration) {
+            return Err(
+                new ListFunctionsError({
+                    code: 'integration_not_found',
+                    message: 'Integration does not exist'
+                })
+            );
+        }
+
         const { rows: dbRows, total } = await functionsModel.findActiveByEnvironment({ environmentId, providerConfigKey, type, search, limit, offset });
         const rows: DeployedNangoFunction[] = [];
 
         for (const row of dbRows) {
             const fn = toDeployedNangoFunction(row);
             if (fn.isErr()) {
-                return Err(new Error('failed_to_list_functions', { cause: fn.error }));
+                return Err(new ListFunctionsError({ code: 'list_failed', message: 'Failed to list functions', cause: fn.error }));
             }
             rows.push(fn.value);
         }
 
         return Ok({ rows, total });
     } catch (err) {
-        return Err(new Error('failed_to_list_functions', { cause: err }));
+        return Err(new ListFunctionsError({ code: 'list_failed', message: 'Failed to list functions', cause: err }));
     }
 }
 

--- a/packages/shared/lib/services/functions/legacy/service.unit.test.ts
+++ b/packages/shared/lib/services/functions/legacy/service.unit.test.ts
@@ -1,15 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getFunction, listFunctions } from './service.js';
+import { getFunction, listFunctions, ListFunctionsError } from './service.js';
 
 import type { FunctionRow } from './models/functions.js';
 
-const { mockFindActiveByEnvironment, mockFindActiveByName } = vi.hoisted(() => {
+const { mockFindActiveByEnvironment, mockFindActiveByName, mockGetProviderConfig } = vi.hoisted(() => {
     return {
         mockFindActiveByEnvironment: vi.fn(),
-        mockFindActiveByName: vi.fn()
+        mockFindActiveByName: vi.fn(),
+        mockGetProviderConfig: vi.fn()
     };
 });
+
+vi.mock('../../config.service.js', () => ({
+    default: { getProviderConfig: mockGetProviderConfig }
+}));
 
 vi.mock('./models/functions.js', () => ({
     findActiveByEnvironment: mockFindActiveByEnvironment,
@@ -35,7 +40,8 @@ const baseRow: FunctionRow = {
 
 describe('functions service', () => {
     beforeEach(() => {
-        vi.clearAllMocks();
+        vi.resetAllMocks();
+        mockGetProviderConfig.mockResolvedValue({ id: 1 });
     });
 
     it('returns mapped rows and total for valid functions', async () => {
@@ -76,6 +82,47 @@ describe('functions service', () => {
             ],
             total: 1
         });
+        expect(mockGetProviderConfig).toHaveBeenCalledWith('github', 1);
+    });
+
+    it('returns a typed error when the integration does not exist', async () => {
+        mockGetProviderConfig.mockResolvedValue(null);
+
+        const result = await listFunctions({
+            environmentId: 1,
+            providerConfigKey: 'missing',
+            type: undefined,
+            search: undefined,
+            limit: 20,
+            offset: 0
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(ListFunctionsError);
+            expect(result.error).toMatchObject({ code: 'integration_not_found', message: 'Integration does not exist' });
+        }
+        expect(mockFindActiveByEnvironment).not.toHaveBeenCalled();
+    });
+
+    it('wraps unexpected listing failures in a typed internal error', async () => {
+        const cause = new Error('database failed');
+        mockFindActiveByEnvironment.mockRejectedValue(cause);
+
+        const result = await listFunctions({
+            environmentId: 1,
+            providerConfigKey: 'github',
+            type: 'sync',
+            search: 'user',
+            limit: 10,
+            offset: 20
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(ListFunctionsError);
+            expect(result.error).toMatchObject({ code: 'list_failed', message: 'Failed to list functions', cause });
+        }
     });
 
     it('returns Err instead of silently dropping invalid on-event rows', async () => {
@@ -95,7 +142,8 @@ describe('functions service', () => {
 
         expect(result.isErr()).toBe(true);
         if (result.isErr()) {
-            expect(result.error.message).toBe('failed_to_list_functions');
+            expect(result.error).toBeInstanceOf(ListFunctionsError);
+            expect(result.error).toMatchObject({ code: 'list_failed', message: 'Failed to list functions' });
         }
     });
 

--- a/packages/shared/lib/services/functions/legacy/service.unit.test.ts
+++ b/packages/shared/lib/services/functions/legacy/service.unit.test.ts
@@ -4,16 +4,16 @@ import { getFunction, listFunctions, ListFunctionsError } from './service.js';
 
 import type { FunctionRow } from './models/functions.js';
 
-const { mockFindActiveByEnvironment, mockFindActiveByName, mockGetProviderConfig } = vi.hoisted(() => {
+const { mockFindActiveByEnvironment, mockFindActiveByName, mockGetIdByProviderConfigKey } = vi.hoisted(() => {
     return {
         mockFindActiveByEnvironment: vi.fn(),
         mockFindActiveByName: vi.fn(),
-        mockGetProviderConfig: vi.fn()
+        mockGetIdByProviderConfigKey: vi.fn()
     };
 });
 
 vi.mock('../../config.service.js', () => ({
-    default: { getProviderConfig: mockGetProviderConfig }
+    default: { getIdByProviderConfigKey: mockGetIdByProviderConfigKey }
 }));
 
 vi.mock('./models/functions.js', () => ({
@@ -41,7 +41,7 @@ const baseRow: FunctionRow = {
 describe('functions service', () => {
     beforeEach(() => {
         vi.resetAllMocks();
-        mockGetProviderConfig.mockResolvedValue({ id: 1 });
+        mockGetIdByProviderConfigKey.mockResolvedValue(1);
     });
 
     it('returns mapped rows and total for valid functions', async () => {
@@ -82,11 +82,11 @@ describe('functions service', () => {
             ],
             total: 1
         });
-        expect(mockGetProviderConfig).toHaveBeenCalledWith('github', 1);
+        expect(mockGetIdByProviderConfigKey).toHaveBeenCalledWith(1, 'github');
     });
 
     it('returns a typed error when the integration does not exist', async () => {
-        mockGetProviderConfig.mockResolvedValue(null);
+        mockGetIdByProviderConfigKey.mockResolvedValue(null);
 
         const result = await listFunctions({
             environmentId: 1,


### PR DESCRIPTION
Adds functions_list to the Management MCP server for integration-scoped deployed functions, with strict filters and pagination, structured output, read-only annotations, and environment:functions:list authorization.

Extends the existing legacy function service with typed errors and reuses it from both the public endpoint and MCP tool, including exhaustive handling of unexpected error codes; it also documents the new tool.

NAN-6300: https://linear.app/nango/issue/NAN-6300/mcp-tool-functions-list

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

