### PR TITLE
refactor(audit): make the controller → middleware coupling a typed claim

### DIFF
--- a/packages/audit/lib/event.ts
+++ b/packages/audit/lib/event.ts
@@ -1,6 +1,6 @@
 // `id` and `version` are stamped at the emit boundary, not by the caller.
 
-import type { AuditActor, AuditContext, AuditEventKey, AuditOutcome, AuditTarget, AuditTrailVersion } from '@nangohq/types';
+import type { AuditActor, AuditContext, AuditEventKey, AuditOutcome, AuditTarget, AuditTrailVersion, AuthOperationType } from '@nangohq/types';
 
 export type {
     AuditActor,
@@ -20,6 +20,7 @@ export type {
 
 export interface ConnectionMetadata {
     providerConfigKey?: string;
+    operation?: AuthOperationType;
 }
 export interface ConnectionUpdatedMetadata {
     providerConfigKey?: string;
@@ -129,7 +130,7 @@ interface AuditEventCommon {
 }
 
 export type AuditResourceAction =
-    | { resource: 'connection'; action: 'created'; metadata?: ConnectionMetadata }
+    | { resource: 'connection'; action: 'created' | 'reauthorized'; metadata?: ConnectionMetadata }
     | { resource: 'connection'; action: 'refreshed' | 'metadata_updated' | 'deleted'; metadata?: ConnectionMetadata }
     | { resource: 'connection'; action: 'updated'; metadata?: ConnectionUpdatedMetadata }
     | { resource: 'integration'; action: 'created'; metadata?: IntegrationCreatedMetadata }

--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -4,10 +4,10 @@ import { accountService, configService, connectionService, errorManager, getProv
 import { report, stringifyError } from '@nangohq/utils';
 
 import publisher from '../clients/publisher.client.js';
-import { noteConnectionUpsert } from '../hooks/auditConnection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../hooks/hooks.js';
 import { getConnectSession } from '../services/connectSession.service.js';
 import oAuthSessionService from '../services/oauth-session.service.js';
+import { claimConnectionUpsert } from '../utils/audited.js';
 import { resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../utils/auth.js';
 import { missesInterpolationParam } from '../utils/utils.js';
 import * as WSErrBuilder from '../utils/web-socket-error.js';
@@ -193,7 +193,7 @@ class AppAuthController {
             }
 
             await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id, connectionName: updatedConnection.connection.connection_id });
-            noteConnectionUpsert(req, {
+            claimConnectionUpsert(res, {
                 operation: updatedConnection.operation,
                 connectionId: updatedConnection.connection.connection_id,
                 providerConfigKey: updatedConnection.connection.provider_config_key,

--- a/packages/server/lib/controllers/appAuth.controller.unit.test.ts
+++ b/packages/server/lib/controllers/appAuth.controller.unit.test.ts
@@ -147,9 +147,7 @@ describe('AppAuthController.connect', () => {
         expect(mockUpsertConnection).toHaveBeenCalledWith(
             expect.objectContaining({ connectionConfig: expect.not.objectContaining({ webhook_url: expect.anything() }) })
         );
-        // The route middleware records the event, so what this handler owes it is the upsert outcome and
-        // the account it happened to — an unauthenticated callback carries neither on its locals.
-        expect(req.audit?.connectionUpsert).toMatchObject({
+        expect(res.locals['auditClaim']).toMatchObject({
             operation: 'creation',
             connectionId: 'conn-1',
             providerConfigKey: 'github-app',

--- a/packages/server/lib/controllers/auth/postApiKey.ts
+++ b/packages/server/lib/controllers/auth/postApiKey.ts
@@ -19,6 +19,7 @@ import {
     testConnectionCredentials
 } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -217,18 +218,6 @@ export const postPublicApiKeyAuthorization = asyncWrapperWithEnvironment<PostPub
         void logCtx.info('API key auth creation was successful');
         await logCtx.success();
 
-        req.audit = {
-            ...req.audit,
-            connectionUpsert: {
-                operation: updatedConnection.operation,
-                connectionId: updatedConnection.connection.connection_id,
-                providerConfigKey: updatedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
-            }
-        };
-
         void connectionCreatedHook(
             {
                 connection: updatedConnection.connection,
@@ -245,7 +234,13 @@ export const postPublicApiKeyAuthorization = asyncWrapperWithEnvironment<PostPub
 
         metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
-        res.status(200).send({ connectionId, providerConfigKey });
+        res.status(200).send(
+            claimAudit<PostPublicApiKeyAuthorization>(
+                res,
+                { connectionId, providerConfigKey },
+                { operation: updatedConnection.operation, connectionId: updatedConnection.connection.connection_id, providerConfigKey }
+            )
+        );
     } catch (err) {
         const prettyError = stringifyError(err, { pretty: true });
 

--- a/packages/server/lib/controllers/auth/postAwsSigV4.ts
+++ b/packages/server/lib/controllers/auth/postAwsSigV4.ts
@@ -23,6 +23,7 @@ import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema,
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -317,18 +318,6 @@ export const postPublicAwsSigV4Authorization = asyncWrapperWithEnvironment<PostP
         void logCtx.info('AWS SigV4 connection creation was successful');
         await logCtx.success();
 
-        req.audit = {
-            ...req.audit,
-            connectionUpsert: {
-                operation: storedConnection.operation,
-                connectionId: storedConnection.connection.connection_id,
-                providerConfigKey: storedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
-            }
-        };
-
         void connectionCreatedHook(
             {
                 connection: storedConnection.connection,
@@ -344,7 +333,13 @@ export const postPublicAwsSigV4Authorization = asyncWrapperWithEnvironment<PostP
         );
 
         metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: 'AWS_SIGV4', provider: config.provider, providerConfigKey: config.unique_key });
-        res.status(200).send({ connectionId, providerConfigKey });
+        res.status(200).send(
+            claimAudit<PostPublicAwsSigV4Authorization>(
+                res,
+                { connectionId, providerConfigKey },
+                { operation: storedConnection.operation, connectionId: storedConnection.connection.connection_id, providerConfigKey }
+            )
+        );
     } catch (err) {
         void connectionCreationFailedHook(
             {

--- a/packages/server/lib/controllers/auth/postBasic.ts
+++ b/packages/server/lib/controllers/auth/postBasic.ts
@@ -19,6 +19,7 @@ import {
     testConnectionCredentials
 } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -216,18 +217,6 @@ export const postPublicBasicAuthorization = asyncWrapperWithEnvironment<PostPubl
         void logCtx.info('Basic auth creation was successful');
         await logCtx.success();
 
-        req.audit = {
-            ...req.audit,
-            connectionUpsert: {
-                operation: updatedConnection.operation,
-                connectionId: updatedConnection.connection.connection_id,
-                providerConfigKey: updatedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
-            }
-        };
-
         void connectionCreatedHook(
             {
                 connection: updatedConnection.connection,
@@ -244,7 +233,13 @@ export const postPublicBasicAuthorization = asyncWrapperWithEnvironment<PostPubl
 
         metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
-        res.status(200).send({ connectionId, providerConfigKey });
+        res.status(200).send(
+            claimAudit<PostPublicBasicAuthorization>(
+                res,
+                { connectionId, providerConfigKey },
+                { operation: updatedConnection.operation, connectionId: updatedConnection.connection.connection_id, providerConfigKey }
+            )
+        );
     } catch (err) {
         const prettyError = stringifyError(err, { pretty: true });
 

--- a/packages/server/lib/controllers/auth/postBill.ts
+++ b/packages/server/lib/controllers/auth/postBill.ts
@@ -18,6 +18,7 @@ import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema,
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -219,18 +220,6 @@ export const postPublicBillAuthorization = asyncWrapperWithEnvironment<PostPubli
         void logCtx.info('Bill connection creation was successful');
         await logCtx.success();
 
-        req.audit = {
-            ...req.audit,
-            connectionUpsert: {
-                operation: updatedConnection.operation,
-                connectionId: updatedConnection.connection.connection_id,
-                providerConfigKey: updatedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
-            }
-        };
-
         void connectionCreatedHook(
             {
                 connection: updatedConnection.connection,
@@ -247,7 +236,13 @@ export const postPublicBillAuthorization = asyncWrapperWithEnvironment<PostPubli
 
         metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
-        res.status(200).send({ connectionId, providerConfigKey });
+        res.status(200).send(
+            claimAudit<PostPublicBillAuthorization>(
+                res,
+                { connectionId, providerConfigKey },
+                { operation: updatedConnection.operation, connectionId: updatedConnection.connection.connection_id, providerConfigKey }
+            )
+        );
     } catch (err) {
         const prettyError = stringifyError(err, { pretty: true });
 

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -22,6 +22,7 @@ import {
     testConnectionCredentials
 } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -233,18 +234,6 @@ export const postPublicJwtAuthorization = asyncWrapperWithEnvironment<PostPublic
         void logCtx.info('JWT connection creation was successful');
         await logCtx.success();
 
-        req.audit = {
-            ...req.audit,
-            connectionUpsert: {
-                operation: updatedConnection.operation,
-                connectionId: updatedConnection.connection.connection_id,
-                providerConfigKey: updatedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
-            }
-        };
-
         void connectionCreatedHook(
             {
                 connection: updatedConnection.connection,
@@ -261,7 +250,13 @@ export const postPublicJwtAuthorization = asyncWrapperWithEnvironment<PostPublic
 
         metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
-        res.status(200).send({ connectionId, providerConfigKey });
+        res.status(200).send(
+            claimAudit<PostPublicJwtAuthorization>(
+                res,
+                { connectionId, providerConfigKey },
+                { operation: updatedConnection.operation, connectionId: updatedConnection.connection.connection_id, providerConfigKey }
+            )
+        );
     } catch (err) {
         const prettyError = stringifyError(err, { pretty: true });
 

--- a/packages/server/lib/controllers/auth/postOauthOutbound.ts
+++ b/packages/server/lib/controllers/auth/postOauthOutbound.ts
@@ -9,6 +9,7 @@ import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema,
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -190,18 +191,6 @@ export const postPublicOauthOutboundAuthorization = asyncWrapperWithEnvironment<
         void logCtx.info('OAuth2 Outbound Installation creation was successful');
         await logCtx.success();
 
-        req.audit = {
-            ...req.audit,
-            connectionUpsert: {
-                operation: updatedConnection.operation,
-                connectionId: updatedConnection.connection.connection_id,
-                providerConfigKey: updatedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
-            }
-        };
-
         void connectionCreatedHook(
             {
                 connection: updatedConnection.connection,
@@ -218,7 +207,13 @@ export const postPublicOauthOutboundAuthorization = asyncWrapperWithEnvironment<
 
         metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
-        res.status(200).send({ connectionId, providerConfigKey });
+        res.status(200).send(
+            claimAudit<PostPublicOauthOutboundAuthorization>(
+                res,
+                { connectionId, providerConfigKey },
+                { operation: updatedConnection.operation, connectionId: updatedConnection.connection.connection_id, providerConfigKey }
+            )
+        );
     } catch (err) {
         const prettyError = stringifyError(err, { pretty: true });
 

--- a/packages/server/lib/controllers/auth/postSignature.ts
+++ b/packages/server/lib/controllers/auth/postSignature.ts
@@ -22,6 +22,7 @@ import {
     testConnectionCredentials
 } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -234,18 +235,6 @@ export const postPublicSignatureAuthorization = asyncWrapperWithEnvironment<Post
         void logCtx.info('Signature connection creation was successful');
         await logCtx.success();
 
-        req.audit = {
-            ...req.audit,
-            connectionUpsert: {
-                operation: updatedConnection.operation,
-                connectionId: updatedConnection.connection.connection_id,
-                providerConfigKey: updatedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
-            }
-        };
-
         void connectionCreatedHook(
             {
                 connection: updatedConnection.connection,
@@ -262,7 +251,13 @@ export const postPublicSignatureAuthorization = asyncWrapperWithEnvironment<Post
 
         metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
-        res.status(200).send({ connectionId, providerConfigKey });
+        res.status(200).send(
+            claimAudit<PostPublicSignatureAuthorization>(
+                res,
+                { connectionId, providerConfigKey },
+                { operation: updatedConnection.operation, connectionId: updatedConnection.connection.connection_id, providerConfigKey }
+            )
+        );
     } catch (err) {
         const prettyError = stringifyError(err, { pretty: true });
 

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -13,6 +13,7 @@ import {
     testConnectionCredentials
 } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -250,18 +251,6 @@ export const postPublicTbaAuthorization = asyncWrapperWithEnvironment<PostPublic
         void logCtx.info('Tba connection creation was successful');
         await logCtx.success();
 
-        req.audit = {
-            ...req.audit,
-            connectionUpsert: {
-                operation: updatedConnection.operation,
-                connectionId: updatedConnection.connection.connection_id,
-                providerConfigKey: updatedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
-            }
-        };
-
         void connectionCreatedHook(
             {
                 connection: updatedConnection.connection,
@@ -278,7 +267,13 @@ export const postPublicTbaAuthorization = asyncWrapperWithEnvironment<PostPublic
 
         metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
-        res.status(200).send({ connectionId, providerConfigKey });
+        res.status(200).send(
+            claimAudit<PostPublicTbaAuthorization>(
+                res,
+                { connectionId, providerConfigKey },
+                { operation: updatedConnection.operation, connectionId: updatedConnection.connection.connection_id, providerConfigKey }
+            )
+        );
     } catch (err) {
         const prettyError = stringifyError(err, { pretty: true });
 

--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -18,6 +18,7 @@ import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema,
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -227,18 +228,6 @@ export const postPublicTwoStepAuthorization = asyncWrapperWithEnvironment<PostPu
         void logCtx.info('TwoStep connection creation was successful');
         await logCtx.success();
 
-        req.audit = {
-            ...req.audit,
-            connectionUpsert: {
-                operation: updatedConnection.operation,
-                connectionId: updatedConnection.connection.connection_id,
-                providerConfigKey: updatedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
-            }
-        };
-
         void connectionCreatedHook(
             {
                 connection: updatedConnection.connection,
@@ -256,7 +245,13 @@ export const postPublicTwoStepAuthorization = asyncWrapperWithEnvironment<PostPu
 
         metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
-        res.status(200).send({ connectionId, providerConfigKey });
+        res.status(200).send(
+            claimAudit<PostPublicTwoStepAuthorization>(
+                res,
+                { connectionId, providerConfigKey },
+                { operation: updatedConnection.operation, connectionId: updatedConnection.connection.connection_id, providerConfigKey }
+            )
+        );
     } catch (err) {
         const prettyError = stringifyError(err, { pretty: true });
 

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -9,6 +9,7 @@ import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema,
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated, connectionCreationFailed } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -182,18 +183,6 @@ export const postPublicUnauthenticated = asyncWrapperWithEnvironment<PostPublicU
         void logCtx.info('Unauthenticated connection creation was successful');
         await logCtx.success();
 
-        req.audit = {
-            ...req.audit,
-            connectionUpsert: {
-                operation: updatedConnection.operation,
-                connectionId: updatedConnection.connection.connection_id,
-                providerConfigKey: updatedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
-            }
-        };
-
         void connectionCreated(
             {
                 connection: updatedConnection.connection,
@@ -211,7 +200,13 @@ export const postPublicUnauthenticated = asyncWrapperWithEnvironment<PostPublicU
 
         metrics.increment(metrics.Types.AUTH_SUCCESS, 1, { auth_mode: provider.auth_mode, provider: config.provider, providerConfigKey: config.unique_key });
 
-        res.status(200).send({ connectionId, providerConfigKey });
+        res.status(200).send(
+            claimAudit<PostPublicUnauthenticatedAuthorization>(
+                res,
+                { connectionId, providerConfigKey },
+                { operation: updatedConnection.operation, connectionId: updatedConnection.connection.connection_id, providerConfigKey }
+            )
+        );
     } catch (err) {
         const prettyError = stringifyError(err, { pretty: true });
 

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -13,7 +13,6 @@ import {
 import { flags, zodErrorToHTTP } from '@nangohq/utils';
 
 import { webhookUrlSchema } from '../helpers/validation.js';
-import { noteConnectionUpsert } from '../hooks/auditConnection.js';
 import { preConnectionDeletion } from '../hooks/connection/on/pre-connection-deletion.js';
 import {
     connectionCreated as connectionCreatedHook,
@@ -22,6 +21,7 @@ import {
 } from '../hooks/hooks.js';
 import { slackService } from '../services/slack.js';
 import { requireEnvironment } from '../utils/asyncWrapper.js';
+import { claimAudit } from '../utils/audited.js';
 import { getOrchestrator } from '../utils/utils.js';
 
 import type { RequestLocals } from '../utils/express.js';
@@ -29,6 +29,7 @@ import type {
     ApiKeyCredentials,
     BasicApiCredentials,
     ConnectionConfig,
+    ConnectionCreateAudit,
     ConnectionUpsertResponse,
     OAuth1Credentials,
     OAuth2ClientCredentials,
@@ -295,14 +296,6 @@ class ConnectionController {
                 }
 
                 const connCreatedHook = (res: ConnectionUpsertResponse) => {
-                    noteConnectionUpsert(req, {
-                        operation: res.operation,
-                        connectionId: res.connection.connection_id,
-                        providerConfigKey: res.connection.provider_config_key,
-                        account: { id: account.id, uuid: account.uuid },
-                        environment: { id: environment.id, name: environment.name },
-                        endUser: undefined
-                    });
                     void connectionCreatedHook(
                         {
                             connection: res.connection,
@@ -367,14 +360,6 @@ class ConnectionController {
                 }
 
                 const connCreatedHook = (res: ConnectionUpsertResponse) => {
-                    noteConnectionUpsert(req, {
-                        operation: res.operation,
-                        connectionId: res.connection.connection_id,
-                        providerConfigKey: res.connection.provider_config_key,
-                        account: { id: account.id, uuid: account.uuid },
-                        environment: { id: environment.id, name: environment.name },
-                        endUser: undefined
-                    });
                     void connectionCreatedHook(
                         {
                             connection: res.connection,
@@ -425,14 +410,6 @@ class ConnectionController {
                 };
 
                 const connCreatedHook = (res: ConnectionUpsertResponse) => {
-                    noteConnectionUpsert(req, {
-                        operation: res.operation,
-                        connectionId: res.connection.connection_id,
-                        providerConfigKey: res.connection.provider_config_key,
-                        account: { id: account.id, uuid: account.uuid },
-                        environment: { id: environment.id, name: environment.name },
-                        endUser: undefined
-                    });
                     void connectionCreatedHook(
                         {
                             connection: res.connection,
@@ -477,14 +454,6 @@ class ConnectionController {
                 };
 
                 const connCreatedHook = (res: ConnectionUpsertResponse) => {
-                    noteConnectionUpsert(req, {
-                        operation: res.operation,
-                        connectionId: res.connection.connection_id,
-                        providerConfigKey: res.connection.provider_config_key,
-                        account: { id: account.id, uuid: account.uuid },
-                        environment: { id: environment.id, name: environment.name },
-                        endUser: undefined
-                    });
                     void connectionCreatedHook(
                         {
                             connection: res.connection,
@@ -527,14 +496,6 @@ class ConnectionController {
                 };
 
                 const connCreatedHook = (res: ConnectionUpsertResponse) => {
-                    noteConnectionUpsert(req, {
-                        operation: res.operation,
-                        connectionId: res.connection.connection_id,
-                        providerConfigKey: res.connection.provider_config_key,
-                        account: { id: account.id, uuid: account.uuid },
-                        environment: { id: environment.id, name: environment.name },
-                        endUser: undefined
-                    });
                     void connectionCreatedHook(
                         {
                             connection: res.connection,
@@ -685,14 +646,6 @@ class ConnectionController {
             }
 
             if (updatedConnection && runHook) {
-                noteConnectionUpsert(req, {
-                    operation: updatedConnection.operation,
-                    connectionId: updatedConnection.connection.connection_id,
-                    providerConfigKey: updatedConnection.connection.provider_config_key,
-                    account: { id: account.id, uuid: account.uuid },
-                    environment: { id: environment.id, name: environment.name },
-                    endUser: undefined
-                });
                 void connectionCreatedHook(
                     {
                         connection: updatedConnection.connection,
@@ -713,10 +666,18 @@ class ConnectionController {
                 await connectionRefreshSuccess({ connection: updatedConnection.connection, config: integration });
             }
 
-            res.status(201).send({
-                ...req.body,
-                connection_id: connectionId
-            });
+            // Not wrapper-based, so the claim is made inline rather than compiler-enforced.
+            res.status(201).send(
+                claimAudit<ConnectionCreateAudit>(
+                    res,
+                    { ...req.body, connection_id: connectionId },
+                    {
+                        operation: updatedConnection?.operation ?? 'unknown',
+                        connectionId: updatedConnection?.connection.connection_id ?? connectionId,
+                        providerConfigKey: provider_config_key
+                    }
+                )
+            );
         } catch (err) {
             next(err);
         }

--- a/packages/server/lib/controllers/connection/postConnection.ts
+++ b/packages/server/lib/controllers/connection/postConnection.ts
@@ -28,10 +28,10 @@ import {
     endUserSchema,
     webhookUrlSchema
 } from '../../helpers/validation.js';
-import { noteConnectionUpsert } from '../../hooks/auditConnection.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated, connectionCreationStartCapCheck, connectionRefreshSuccess, testConnectionCredentials } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { claimAudit } from '../../utils/audited.js';
 
 import type { AuthOperationType, ConnectionConfig, ConnectionUpsertResponse, EndUser, PostPublicConnection, ProviderGithubApp } from '@nangohq/types';
 
@@ -435,15 +435,6 @@ export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnec
         return;
     }
 
-    noteConnectionUpsert(req, {
-        operation: updatedConnection.operation as unknown as AuthOperationType,
-        connectionId: updatedConnection.connection.connection_id,
-        providerConfigKey: body.provider_config_key,
-        account: { id: account.id, uuid: account.uuid },
-        environment: { id: environment.id, name: environment.name },
-        endUser: undefined
-    });
-
     if (updatedConnection.operation === 'override') {
         await connectionRefreshSuccess({ connection: updatedConnection.connection, config: integration });
     }
@@ -484,13 +475,21 @@ export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnec
     await logCtx.success();
 
     res.status(201).send(
-        connectionFullToPublicApi({
-            data: connection,
-            credentials: connection.credentials,
-            provider: providerName,
-            activeLog: [],
-            endUser: endUser ? EndUserMapper.to(endUser) : null,
-            includeCredentials: true
-        })
+        claimAudit<PostPublicConnection>(
+            res,
+            connectionFullToPublicApi({
+                data: connection,
+                credentials: connection.credentials,
+                provider: providerName,
+                activeLog: [],
+                endUser: endUser ? EndUserMapper.to(endUser) : null,
+                includeCredentials: true
+            }),
+            {
+                operation: updatedConnection.operation as unknown as AuthOperationType,
+                connectionId: updatedConnection.connection.connection_id,
+                providerConfigKey: body.provider_config_key
+            }
+        )
     );
 });

--- a/packages/server/lib/controllers/mcp/audit.ts
+++ b/packages/server/lib/controllers/mcp/audit.ts
@@ -4,7 +4,7 @@ import { audit } from '../../audit.js';
 import { canRecordAuditTrail } from '../../utils/auditTrail.js';
 
 import type { AuditEvent } from '@nangohq/audit';
-import type { AuditAttribution, AuditOutcome, AuditPolicy, AuditTarget, DBEnvironment, DBPlan, DBTeam } from '@nangohq/types';
+import type { AnyAuditPolicy, AuditAttribution, AuditOutcome, AuditTarget, DBEnvironment, DBPlan, DBTeam } from '@nangohq/types';
 
 const logger = getLogger('Server.ManagementMcpAudit');
 
@@ -22,7 +22,7 @@ export function recordManagementMcpAudit({
     environment: DBEnvironment;
     plan: DBPlan | null;
     auditContext: AuditAttribution;
-    policy: AuditPolicy;
+    policy: AnyAuditPolicy;
     outcome: AuditOutcome;
     target?: AuditTarget | AuditTarget[] | undefined;
     metadata?: Record<string, unknown> | undefined;

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -35,7 +35,7 @@ import { errorToObject, metrics, stringifyError } from '@nangohq/utils';
 
 import { OAuth1Client } from '../clients/oauth1.client.js';
 import publisher from '../clients/publisher.client.js';
-import { noteConnectionUpsert, recordConnectionCreated } from '../hooks/auditConnection.js';
+import { recordConnectionCreated } from '../hooks/auditConnection.js';
 import { handleValidateConnectionFailure, validateConnection } from '../hooks/connection/on/validate-connection.js';
 import {
     connectionCreated as connectionCreatedHook,
@@ -45,6 +45,7 @@ import {
 import { getConnectSession } from '../services/connectSession.service.js';
 import oAuthSessionService from '../services/oauth-session.service.js';
 import { requireEnvironment } from '../utils/asyncWrapper.js';
+import { claimConnectionUpsert } from '../utils/audited.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveOutboundWebhookUrlOverride } from '../utils/auth.js';
 import { hmacCheck } from '../utils/hmac.js';
 import { authHtml } from '../utils/html.js';
@@ -589,13 +590,10 @@ class OAuthController {
             await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id, connectionName: updatedConnection.connection.connection_id });
             void logCtx.info('OAuth2 client credentials creation was successful');
             await logCtx.success();
-            noteConnectionUpsert(req, {
+            claimConnectionUpsert(res, {
                 operation: updatedConnection.operation,
                 connectionId: updatedConnection.connection.connection_id,
-                providerConfigKey: updatedConnection.connection.provider_config_key,
-                account: { id: account.id, uuid: account.uuid },
-                environment: { id: environment.id, name: environment.name },
-                endUser: res.locals.endUser
+                providerConfigKey: updatedConnection.connection.provider_config_key
             });
 
             void connectionCreatedHook(
@@ -1420,7 +1418,7 @@ class OAuthController {
         const tags = connectSession?.connectSession.tags;
 
         const connCreatedHook = (upsertResult: ConnectionUpsertResponse) => {
-            noteConnectionUpsert(res.req, {
+            claimConnectionUpsert(res, {
                 operation: upsertResult.operation,
                 connectionId: upsertResult.connection.connection_id,
                 providerConfigKey: upsertResult.connection.provider_config_key,
@@ -1706,7 +1704,6 @@ class OAuthController {
     ) {
         // Entered twice: from the OAuth callback, which has a response and so a route middleware to record
         // the event, and from a provider webhook (a Sentry install), which has neither.
-        const auditRequest = res?.req;
         const markUpsert = (upserted: ConnectionUpsertResponse, endUser: InternalEndUser | undefined) => {
             const upsert = {
                 operation: upserted.operation as unknown as AuthOperationType,
@@ -1716,8 +1713,15 @@ class OAuthController {
                 environment: { id: environment.id, name: environment.name },
                 endUser
             };
-            if (auditRequest) {
-                noteConnectionUpsert(auditRequest, upsert);
+            if (res) {
+                claimConnectionUpsert(res, {
+                    operation: upsert.operation,
+                    connectionId: upsert.connectionId,
+                    providerConfigKey: upsert.providerConfigKey,
+                    account: { id: account.id, uuid: account.uuid },
+                    environment: { id: environment.id, name: environment.name },
+                    endUser
+                });
                 return;
             }
             void recordConnectionCreated({ ...upsert, auditAttribution: { kind: 'no-attribution', reason: 'provider webhook' } });
@@ -2238,7 +2242,7 @@ class OAuthController {
         });
 
         await logCtx.enrichOperation({ connectionId: updatedConnection.connection.id, connectionName: updatedConnection.connection.connection_id });
-        noteConnectionUpsert(req, {
+        claimConnectionUpsert(res, {
             operation: updatedConnection.operation,
             connectionId: updatedConnection.connection.connection_id,
             providerConfigKey: updatedConnection.connection.provider_config_key,
@@ -2413,13 +2417,10 @@ class OAuthController {
                 });
                 const initiateSync = true;
                 const runPostConnectionScript = true;
-                noteConnectionUpsert(req, {
+                claimConnectionUpsert(res, {
                     operation: updatedConnection.operation,
                     connectionId: updatedConnection.connection.connection_id,
-                    providerConfigKey: updatedConnection.connection.provider_config_key,
-                    account: { id: account.id, uuid: account.uuid },
-                    environment: { id: environment.id, name: environment.name },
-                    endUser: connectSession?.connectSession.endUser ?? undefined
+                    providerConfigKey: updatedConnection.connection.provider_config_key
                 });
 
                 void connectionCreatedHook(
@@ -2459,6 +2460,8 @@ class OAuthController {
                     metadata: {
                         ...metadata,
                         providerConfigKey: session.providerConfigKey,
+                        account: { id: account.id, uuid: account.uuid },
+                        environment: { id: environment.id, name: environment.name },
                         connectionId: session.connectionId
                     }
                 });
@@ -2594,13 +2597,10 @@ class OAuthController {
             }
 
             if (updatedConnection) {
-                noteConnectionUpsert(req, {
+                claimConnectionUpsert(res, {
                     operation: updatedConnection.operation,
                     connectionId: updatedConnection.connection.connection_id,
-                    providerConfigKey: updatedConnection.connection.provider_config_key,
-                    account: { id: account.id, uuid: account.uuid },
-                    environment: { id: environment.id, name: environment.name },
-                    endUser: connectSession?.connectSession.endUser ?? undefined
+                    providerConfigKey: updatedConnection.connection.provider_config_key
                 });
 
                 void connectionCreatedHook(
@@ -2641,6 +2641,8 @@ class OAuthController {
                 environmentId: session.environmentId,
                 metadata: {
                     providerConfigKey: session.providerConfigKey,
+                    account: { id: account.id, uuid: account.uuid },
+                    environment: { id: environment.id, name: environment.name },
                     connectionId: session.connectionId
                 }
             });

--- a/packages/server/lib/controllers/v1/account/managed/auth.ts
+++ b/packages/server/lib/controllers/v1/account/managed/auth.ts
@@ -3,6 +3,7 @@ import { acceptInvitation, accountService, expirePreviousInvitations, getInvitat
 import { basePublicUrl, flagHasUsage, nanoid, report } from '@nangohq/utils';
 
 import { envs } from '../../../../env.js';
+import { claimAppAuth } from '../../../../utils/audited.js';
 import { linkBillingCustomer, linkBillingFreeSubscription } from '../../../../utils/billing.js';
 import { loginOrStartPendingMfa } from '../mfa/login.js';
 
@@ -223,6 +224,9 @@ export async function finalizeManagedAuthentication({
 
     try {
         const pendingMfa = await loginOrStartPendingMfa(req, user, destination);
+        if (!pendingMfa) {
+            claimAppAuth(res, { authenticated: true });
+        }
         if (pendingMfa) {
             respondWithSuccess(res, `${basePublicUrl}/signin/mfa`, responseMode);
             return;
@@ -233,7 +237,7 @@ export async function finalizeManagedAuthentication({
         return;
     }
 
-    req.audit = { ...req.audit, managedSignup: isNewUser };
+    claimAppAuth(res, { signup: isNewUser });
 
     respondWithSuccess(res, `${basePublicUrl}${destination}`, responseMode);
 }

--- a/packages/server/lib/controllers/v1/account/managed/auth.ts
+++ b/packages/server/lib/controllers/v1/account/managed/auth.ts
@@ -224,13 +224,11 @@ export async function finalizeManagedAuthentication({
 
     try {
         const pendingMfa = await loginOrStartPendingMfa(req, user, destination);
-        if (!pendingMfa) {
-            claimAppAuth(res, { authenticated: true });
-        }
         if (pendingMfa) {
             respondWithSuccess(res, `${basePublicUrl}/signin/mfa`, responseMode);
             return;
         }
+        claimAppAuth(res, { authenticated: true });
     } catch (err) {
         report(err);
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to login' } });

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -80,7 +80,6 @@ async function loginUser(req: Request, user: DBUser): Promise<void> {
                 reject(err instanceof Error ? err : new Error(String(err)));
                 return;
             }
-            req.audit = { ...req.audit, authSucceeded: true };
             resolve();
         });
     });

--- a/packages/server/lib/controllers/v1/account/signin.ts
+++ b/packages/server/lib/controllers/v1/account/signin.ts
@@ -5,6 +5,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { userToAPI } from '../../../formatters/user.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { claimAppAuth } from '../../../utils/audited.js';
 import { loginOrStartPendingMfa } from './mfa/login.js';
 import { safeReturnTo } from './returnTo.js';
 
@@ -69,6 +70,9 @@ export const signin = asyncWrapper<PostSignin>(async (req, res: Response<any, Re
 
     const destination = resolvePostLoginDestination(user, req.body.returnTo);
     const pendingMfa = await loginOrStartPendingMfa(req, user, destination);
+    if (!pendingMfa) {
+        claimAppAuth(res, { authenticated: true });
+    }
     if (pendingMfa) {
         res.status(200).send({ data: { mfaRequired: true } });
         return;

--- a/packages/server/lib/controllers/v1/account/signin.ts
+++ b/packages/server/lib/controllers/v1/account/signin.ts
@@ -5,7 +5,6 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { userToAPI } from '../../../formatters/user.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
-import { claimAppAuth } from '../../../utils/audited.js';
 import { loginOrStartPendingMfa } from './mfa/login.js';
 import { safeReturnTo } from './returnTo.js';
 
@@ -70,9 +69,6 @@ export const signin = asyncWrapper<PostSignin>(async (req, res: Response<any, Re
 
     const destination = resolvePostLoginDestination(user, req.body.returnTo);
     const pendingMfa = await loginOrStartPendingMfa(req, user, destination);
-    if (!pendingMfa) {
-        claimAppAuth(res, { authenticated: true });
-    }
     if (pendingMfa) {
         res.status(200).send({ data: { mfaRequired: true } });
         return;

--- a/packages/server/lib/express.d.ts
+++ b/packages/server/lib/express.d.ts
@@ -4,31 +4,8 @@ declare global {
          * You should avoid using this type (req.user)
          * It's serialized in session, which means we can't easily add / remove fields
          */
-        /**
-         * Facts only a handler can know, for the audit middleware to act on at finish: whether a managed
-         * callback created the user or logged one back in, whether this request established a session, and
-         * what a connection upsert did. One namespace rather than an attribute per scenario.
-         *
-         * On the request rather than `res.locals` for two reasons: the connection controllers shadow `res`
-         * with the upsert response, so the response is not reachable where the fact is known; and two
-         * creation routes type it as `Response<any, any>`, which would leave those writes unchecked.
-         */
-        interface AuditFacts {
-            managedSignup?: boolean;
-            authSucceeded?: boolean;
-            connectionUpsert?: {
-                operation: import('@nangohq/types').AuthOperationType;
-                connectionId: string;
-                providerConfigKey: string;
-                account: { id: number; uuid: string };
-                environment: { id: number; name: string };
-                endUser?: import('@nangohq/types').InternalEndUser | null | undefined;
-            };
-        }
 
-        interface Request {
-            audit?: AuditFacts;
-        }
+        interface Request {}
 
         interface User {
             id: number;

--- a/packages/server/lib/hooks/auditConnection.integration.test.ts
+++ b/packages/server/lib/hooks/auditConnection.integration.test.ts
@@ -6,7 +6,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import db from '@nangohq/database';
 import * as featureFlags from '@nangohq/feature-flags';
 import { logContextGetter } from '@nangohq/logs';
-import { seeders } from '@nangohq/shared';
+import { connectionService, githubAppClient, seeders } from '@nangohq/shared';
+import { Ok } from '@nangohq/utils';
 
 import { audit } from '../audit.js';
 import oAuthSessionService from '../services/oauth-session.service.js';
@@ -223,6 +224,104 @@ describe('connection.created — live-stack contract', () => {
             outcome: 'success',
             actor: { type: 'connect_session', id: 'end-user-1', display: 'buyer@customer.com' },
             targets: [{ type: 'connection', id: res.json.connectionId }]
+        });
+    });
+    // OAuth2 client credentials: a claim-owing route with no compile-time enforcement, so this test is the
+    // guarantee that it keeps reporting what the upsert did.
+    it('records an OAuth2 client-credentials creation', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser({ plan: { has_audit_trail_control_plane: true } });
+        const config = await seeders.createConfigSeed(env, '8x8', '8x8');
+
+        const session = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: { end_user: { id: 'cc-end-user', email: 'cc@customer.com' } }
+        });
+        isSuccess(session.json);
+
+        // The provider is the only part of the flow we cannot run for real.
+        vi.spyOn(connectionService, 'getOauthClientCredentials').mockResolvedValue({
+            success: true,
+            error: null,
+            response: {
+                type: 'OAUTH2_CC',
+                token: 'a-cc-token',
+                client_id: 'a-client',
+                client_secret: 'a-secret',
+                expires_at: new Date(Date.now() + 3600_000),
+                raw: {}
+            }
+        } as never);
+
+        // A session token forbids a caller-supplied connection_id, so the route generates it — which is
+        // exactly why the id has to come from the handler's claim.
+        const res = await fetch(`${api.url}/oauth2/auth/${config.unique_key}?connect_session_token=${session.json.data.token}`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ client_id: 'a-client', client_secret: 'a-secret' })
+        });
+        expect(res.status, await res.clone().text()).toBe(200);
+        const { connectionId } = (await res.json()) as { connectionId: string };
+
+        await vi.waitFor(() => {
+            expect(auditEvent('connection', 'created')).toBeDefined();
+        });
+        expect(auditEvent('connection', 'created')).toMatchObject({
+            resource: 'connection',
+            action: 'created',
+            outcome: 'success',
+            targets: [{ type: 'connection', id: connectionId }],
+            metadata: { providerConfigKey: config.unique_key, operation: 'creation' }
+        });
+    });
+    // The GitHub App install: answers the browser, so there is no body to brand and this test is the only
+    // thing standing between a forgotten claim and a silent hole in the trail.
+    it('records a GitHub App installation', async () => {
+        const { account, env } = await seeders.seedAccountEnvAndUser({ plan: { has_audit_trail_control_plane: true } });
+        const config = await seeders.createConfigSeed(env, 'github-app', 'github-app', {
+            oauth_client_id: 'an-app-id',
+            oauth_client_secret: Buffer.from('a-private-key').toString('base64'),
+            app_link: 'https://github.com/apps/an-app'
+        });
+
+        const logCtx = await logContextGetter.create({ operation: { type: 'auth', action: 'create_connection' } }, { account, environment: env });
+        const state = randomUUID();
+        await oAuthSessionService.create({
+            id: state,
+            providerConfigKey: config.unique_key,
+            provider: 'github-app',
+            connectionId: 'app-install-conn',
+            callbackUrl: `${api.url}/app-auth/connect`,
+            authMode: 'APP',
+            connectSessionId: null,
+            connectionConfig: {},
+            webhookUrlOverride: null,
+            environmentId: env.id,
+            webSocketClientId: undefined,
+            activityLogId: logCtx.id,
+            codeVerifier: 'code-verifier',
+            requestTokenSecret: null,
+            createdAt: new Date(),
+            updatedAt: new Date()
+        });
+
+        // The provider is the only part of the flow we cannot run for real.
+        vi.spyOn(githubAppClient, 'createCredentials').mockResolvedValue(
+            Ok({ type: 'APP', access_token: 'an-app-token', expires_at: new Date(Date.now() + 3600_000), raw: {} }) as never
+        );
+
+        const res = await fetch(`${api.url}/app-auth/connect?state=${state}&installation_id=42&setup_action=install`, { redirect: 'manual' });
+        expect(res.status, await res.clone().text()).toBeLessThan(400);
+
+        await vi.waitFor(() => {
+            expect(auditEvent('connection', 'created')).toBeDefined();
+        });
+        expect(auditEvent('connection', 'created')).toMatchObject({
+            resource: 'connection',
+            action: 'created',
+            outcome: 'success',
+            targets: [{ type: 'connection', id: 'app-install-conn' }],
+            metadata: { providerConfigKey: config.unique_key, operation: 'creation' }
         });
     });
 });

--- a/packages/server/lib/hooks/auditConnection.ts
+++ b/packages/server/lib/hooks/auditConnection.ts
@@ -5,7 +5,6 @@ import { canRecordAuditTrailForAccount } from '../utils/auditTrail.js';
 
 import type { AuditActor, AuditAttribution, AuditEvent, NoAttribution } from '@nangohq/audit';
 import type { AuthOperationType, InternalEndUser } from '@nangohq/types';
-import type { Request } from 'express';
 
 const logger = getLogger('Audit');
 
@@ -61,16 +60,4 @@ export async function recordConnectionCreated(params: {
     } catch (err) {
         logger.error(`failed to emit connection.created audit event`, err);
     }
-}
-
-/**
- * A request can upsert more than once — a CUSTOM OAuth install completes with a second upsert whose
- * operation is `override` — so a creation already recorded this request is never downgraded, or the route
- * audit would drop the event it exists to record.
- */
-export function noteConnectionUpsert(req: Request, upsert: NonNullable<Express.AuditFacts['connectionUpsert']>): void {
-    if (req.audit?.connectionUpsert?.operation === 'creation' && upsert.operation !== 'creation') {
-        return;
-    }
-    req.audit = { ...req.audit, connectionUpsert: upsert };
 }

--- a/packages/server/lib/hooks/auditConnection.unit.test.ts
+++ b/packages/server/lib/hooks/auditConnection.unit.test.ts
@@ -2,10 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { flags } from '@nangohq/utils';
 
-import { noteConnectionUpsert, recordConnectionCreated } from './auditConnection.js';
+import { claimConnectionUpsert } from '../utils/audited.js';
+import { recordConnectionCreated } from './auditConnection.js';
 
 import type * as AuditModule from '../audit.js';
-import type { Request } from 'express';
+import type { RequestLocals } from '../utils/express.js';
+import type { AuthOperationType, ConnectionAuthClaim } from '@nangohq/types';
+import type { Response } from 'express';
 
 const recordMock = vi.hoisted(() => vi.fn());
 vi.mock('../audit.js', async (importOriginal) => {
@@ -129,33 +132,28 @@ describe('recordConnectionCreated (hook-side emitter, unit)', () => {
     });
 });
 
-describe('noteConnectionUpsert', () => {
-    const upsert = (operation: 'creation' | 'override') => ({
-        operation: operation as never,
-        connectionId: 'conn-1',
-        providerConfigKey: 'github',
-        account: { id: 1, uuid: 'uuid-1' },
-        environment: { id: 2, name: 'dev' }
-    });
+describe('claimConnectionUpsert', () => {
+    const res = () => ({ locals: {} }) as unknown as Response<any, RequestLocals>;
+    const claim = (operation: AuthOperationType): ConnectionAuthClaim => ({ operation, connectionId: 'conn-1', providerConfigKey: 'github' });
 
     it('records what the handler reports', () => {
-        const req = {} as Request;
-        noteConnectionUpsert(req, upsert('creation'));
-        expect(req.audit?.connectionUpsert?.operation).toBe('creation');
+        const target = res();
+        claimConnectionUpsert(target, claim('creation'));
+        expect(target.locals.auditClaim).toMatchObject({ operation: 'creation', connectionId: 'conn-1', providerConfigKey: 'github' });
     });
 
-    // A CUSTOM OAuth install completes with a second upsert that reports `override`; letting it win would
-    // drop the creation the route audit exists to record.
+    // A CUSTOM OAuth install upserts twice in one request; the second must not turn the row into a
+    // re-authorization.
     it('does not let a later override erase a creation from the same request', () => {
-        const req = {} as Request;
-        noteConnectionUpsert(req, upsert('creation'));
-        noteConnectionUpsert(req, upsert('override'));
-        expect(req.audit?.connectionUpsert?.operation).toBe('creation');
+        const target = res();
+        claimConnectionUpsert(target, claim('creation'));
+        claimConnectionUpsert(target, claim('override'));
+        expect(target.locals.auditClaim).toMatchObject({ operation: 'creation' });
     });
 
     it('still records an override when that is all the request did', () => {
-        const req = {} as Request;
-        noteConnectionUpsert(req, upsert('override'));
-        expect(req.audit?.connectionUpsert?.operation).toBe('override');
+        const target = res();
+        claimConnectionUpsert(target, claim('override'));
+        expect(target.locals.auditClaim).toMatchObject({ operation: 'override' });
     });
 });

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -11,10 +11,13 @@ import type { RequestLocals } from '../utils/express.js';
 import type { AuditActor, AuditAttribution, AuditContext, AuditEvent, AuditOutcome, AuditTarget, AuditTargetType, MfaVerifiedMetadata } from '@nangohq/audit';
 import type {
     AcceptInvite,
+    AnyAuditPolicy,
     AuditActionOf,
+    AuditClaimOf,
     AuditPolicy,
     AuditResource,
     AuditScope,
+    ConnectionAuthClaim,
     CreateAccountApiKey,
     CreateApiKey,
     DeclineInvite,
@@ -89,7 +92,7 @@ const logger = getLogger('Audit');
 
 type AuditRequest<TEndpoint extends Endpoint<any>> = Request<TEndpoint['Params'], TEndpoint['Reply'], TEndpoint['Body'], TEndpoint['Querystring']>;
 
-type AuditableEndpoint = Endpoint<any> & { Audit: AuditPolicy };
+type AuditableEndpoint = Endpoint<any> & { Audit: AnyAuditPolicy };
 
 const Audit = {
     auditable: <R extends AuditResource, A extends AuditActionOf<R>, S extends AuditScope>(policy: {
@@ -198,7 +201,7 @@ async function resolveDisplay(target: AuditTargetType, lookup: () => Promise<str
 }
 
 async function emit(
-    policy: AuditPolicy,
+    policy: AnyAuditPolicy,
     req: Request,
     res: Response,
     resolved: ResolvedAudit | undefined,
@@ -264,38 +267,34 @@ export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<T
 }
 
 /**
- * For an endpoint that only sometimes does the audited thing — a connection upsert that may have
- * re-authorized rather than created. `skipWhen` is read at finish, so it sees what the handler recorded on
- * the request, and it is deliberately a negative condition: the default stays "emit", so a denial or a
- * failure is still recorded and only the named case is dropped.
- *
- * A separate factory rather than a field on `AuditSpec`, so `auditable`'s promise to record every outcome
- * cannot be weakened one spec at a time.
+ * For an endpoint whose subject, actor or target are only known once the handler has run: an unauthenticated
+ * callback has no `res.locals` for the middleware to resolve them from, so they come from the claim at finish.
+ * Every outcome is still recorded, exactly as with `auditable`.
  */
-export function maybeAuditable<TEndpoint extends AuditableEndpoint>(
+export function auditableAtFinish<TEndpoint extends AuditableEndpoint>(
     spec: AuditSpec<TEndpoint> & {
-        skipWhen: (req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>) => boolean;
-        subject: (req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>) => AuditSubject | undefined;
-        actor?: ((req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>) => AuditActor) | undefined;
+        subject: (req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>, claim: AuditClaimOf<TEndpoint> | undefined) => AuditSubject | undefined;
+        actor?: ((req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>, claim: AuditClaimOf<TEndpoint> | undefined) => AuditActor) | undefined;
+        action?: ((claim: AuditClaimOf<TEndpoint> | undefined) => TEndpoint['Audit']['action']) | undefined;
         // `target`/`metadata` are resolved before the handler runs and `*FromResponse` needs a JSON body, so
         // neither can read what the handler recorded — and the OAuth callback answers with HTML. This fills
         // whatever is still missing, at finish, from the request.
-        atFinish?: (req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>) => ResolvedAudit;
+        atFinish?: (req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>, claim: AuditClaimOf<TEndpoint> | undefined) => ResolvedAudit;
     }
 ): RequestHandler {
-    const { skipWhen, atFinish, subject, actor, ...rest } = spec;
-    return build(rest as AuditSpec<TEndpoint>, { skipWhen, atFinish, subject, actor });
+    const { atFinish, subject, actor, action, ...rest } = spec;
+    return build(rest as AuditSpec<TEndpoint>, { atFinish, subject, actor, action });
 }
 
 function build<TEndpoint extends AuditableEndpoint>(
     spec: AuditSpec<TEndpoint>,
     conditional?: {
-        skipWhen: (req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>) => boolean;
-        atFinish?: ((req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>) => ResolvedAudit) | undefined;
+        atFinish?: ((req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>, claim: AuditClaimOf<TEndpoint> | undefined) => ResolvedAudit) | undefined;
+        action?: ((claim: AuditClaimOf<TEndpoint> | undefined) => TEndpoint['Audit']['action']) | undefined;
         // Who the event belongs to, read at finish. `auditable` takes this from `res.locals` before the
         // handler runs, which an unauthenticated route cannot supply.
-        subject: (req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>) => AuditSubject | undefined;
-        actor?: ((req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>) => AuditActor) | undefined;
+        subject: (req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>, claim: AuditClaimOf<TEndpoint> | undefined) => AuditSubject | undefined;
+        actor?: ((req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>, claim: AuditClaimOf<TEndpoint> | undefined) => AuditActor) | undefined;
     }
 ): RequestHandler {
     return (req, res, next) => {
@@ -309,21 +308,20 @@ function build<TEndpoint extends AuditableEndpoint>(
                     res.on('finish', () => {
                         void (async () => {
                             const typedReq = req as AuditRequest<TEndpoint>;
-                            if (conditional.skipWhen(typedReq, locals)) {
-                                return;
-                            }
-                            const subject = conditional.subject(typedReq, locals);
+                            const claim = locals.auditClaim as AuditClaimOf<TEndpoint> | undefined;
+                            const subject = conditional.subject(typedReq, locals, claim);
                             if (!subject || !(await canRecordAuditTrail(subject.account.uuid, await auditedAccountPlan(subject.account, locals)))) {
                                 return;
                             }
+                            const action = conditional.action?.(claim);
                             await emit(
-                                spec.policy,
+                                action ? { ...spec.policy, action } : spec.policy,
                                 req,
                                 res,
-                                conditional.atFinish?.(typedReq, locals),
+                                conditional.atFinish?.(typedReq, locals, claim),
                                 subject.account,
                                 subject.environment,
-                                conditional.actor?.(typedReq, locals)
+                                conditional.actor?.(typedReq, locals, claim)
                             );
                         })();
                     });
@@ -572,29 +570,28 @@ export const auditTrailQueried = auditable<GetAuditTrail>({
  * A re-authorization is skipped: it upserts through the same endpoints and answers the same 200.
  * `connection.reauthorized` exists in the vocabulary if we ever want it, and it belongs here.
  */
-export const auditConnectionCreated = maybeAuditable<Endpoint<any> & { Audit: AuditPolicy<'connection', 'created', 'environment'> }>({
+export const auditConnectionCreated = auditableAtFinish<
+    Endpoint<any> & { Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim> }
+>({
     policy: Audit.auditable({ resource: 'connection', action: 'created', scope: 'environment' }),
-    skipWhen: (req) => req.audit?.connectionUpsert?.operation === 'override',
-    subject: (req, locals) => {
-        const upsert = req.audit?.connectionUpsert;
-        if (upsert) {
-            return { account: upsert.account, environment: upsert.environment };
+    // No claim means the request never reached the upsert — a denial or a failure. It records as an attempted
+    // creation, with the metadata saying the operation is unknown rather than the row asserting one.
+    action: (claim) => (claim?.operation === 'override' ? 'reauthorized' : 'created'),
+    // An unauthenticated callback has no locals to read the account from; a denial there has neither.
+    subject: (_req, locals, claim) =>
+        claim?.account
+            ? { account: claim.account, environment: claim.environment }
+            : locals.account
+              ? { account: locals.account, environment: locals.environment }
+              : undefined,
+    actor: (_req, locals, claim) => connectionCreatedActor(resolveActor(locals), claim?.endUser ?? locals.endUser),
+    atFinish: (_req, _locals, claim) => ({
+        target: makeTarget('connection', claim?.connectionId),
+        metadata: {
+            ...(claim?.providerConfigKey ? { providerConfigKey: claim.providerConfigKey } : {}),
+            operation: claim?.operation ?? 'unknown'
         }
-        // Nothing was created, so this is a denial or a failure, and the account comes from the request
-        // instead. An attempt on an unauthenticated route has neither, and one nobody can be attributed to
-        // is not worth a row.
-        return locals.account ? { account: locals.account, environment: locals.environment } : undefined;
-    },
-    // The request wins when it proves who called; a connect session's end user reaches an unauthenticated
-    // callback only through the handler, so it fills the gap the request leaves.
-    actor: (req, locals) => connectionCreatedActor(resolveActor(locals), req.audit?.connectionUpsert?.endUser),
-    atFinish: (req) => {
-        const upsert = req.audit?.connectionUpsert;
-        return {
-            target: makeTarget('connection', upsert?.connectionId),
-            metadata: upsert?.providerConfigKey ? { providerConfigKey: upsert.providerConfigKey } : undefined
-        };
-    }
+    })
 });
 
 export const auditPublicConnectionUpdated = auditable<PatchPublicConnection>({

--- a/packages/server/lib/middleware/auditAuth.middleware.ts
+++ b/packages/server/lib/middleware/auditAuth.middleware.ts
@@ -8,8 +8,10 @@ import { audit } from '../audit.js';
 import { canRecordAuditTrail } from '../utils/auditTrail.js';
 import { contextFromRequest, outcomeFromStatus } from './audit.middleware.js';
 
+import type { RequestLocals } from '../utils/express.js';
 import type { AppAuthLoginMethod, AuditActor, AuditEvent, AuditOutcome } from '@nangohq/audit';
 import type {
+    AppAuthClaim,
     DBTeam,
     DBUser,
     Endpoint,
@@ -40,7 +42,7 @@ type AuthRequest<TEndpoint extends Endpoint<any>> = Request<TEndpoint['Params'],
 type PrincipalResolver<TEndpoint extends Endpoint<any>> = (req: AuthRequest<TEndpoint>) => Promise<AuthPrincipal | null>;
 // The SSO callback resolves login vs signup only at request time (a first sign-in creates the user),
 // so the action can be a function of the request rather than a fixed value.
-type AuthActionResolver<TEndpoint extends Endpoint<any>> = AuthAction | ((req: AuthRequest<TEndpoint>) => AuthAction);
+type AuthActionResolver = AuthAction | ((claim: AppAuthClaim | undefined) => AuthAction);
 
 // Interface (not an intersection, which widens `Body` back to `any`) so `req.body.email` stays typed.
 interface EmailBodyEndpoint extends Endpoint<any> {
@@ -51,7 +53,6 @@ interface AuthAuditOptions {
     recordNonSuccess?: boolean;
     method?: AppAuthLoginMethod;
     // These routes can't be classified by status (the SSO callback replies 302 on both success and
-    // failure). Success is instead signaled by the controller setting req.audit?.authSucceeded when
     // req.login actually established a session this request — not by a pre-existing session's req.user.
     sessionOutcome?: boolean;
 }
@@ -85,7 +86,7 @@ async function principalFromSessionUser(req: Request): Promise<AuthPrincipal | n
 }
 
 async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
-    actionOrResolver: AuthActionResolver<TEndpoint>,
+    actionOrResolver: AuthActionResolver,
     resolve: PrincipalResolver<TEndpoint>,
     options: AuthAuditOptions,
     req: AuthRequest<TEndpoint>,
@@ -94,13 +95,14 @@ async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
     // Stamp occurredAt now so it reflects the response time, not audit-write latency.
     const occurredAt = new Date().toISOString();
     try {
-        const action = typeof actionOrResolver === 'function' ? actionOrResolver(req) : actionOrResolver;
+        const claim = (res.locals as Partial<RequestLocals>).auditClaim as AppAuthClaim | undefined;
+        const action = typeof actionOrResolver === 'function' ? actionOrResolver(claim) : actionOrResolver;
         let outcome: AuditOutcome;
         if (options.sessionOutcome) {
-            // Only a login this request actually established (req.login → req.audit?.authSucceeded) is a
-            // success. Without it, req.user may just be a pre-existing session, so a failed attempt by an
-            // already-signed-in user would otherwise be recorded as a successful login for that user.
-            if (!req.audit?.authSucceeded) {
+            // Only a login this request actually established (the handler's claim) is a success. Without it,
+            // req.user may just be a pre-existing session, so a failed attempt by an already-signed-in user
+            // would otherwise be recorded as a successful login for that user.
+            if (!claim?.authenticated) {
                 return;
             }
             outcome = 'success';
@@ -152,7 +154,7 @@ async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
 }
 
 function auditAuth<TEndpoint extends Endpoint<any>>(
-    action: AuthActionResolver<TEndpoint>,
+    action: AuthActionResolver,
     resolve: PrincipalResolver<TEndpoint>,
     options: AuthAuditOptions = {}
 ): RequestHandler {
@@ -169,16 +171,15 @@ function auditAuth<TEndpoint extends Endpoint<any>>(
 export const auditAuthLogin = auditAuth<PostSignin>('login', principalFromBodyEmail, { recordNonSuccess: true, method: 'local' });
 
 // Session-establishing routes: the controller authenticates then req.login, so the actor is the session user and success comes from sessionOutcome.
-export const auditAuthManagedCallback = auditAuth<GetManagedCallback>((req) => (req.audit?.managedSignup ? 'signup' : 'login'), principalFromSessionUser, {
+export const auditAuthManagedCallback = auditAuth<GetManagedCallback>((claim) => (claim?.signup ? 'signup' : 'login'), principalFromSessionUser, {
     sessionOutcome: true,
     method: 'sso'
 });
 
-export const auditAuthManagedVerification = auditAuth<PostManagedEmailVerification>(
-    (req) => (req.audit?.managedSignup ? 'signup' : 'login'),
-    principalFromSessionUser,
-    { sessionOutcome: true, method: 'managed' }
-);
+export const auditAuthManagedVerification = auditAuth<PostManagedEmailVerification>((claim) => (claim?.signup ? 'signup' : 'login'), principalFromSessionUser, {
+    sessionOutcome: true,
+    method: 'managed'
+});
 
 export const auditAuthSignup = auditAuth<PostSignup>('signup', principalFromBodyEmail);
 

--- a/packages/server/lib/middleware/auditAuth.middleware.ts
+++ b/packages/server/lib/middleware/auditAuth.middleware.ts
@@ -12,6 +12,7 @@ import type { RequestLocals } from '../utils/express.js';
 import type { AppAuthLoginMethod, AuditActor, AuditEvent, AuditOutcome } from '@nangohq/audit';
 import type {
     AppAuthClaim,
+    AuditClaimOf,
     DBTeam,
     DBUser,
     Endpoint,
@@ -42,7 +43,7 @@ type AuthRequest<TEndpoint extends Endpoint<any>> = Request<TEndpoint['Params'],
 type PrincipalResolver<TEndpoint extends Endpoint<any>> = (req: AuthRequest<TEndpoint>) => Promise<AuthPrincipal | null>;
 // The SSO callback resolves login vs signup only at request time (a first sign-in creates the user),
 // so the action can be a function of the request rather than a fixed value.
-type AuthActionResolver = AuthAction | ((claim: AppAuthClaim | undefined) => AuthAction);
+type AuthActionResolver<TEndpoint extends Endpoint<any>> = AuthAction | ((claim: AuditClaimOf<TEndpoint> | undefined) => AuthAction);
 
 // Interface (not an intersection, which widens `Body` back to `any`) so `req.body.email` stays typed.
 interface EmailBodyEndpoint extends Endpoint<any> {
@@ -86,7 +87,7 @@ async function principalFromSessionUser(req: Request): Promise<AuthPrincipal | n
 }
 
 async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
-    actionOrResolver: AuthActionResolver,
+    actionOrResolver: AuthActionResolver<TEndpoint>,
     resolve: PrincipalResolver<TEndpoint>,
     options: AuthAuditOptions,
     req: AuthRequest<TEndpoint>,
@@ -95,7 +96,7 @@ async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
     // Stamp occurredAt now so it reflects the response time, not audit-write latency.
     const occurredAt = new Date().toISOString();
     try {
-        const claim = (res.locals as Partial<RequestLocals>).auditClaim as AppAuthClaim | undefined;
+        const claim = (res.locals as Partial<RequestLocals>).auditClaim as (AuditClaimOf<TEndpoint> & AppAuthClaim) | undefined;
         const action = typeof actionOrResolver === 'function' ? actionOrResolver(claim) : actionOrResolver;
         let outcome: AuditOutcome;
         if (options.sessionOutcome) {
@@ -154,7 +155,7 @@ async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
 }
 
 function auditAuth<TEndpoint extends Endpoint<any>>(
-    action: AuthActionResolver,
+    action: AuthActionResolver<TEndpoint>,
     resolve: PrincipalResolver<TEndpoint>,
     options: AuthAuditOptions = {}
 ): RequestHandler {

--- a/packages/server/lib/utils/asyncWrapper.ts
+++ b/packages/server/lib/utils/asyncWrapper.ts
@@ -4,14 +4,28 @@ import tracer from 'dd-trace';
 
 import { metrics, report } from '@nangohq/utils';
 
+import type { Claimed } from './audited.js';
 import type { RequestLocals, RequestLocalsWithEnvironment } from './express.js';
-import type { DBEnvironment, Endpoint } from '@nangohq/types';
+import type { AuditClaimOf, DBEnvironment, Endpoint } from '@nangohq/types';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+// `unknown` arm first: `AuditClaimOf<any>` widens to `unknown`, so without it every `asyncWrapper<any>`
+// handler would look like it owes a claim and lose its success body.
+type ClaimRequired<TEndpoint> = unknown extends AuditClaimOf<TEndpoint> ? false : AuditClaimOf<TEndpoint> extends never ? false : true;
+
+/**
+ * When the endpoint's audit policy declares a claim, its success body is only accepted in the branded form
+ * `claimAudit` returns, so a success that says nothing about what happened does not compile. Errors are
+ * untouched, and no response method is withdrawn.
+ */
+type AuditedBody<TEndpoint extends Endpoint<any>> =
+    ClaimRequired<TEndpoint> extends true ? Exclude<TEndpoint['Reply'], TEndpoint['Success']> | Claimed<TEndpoint['Success']> : TEndpoint['Reply'];
+type EndpointResponse<TEndpoint extends Endpoint<any>, Locals extends Record<string, any>> = Response<AuditedBody<TEndpoint>, Locals>;
 
 export function asyncWrapper<TEndpoint extends Endpoint<any>, Locals extends Record<string, any> = RequestLocals>(
     fn: (
         req: Request<TEndpoint['Params'], TEndpoint['Reply'], TEndpoint['Body'], TEndpoint['Querystring']>,
-        res: Response<TEndpoint['Reply'], Locals>,
+        res: EndpointResponse<TEndpoint, Locals>,
         next: NextFunction
     ) => Promise<void> | void
 ): RequestHandler<any, TEndpoint['Reply'], any, any, any> {
@@ -28,11 +42,11 @@ export function asyncWrapper<TEndpoint extends Endpoint<any>, Locals extends Rec
         }
 
         if (isAsyncFunction(fn)) {
-            return (fn(req, res, next) as unknown as Promise<any>).catch((err: unknown) => {
+            return (fn(req, res as EndpointResponse<TEndpoint, Locals>, next) as unknown as Promise<any>).catch((err: unknown) => {
                 next(err);
             });
         } else {
-            return fn(req, res, next);
+            return fn(req, res as EndpointResponse<TEndpoint, Locals>, next);
         }
     };
 }
@@ -44,7 +58,7 @@ export function asyncWrapper<TEndpoint extends Endpoint<any>, Locals extends Rec
 export function asyncWrapperWithEnvironment<TEndpoint extends Endpoint<any>>(
     fn: (
         req: Request<TEndpoint['Params'], TEndpoint['Reply'], TEndpoint['Body'], TEndpoint['Querystring']>,
-        res: Response<TEndpoint['Reply'], RequestLocalsWithEnvironment>,
+        res: EndpointResponse<TEndpoint, RequestLocalsWithEnvironment>,
         next: NextFunction
     ) => Promise<void> | void
 ): RequestHandler<any, TEndpoint['Reply'], any, any, any> {
@@ -54,7 +68,7 @@ export function asyncWrapperWithEnvironment<TEndpoint extends Endpoint<any>>(
             return;
         }
 
-        await fn(req, res as Response<TEndpoint['Reply'], RequestLocalsWithEnvironment>, next);
+        await fn(req, res as EndpointResponse<TEndpoint, RequestLocalsWithEnvironment>, next);
     });
 }
 

--- a/packages/server/lib/utils/audited.ts
+++ b/packages/server/lib/utils/audited.ts
@@ -1,0 +1,52 @@
+import type { RequestLocals } from './express.js';
+import type { AnyAuditPolicy, AppAuthClaim, AuditClaimOf, AuditPolicy, ConnectionAuthClaim, ConnectionCreateAudit } from '@nangohq/types';
+import type { Response } from 'express';
+
+declare const claimed: unique symbol;
+
+// Merged, not replaced: an auth route learns whether it authenticated in one place and whether it was a
+// first sign-in in another, so two calls contribute to one claim.
+function mergeClaim(res: Response<any, RequestLocals>, claim: unknown): void {
+    res.locals.auditClaim = { ...(res.locals.auditClaim as object | undefined), ...(claim as object) };
+}
+
+/** A success body that carries its audit claim. Only `claimAudit` can produce one. */
+export type Claimed<TBody> = TBody & { readonly [claimed]: true };
+
+interface AuditedEndpoint {
+    Success: unknown;
+    Audit: AnyAuditPolicy;
+}
+
+/**
+ * Call it at the send, not where the fact first becomes known: a connection rejected by validate-connection is
+ * hard-deleted, so claiming any earlier records a creation that no longer exists. The type enforces that a
+ * claim is made, never where.
+ */
+export function claimAudit<TEndpoint extends AuditedEndpoint>(
+    res: Response<any, RequestLocals>,
+    body: TEndpoint['Success'],
+    claim: AuditClaimOf<TEndpoint>
+): Claimed<TEndpoint['Success']> {
+    mergeClaim(res, claim);
+    return body as Claimed<TEndpoint['Success']>;
+}
+
+/** For a response with no body to brand — a redirect, or HTML — so nothing forces the call. */
+function claimUnbranded<TEndpoint extends AuditedEndpoint>(res: Response<any, any>, claim: AuditClaimOf<TEndpoint>): void {
+    // These routes are typed `Response<any, any>`, so the locals are narrowed here rather than at the call.
+    mergeClaim(res as Response<any, RequestLocals>, claim);
+}
+
+/**
+ * One request can upsert twice — a CUSTOM OAuth install creates, then overrides — and the second report must
+ * not turn the row into a re-authorization. Creation is sticky for that reason.
+ */
+export function claimConnectionUpsert(res: Response<any, any>, claim: ConnectionAuthClaim): void {
+    const existing = (res.locals as RequestLocals).auditClaim as ConnectionAuthClaim | undefined;
+    claimUnbranded<ConnectionCreateAudit>(res, existing?.operation === 'creation' ? { ...claim, operation: 'creation' } : claim);
+}
+
+export function claimAppAuth(res: Response<any, any>, claim: AppAuthClaim): void {
+    claimUnbranded<{ Success: unknown; Audit: AuditPolicy<'app_auth', 'login' | 'signup', 'account', AppAuthClaim> }>(res, claim);
+}

--- a/packages/server/lib/utils/express.ts
+++ b/packages/server/lib/utils/express.ts
@@ -34,6 +34,9 @@ export interface RequestLocals {
     agentSession: AgentSession;
     user: DBUser;
 
+    // `unknown` because Locals is shared by every route; the audit middleware narrows it from the policy.
+    auditClaim?: unknown;
+
     // Set only by some auth paths, so a handler must check before use.
     environment?: DBEnvironment;
     endUser?: InternalEndUser | null;

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -1,6 +1,6 @@
 import type { AccountApiKeyScope } from '../api-keys/scopes.js';
 import type { ApiEndpoint, ApiError } from '../api.js';
-import type { AuditPolicy } from '../audit-trail/event.js';
+import type { AppAuthClaim, AuditPolicy } from '../audit-trail/event.js';
 import type { MFACredential } from '../mfa/credential.js';
 import type { ApiUser } from '../user/api.js';
 
@@ -206,7 +206,7 @@ export type GetManagedEmailVerification = ApiEndpoint<{
 export type PostManagedEmailVerification = ApiEndpoint<{
     // Establishes a session (login, or signup when a new user is created); the emitted action is
     // resolved at runtime, so the policy declares both.
-    Audit: AuditPolicy<'app_auth', 'login' | 'signup', 'account'>;
+    Audit: AuditPolicy<'app_auth', 'login' | 'signup', 'account', AppAuthClaim>;
     Method: 'POST';
     Path: '/api/v1/account/managed/verification';
     Body: {
@@ -223,7 +223,7 @@ export type PostManagedEmailVerification = ApiEndpoint<{
 export type GetManagedCallback = ApiEndpoint<{
     // SSO callback establishes a session (login, or signup when a new user is created); the emitted
     // action is resolved at runtime, so the policy declares both.
-    Audit: AuditPolicy<'app_auth', 'login' | 'signup', 'account'>;
+    Audit: AuditPolicy<'app_auth', 'login' | 'signup', 'account', AppAuthClaim>;
     Method: 'GET';
     Path: '/api/v1/login/callback';
     Querystring: {

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -6,7 +6,7 @@ export type AuditOutcome = 'success' | 'failure' | 'denied';
 export type AuditInterface = 'api' | 'mcp';
 
 interface AuditEventTable {
-    connection: 'created' | 'updated' | 'metadata_updated' | 'refreshed' | 'deleted';
+    connection: 'created' | 'reauthorized' | 'updated' | 'metadata_updated' | 'refreshed' | 'deleted';
     sync: 'enabled' | 'disabled' | 'paused' | 'started' | 'triggered' | 'cancelled' | 'frequency_changed' | 'variant_created' | 'variant_deleted';
     function: 'deployed' | 'upgraded' | 'deleted';
     integration: 'created' | 'updated' | 'deleted';
@@ -70,17 +70,39 @@ export interface NoAttribution {
 // decision — a customer endpoint cannot be added without consciously opting in or out. The policy's
 // resource/action/scope are captured as type parameters so the endpoint's declaration and the
 // middleware spec that services it are checked against each other by the compiler.
-export interface AuditPolicy<R extends AuditResource = AuditResource, A extends AuditActionOf<R> = AuditActionOf<R>, S extends AuditScope = AuditScope> {
+export interface AuditPolicy<
+    R extends AuditResource = AuditResource,
+    A extends AuditActionOf<R> = AuditActionOf<R>,
+    S extends AuditScope = AuditScope,
+    Claim = never
+> {
     kind: 'audit';
     resource: R;
     action: A;
     scope: S;
+    /** Phantom, never constructed: `never` leaves the handler's signature alone, anything else obliges it. */
+    claim?: Claim;
 }
+
+export type AuditClaimOf<TEndpoint> = TEndpoint extends { Audit: AuditPolicy<AuditResource, AuditActionOf<AuditResource>, AuditScope, infer Claim> }
+    ? Claim
+    : never;
+
+/**
+ * What an auth route owes the audit middleware: whether this request actually established a session (the SSO
+ * callback answers 302 either way) and whether it was a first sign-in rather than a return visit.
+ */
+export interface AppAuthClaim {
+    authenticated?: boolean;
+    signup?: boolean;
+}
+
+export type AnyAuditPolicy = AuditPolicy<AuditResource, AuditActionOf<AuditResource>, AuditScope, unknown>;
 export interface NoAudit<Reason extends string = 'non-auditable'> {
     kind: 'no-audit';
     reason: Reason;
 }
-export type EndpointAudit = AuditPolicy | NoAudit<string>;
+export type EndpointAudit = AnyAuditPolicy | NoAudit<string>;
 
 // `type`, not `interface`: an interface has no implicit index signature and so fails the pub/sub
 // Serializable payload constraint.

--- a/packages/types/lib/auth/http.api.ts
+++ b/packages/types/lib/auth/http.api.ts
@@ -1,5 +1,22 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 import type { AuditPolicy } from '../audit-trail/event.js';
+import type { InternalEndUser } from '../endUser/index.js';
+import type { AuthOperationType } from './api.js';
+
+export interface ConnectionAuthClaim {
+    operation: AuthOperationType;
+    connectionId: string;
+    providerConfigKey: string;
+    account?: { id: number; uuid: string } | undefined;
+    environment?: { id: number; name: string } | undefined;
+    endUser?: InternalEndUser | null | undefined;
+}
+
+/** For the legacy connection routes, which have no `ApiEndpoint` declaration to read a policy from. */
+export interface ConnectionCreateAudit {
+    Success: unknown;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
+}
 
 export type ConnectionQueryString = {
     connection_id?: string | undefined;
@@ -52,7 +69,7 @@ type AuthErrors =
     | ApiError<'connection_validation_failed'>;
 
 export type PostPublicApiKeyAuthorization = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Body: {
         apiKey: string;
@@ -67,7 +84,7 @@ export type PostPublicApiKeyAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicBasicAuthorization = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Body: {
         username: string;
@@ -83,7 +100,7 @@ export type PostPublicBasicAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicTbaAuthorization = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Body: {
         token_id: string;
@@ -102,7 +119,7 @@ export type PostPublicTbaAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicJwtAuthorization = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Body: Record<string, any>;
     Querystring: ConnectionQueryString;
@@ -115,7 +132,7 @@ export type PostPublicJwtAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicUnauthenticatedAuthorization = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Querystring: ConnectionQueryString;
     Params: {
@@ -127,7 +144,7 @@ export type PostPublicUnauthenticatedAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicBillAuthorization = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Body: {
         username: string;
@@ -145,7 +162,7 @@ export type PostPublicBillAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicTwoStepAuthorization = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Body: Record<string, any>;
     Querystring: ConnectionQueryString;
@@ -158,7 +175,7 @@ export type PostPublicTwoStepAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicSignatureAuthorization = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Body: {
         username: string;
@@ -183,7 +200,7 @@ type AwsSigV4AuthErrors =
     | ApiError<'aws_sigv4_sts_request_failed'>;
 
 export type PostPublicAwsSigV4Authorization = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Body: {
         role_arn: string;
@@ -199,7 +216,7 @@ export type PostPublicAwsSigV4Authorization = ApiEndpoint<{
 }>;
 
 export type PostPublicOauthOutboundAuthorization = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Body: {
         username: string;

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -9,6 +9,7 @@ import type {
     OAuth2Credentials,
     TbaCredentials
 } from '../../auth/api.js';
+import type { ConnectionAuthClaim } from '../../auth/http.api.js';
 import type { EndUserInput } from '../../connect/api.js';
 import type { Tags } from '../../db.js';
 import type { ApiEndUser } from '../../endUser/index.js';
@@ -84,7 +85,7 @@ export type GetPublicConnections = ApiEndpoint<{
 }>;
 
 export type PostPublicConnection = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'created', 'environment'>;
+    Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>;
     Method: 'POST';
     Path: '/connections';
     Body: {

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -8,7 +8,7 @@ import type { AuditAction, AuditActionOf, AuditEventKey, AuditResource } from '@
  * step by the checks below, as `apiKeyScopes` does in `@nangohq/utils`.
  */
 const actionsByResource = {
-    connection: ['created', 'updated', 'metadata_updated', 'refreshed', 'deleted'],
+    connection: ['created', 'reauthorized', 'updated', 'metadata_updated', 'refreshed', 'deleted'],
     sync: ['enabled', 'disabled', 'paused', 'started', 'triggered', 'cancelled', 'frequency_changed', 'variant_created', 'variant_deleted'],
     function: ['deployed', 'upgraded', 'deleted'],
     integration: ['created', 'updated', 'deleted'],


### PR DESCRIPTION
**Draft, for a first reaction on the approach rather than a merge.** It answers one of the three friction points behind your "the auditing code is getting complicated" note; the other two are separate and listed at the bottom.

- **The controller → middleware coupling is now a typed claim instead of a fact bag.** `req.audit` — a flat optional object any of 16 controllers could write any field of — is deleted. What a handler owes the middleware is declared on the endpoint's own audit policy, as a fourth type parameter, and an endpoint that declares one *cannot answer with its success body* unless it supplies it. A handler that forgets to say what it did is a compile error rather than a missing row.
- **A connection override is no longer invisible.** The operation now comes from the handler that knows it, so a re-authorization records as `connection.reauthorized` instead of being dropped. Before this, an override left no row when it succeeded and was recorded as a *denied creation* when it was refused — so counting denied creations included denied overrides.
- **Net −13 lines**, and `req` is no longer mutated anywhere for auditing.

## The rule this establishes — the part worth agreeing on first

One sentence generates the rest: **the claim is the set of facts your audit row loses when the request is refused.** No handler runs on a 403, so anything living only in the claim is missing from exactly the rows an auditor cares most about. That makes "keep the claim small" a consequence rather than a preference, and it orders the three places an event's data can come from:

1. **The request first** — `params`, `query`, `body`. Typed by the endpoint contract, needs nothing from the handler, and present on denials and failures too. This is where 52 of the 66 specs get everything they need; if a value is readable here, read it here.
2. **The response body second**, via `targetFromResponse`, when the value is in the endpoint's declared `Success`. Still contract-typed, but it only exists on success, so a denial row goes without it.
3. **The claim last**, and only for what neither can supply. In practice four cases, all of which this PR hit: the value is generated server-side and not derivable from the request (a `connection_id` the caller omitted); the response cannot carry it (a 302 or HTML); the fact is not a value in the payload at all (*which* of two actions happened, whether a session was established); or the route has no auth middleware, so even the subject is handler knowledge.

Two corollaries, both learned the hard way here:

- **Do not duplicate into the claim what the request already has** — but check the whole family first. I kept `providerConfigKey` off the claim on exactly that basis, and it turned out to sit in `params` for the per-auth-mode routes and in the *body* for `/connections`. If a value is not in the same place on every route in the family, the handler is the only uniform source.
- **Claim at the send, not where the fact first becomes known.** A connection rejected by `validate-connection` is hard-deleted, so claiming any earlier records a creation that no longer exists. The type enforces *that* a claim is made, never *where*.

One question I would rather settle with you than decide: whether the subject (account/environment) belongs in a claim at all, or whether the two unauthenticated callbacks should be made to populate `res.locals` like every other route. They are the only reason the claim carries a subject today, and it is the field most likely to be misused by a future route that does have locals.

## How the enforcement works

The policy gains a phantom fourth parameter, so `Audit: AuditPolicy<'connection', 'created' | 'reauthorized', 'environment', ConnectionAuthClaim>` is the only thing an endpoint author writes. From there it is derived: a type extracts the claim back out, a predicate turns it into a boolean, and the boolean swaps the success member of the handler's response-body union for a branded form that only `claimAudit` can produce. Express's own `send(body?: ResBody)` does the refusing, so no response method is taken away — `send`, `json` and `jsonp` all still work, they just need a body that carries a claim.

It is entirely compile-time: the emitted JS for the wrapper is unchanged. Endpoints that declare no claim — 105 `no-audit` plus every other audited one — keep byte-identical typing, so this is opt-in per endpoint and migrates one route at a time.

**The second rule, for the routes a type cannot reach:** a claim-owing route that answers the browser has no body to brand, so the guarantee there is a test — *every claim-owing route that cannot be enforced needs an integration test asserting the event it records*. That is now true rather than aspirational: the two that had no such test, the GitHub App install and the OAuth2 client-credentials route, have one, and each was verified to go red with its claim removed. 11 of 17 claim-owing routes are enforced by the compiler; the remaining 6 are held by tests.

## Where it is deliberately not enforced

The routes that answer the browser have no body to brand: `/oauth/callback`, `/app-auth/connect`, the SSO callback, the deprecated `POST /connection`. They call a named helper per family (`claimConnectionUpsert`, `claimAppAuth`) which records the claim without any compile-time obligation. The naming is meant to make that gap visible rather than uniform-looking.

## Two things I would rather you pushed back on early

- **The denial row is still a guess.** With no handler run there is no claim, so a refused upsert records as an attempted `created` with `operation: 'unknown'` in the metadata. The honest fix is probably that those 15 routes are *authorize* endpoints and created-vs-override is an outcome rather than an identity — one action, operation as metadata, success and denial symmetric. That is a vocabulary change with a rollout question, so it is not in here.
- **`unknown` or `any` in the claim slot silently disables enforcement**, because the predicate has to treat `unknown` as "no claim" (`AuditClaimOf<any>` widens to `unknown`). `Claim extends object = never` closes it; I left it out so the mechanism is easy to read.

## Not in this PR

The mount is still hand-written and unrelated to the declared policy — 82 endpoints declare a policy, 78 mounts exist, and nothing ties them together, which is where the three mount bugs in #7146 came from. The deprecated `POST /connection` has no `ApiEndpoint` type at all, so its policy exists only on the mount. And the five duplicated gate → build → record → log tails belong to #6980.

## Test plan

- [x] Every existing audit assertion still holds: 632 server unit, 1682 integration, lint and format clean.
- [x] Verified the enforcement bites: replacing `claimAudit` with a plain `res.status(200).send(body)` fails to compile, and removing the fourth type parameter makes it compile again.
- [x] Restored the three cases that guarded "a later override must not erase a creation from the same request" — a CUSTOM OAuth install upserts twice — against the new helper, and confirmed the key one goes red without the rule.
- [x] Pinned `operation: 'unknown'` on the denial path, and confirmed that assertion goes red without it.
- [ ] Not covered: no test asserts that an endpoint declaring a claim cannot be mounted without one — that is pillar 1's job.
