### PR TITLE
fix(providers): update instagram authorization url

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -11397,7 +11397,7 @@ instagram:
         - social
     auth_mode: OAUTH2
     scope_separator: ','
-    authorization_url: https://api.instagram.com/oauth/authorize
+    authorization_url: https://www.instagram.com/oauth/authorize
     token_url: https://api.instagram.com/oauth/access_token
     refresh_url: https://graph.instagram.com/refresh_access_token
     proxy:


### PR DESCRIPTION
## Describe the problem and your solution

- update instagram authorization url to use the latest one based on their [docs](https://developers.facebook.com/documentation/instagram-platform/instagram-api-with-instagram-login/business-login).

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

