### PR TITLE
chore: postInvocation create a orchestrator task

### DIFF
--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -9,7 +9,7 @@ import { Ok, stringifyError } from '@nangohq/utils';
 import { envs } from '../env.js';
 import { handleSyncSuccess, startSync } from './sync.js';
 
-import type { TaskAbort, TaskAction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
+import type { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
 import type { ReturnedRecord, UnencryptedRecordData } from '@nangohq/records';
 import type { Sync, Job as SyncJob } from '@nangohq/shared';
 import type { ConnectionJobs, DBSyncConfig, SyncResult } from '@nangohq/types';
@@ -211,7 +211,8 @@ const runJob = async (
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
-        isAbort: (): this is TaskAbort => false
+        isAbort: (): this is TaskAbort => false,
+        isFunction: (): this is TaskFunction => false
     };
     const nangoProps = await startSync(task, mockStartScript);
     if (nangoProps.isErr()) {

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -20,6 +20,8 @@ import type {
     ClientError,
     ExecuteActionProps,
     ExecuteAsyncReturn,
+    ExecuteFunctionProps,
+    ExecuteFunctionReturn,
     ExecuteOnEventProps,
     ExecuteProps,
     ExecuteReturn,
@@ -310,6 +312,43 @@ export class OrchestratorClient {
             }
         };
         return this.immediate(schedulingProps);
+    }
+
+    public async executeFunction(props: ExecuteFunctionProps): Promise<ExecuteFunctionReturn> {
+        const { args, ...rest } = props;
+        const schedulingProps: ImmediateProps = {
+            ...rest,
+            retry: { count: props.retry?.count || 0, max: props.retry?.max || 0 },
+            timeoutSettingsInSecs: args.async
+                ? {
+                      createdToStarted: 24 * 60 * 60, // async function invocations must start within 24h after being created
+                      startedToCompleted: 15 * 60, // async function invocations have 15 minutes to complete
+                      heartbeat: 2 * 60
+                  }
+                : {
+                      createdToStarted: 30,
+                      startedToCompleted: 2 * 60, // synchronous invocations have 2 minutes to complete
+                      heartbeat: 60
+                  },
+            args: {
+                ...args,
+                type: 'function' as const
+            }
+        };
+
+        if (args.async) {
+            const res = await this.immediate(schedulingProps);
+            if (res.isErr()) {
+                return Err(res.error);
+            }
+            return Ok({ kind: 'scheduled', taskId: res.value.taskId, retryKey: res.value.retryKey });
+        }
+
+        const res = await this.immediateAndWait(schedulingProps);
+        if (res.isErr()) {
+            return Err(res.error);
+        }
+        return Ok({ kind: 'completed', output: res.value });
     }
 
     private buildWebhookSchedulingProps(props: ExecuteWebhookProps) {

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -20,6 +20,8 @@ import type {
     ClientError,
     ExecuteActionProps,
     ExecuteAsyncReturn,
+    ExecuteFunctionProps,
+    ExecuteFunctionReturn,
     ExecuteOnEventProps,
     ExecuteProps,
     ExecuteReturn,
@@ -310,6 +312,43 @@ export class OrchestratorClient {
             }
         };
         return this.immediate(schedulingProps);
+    }
+
+    public async executeFunction(props: ExecuteFunctionProps): Promise<ExecuteFunctionReturn> {
+        const { args, ...rest } = props;
+        const schedulingProps: ImmediateProps = {
+            retry: { count: props.retry?.count || 0, max: props.retry?.max || 0 },
+            ...rest,
+            timeoutSettingsInSecs: args.async
+                ? {
+                      createdToStarted: 24 * 60 * 60, // async function invocations must start within 24h after being created
+                      startedToCompleted: 15 * 60, // async function invocations have 15 minutes to complete
+                      heartbeat: 2 * 60
+                  }
+                : {
+                      createdToStarted: 30,
+                      startedToCompleted: 2 * 60, // synchronous invocations have 2 minutes to complete
+                      heartbeat: 60
+                  },
+            args: {
+                ...args,
+                type: 'function' as const
+            }
+        };
+
+        if (args.async) {
+            const res = await this.immediate(schedulingProps);
+            if (res.isErr()) {
+                return Err(res.error);
+            }
+            return Ok({ kind: 'scheduled', taskId: res.value.taskId, retryKey: res.value.retryKey });
+        }
+
+        const res = await this.immediateAndWait(schedulingProps);
+        if (res.isErr()) {
+            return Err(res.error);
+        }
+        return Ok({ kind: 'completed', output: res.value });
     }
 
     private buildWebhookSchedulingProps(props: ExecuteWebhookProps) {

--- a/packages/orchestrator/lib/clients/client.unit.test.ts
+++ b/packages/orchestrator/lib/clients/client.unit.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { OrchestratorClient } from './client.js';
 
-import type { ExecuteWebhookProps, ImmediateProps } from './types.js';
+import type { ExecuteFunctionProps, ExecuteWebhookProps, ImmediateProps } from './types.js';
 
 function buildImmediateRequest(): ImmediateProps {
     return {
@@ -117,6 +117,84 @@ function buildWebhookProps(name: string): ExecuteWebhookProps {
         }
     };
 }
+
+function buildFunctionProps(async: boolean): ExecuteFunctionProps {
+    return {
+        name: 'function-task-1',
+        group: { key: 'function:environment:456:connection:123:function:my-function', maxConcurrency: 0 },
+        retry: { count: 0, max: 2 },
+        args: {
+            functionName: 'my-function',
+            connection: {
+                id: 123,
+                connection_id: 'connection-1',
+                provider_config_key: 'provider-config-key-1',
+                environment_id: 456
+            },
+            activityLogId: 'activity-log-1',
+            input: { foo: 'bar' },
+            async
+        }
+    };
+}
+
+describe('OrchestratorClient executeFunction', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('invoke a function task and waits for its output when not async', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ taskId: 'task-1', retryKey: 'retry-key-1' }), { status: 200, headers: { 'content-type': 'application/json' } })
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ state: 'SUCCEEDED', output: { ok: true } }), { status: 200, headers: { 'content-type': 'application/json' } })
+            );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const client = new OrchestratorClient({ baseUrl: 'http://orchestrator.test' });
+        const res = await client.executeFunction(buildFunctionProps(false));
+
+        expect(res.isOk()).toBe(true);
+        if (res.isOk()) {
+            expect(res.value).toEqual({ kind: 'completed', output: { ok: true } });
+        }
+
+        const [url, init] = fetchMock.mock.calls[0] as [string, { body: string }];
+        expect(url).toBe('http://orchestrator.test/v1/immediate');
+        const body = JSON.parse(init.body);
+        expect(body.args).toMatchObject({ type: 'function', functionName: 'my-function', async: false });
+        expect(body.timeoutSettingsInSecs).toEqual({ createdToStarted: 30, startedToCompleted: 2 * 60, heartbeat: 60 });
+    });
+
+    it('schedules a function task without waiting', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(
+                new Response(JSON.stringify({ taskId: 'task-1', retryKey: 'retry-key-1' }), { status: 200, headers: { 'content-type': 'application/json' } })
+            );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const client = new OrchestratorClient({ baseUrl: 'http://orchestrator.test' });
+        const res = await client.executeFunction(buildFunctionProps(true));
+
+        expect(res.isOk()).toBe(true);
+        if (res.isOk()) {
+            expect(res.value).toEqual({ kind: 'scheduled', taskId: 'task-1', retryKey: 'retry-key-1' });
+        }
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        const [url, init] = fetchMock.mock.calls[0] as [string, { body: string }];
+        expect(url).toBe('http://orchestrator.test/v1/immediate');
+        const body = JSON.parse(init.body);
+        expect(body.args).toMatchObject({ type: 'function', functionName: 'my-function', async: true });
+        expect(body.retry).toEqual({ count: 0, max: 2 });
+        expect(body.timeoutSettingsInSecs).toEqual({ createdToStarted: 24 * 60 * 60, startedToCompleted: 15 * 60, heartbeat: 2 * 60 });
+    });
+});
 
 describe('OrchestratorClient executeWebhookBatch', () => {
     afterEach(() => {

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -50,6 +50,13 @@ interface OnEventArgs {
     activityLogId: string;
     sdkVersion: string | null;
 }
+interface FunctionArgs {
+    functionName: string;
+    connection: ConnectionJobs;
+    activityLogId: string;
+    input: JsonValue;
+    async: boolean;
+}
 export type SchedulesReturn = Result<OrchestratorSchedule[]>;
 export type VoidReturn = Result<void, ClientError>;
 export type ExecuteProps = SetOptional<ImmediateProps, 'retry' | 'timeoutSettingsInSecs'>;
@@ -58,6 +65,8 @@ export type ExecuteAsyncReturn = Result<{ taskId: string; retryKey: string }, Cl
 export type ExecuteActionProps = Omit<ExecuteProps, 'args'> & { args: ActionArgs };
 export type ExecuteWebhookProps = Omit<ExecuteProps, 'args'> & { args: WebhookArgs };
 export type ExecuteOnEventProps = Omit<ExecuteProps, 'args'> & { args: OnEventArgs };
+export type ExecuteFunctionProps = Omit<ExecuteProps, 'args'> & { args: FunctionArgs };
+export type ExecuteFunctionReturn = Result<{ kind: 'completed'; output: JsonValue } | { kind: 'scheduled'; taskId: string; retryKey: string }, ClientError>;
 export type ExecuteSyncProps = PostScheduleRun['Body'];
 
 export interface OrchestratorSchedule {
@@ -68,7 +77,7 @@ export interface OrchestratorSchedule {
     nextDueDate: Date | null;
 }
 
-export type OrchestratorTask = TaskSync | TaskSyncAbort | TaskAction | TaskWebhook | TaskOnEvent | TaskAbort;
+export type OrchestratorTask = TaskSync | TaskSyncAbort | TaskAction | TaskWebhook | TaskOnEvent | TaskAbort | TaskFunction;
 
 interface TaskCommonFields {
     id: string;
@@ -89,6 +98,7 @@ interface TaskCommon extends TaskCommonFields {
     isOnEvent(this: OrchestratorTask): this is TaskOnEvent;
     isSyncAbort(this: OrchestratorTask): this is TaskSyncAbort;
     isAbort(this: OrchestratorTask): this is TaskAbort;
+    isFunction(this: OrchestratorTask): this is TaskFunction;
 }
 export interface TaskAbort extends TaskCommon, AbortArgs {}
 export function TaskAbort(props: TaskCommonFields & AbortArgs): TaskAbort {
@@ -111,7 +121,8 @@ export function TaskAbort(props: TaskCommonFields & AbortArgs): TaskAbort {
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
-        isAbort: (): this is TaskAbort => true
+        isAbort: (): this is TaskAbort => true,
+        isFunction: (): this is TaskFunction => false
     };
 }
 
@@ -139,7 +150,8 @@ export function TaskSync(props: TaskCommonFields & SyncArgs & SyncExecutionArgs)
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
-        isAbort: (): this is TaskAbort => false
+        isAbort: (): this is TaskAbort => false,
+        isFunction: (): this is TaskFunction => false
     };
 }
 
@@ -168,7 +180,8 @@ export function TaskSyncAbort(props: TaskCommonFields & SyncArgs & AbortArgs): T
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => true,
-        isAbort: (): this is TaskAbort => false
+        isAbort: (): this is TaskAbort => false,
+        isFunction: (): this is TaskFunction => false
     };
 }
 
@@ -195,7 +208,8 @@ export function TaskAction(props: TaskCommonFields & ActionArgs): TaskAction {
         isAction: (): this is TaskAction => true,
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
-        isAbort: (): this is TaskAbort => false
+        isAbort: (): this is TaskAbort => false,
+        isFunction: (): this is TaskFunction => false
     };
 }
 
@@ -222,7 +236,8 @@ export function TaskWebhook(props: TaskCommonFields & WebhookArgs): TaskWebhook 
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
-        isAbort: (): this is TaskAbort => false
+        isAbort: (): this is TaskAbort => false,
+        isFunction: (): this is TaskFunction => false
     };
 }
 
