### PR TITLE
feat(logs): add an actor to operations (NAN-6592)

### DIFF
--- a/packages/logs/lib/es/__snapshots__/index.integration.test.ts.snap
+++ b/packages/logs/lib/es/__snapshots__/index.integration.test.ts.snap
@@ -30,8 +30,15 @@ exports[`mapping > should create one index automatically on operation > elastics
       "accountName": {
         "type": "keyword",
       },
-      "agentSessionId": {
-        "type": "keyword",
+      "actor": {
+        "properties": {
+          "id": {
+            "type": "keyword",
+          },
+          "kind": {
+            "type": "keyword",
+          },
+        },
       },
       "connectionId": {
         "type": "keyword",
@@ -198,9 +205,6 @@ exports[`mapping > should create one index automatically on operation > elastics
       },
       "updatedAt": {
         "type": "date",
-      },
-      "userId": {
-        "type": "keyword",
       },
     },
   },

--- a/packages/logs/lib/es/__snapshots__/index.integration.test.ts.snap
+++ b/packages/logs/lib/es/__snapshots__/index.integration.test.ts.snap
@@ -30,6 +30,9 @@ exports[`mapping > should create one index automatically on operation > elastics
       "accountName": {
         "type": "keyword",
       },
+      "agentSessionId": {
+        "type": "keyword",
+      },
       "connectionId": {
         "type": "keyword",
       },

--- a/packages/logs/lib/es/index.integration.test.ts
+++ b/packages/logs/lib/es/index.integration.test.ts
@@ -91,13 +91,16 @@ describe('mapping', () => {
         expect(doc.state).toBe('failed');
     });
 
-    it('should index agentSessionId as a searchable term', async () => {
+    it('should index the actor as a searchable term', async () => {
         const id = nanoid();
-        const agentSessionId = nanoid();
-        await createOperation(getFormattedOperation({ id, agentSessionId, operation: { type: 'action', action: 'run' } }));
-        await createOperation(getFormattedOperation({ id: nanoid(), operation: { type: 'proxy', action: 'call' } }));
+        const sessionId = nanoid();
+        await createOperation(getFormattedOperation({ id, actor: { kind: 'session', id: sessionId }, operation: { type: 'action', action: 'run' } }));
+        await createOperation(getFormattedOperation({ id: nanoid(), actor: { kind: 'user', id: 1 }, operation: { type: 'proxy', action: 'call' } }));
 
-        const res = await client.search<OperationRow>({ index: fullIndexName, query: { term: { agentSessionId } } });
+        const res = await client.search<OperationRow>({
+            index: fullIndexName,
+            query: { bool: { must: [{ term: { 'actor.kind': 'session' } }, { term: { 'actor.id': sessionId } }] } }
+        });
 
         expect(res.hits.hits.map((hit) => hit._source?.id)).toStrictEqual([id]);
     });

--- a/packages/logs/lib/es/index.integration.test.ts
+++ b/packages/logs/lib/es/index.integration.test.ts
@@ -12,6 +12,8 @@ import { client, logsStorage } from '../storage/client.js';
 import { deleteIndex, migrateMapping } from './helpers.js';
 import { indexOperations, policyMessages, policyOperations, retentionMinAge } from './schema.js';
 
+import type { OperationRow } from '@nangohq/types';
+
 interface IsmPolicyBody {
     policy: { states: { name: string; transitions?: { conditions: { min_index_age: string } }[] }[] };
 }
@@ -87,6 +89,17 @@ describe('mapping', () => {
         await client.indices.getMapping({ index: yesterdayIndexName });
         const doc = await getOperation({ id });
         expect(doc.state).toBe('failed');
+    });
+
+    it('should index agentSessionId as a searchable term', async () => {
+        const id = nanoid();
+        const agentSessionId = nanoid();
+        await createOperation(getFormattedOperation({ id, agentSessionId, operation: { type: 'action', action: 'run' } }));
+        await createOperation(getFormattedOperation({ id: nanoid(), operation: { type: 'proxy', action: 'call' } }));
+
+        const res = await client.search<OperationRow>({ index: fullIndexName, query: { term: { agentSessionId } } });
+
+        expect(res.hits.hits.map((hit) => hit._source?.id)).toStrictEqual([id]);
     });
 });
 

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -12,7 +12,6 @@ export const operationIdRegex = z.string().regex(/^[a-zA-Z0-9_]{20,25}$/);
 
 export interface AdditionalOperationData {
     account?: { id: number; name: string };
-    user?: { id: number } | undefined;
     environment?: { id: number; name: string } | undefined;
     connection?: { id: number; name: string } | undefined;
     integration?: { id: number; name: string; provider: string } | undefined;
@@ -22,7 +21,7 @@ export interface AdditionalOperationData {
 
 export function getFormattedOperation(
     data: OperationRowInsert,
-    { account, user, environment, integration, connection, syncConfig, meta }: AdditionalOperationData = {}
+    { account, environment, integration, connection, syncConfig, meta }: AdditionalOperationData = {}
 ): OperationRow {
     const now = new Date();
     const createdAt = data.createdAt ? new Date(data.createdAt) : now;
@@ -54,9 +53,7 @@ export function getFormattedOperation(
         jobId: data.jobId || undefined,
         meta: meta || data.meta || undefined,
 
-        userId: user?.id || data.userId || undefined,
-
-        agentSessionId: data.agentSessionId || undefined,
+        actor: data.actor || undefined,
 
         createdAt: data.createdAt || now.toISOString(),
         updatedAt: data.updatedAt || now.toISOString(),

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -56,6 +56,8 @@ export function getFormattedOperation(
 
         userId: user?.id || data.userId || undefined,
 
+        agentSessionId: data.agentSessionId || undefined,
+
         createdAt: data.createdAt || now.toISOString(),
         updatedAt: data.updatedAt || now.toISOString(),
         startedAt: data.startedAt || null,

--- a/packages/logs/lib/schema/mappings.ts
+++ b/packages/logs/lib/schema/mappings.ts
@@ -53,6 +53,8 @@ export const propsOperations: Record<keyof OperationRow, estypes.MappingProperty
 
     userId: { type: 'keyword' },
 
+    agentSessionId: { type: 'keyword' },
+
     operation: {
         properties: {
             type: { type: 'keyword' },
@@ -158,6 +160,8 @@ export const propsMessages: Record<keyof MessageRow | keyof OperationRow, estype
     jobId: { type: 'keyword' },
 
     userId: { type: 'keyword' },
+
+    agentSessionId: { type: 'keyword' },
 
     operation: {
         properties: {

--- a/packages/logs/lib/schema/mappings.ts
+++ b/packages/logs/lib/schema/mappings.ts
@@ -51,9 +51,12 @@ export const propsOperations: Record<keyof OperationRow, estypes.MappingProperty
 
     jobId: { type: 'keyword' },
 
-    userId: { type: 'keyword' },
-
-    agentSessionId: { type: 'keyword' },
+    actor: {
+        properties: {
+            kind: { type: 'keyword' },
+            id: { type: 'keyword' }
+        }
+    },
 
     operation: {
         properties: {
@@ -159,9 +162,12 @@ export const propsMessages: Record<keyof MessageRow | keyof OperationRow, estype
 
     jobId: { type: 'keyword' },
 
-    userId: { type: 'keyword' },
-
-    agentSessionId: { type: 'keyword' },
+    actor: {
+        properties: {
+            kind: { type: 'keyword' },
+            id: { type: 'keyword' }
+        }
+    },
 
     operation: {
         properties: {

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -76,6 +76,11 @@ export type OperationList =
     | OperationDeploy
     | OperationAuth
     | OperationAdmin;
+/**
+ * Who triggered an operation
+ */
+export type OperationActor = { kind: 'user'; id: number } | { kind: 'session'; id: string };
+
 export interface MessageError {
     name: string;
     message: string;
@@ -187,12 +192,10 @@ export interface OperationRow {
 
     jobId?: string | undefined;
 
-    userId?: number | undefined;
-
     /**
-     * Agent session that originated this operation, i.e: an action or proxy call made through a session
+     * Who triggered this operation, i.e: a dashboard user or an agent session
      */
-    agentSessionId?: string | undefined;
+    actor?: OperationActor | undefined;
 
     // Associated meta
     error?: MessageError | undefined;

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -189,6 +189,11 @@ export interface OperationRow {
 
     userId?: number | undefined;
 
+    /**
+     * Agent session that originated this operation, i.e: an action or proxy call made through a session
+     */
+    agentSessionId?: string | undefined;
+
     // Associated meta
     error?: MessageError | undefined;
     request?: MessageHTTPRequest | undefined;


### PR DESCRIPTION
Closes [NAN-6592](https://linear.app/nango/issue/NAN-6592/add-actor-to-action-and-proxy-operations).

Adds an indexed `actor` on operations so we can tell who triggered one, a dashboard user or an agent session.

```ts
actor: { kind: 'user'; id: number } | { kind: 'session'; id: string }
```

This replaces `userId`, which nothing set and nothing read. Thanks @TBonnin and @marcindobry for the shape.

Nothing stamps it yet.
