### PR TITLE
docs: start MDX body headings at H2

### DIFF
--- a/.agents/skills/creating-integration-docs/SKILL.md
+++ b/.agents/skills/creating-integration-docs/SKILL.md
@@ -1,25 +1,33 @@
 ---
 name: creating-integration-docs
-description: Use when adding documentation for a new Nango integration - creates main page, setup guide, and updates docs.json and providers.yaml following established patterns
+description: Use when adding or editing Nango integration documentation - creates and maintains integration pages, setup guides, connect guides, navigation, and provider metadata following established patterns
 ---
 
 # Creating Integration Documentation
 
 ## Overview
 
-Create documentation for new Nango integrations following the established structure: main integration page with 4-step quickstart, separate setup guide, and proper configuration in docs.json and providers.yaml.
+Create and maintain Nango integration documentation following the established structure: main integration page with 4-step quickstart, separate setup guide, optional connect guide, and proper configuration in docs.json and providers.yaml.
 
 ## When to Use
 
 - Adding documentation for a brand new integration
 - Creating docs for an integration that doesn't exist yet
 - User asks to "add docs for [integration]" or "create documentation for [integration]"
+- Editing an existing integration's main page, setup guide, or connect guide
 
 ## When NOT to Use
 
 - Migrating existing docs (use nango-docs-migrator agent instead)
-- Editing existing integration docs
 - General documentation changes
+
+## Docs Conventions
+
+`docs/AGENTS.md` is the source of truth for site-wide docs conventions and applies to every page this skill creates or edits. The rules that bite most often on integration pages:
+
+- **Start body headings at H2** — the frontmatter `title` is the page's only H1, so `connect.mdx` and setup guides open at `## Overview`, never `# Overview`.
+- **Sentence case** for titles, sidebar titles, and headings.
+- **Run `mintlify broken-links` from `docs/`** after any change to headings, page paths, or internal links, and confirm `success no broken links found`.
 
 ## Quick Reference
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -67,6 +67,22 @@ Generated docs output must stay out of link-only PRs unless the user explicitly 
 
 When guiding readers to a tab in the Nango dashboard, reference the tab by its visible name instead of linking to a dashboard URL. Dashboard URLs include the environment, and that environment is not predictable across accounts.
 
+## Start body headings at H2
+
+Mintlify renders the frontmatter `title` as the page's only H1. Never add an H1 (`# Heading`) to an MDX body — it produces a second H1, which breaks the document outline for screen readers and SEO. Body sections start at `##` and nest from there without skipping a level.
+
+Do not repeat the page title as a body heading either. If a page opens with a heading that restates its `title`, delete the heading rather than demoting it.
+
+After creating or editing docs pages, scan the files you touched:
+
+```bash
+rg -n '^# ' <changed-mdx-files>
+```
+
+Every hit is either a body H1 to fix or a `#` comment inside a fenced code block, which must be left alone. When demoting a heading that has `##` children, demote the children too so the hierarchy stays intact.
+
+Heading anchors are derived from heading text, not level, so changing a heading's level keeps its anchor. Deleting or retitling one does not — see the link validation section above.
+
 ## Never use `{#anchor}` heading-id syntax
 
 Mintlify's MDX parser treats `{...}` as a JavaScript expression and chokes on `#` inside it. A single `## Heading {#anchor}` anywhere in the docs aborts `mintlify broken-links` for the **entire site** before it can scan for actual broken links.


### PR DESCRIPTION
## Why

Mintlify renders the frontmatter `title` as a page's only H1. An `# H1` in the MDX body therefore produces a **second H1**, which breaks the document outline for screen readers and hurts SEO.

There are currently ~600 pages with this problem, almost all of them integration `connect.mdx` guides. This PR lands the convention and closes the authoring hole that kept reintroducing it. The bulk content fix follows in separate PRs so this decision can be reviewed on its own.

## What

**`docs/AGENTS.md`** — new "Start body headings at H2" section:

- Body sections start at `##` and nest without skipping a level.
- A heading that restates the page `title` gets **deleted**, not demoted.
- How to scan changed pages, and that a `#` inside a fenced code block is not a violation.
- Heading anchors derive from heading **text**, not level — so changing a level is anchor-safe, while deleting or retitling a heading is not.

**`.agents/skills/creating-integration-docs/SKILL.md`**:

- Points at `docs/AGENTS.md` as the source of truth for site-wide conventions, and calls out the three rules that bite most often on integration pages (H2 start, sentence case, `mintlify broken-links`).
- Widens scope to cover **editing** existing integration pages. Editing was previously listed under "When NOT to Use", which is how these H1s kept getting introduced — the skill was only consulted when creating a page.

## Review notes

Guidance only. No docs pages change, so the rendered site is unaffected by this PR.

Not auto-approved by `auto-approve-docs` because `SKILL.md` lives outside `docs/` — this one wants a human read, since it's the convention decision itself.

## Follow-ups

1. Mechanical `# Overview` → `## Overview` across ~583 `connect.mdx` files (anchor-safe, no generated-file change).
2. Heading-hierarchy fixes on core pages and 8 integration pages, including 3 anchor-affecting changes, plus the `llms-full.txt` regeneration.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