@@ -250,7 +265,36 @@ export function TaskOnEvent(props: TaskCommonFields & OnEventArgs): TaskOnEvent 
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => true,
         isSyncAbort: (): this is TaskSyncAbort => false,
-        isAbort: (): this is TaskAbort => false
+        isAbort: (): this is TaskAbort => false,
+        isFunction: (): this is TaskFunction => false
+    };
+}
+
+export interface TaskFunction extends TaskCommon, FunctionArgs {}
+export function TaskFunction(props: TaskCommonFields & FunctionArgs): TaskFunction {
+    return {
+        id: props.id,
+        name: props.name,
+        state: props.state,
+        attempt: props.attempt,
+        retryKey: props.retryKey,
+        attemptMax: props.attemptMax,
+        functionName: props.functionName,
+        connection: props.connection,
+        activityLogId: props.activityLogId,
+        input: props.input,
+        groupKey: props.groupKey,
+        groupMaxConcurrency: props.groupMaxConcurrency,
+        ownerKey: props.ownerKey,
+        async: props.async,
+        heartbeatTimeoutSecs: props.heartbeatTimeoutSecs,
+        isSync: (): this is TaskSync => false,
+        isWebhook: (): this is TaskWebhook => false,
+        isAction: (): this is TaskAction => false,
+        isOnEvent: (): this is TaskOnEvent => false,
+        isSyncAbort: (): this is TaskSyncAbort => false,
+        isAbort: (): this is TaskAbort => false,
+        isFunction: (): this is TaskFunction => true
     };
 }
 

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -4,7 +4,7 @@ import { taskStates } from '@nangohq/scheduler';
 import { Err, Ok } from '@nangohq/utils';
 
 import { jsonSchema } from '../utils/validation.js';
-import { TaskAbort, TaskAction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from './types.js';
+import { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from './types.js';
 
 import type { OrchestratorSchedule, OrchestratorTask } from './types.js';
 import type { Schedule, Task } from '@nangohq/scheduler';
@@ -73,6 +73,14 @@ export const onEventArgsSchema = z.object({
     activityLogId: z.string(),
     ...commonSchemaArgsFields
 });
+export const functionArgsSchema = z.object({
+    type: z.literal('function'),
+    functionName: z.string().min(1),
+    activityLogId: z.string(),
+    input: jsonSchema,
+    async: z.boolean().optional().default(false),
+    ...commonSchemaArgsFields
+});
 
 const commonSchemaFields = {
     id: z.string().uuid(),
@@ -109,6 +117,10 @@ const webhookSchema = z.object({
 const onEventSchema = z.object({
     ...commonSchemaFields,
     payload: onEventArgsSchema
+});
+const functionSchema = z.object({
+    ...commonSchemaFields,
+    payload: functionArgsSchema
 });
 
 export function validateTask(task: Task): Result<OrchestratorTask> {
@@ -223,6 +235,28 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 sdkVersion: onEvent.data.payload.sdkVersion,
                 activityLogId: onEvent.data.payload.activityLogId,
                 heartbeatTimeoutSecs: onEvent.data.heartbeatTimeoutSecs
+            })
+        );
+    }
+    const func = functionSchema.safeParse(task);
+    if (func.success) {
+        return Ok(
+            TaskFunction({
+                id: func.data.id,
+                state: func.data.state,
+                name: func.data.name,
+                attempt: func.data.retryCount + 1,
+                attemptMax: func.data.retryMax + 1,
+                functionName: func.data.payload.functionName,
+                connection: func.data.payload.connection,
+                activityLogId: func.data.payload.activityLogId,
+                input: func.data.payload.input,
+                async: func.data.payload.async,
+                groupKey: func.data.groupKey,
+                groupMaxConcurrency: func.data.groupMaxConcurrency,
+                ownerKey: func.data.ownerKey,
+                retryKey: func.data.retryKey,
+                heartbeatTimeoutSecs: func.data.heartbeatTimeoutSecs
             })
         );
     }

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { isDuplicateTaskNameError } from '@nangohq/scheduler';
 import { validateRequest } from '@nangohq/utils';
 
-import { actionArgsSchema, onEventArgsSchema, syncAbortArgsSchema, syncArgsSchema, webhookArgsSchema } from '../../clients/validate.js';
+import { actionArgsSchema, functionArgsSchema, onEventArgsSchema, syncAbortArgsSchema, syncArgsSchema, webhookArgsSchema } from '../../clients/validate.js';
 
 import type { TaskType } from '../../types.js';
 import type { Scheduler } from '@nangohq/scheduler';
@@ -36,7 +36,7 @@ export const immediateTaskSchema = z
             startedToCompleted: z.number().int().positive(),
             heartbeat: z.number().int().positive()
         }),
