### PR TITLE
fix(webapp): overdue alert sends you to the billing page

### DIFF
--- a/packages/webapp/src/features/Billing/OverdueInvoiceAlert.tsx
+++ b/packages/webapp/src/features/Billing/OverdueInvoiceAlert.tsx
@@ -15,7 +15,7 @@ export function OverdueInvoiceAlert({ size = 'compact', canManageBilling, childr
         <Alert variant="danger" size={size}>
             <CircleAlert />
             <AlertTitle>Invoice(s) overdue</AlertTitle>
-            <AlertDescription>{canManageBilling ? 'Pay it to avoid interruption.' : 'Reach out to an admin to get it resolved.'}</AlertDescription>
+            <AlertDescription>{canManageBilling ? 'Pay now to avoid interruption.' : 'Reach out to an admin to get it resolved.'}</AlertDescription>
             {canManageBilling && children && <AlertActions>{children}</AlertActions>}
         </Alert>
     );

--- a/packages/webapp/src/features/Billing/OverdueInvoiceAlert.tsx
+++ b/packages/webapp/src/features/Billing/OverdueInvoiceAlert.tsx
@@ -7,7 +7,6 @@ import type { AlertProps } from '@nangohq/design-system';
 interface OverdueInvoiceAlertProps {
     size?: AlertProps['size'];
     canManageBilling: boolean;
-    /** Actions differ per context: the Billing page opens the Stripe dialog, the sidebar links to it. */
     children?: React.ReactNode;
 }
 
@@ -16,9 +15,7 @@ export function OverdueInvoiceAlert({ size = 'compact', canManageBilling, childr
         <Alert variant="danger" size={size}>
             <CircleAlert />
             <AlertTitle>Invoice(s) overdue</AlertTitle>
-            <AlertDescription>
-                {canManageBilling ? 'Edit payment method to avoid interruption.' : 'Reach out to your admin to update the payment method.'}
-            </AlertDescription>
+            <AlertDescription>{canManageBilling ? 'Pay it to avoid interruption.' : 'Reach out to your admin to update the payment method.'}</AlertDescription>
             {canManageBilling && children && <AlertActions>{children}</AlertActions>}
         </Alert>
     );

--- a/packages/webapp/src/features/Billing/OverdueInvoiceAlert.tsx
+++ b/packages/webapp/src/features/Billing/OverdueInvoiceAlert.tsx
@@ -15,7 +15,9 @@ export function OverdueInvoiceAlert({ size = 'compact', canManageBilling, childr
         <Alert variant="danger" size={size}>
             <CircleAlert />
             <AlertTitle>Invoice(s) overdue</AlertTitle>
-            <AlertDescription>{canManageBilling ? 'Pay now to avoid interruption.' : 'Reach out to an admin to get it resolved.'}</AlertDescription>
+            <AlertDescription>
+                {canManageBilling ? 'Pay now to avoid interruption.' : 'Reach out to your admin to update the payment method and avoid interruption.'}
+            </AlertDescription>
             {canManageBilling && children && <AlertActions>{children}</AlertActions>}
         </Alert>
     );

--- a/packages/webapp/src/features/Billing/OverdueInvoiceAlert.tsx
+++ b/packages/webapp/src/features/Billing/OverdueInvoiceAlert.tsx
@@ -15,7 +15,7 @@ export function OverdueInvoiceAlert({ size = 'compact', canManageBilling, childr
         <Alert variant="danger" size={size}>
             <CircleAlert />
             <AlertTitle>Invoice(s) overdue</AlertTitle>
-            <AlertDescription>{canManageBilling ? 'Pay it to avoid interruption.' : 'Reach out to your admin to update the payment method.'}</AlertDescription>
+            <AlertDescription>{canManageBilling ? 'Pay it to avoid interruption.' : 'Reach out to an admin to get it resolved.'}</AlertDescription>
             {canManageBilling && children && <AlertActions>{children}</AlertActions>}
         </Alert>
     );

--- a/packages/webapp/src/layout/AppSidebar/index.tsx
+++ b/packages/webapp/src/layout/AppSidebar/index.tsx
@@ -117,11 +117,8 @@ export const AppSidebar: React.FC = () => {
                 {showOverdueAlert && (
                     <div className="px-2.5 mb-4">
                         <OverdueInvoiceAlert canManageBilling={canManageBilling}>
-                            <AlertButtonLink
-                                to="/team/billing#payment-and-invoices"
-                                onClick={() => track('web:usage:edit_payment_method_clicked', { source: 'sidebar' })}
-                            >
-                                Edit payment method <ArrowUpRight />
+                            <AlertButtonLink to="/team/billing" onClick={() => track('web:usage:overdue_alert_clicked', {})}>
+                                View billing <ArrowUpRight />
                             </AlertButtonLink>
                         </OverdueInvoiceAlert>
                     </div>

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -27,7 +27,8 @@ export interface AnalyticsEvents {
     'web:usage:invoice_details_clicked': Record<string, never>;
     'web:usage:billing_portal_clicked': Record<string, never>;
     'web:usage:upgrade_clicked': Record<string, never>;
-    'web:usage:edit_payment_method_clicked': { source: 'sidebar' | 'billing_page' };
+    'web:usage:edit_payment_method_clicked': { source: 'billing_page' };
+    'web:usage:overdue_alert_clicked': Record<string, never>;
 
     // Playground
     'web:playground:opened': { source: 'header' | 'connection' | 'integration' | 'function' };


### PR DESCRIPTION
## Problem

The sidebar's overdue-invoice alert offered **Edit payment method** and deep-linked to the card form. That presumes the cause — an overdue invoice usually means a charge failed or an invoice is simply unpaid, and the card on file is often correct — and it landed on a form that says nothing about what is overdue.

The anchor was unreliable too: `#payment-and-invoices` renders only for billing managers and only once its data resolves, so the scroll often found nothing.

## Solution

- The alert now offers one neutral **View billing** action to the top of Billing & usage, where the wide alert already offers both the invoices and the card dialog — so the remedy is chosen where the context is rather than guessed in the sidebar.
- Copy now matches the `Paid-Overdue-Alert` set in Figma (node `1169:7925`): the admin line becomes `Pay now to avoid interruption.`, and the non-admin line becomes `Reach out to your admin to update the payment method and avoid interruption.`
- Analytics: adds `web:usage:overdue_alert_clicked`, and narrows `edit_payment_method_clicked` to `{ source: 'billing_page' }` — its only remaining caller.

Fixes [NAN-6688](https://linear.app/nango/issue/NAN-6688)

## Testing

Verified against the remote dev API with the overdue dev override: the alert links to `/team/billing` and lands at the top of the page, with the wide banner's **View invoices** and **Edit payment method** both visible.

322 webapp unit tests pass; typecheck and `format:check` clean.