-        args: z.discriminatedUnion('type', [syncArgsSchema, actionArgsSchema, webhookArgsSchema, onEventArgsSchema, syncAbortArgsSchema])
+        args: z.discriminatedUnion('type', [syncArgsSchema, actionArgsSchema, webhookArgsSchema, onEventArgsSchema, syncAbortArgsSchema, functionArgsSchema])
     })
     .strict();
 

--- a/packages/orchestrator/lib/routes/v1/postRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/postRecurring.ts
@@ -4,7 +4,6 @@ import { validateRequest } from '@nangohq/utils';
 
 import { syncArgsSchema } from '../../clients/validate.js';
 
-import type { TaskType } from '../../types.js';
 import type { Scheduler } from '@nangohq/scheduler';
 import type { ApiError, Endpoint } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
@@ -33,7 +32,7 @@ export type PostRecurring = Endpoint<{
             startedToCompleted: number;
             heartbeat: number;
         };
-        args: JsonObject & { type: TaskType };
+        args: JsonObject & { type: 'sync' };
     };
     Error: ApiError<'recurring_failed'>;
     Success: { scheduleId: string };

--- a/packages/orchestrator/lib/types.ts
+++ b/packages/orchestrator/lib/types.ts
@@ -1,2 +1,2 @@
-export const taskTypes = ['action', 'webhook', 'sync', 'on-event', 'abort'] as const;
+export const taskTypes = ['action', 'webhook', 'sync', 'on-event', 'abort', 'function'] as const;
 export type TaskType = (typeof taskTypes)[number];

--- a/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto';
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db from '@nangohq/database';
-import { customerKeyService, functionConfigService, seeders } from '@nangohq/shared';
+import { customerKeyService, functionConfigService, NangoError, Orchestrator, seeders } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
 
 import { runServer, shouldBeProtected } from '../../utils/tests.js';
 
@@ -71,7 +72,7 @@ async function seedFunction() {
         version: functionVersion()
     });
 
-    return { apiKey, connection, integration };
+    return { apiKey, connection, integration, env };
 }
 
 describe(`POST ${endpoint}`, () => {
@@ -81,6 +82,10 @@ describe(`POST ${endpoint}`, () => {
 
     afterAll(() => {
         api.server.close();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('should be protected', async () => {
@@ -199,8 +204,8 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should return forbidden when the function is disabled', async () => {
-        const { apiKey, connection, integration } = await seedFunction();
-        await db.knex('function_configs').where({ name: 'test-function' }).update({ enabled: false });
+        const { apiKey, connection, integration, env } = await seedFunction();
+        await db.knex('function_configs').where({ environment_id: env.id, name: 'test-function' }).update({ enabled: false });
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
@@ -254,8 +259,11 @@ describe(`POST ${endpoint}`, () => {
         });
     });
 
-    it('should return not implemented', async () => {
+    it('should schedule an orchestrator task for no_wait invocations', async () => {
         const { apiKey, connection, integration } = await seedFunction();
+        const spy = vi
+            .spyOn(Orchestrator.prototype, 'invokeFunction')
+            .mockResolvedValue(Ok({ id: 'retry-key-1', statusUrl: '/functions/invocations/retry-key-1' }));
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
@@ -269,11 +277,85 @@ describe(`POST ${endpoint}`, () => {
             }
         });
 
-        expect(res.res.status).toBe(501);
+        expect(res.res.status).toBe(202);
+        expect(res.res.headers.get('location')).toBe('/functions/invocations/retry-key-1');
+        expect(res.json).toStrictEqual({ id: 'retry-key-1', statusUrl: '/functions/invocations/retry-key-1' });
+        expect(spy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                functionName: 'test-function',
+                input: { value: 'test' },
+                async: true,
+                maxConcurrency: 0 // seeded function has perConnection: 'max'
+            })
+        );
+    });
+
+    it('should return the function output for wait invocations', async () => {
+        const { apiKey, connection, integration } = await seedFunction();
+        const spy = vi.spyOn(Orchestrator.prototype, 'invokeFunction').mockResolvedValue(Ok({ data: { echoed: 'test' } }));
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'wait'
+            }
+        });
+
+        expect(res.res.status).toBe(200);
+        expect(res.json).toStrictEqual({ echoed: 'test' });
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining({ async: false }));
+    });
+
+    it('should serialize invocations when the function limits concurrency per connection', async () => {
+        const { apiKey, connection, integration, env } = await seedFunction();
+        await db
+            .knex('function_config_versions')
+            .whereIn('function_config_id', db.knex('function_configs').select('id').where({ environment_id: env.id, name: 'test-function' }))
+            .update({ limits: { concurrency: { perConnection: 1 } } });
+        const spy = vi.spyOn(Orchestrator.prototype, 'invokeFunction').mockResolvedValue(Ok({ data: null }));
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'wait'
+            }
+        });
+
+        expect(res.res.status).toBe(200);
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining({ maxConcurrency: 1 }));
+    });
+
+    it('should return an error when the invocation fails', async () => {
+        const { apiKey, connection, integration } = await seedFunction();
+        vi.spyOn(Orchestrator.prototype, 'invokeFunction').mockResolvedValue(Err(new NangoError('function_failure')));
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'no_wait'
+            }
+        });
+
+        expect(res.res.status).toBe(500);
         expect(res.json).toStrictEqual({
             error: {
-                code: 'not_implemented',
-                message: 'Function invocation is not implemented yet'
+                code: 'function_failed',
+                message: 'Failed to invoke the function'
             }
         });
     });

--- a/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto';
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db from '@nangohq/database';
-import { customerKeyService, functionConfigService, seeders } from '@nangohq/shared';
+import { customerKeyService, functionConfigService, NangoError, Orchestrator, seeders } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
 
 import { runServer, shouldBeProtected } from '../../utils/tests.js';
 
@@ -71,7 +72,7 @@ async function seedFunction() {
         version: functionVersion()
     });
 
-    return { apiKey, connection, integration };
+    return { apiKey, connection, integration, env };
 }
 
 describe(`POST ${endpoint}`, () => {
@@ -81,6 +82,10 @@ describe(`POST ${endpoint}`, () => {
 
     afterAll(() => {
         api.server.close();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('should be protected', async () => {
@@ -199,8 +204,8 @@ describe(`POST ${endpoint}`, () => {
     });
 
     it('should return forbidden when the function is disabled', async () => {
-        const { apiKey, connection, integration } = await seedFunction();
-        await db.knex('function_configs').where({ name: 'test-function' }).update({ enabled: false });
+        const { apiKey, connection, integration, env } = await seedFunction();
+        await db.knex('function_configs').where({ environment_id: env.id, name: 'test-function' }).update({ enabled: false });
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
@@ -254,8 +259,11 @@ describe(`POST ${endpoint}`, () => {
         });
     });
 
-    it('should return not implemented', async () => {
+    it('should schedule an orchestrator task for no_wait invocations', async () => {
         const { apiKey, connection, integration } = await seedFunction();
+        const spy = vi
+            .spyOn(Orchestrator.prototype, 'invokeFunction')
+            .mockResolvedValue(Ok({ id: 'retry-key-1', statusUrl: '/functions/invocations/retry-key-1' }));
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
@@ -269,11 +277,110 @@ describe(`POST ${endpoint}`, () => {
             }
         });
 
-        expect(res.res.status).toBe(501);
+        expect(res.res.status).toBe(202);
+        expect(res.res.headers.get('location')).toBe('/functions/invocations/retry-key-1');
+        expect(res.json).toStrictEqual({ id: 'retry-key-1', statusUrl: '/functions/invocations/retry-key-1' });
+        expect(spy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                functionName: 'test-function',
+                input: { value: 'test' },
+                async: true,
+                maxConcurrency: 0 // seeded function has perConnection: 'max'
+            })
+        );
+    });
+
+    it('should return the function output for wait invocations', async () => {
+        const { apiKey, connection, integration } = await seedFunction();
+        const spy = vi.spyOn(Orchestrator.prototype, 'invokeFunction').mockResolvedValue(Ok({ data: { echoed: 'test' } }));
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'wait'
+            }
+        });
+
+        expect(res.res.status).toBe(200);
+        expect(res.json).toStrictEqual({ echoed: 'test' });
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining({ async: false }));
+    });
+
+    it('should serialize invocations when the function limits concurrency per connection', async () => {
+        const { apiKey, connection, integration, env } = await seedFunction();
+        await db
+            .knex('function_config_versions')
+            .whereIn('function_config_id', db.knex('function_configs').select('id').where({ environment_id: env.id, name: 'test-function' }))
+            .update({ limits: { concurrency: { perConnection: 1 } } });
+        const spy = vi.spyOn(Orchestrator.prototype, 'invokeFunction').mockResolvedValue(Ok({ data: null }));
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'wait'
+            }
+        });
+
+        expect(res.res.status).toBe(200);
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining({ maxConcurrency: 1 }));
+    });
+
+    it('should return an error when the invocation fails', async () => {
+        const { apiKey, connection, integration } = await seedFunction();
+        vi.spyOn(Orchestrator.prototype, 'invokeFunction').mockResolvedValue(Err(new NangoError('function_failure')));
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'no_wait'
+            }
+        });
+
+        expect(res.res.status).toBe(500);
         expect(res.json).toStrictEqual({
             error: {
-                code: 'not_implemented',
-                message: 'Function invocation is not implemented yet'
+                code: 'function_failed',
+                message: 'Failed to invoke the function'
+            }
+        });
+    });
+
+    it('should preserve script errors returned by the function', async () => {
+        const { apiKey, connection, integration } = await seedFunction();
+        vi.spyOn(Orchestrator.prototype, 'invokeFunction').mockResolvedValue(Err(new NangoError('script_http_error', { error: 'upstream failed' })));
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'wait'
+            }
+        });
+
+        expect(res.res.status).toBe(424);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'script_http_error',
+                payload: { error: 'upstream failed' }
             }
         });
     });

--- a/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
@@ -192,8 +192,33 @@ describe(`POST ${endpoint}`, () => {
         expect(res.res.status).toBe(404);
         expect(res.json).toStrictEqual({
             error: {
-                code: 'unknown_function',
+                code: 'function_not_found',
                 message: "Function 'missing-function' was not found"
+            }
+        });
+    });
+
+    it('should return forbidden when the function is disabled', async () => {
+        const { apiKey, connection, integration } = await seedFunction();
+        await db.knex('function_configs').where({ name: 'test-function' }).update({ enabled: false });
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'no_wait'
+            }
+        });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'function_disabled',
+                message: "Function 'test-function' is disabled"
             }
         });
     });

--- a/packages/server/lib/controllers/functions/postInvocation.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.ts
@@ -5,6 +5,7 @@ import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema, scriptNameSchema } from '../../helpers/validation.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { getOrchestrator } from '../../utils/utils.js';
 
 import type { FunctionInvocationType, PostFunctionInvocation } from '@nangohq/types';
 
@@ -43,39 +44,41 @@ export const postFunctionInvocation = asyncWrapperWithEnvironment<PostFunctionIn
         functionName: body.data.name,
         input: body.data.input,
         invocationType: body.data.invocation_type,
-        options: body.data.options
+        options: body.data.options,
+        orchestrator: getOrchestrator()
     });
 
-    if (invoke.isErr()) {
-        switch (invoke.error.code) {
-            case 'connection_not_found':
-            case 'function_not_found':
-                res.status(404).send({ error: { code: invoke.error.code, message: invoke.error.message } });
-                return;
-            case 'function_disabled':
-                res.status(403).send({ error: { code: invoke.error.code, message: invoke.error.message } });
-                return;
-            case 'invalid_invocation':
-                res.status(400).send({ error: { code: invoke.error.code, message: invoke.error.message } });
-                return;
-            case 'validation_error':
-                res.status(400).send({ error: { code: invoke.error.code, message: invoke.error.message, errors: invoke.error.errors } });
-                return;
-            case 'server_error':
-                report(invoke.error);
-                res.status(500).send({ error: { code: invoke.error.code, message: invoke.error.message } });
-                return;
-            case 'not_implemented':
-                res.status(501).send({ error: { code: invoke.error.code, message: invoke.error.message } });
-                return;
-            default: {
-                ((_exhaustiveCheck: never) => {
-                    res.status(500).send({ error: { code: 'server_error', message: 'Unknown invocation failure' } });
-                    return;
-                })(invoke.error.code);
-            }
+    if (invoke.isOk()) {
+        if (body.data.invocation_type === 'no_wait') {
+            res.status(202).location(invoke.value.statusUrl).json(invoke.value);
+            return;
         }
+        res.status(200).json(invoke.value.data as PostFunctionInvocation['Success']);
+        return;
     }
 
-    res.status(204).send();
+    switch (invoke.error.code) {
+        case 'connection_not_found':
+        case 'function_not_found':
+            res.status(404).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+            return;
+        case 'function_disabled':
+            res.status(403).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+            return;
+        case 'invalid_invocation':
+            res.status(400).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+            return;
+        case 'validation_error':
+            res.status(400).send({ error: { code: invoke.error.code, message: invoke.error.message, errors: invoke.error.errors } });
+            return;
+        case 'function_failed':
+        case 'server_error':
+            report(invoke.error);
+            res.status(500).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+            return;
+        default:
+            return ((_exhaustiveCheck: never) => {
+                res.status(500).send({ error: { code: 'server_error', message: 'Unknown invocation failure' } });
+            })(invoke.error.code);
+    }
 });

--- a/packages/server/lib/controllers/functions/postInvocation.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
 
-import { invokeFunction } from '@nangohq/shared';
+import { errorManager, invokeFunction, NangoError } from '@nangohq/shared';
 import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema, scriptNameSchema } from '../../helpers/validation.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+import { getOrchestrator } from '../../utils/utils.js';
 
 import type { FunctionInvocationType, PostFunctionInvocation } from '@nangohq/types';
 
@@ -43,39 +44,53 @@ export const postFunctionInvocation = asyncWrapperWithEnvironment<PostFunctionIn
         functionName: body.data.name,
         input: body.data.input,
         invocationType: body.data.invocation_type,
-        options: body.data.options
+        options: body.data.options,
+        orchestrator: getOrchestrator()
     });
 
-    if (invoke.isErr()) {
-        switch (invoke.error.code) {
-            case 'connection_not_found':
-            case 'function_not_found':
-                res.status(404).send({ error: { code: invoke.error.code, message: invoke.error.message } });
-                return;
-            case 'function_disabled':
-                res.status(403).send({ error: { code: invoke.error.code, message: invoke.error.message } });
-                return;
-            case 'invalid_invocation':
-                res.status(400).send({ error: { code: invoke.error.code, message: invoke.error.message } });
-                return;
-            case 'validation_error':
-                res.status(400).send({ error: { code: invoke.error.code, message: invoke.error.message, errors: invoke.error.errors } });
-                return;
-            case 'server_error':
-                report(invoke.error);
-                res.status(500).send({ error: { code: invoke.error.code, message: invoke.error.message } });
-                return;
-            case 'not_implemented':
-                res.status(501).send({ error: { code: invoke.error.code, message: invoke.error.message } });
-                return;
-            default: {
-                ((_exhaustiveCheck: never) => {
-                    res.status(500).send({ error: { code: 'server_error', message: 'Unknown invocation failure' } });
-                    return;
-                })(invoke.error.code);
-            }
+    if (invoke.isOk()) {
+        if ('statusUrl' in invoke.value) {
+            res.status(202).location(invoke.value.statusUrl).json(invoke.value);
+            return;
         }
+        res.status(200).json(invoke.value.data as PostFunctionInvocation['Success']);
+        return;
     }
 
-    res.status(204).send();
+    switch (invoke.error.code) {
+        case 'connection_not_found':
+        case 'function_not_found':
+            res.status(404).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+            return;
+        case 'function_disabled':
+            res.status(403).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+            return;
+        case 'invalid_invocation':
+            res.status(400).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+            return;
+        case 'validation_error':
+            res.status(400).send({ error: { code: invoke.error.code, message: invoke.error.message, errors: invoke.error.errors } });
+            return;
+        case 'function_failed': {
+            const cause = invoke.error.cause;
+            const isInfrastructureFailure = !(cause instanceof NangoError) || cause.type === 'function_execution_failure' || cause.type === 'function_failure';
+
+            if (!isInfrastructureFailure) {
+                errorManager.errResFromNangoErr(res, cause);
+                return;
+            }
+
+            report(invoke.error);
+            res.status(500).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+            return;
+        }
+        case 'server_error':
+            report(invoke.error);
+            res.status(500).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+            return;
+        default:
+            return void ((_exhaustiveCheck: never) => {
+                res.status(500).send({ error: { code: 'server_error', message: 'Unknown invocation failure' } });
+            })(invoke.error.code);
+    }
 });

--- a/packages/server/lib/controllers/functions/postInvocation.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.ts
@@ -1,15 +1,12 @@
-import tracer from 'dd-trace';
 import { z } from 'zod';
 
-import db from '@nangohq/database';
-import { logContextGetter, OtlpSpan } from '@nangohq/logs';
-import { connectionService, functionConfigService, validateFunctionInput } from '@nangohq/shared';
-import { report, requireEmptyQuery, truncateJson, zodErrorToHTTP } from '@nangohq/utils';
+import { invokeFunction } from '@nangohq/shared';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema, scriptNameSchema } from '../../helpers/validation.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 
-import type { DBFunctionConfigVersion, FunctionInvocationType, PostFunctionInvocation } from '@nangohq/types';
+import type { FunctionInvocationType, PostFunctionInvocation } from '@nangohq/types';
 
 const bodyValidation = z
     .object({
@@ -32,100 +29,53 @@ export const postFunctionInvocation = asyncWrapperWithEnvironment<PostFunctionIn
         return;
     }
 
-    const bodyValidationResult = bodyValidation.safeParse(req.body);
-    if (!bodyValidationResult.success) {
-        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(bodyValidationResult.error) } });
+    const body = bodyValidation.safeParse(req.body);
+    if (!body.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(body.error) } });
         return;
     }
 
-    const body: PostFunctionInvocation['Body'] = bodyValidationResult.data;
-
-    const connectionRes = await connectionService.getConnection(body.connection_id, body.integration_id, res.locals.environment.id);
-
-    if (!connectionRes.success) {
-        res.status(404).send({
-            error: {
-                code: 'connection_not_found',
-                message: `Connection '${body.connection_id}' was not found for integration '${body.integration_id}'`
-            }
-        });
-        return;
-    }
-
-    const functionRes = await functionConfigService.search(db.knex, {
-        environmentId: res.locals.environment.id,
-        filter: { integrationKey: body.integration_id, name: body.name }
+    const invoke = await invokeFunction({
+        account: res.locals.account,
+        environment: res.locals.environment,
+        integrationId: body.data.integration_id,
+        connectionId: body.data.connection_id,
+        functionName: body.data.name,
+        input: body.data.input,
+        invocationType: body.data.invocation_type,
+        options: body.data.options
     });
 
-    if (functionRes.isErr()) {
-        report(functionRes.error);
-        res.status(500).send({ error: { code: 'server_error', message: 'Failed to find function' } });
-        return;
-    }
-
-    if (functionRes.value.length !== 1) {
-        res.status(404).send({ error: { code: 'unknown_function', message: `Function '${body.name}' was not found` } });
-        return;
-    }
-
-    if (!functionRes.value[0]?.config.enabled) {
-        res.status(403).send({ error: { code: 'function_disabled', message: 'Function is disabled' } });
-        return;
-    }
-
-    const { currentVersion, integration, config } = functionRes.value[0];
-
-    if (!supportInvocation(currentVersion, body.invocation_type)) {
-        res.status(400).send({ error: { code: 'invalid_invocation', message: `Function '${body.name}' is not invokable with ${body.invocation_type}` } });
-        return;
-    }
-
-    const { input, ...rest } = body;
-
-    const validation = validateFunctionInput(currentVersion, input);
-
-    if (validation.isErr()) {
-        res.status(400).send({ error: { code: 'validation_error', message: validation.error.message, errors: validation.error.validationErrors } });
-        return;
-    }
-
-    return tracer.trace('server.function.invocation', async (span) => {
-        span.addTags(rest);
-
-        const timeoutMs =
-            rest.invocation_type === 'wait'
-                ? 2 * 60 * 1000 // 2 minutes for synchronous invocations
-                : 24 * 60 * 60 * 1000; // 24 hours for asynchronous invocations
-        const connection = connectionRes.response!;
-
-        const logCtx = await logContextGetter.create(
-            { operation: { type: 'function', action: 'invoke' }, expiresAt: new Date(Date.now() + timeoutMs).toISOString() },
-            {
-                account: res.locals.account,
-                environment: res.locals.environment,
-                integration: { id: integration.id, name: integration.unique_key, provider: integration.provider },
-                connection: { id: connection.id, name: connection.connection_id },
-                syncConfig: { id: currentVersion.id, name: config.name },
-                meta: {
-                    invocation_type: rest.invocation_type,
-                    ...(rest.options ? { options: rest.options } : {}),
-                    ...(input ? { input: truncateJson(input) } : {})
-                }
+    if (invoke.isErr()) {
+        switch (invoke.error.code) {
+            case 'connection_not_found':
+            case 'function_not_found':
+                res.status(404).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+                return;
+            case 'function_disabled':
+                res.status(403).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+                return;
+            case 'invalid_invocation':
+                res.status(400).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+                return;
+            case 'validation_error':
+                res.status(400).send({ error: { code: invoke.error.code, message: invoke.error.message, errors: invoke.error.errors } });
+                return;
+            case 'server_error':
+                report(invoke.error);
+                res.status(500).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+                return;
+            case 'not_implemented':
+                res.status(501).send({ error: { code: invoke.error.code, message: invoke.error.message } });
+                return;
+            default: {
+                ((_exhaustiveCheck: never) => {
+                    res.status(500).send({ error: { code: 'server_error', message: 'Unknown invocation failure' } });
+                    return;
+                })(invoke.error.code);
             }
-        );
-        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+        }
+    }
 
-        void logCtx.failed();
-        res.status(501).send({ error: { code: 'not_implemented', message: 'Function invocation is not implemented yet' } });
-    });
+    res.status(204).send();
 });
-
-function supportInvocation(version: DBFunctionConfigVersion, invocationType: FunctionInvocationType): boolean {
-    const supported: Record<DBFunctionConfigVersion['trigger']['kind'], FunctionInvocationType[]> = {
-        http: ['wait', 'no_wait'],
-        schedule: ['no_wait'],
-        event: ['no_wait'],
-        none: []
-    };
-    return supported[version.trigger.kind]?.includes(invocationType) ?? false;
-}

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -23,6 +23,8 @@ import type { LogContext, LogContextGetter, LogContextOrigin } from '@nangohq/lo
 import type {
     ExecuteActionProps,
     ExecuteAsyncReturn,
+    ExecuteFunctionProps,
+    ExecuteFunctionReturn,
     ExecuteOnEventProps,
     ExecuteReturn,
     ExecuteSyncProps,
@@ -34,7 +36,16 @@ import type {
     VoidReturn
 } from '@nangohq/nango-orchestrator';
 import type { RecordCount } from '@nangohq/records';
-import type { AsyncActionResponse, ConnectionInternal, ConnectionJobs, DBConnection, DBConnectionDecrypted, DBSyncConfig } from '@nangohq/types';
+import type {
+    AsyncActionResponse,
+    AsyncFunctionResponse,
+    ConnectionInternal,
+    ConnectionJobs,
+    DBConnection,
+    DBConnectionDecrypted,
+    DBEnvironment,
+    DBSyncConfig
+} from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
 
@@ -58,6 +69,7 @@ export interface OrchestratorClientInterface {
     recurring(props: RecurringProps): Promise<Result<{ scheduleId: string }>>;
     executeAction(props: ExecuteActionProps): Promise<ExecuteReturn>;
     executeActionAsync(props: ExecuteActionProps): Promise<ExecuteAsyncReturn>;
+    executeFunction(props: ExecuteFunctionProps): Promise<ExecuteFunctionReturn>;
     executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn>;
     executeOnEvent(props: ExecuteOnEventProps & { async: boolean }): Promise<VoidReturn>;
     executeSync(props: ExecuteSyncProps): Promise<VoidReturn>;
@@ -105,6 +117,88 @@ export class Orchestrator {
             return map;
         }, new Map<string, OrchestratorSchedule>());
         return Ok(scheduleMap);
+    }
+
+    async invokeFunction({
+        environment,
+        connection,
+        functionName,
+        input,
+        async,
+        retryMax,
+        maxConcurrency,
+        logCtx
+    }: {
+        environment: DBEnvironment;
+        connection: ConnectionJobs;
+        functionName: string;
+        input: JsonValue;
+        async: boolean;
+        retryMax: number;
+        maxConcurrency: number;
+        logCtx: LogContext;
+    }): Promise<Result<AsyncFunctionResponse | { data: JsonValue }, NangoError>> {
+        try {
+            const groupKey = `function:environment:${environment.id}:connection:${connection.id}:function:${functionName}`;
+            const executionId = `${groupKey}:at:${new Date().toISOString()}:${uuid()}`;
+            const args = {
+                functionName,
+                connection: {
+                    id: connection.id,
+                    connection_id: connection.connection_id,
+                    provider_config_key: connection.provider_config_key,
+                    environment_id: connection.environment_id
+                },
+                activityLogId: logCtx.id,
+                input,
+                async
+            };
+
+            const res = await this.client.executeFunction({
+                name: executionId,
+                group: { key: groupKey, maxConcurrency },
+                retry: { count: 0, max: retryMax },
+                ownerKey: `environment:${environment.id}`,
+                args
+            });
+            if (res.isErr()) {
+                if (async) {
+                    throw res.error;
+                }
+
+                throw (
+                    deserializeNangoError(res.error.payload) ||
+                    new NangoError('function_execution_failure', {
+                        error: res.error.message,
+                        ...(res.error.payload ? { payload: res.error.payload } : {})
+                    })
+                );
+            }
+
+            if (res.value.kind === 'scheduled') {
+                void logCtx.info('The function was successfully scheduled for asynchronous execution', {
+                    function: functionName,
+                    connection: connection.connection_id,
+                    integration: connection.provider_config_key
+                });
+                return Ok({ id: res.value.retryKey, statusUrl: `/functions/invocations/${res.value.retryKey}` });
+            }
+
+            void logCtx.enrichOperation({
+                meta: { truncated_response: JSON.stringify(res.value.output)?.slice(0, 100) }
+            });
+
+            return Ok({ data: res.value.output });
+        } catch (err) {
+            let formattedError: NangoError;
+            if (err instanceof NangoError) {
+                formattedError = err;
+            } else {
+                formattedError = new NangoError('function_failure', { error: errorToObject(err) });
+            }
+
+            return Err(formattedError);
+        }
     }
 
     async triggerAction<T = unknown>({

--- a/packages/shared/lib/services/functions/index.ts
+++ b/packages/shared/lib/services/functions/index.ts
@@ -6,3 +6,4 @@ export { reconcile } from './reconcile.js';
 export type { DeploymentBundleReconciliation } from './reconcile.js';
 export { functionVersionHash } from './version.js';
 export { validateFunctionInput } from './models/validate.js';
+export { invokeFunction } from './invoke.js';

--- a/packages/shared/lib/services/functions/invoke.ts
+++ b/packages/shared/lib/services/functions/invoke.ts
@@ -1,0 +1,170 @@
+import tracer from 'dd-trace';
+
+import db from '@nangohq/database';
+import { logContextGetter, OtlpSpan } from '@nangohq/logs';
+import { Err, truncateJson } from '@nangohq/utils';
+
+import connectionService from '../connection.service.js';
+import * as functionConfigService from './models/functions.js';
+import { validateFunctionInput } from './models/validate.js';
+
+import type { FunctionInputValidationError } from './models/validate.js';
+import type { DBEnvironment, DBFunctionConfigVersion, DBTeam, FunctionInvocationErrorCode, FunctionInvocationType } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+type ValidationErrors = FunctionInputValidationError['validationErrors'];
+
+export class FunctionInvokeError extends Error {
+    readonly code: FunctionInvocationErrorCode;
+    readonly errors: ValidationErrors;
+
+    constructor({ message, code, cause, errors }: { message: string; code: FunctionInvocationErrorCode; cause?: unknown; errors?: ValidationErrors }) {
+        super(message, { cause });
+        this.name = 'FunctionInvokeError';
+        this.code = code;
+        this.errors = errors ?? [];
+        Error.captureStackTrace?.(this, FunctionInvokeError);
+    }
+}
+
+export async function invokeFunction({
+    account,
+    environment,
+    integrationId,
+    connectionId,
+    functionName,
+    input,
+    invocationType,
+    options
+}: {
+    account: DBTeam;
+    environment: DBEnvironment;
+    integrationId: string;
+    connectionId: string;
+    functionName: string;
+    input?: unknown | undefined;
+    invocationType: FunctionInvocationType;
+    options?: Record<string, unknown> | undefined;
+}): Promise<Result<void, FunctionInvokeError>> {
+    return tracer.trace('nango.function.invocation', async (span) => {
+        span.addTags({
+            accountId: account.id,
+            environmentId: environment.id,
+            integrationId,
+            connectionId,
+            functionName,
+            invocationType
+        });
+
+        const connectionRes = await connectionService.getConnection(connectionId, integrationId, environment.id);
+
+        if (!connectionRes.success) {
+            return Err(
+                new FunctionInvokeError({
+                    code: 'connection_not_found',
+                    message: `Connection '${connectionId}' was not found for integration '${integrationId}'`
+                })
+            );
+        }
+
+        const functionRes = await functionConfigService.search(db.knex, {
+            environmentId: environment.id,
+            filter: { integrationKey: integrationId, name: functionName }
+        });
+
+        if (functionRes.isErr()) {
+            return Err(
+                new FunctionInvokeError({
+                    code: 'server_error',
+                    message: 'Failed to find function',
+                    cause: functionRes.error
+                })
+            );
+        }
+
+        if (functionRes.value.length !== 1) {
+            return Err(
+                new FunctionInvokeError({
+                    code: 'function_not_found',
+                    message: `Function '${functionName}' was not found`
+                })
+            );
+        }
+
+        if (!functionRes.value[0]?.config.enabled) {
+            return Err(
+                new FunctionInvokeError({
+                    code: 'function_disabled',
+                    message: `Function '${functionName}' is disabled`
+                })
+            );
+        }
+
+        const { currentVersion, integration, config } = functionRes.value[0];
+
+        if (!supportInvocation(currentVersion, invocationType)) {
+            return Err(
+                new FunctionInvokeError({
+                    code: 'invalid_invocation',
+                    message: `Function '${functionName}' is not invokable with ${invocationType}`
+                })
+            );
+        }
+
+        const validation = validateFunctionInput(currentVersion, input);
+
+        if (validation.isErr()) {
+            return Err(
+                new FunctionInvokeError({
+                    code: 'validation_error',
+                    message: validation.error.message,
+                    errors: validation.error.validationErrors
+                })
+            );
+        }
+
+        const connection = connectionRes.response!;
+        const timeoutMs = executionTimeoutMs(invocationType);
+
+        const logCtx = await logContextGetter.create(
+            { operation: { type: 'function', action: 'invoke' }, expiresAt: new Date(Date.now() + timeoutMs).toISOString() },
+            {
+                account,
+                environment,
+                integration: { id: integration.id, name: integration.unique_key, provider: integration.provider },
+                connection: { id: connection.id, name: connection.connection_id },
+                syncConfig: { id: currentVersion.id, name: config.name },
+                meta: {
+                    invocation_type: invocationType,
+                    ...(options ? { options } : {}),
+                    ...(input ? { input: truncateJson(input) } : {})
+                }
+            }
+        );
+        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
+        void logCtx.failed();
+        return Err(
+            new FunctionInvokeError({
+                code: 'not_implemented',
+                message: 'Function invocation is not implemented yet'
+            })
+        );
+    });
+}
+
+function executionTimeoutMs(invocationType: FunctionInvocationType): number {
+    return invocationType === 'wait'
+        ? 2 * 60 * 1000 // 2 minutes for synchronous invocations
+        : 24 * 60 * 60 * 1000; // 24 hours for asynchronous invocations
+}
+
+function supportInvocation(version: DBFunctionConfigVersion, invocationType: FunctionInvocationType): boolean {
+    const supported: Record<DBFunctionConfigVersion['trigger']['kind'], FunctionInvocationType[]> = {
+        http: ['wait', 'no_wait'],
+        schedule: ['no_wait'],
+        event: ['no_wait'],
+        none: []
+    };
+    return supported[version.trigger.kind]?.includes(invocationType) ?? false;
+}

--- a/packages/shared/lib/services/functions/invoke.ts
+++ b/packages/shared/lib/services/functions/invoke.ts
@@ -2,17 +2,28 @@ import tracer from 'dd-trace';
 
 import db from '@nangohq/database';
 import { logContextGetter, OtlpSpan } from '@nangohq/logs';
-import { Err, truncateJson } from '@nangohq/utils';
+import { Err, Ok, truncateJson } from '@nangohq/utils';
 
 import connectionService from '../connection.service.js';
 import * as functionConfigService from './models/functions.js';
 import { validateFunctionInput } from './models/validate.js';
 
+import type { Orchestrator } from '../../clients/orchestrator.js';
 import type { FunctionInputValidationError } from './models/validate.js';
-import type { DBEnvironment, DBFunctionConfigVersion, DBTeam, FunctionInvocationErrorCode, FunctionInvocationType } from '@nangohq/types';
+import type {
+    AsyncFunctionResponse,
+    DBEnvironment,
+    DBFunctionConfigVersion,
+    DBTeam,
+    FunctionInvocationErrorCode,
+    FunctionInvocationType
+} from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+import type { JsonValue } from 'type-fest';
 
 type ValidationErrors = FunctionInputValidationError['validationErrors'];
+
+export type FunctionInvocationResult = AsyncFunctionResponse | { data: JsonValue };
 
 export class FunctionInvokeError extends Error {
     readonly code: FunctionInvocationErrorCode;
@@ -35,7 +46,8 @@ export async function invokeFunction({
     functionName,
     input,
     invocationType,
-    options
+    options,
+    orchestrator
 }: {
     account: DBTeam;
     environment: DBEnvironment;
@@ -45,7 +57,8 @@ export async function invokeFunction({
     input?: unknown | undefined;
     invocationType: FunctionInvocationType;
     options?: Record<string, unknown> | undefined;
-}): Promise<Result<void, FunctionInvokeError>> {
+    orchestrator: Orchestrator;
+}): Promise<Result<FunctionInvocationResult, FunctionInvokeError>> {
     return tracer.trace('nango.function.invocation', async (span) => {
         span.addTags({
             accountId: account.id,
@@ -143,13 +156,36 @@ export async function invokeFunction({
         );
         logCtx.attachSpan(new OtlpSpan(logCtx.operation));
 
-        void logCtx.failed();
-        return Err(
-            new FunctionInvokeError({
-                code: 'not_implemented',
-                message: 'Function invocation is not implemented yet'
-            })
-        );
+        // `perConnection: 1` serializes concurrent invocations of the same function for a connection; 'max' is unbounded
+        const maxConcurrency = currentVersion.limits?.concurrency?.perConnection === 1 ? 1 : 0;
+
+        const invocation = await orchestrator.invokeFunction({
+            environment,
+            connection,
+            functionName,
+            input: validation.value,
+            async: invocationType === 'no_wait',
+            retryMax: 0,
+            maxConcurrency,
+            logCtx
+        });
+
+        if (invocation.isErr()) {
+            void logCtx.error(invocation.error.message, { error: invocation.error });
+            void logCtx.failed();
+            return Err(
+                new FunctionInvokeError({
+                    code: 'function_failed',
+                    message: invocation.error.message,
+                    cause: invocation.error
+                })
+            );
+        }
+
+        if (invocationType === 'wait') {
+            void logCtx.success();
+        }
+        return Ok(invocation.value);
     });
 }
 

--- a/packages/shared/lib/services/functions/invoke.ts
+++ b/packages/shared/lib/services/functions/invoke.ts
@@ -2,17 +2,28 @@ import tracer from 'dd-trace';
 
 import db from '@nangohq/database';
 import { logContextGetter, OtlpSpan } from '@nangohq/logs';
-import { Err, truncateJson } from '@nangohq/utils';
+import { Err, Ok, truncateJson } from '@nangohq/utils';
 
 import connectionService from '../connection.service.js';
 import * as functionConfigService from './models/functions.js';
 import { validateFunctionInput } from './models/validate.js';
 
+import type { Orchestrator } from '../../clients/orchestrator.js';
 import type { FunctionInputValidationError } from './models/validate.js';
-import type { DBEnvironment, DBFunctionConfigVersion, DBTeam, FunctionInvocationErrorCode, FunctionInvocationType } from '@nangohq/types';
+import type {
+    AsyncFunctionResponse,
+    DBEnvironment,
+    DBFunctionConfigVersion,
+    DBTeam,
+    FunctionInvocationErrorCode,
+    FunctionInvocationType
+} from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+import type { JsonValue } from 'type-fest';
 
 type ValidationErrors = FunctionInputValidationError['validationErrors'];
+
+export type FunctionInvocationResult = AsyncFunctionResponse | { data: JsonValue };
 
 export class FunctionInvokeError extends Error {
     readonly code: FunctionInvocationErrorCode;
@@ -35,7 +46,8 @@ export async function invokeFunction({
     functionName,
     input,
     invocationType,
-    options
+    options,
+    orchestrator
 }: {
     account: DBTeam;
     environment: DBEnvironment;
@@ -45,7 +57,8 @@ export async function invokeFunction({
     input?: unknown | undefined;
     invocationType: FunctionInvocationType;
     options?: Record<string, unknown> | undefined;
-}): Promise<Result<void, FunctionInvokeError>> {
+    orchestrator: Orchestrator;
+}): Promise<Result<FunctionInvocationResult, FunctionInvokeError>> {
     return tracer.trace('nango.function.invocation', async (span) => {
         span.addTags({
             accountId: account.id,
@@ -137,19 +150,42 @@ export async function invokeFunction({
                 meta: {
                     invocation_type: invocationType,
                     ...(options ? { options } : {}),
-                    ...(input ? { input: truncateJson(input) } : {})
+                    ...(input !== undefined ? truncateJson({ input }) : {})
                 }
             }
         );
         logCtx.attachSpan(new OtlpSpan(logCtx.operation));
 
-        void logCtx.failed();
-        return Err(
-            new FunctionInvokeError({
-                code: 'not_implemented',
-                message: 'Function invocation is not implemented yet'
-            })
-        );
+        // `perConnection: 1` serializes concurrent invocations of the same function for a connection; 'max' is unbounded
+        const maxConcurrency = currentVersion.limits?.concurrency?.perConnection === 1 ? 1 : 0;
+
+        const invocation = await orchestrator.invokeFunction({
+            environment,
+            connection,
+            functionName,
+            input: validation.value,
+            async: invocationType === 'no_wait',
+            retryMax: 0,
+            maxConcurrency,
+            logCtx
+        });
+
+        if (invocation.isErr()) {
+            void logCtx.error(invocation.error.message, { error: invocation.error });
+            void logCtx.failed();
+            return Err(
+                new FunctionInvokeError({
+                    code: 'function_failed',
+                    message: invocation.error.message,
+                    cause: invocation.error
+                })
+            );
+        }
+
+        if (invocationType === 'wait') {
+            void logCtx.success();
+        }
+        return Ok(invocation.value);
     });
 }
 

--- a/packages/shared/lib/services/functions/models/validate.ts
+++ b/packages/shared/lib/services/functions/models/validate.ts
@@ -57,11 +57,12 @@ export function validateFunctionInput(version: DBFunctionConfigVersion, input: u
             return Err(new FunctionInputValidationError('invalid_function_input_schema'));
         }
 
-        const valid = validate(input);
+        const normalizedInput = input === undefined ? null : input;
+        const valid = validate(normalizedInput);
         if (!valid) {
             return Err(new FunctionInputValidationError('invalid_function_input', toValidationErrors(validate.errors || [])));
         }
-        return Ok(input);
+        return Ok(normalizedInput);
     } catch (_err) {
         return Err(new FunctionInputValidationError('invalid_function_input_schema'));
     }

--- a/packages/shared/lib/services/functions/models/validate.ts
+++ b/packages/shared/lib/services/functions/models/validate.ts
@@ -6,6 +6,7 @@ import { Err, Ok } from '@nangohq/utils';
 import type { DBFunctionConfigVersion, ValidationError } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { AnySchema, ErrorObject, ValidateFunction } from 'ajv';
+import type { JsonValue } from 'type-fest';
 
 export const MAX_VALIDATOR_CACHE_SIZE = 1000;
 
@@ -45,9 +46,9 @@ export class FunctionInputValidationError extends Error {
     }
 }
 
-export function validateFunctionInput(version: DBFunctionConfigVersion, input: unknown): Result<unknown, FunctionInputValidationError> {
+export function validateFunctionInput(version: DBFunctionConfigVersion, input: unknown): Result<JsonValue, FunctionInputValidationError> {
     if (!version.input_schema_ref) {
-        return input === undefined ? Ok(input) : Err(new FunctionInputValidationError('unexpected_function_input'));
+        return input === undefined ? Ok(null) : Err(new FunctionInputValidationError('unexpected_function_input'));
     }
 
     try {
@@ -66,7 +67,7 @@ export function validateFunctionInput(version: DBFunctionConfigVersion, input: u
     }
 }
 
-function getValidator(version: DBFunctionConfigVersion): ValidateFunction | null {
+function getValidator(version: DBFunctionConfigVersion): ValidateFunction<JsonValue> | null {
     const cached = validatorCache.get(version.id);
     if (cached) {
         // Re-insert the cached validator to mark it as recently used
@@ -81,7 +82,7 @@ function getValidator(version: DBFunctionConfigVersion): ValidateFunction | null
 
         // If the cached validator is marked as valid,
         // retrieve it from Ajv and return it
-        const validate = ajv.getSchema(validatorSchemaId(version.id));
+        const validate = ajv.getSchema<JsonValue>(validatorSchemaId(version.id));
         if (validate) {
             return validate;
         }
@@ -94,7 +95,7 @@ function getValidator(version: DBFunctionConfigVersion): ValidateFunction | null
     const schemaId = validatorSchemaId(version.id);
     try {
         ajv.addSchema({ ...version.json_schema, $id: schemaId, $ref: version.input_schema_ref } as AnySchema);
-        const validate = ajv.getSchema(schemaId);
+        const validate = ajv.getSchema<JsonValue>(schemaId);
         if (!validate) {
             throw new Error('failed_to_compile_function_input_schema');
         }

--- a/packages/shared/lib/services/functions/models/validate.ts
+++ b/packages/shared/lib/services/functions/models/validate.ts
@@ -35,7 +35,7 @@ export function clearFunctionInputValidatorCache(): void {
     validatorCache.clear();
 }
 
-class FunctionInputValidationError extends Error {
+export class FunctionInputValidationError extends Error {
     public validationErrors: ValidationError[];
 
     constructor(message: string, errors: ValidationError[] = []) {

--- a/packages/shared/lib/services/functions/models/validate.unit.test.ts
+++ b/packages/shared/lib/services/functions/models/validate.unit.test.ts
@@ -128,6 +128,18 @@ describe('validateFunctionInput', () => {
         expect(result.error.validationErrors).toContainEqual({ code: 'type', message: 'must be object', path: [] });
     });
 
+    it('normalizes omitted input to null', () => {
+        const permissiveVersion: DBFunctionConfigVersion = {
+            ...version,
+            id: 6,
+            json_schema: { definitions: { Input: {} } }
+        };
+
+        const result = validateFunctionInput(permissiveVersion, undefined);
+
+        expect(result.unwrap()).toBeNull();
+    });
+
     it('validates falsy input values', () => {
         const booleanVersion: DBFunctionConfigVersion = {
             ...version,

--- a/packages/shared/lib/services/functions/models/validate.unit.test.ts
+++ b/packages/shared/lib/services/functions/models/validate.unit.test.ts
@@ -97,7 +97,7 @@ describe('validateFunctionInput', () => {
     it('accepts omitted input when the function has no input schema', () => {
         const result = validateFunctionInput({ ...version, input_schema_ref: null }, undefined);
 
-        expect(result.unwrap()).toBeUndefined();
+        expect(result.unwrap()).toBeNull();
     });
 
     it.each([{}, null, false])('rejects provided input when the function has no input schema: %j', (input) => {

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -22,6 +22,7 @@ const orchestratorClientNoop: OrchestratorClientInterface = {
     recurring: () => Promise.resolve({}) as any,
     executeAction: () => Promise.resolve({}) as any,
     executeActionAsync: () => Promise.resolve({}) as any,
+    executeFunction: () => Promise.resolve({}) as any,
     executeWebhook: () => Promise.resolve({}) as any,
     executeOnEvent: () => Promise.resolve({}) as any,
     executeSync: () => Promise.resolve({}) as any,

--- a/packages/shared/lib/services/sync/sync.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/sync.service.unit.test.ts
@@ -19,6 +19,7 @@ const orchestratorClientNoop: OrchestratorClientInterface = {
     recurring: () => Promise.resolve({}) as any,
     executeAction: () => Promise.resolve({}) as any,
     executeActionAsync: () => Promise.resolve({}) as any,
+    executeFunction: () => Promise.resolve({}) as any,
     executeWebhook: () => Promise.resolve({}) as any,
     executeOnEvent: () => Promise.resolve({}) as any,
     executeSync: () => Promise.resolve({}) as any,

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -256,6 +256,11 @@ export class NangoError extends NangoInternalError {
                 this.message = `Failed to perform the action`;
                 break;
 
+            case 'function_failure':
+                this.status = 400;
+                this.message = `Failed to invoke the function`;
+                break;
+
             case 'webhook_failure':
                 this.status = 400;
                 this.message = `Failed to perform the webhook`;
@@ -504,6 +509,10 @@ export class NangoError extends NangoInternalError {
             case 'invalid_app_secret':
                 this.status = 400;
                 this.message = `Invalid app secret key. Please make sure the app secret is correct.`;
+                break;
+
+            case 'function_execution_failure':
+                this.message = `The function failed with an error.`;
                 break;
 
             case 'action_script_failure':

--- a/packages/types/lib/action/api.ts
+++ b/packages/types/lib/action/api.ts
@@ -1,5 +1,10 @@
 import type { ApiEndpoint } from '../api.js';
 
+export interface AsyncFunctionResponse {
+    id: string;
+    statusUrl: string;
+}
+
 export interface AsyncActionResponse {
     id: string;
     statusUrl: string;

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -235,6 +235,15 @@ export type PostFunctionDeploymentResult = ApiEndpoint<{
 
 export type FunctionInvocationType = 'wait' | 'no_wait';
 
+export type FunctionInvocationErrorCode =
+    | 'not_implemented'
+    | 'server_error'
+    | 'connection_not_found'
+    | 'function_not_found'
+    | 'function_disabled'
+    | 'validation_error'
+    | 'invalid_invocation';
+
 export type PostFunctionInvocation = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
@@ -247,7 +256,7 @@ export type PostFunctionInvocation = ApiEndpoint<{
         invocation_type: FunctionInvocationType;
         options?: Record<string, unknown> | undefined;
     };
-    Error: ApiError<'not_implemented' | 'connection_not_found' | 'unknown_function' | 'function_disabled' | 'validation_error' | 'invalid_invocation'>;
+    Error: ApiError<FunctionInvocationErrorCode>;
     Success: Record<string, unknown>;
 }>;
 

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -236,7 +236,7 @@ export type PostFunctionDeploymentResult = ApiEndpoint<{
 export type FunctionInvocationType = 'wait' | 'no_wait';
 
 export type FunctionInvocationErrorCode =
-    | 'not_implemented'
+    | 'function_failed'
     | 'server_error'
     | 'connection_not_found'
     | 'function_not_found'
@@ -257,7 +257,10 @@ export type PostFunctionInvocation = ApiEndpoint<{
         options?: Record<string, unknown> | undefined;
     };
     Error: ApiError<FunctionInvocationErrorCode>;
-    Success: Record<string, unknown>;
+    // `wait` invocations return the function output (any json value); `no_wait` invocations return `{ id, statusUrl }`.
+    // ApiEndpoint definition is not flexible enough to support any json value.
+    // TODO: fix ApiEndpoint definition to support any json value
+    Success: any;
 }>;
 
 // Shared between the private and public function-management endpoints. The two surfaces differ only in auth,


### PR DESCRIPTION
1st commit is me following my own advise regarding thin endpoint handler. http-agnostic logic is moved to the `shared` package with only request validation and http error handling left in the handler.
2nd commit is tightening the return type of input validation from unknown to `JsonValue`
Last commit is adding support for creating function tasks in the orchestrator.

Function tasks are not processed/dequeued so for now they all timeout. It is yet not possible to deploy a function with a trigger anyway.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

