### PR TITLE
fix(webapp): correct the spend headline's reveal and tooltip

### DIFF
--- a/packages/design-system/stories/SummaryStrip.stories.tsx
+++ b/packages/design-system/stories/SummaryStrip.stories.tsx
@@ -43,7 +43,7 @@ export const Paid: Story = {
 /** The startup deal rates to $0.00 at any volume, so zero is the figure rather than a missing one. */
 export const DealWithZeroSpend: Story = {
     args: {
-        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP },
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00' },
         plan: { value: 'Startup deal' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
     }
@@ -107,7 +107,7 @@ export const DowngradingToSmallerPlan: Story = {
 /** A YC startup deal converting to Growth — same treatment, opposite direction. */
 export const DealConverting: Story = {
     args: {
-        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP },
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00' },
         plan: { value: 'Startup deal' },
         date: { label: 'CHANGES ON', value: 'September 25, 2026' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
@@ -122,7 +122,7 @@ export const DealConverting: Story = {
 /** A deal with no conversion date stored yet — no date rather than a false renewal (NAN-6640). */
 export const DealWithoutDate: Story = {
     args: {
-        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP },
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00' },
         plan: { value: 'Startup deal' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
     }

--- a/packages/design-system/stories/SummaryStrip.stories.tsx
+++ b/packages/design-system/stories/SummaryStrip.stories.tsx
@@ -1,7 +1,7 @@
 import { Pencil } from 'lucide-react';
 
 import { SummaryStrip } from '@/pages/Team/Billing/components/SummaryStrip';
-import { SPEND_TOOLTIP } from '@/pages/Team/Billing/summaryState';
+import { SPEND_TOOLTIP, SPEND_TOOLTIP_WITHOUT_CHARGES } from '@/pages/Team/Billing/summaryState';
 import { IconButton } from '../src';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -43,7 +43,7 @@ export const Paid: Story = {
 /** The startup deal rates to $0.00 at any volume, so zero is the figure rather than a missing one. */
 export const DealWithZeroSpend: Story = {
     args: {
-        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00' },
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP_WITHOUT_CHARGES },
         plan: { value: 'Startup deal' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
     }
@@ -107,7 +107,7 @@ export const DowngradingToSmallerPlan: Story = {
 /** A YC startup deal converting to Growth — same treatment, opposite direction. */
 export const DealConverting: Story = {
     args: {
-        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00' },
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP_WITHOUT_CHARGES },
         plan: { value: 'Startup deal' },
         date: { label: 'CHANGES ON', value: 'September 25, 2026' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard },
@@ -122,7 +122,7 @@ export const DealConverting: Story = {
 /** A deal with no conversion date stored yet — no date rather than a false renewal (NAN-6640). */
 export const DealWithoutDate: Story = {
     args: {
-        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00' },
+        headline: { label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP_WITHOUT_CHARGES },
         plan: { value: 'Startup deal' },
         payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
     }

--- a/packages/design-system/stories/SummaryStrip.stories.tsx
+++ b/packages/design-system/stories/SummaryStrip.stories.tsx
@@ -40,16 +40,6 @@ export const Paid: Story = {
     }
 };
 
-/** Spend resolves after the plan, so only the figure is skeletoned and nothing reflows when it lands. */
-export const SpendLoading: Story = {
-    args: {
-        headline: { label: 'CURRENT PERIOD SPEND', value: null, tooltip: SPEND_TOOLTIP },
-        plan: { value: 'Growth' },
-        date: { label: 'RENEWS ON', value: 'September 1, 2026' },
-        payment: { card: { brand: 'visa', last4: '7065' }, action: editCard }
-    }
-};
-
 /** The startup deal rates to $0.00 at any volume, so zero is the figure rather than a missing one. */
 export const DealWithZeroSpend: Story = {
     args: {
@@ -138,7 +128,7 @@ export const DealWithoutDate: Story = {
     }
 };
 
-/** While the plan resolves, nothing else can — the plan decides which slots exist. */
+/** The only loading state: the card waits for the plan *and* the spend figure, then reveals at once. */
 export const Loading: Story = {
     args: {
         headline: null

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -39,18 +39,21 @@ export const Summary: React.FC = () => {
         // React Query keeps the last successful data when a refetch fails, so the error flag has to
         // clear the amount too, or a failed refresh leaves a stale figure on screen.
         return {
-            pending: isSpendPending && !didSpendFail,
             amountInCents: didSpendFail ? null : (upcoming?.data.amountInCents ?? null),
             currency: didSpendFail ? null : (upcoming?.data.currency ?? null)
         };
-    }, [spendEnabled, isSpendPending, didSpendFail, upcoming]);
+    }, [spendEnabled, didSpendFail, upcoming]);
+
+    // Spend decides both the headline and whether the plan gets its own slot, so revealing before it
+    // lands means relabelling the card a moment later — worse than a skeleton held a beat longer.
+    const isSpendResolving = spendEnabled && isSpendPending && !didSpendFail;
 
     const state = useMemo(() => {
-        if (!plan || arePlansPending) {
+        if (!plan || arePlansPending || isSpendResolving) {
             return null;
         }
         return buildSummaryState({ plan, plans: plansList?.data, paymentMethod, canManageBilling, spend, now: new Date() });
-    }, [plan, plansList, arePlansPending, paymentMethod, canManageBilling, spend]);
+    }, [plan, plansList, arePlansPending, isSpendResolving, paymentMethod, canManageBilling, spend]);
 
     // Legacy, enterprise and free-uncapped accounts get no strip at all — their terms are negotiated
     // per customer or nothing is billable, so every field would be empty or untrue.

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -57,6 +57,23 @@ const SHOWS_SPEND_HEADLINE: Record<DBPlan['name'], boolean> = {
     'growth-legacy': false
 };
 
+// Plans whose spend figure has components worth explaining. The startup deal has no base fee and
+// never bills overage, so the tooltip would name charges that don't exist.
+const SHOWS_SPEND_TOOLTIP: Record<DBPlan['name'], boolean> = {
+    'starter-v2': true,
+    'growth-v2': true,
+    'startup-deal': false,
+    free: false,
+    'free-uncapped': false,
+    enterprise: false,
+    'enterprise-cloud-hosted': false,
+    starter: false,
+    growth: false,
+    'starter-legacy': false,
+    'scale-legacy': false,
+    'growth-legacy': false
+};
+
 export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {
     if (!plan) {
         return false;
@@ -76,4 +93,11 @@ export function showsSpendHeadline(plan: ApiPlan | null | undefined): boolean {
         return false;
     }
     return SHOWS_SPEND_HEADLINE[plan.name];
+}
+
+export function showsSpendTooltip(plan: ApiPlan | null | undefined): boolean {
+    if (!plan) {
+        return false;
+    }
+    return SHOWS_SPEND_TOOLTIP[plan.name];
 }

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -75,9 +75,9 @@ const PLAN_IS_BILLED: Record<DBPlan['name'], boolean> = {
     'free-uncapped': false
 };
 
-// Plans whose spend figure has components worth explaining. The startup deal has no base fee and
-// never bills overage, so the tooltip would name charges that don't exist.
-const SHOWS_SPEND_TOOLTIP: Record<DBPlan['name'], boolean> = {
+// Whether the plan can put a charge on the invoice at all. The startup deal has no base fee and
+// never bills overage, so nothing accrues until it converts.
+const PLAN_ACCRUES_CHARGES: Record<DBPlan['name'], boolean> = {
     'starter-v2': true,
     'growth-v2': true,
     'startup-deal': false,
@@ -121,9 +121,9 @@ export function isBilledPlan(plan: ApiPlan | null | undefined): boolean {
     return PLAN_IS_BILLED[plan.name];
 }
 
-export function showsSpendTooltip(plan: ApiPlan | null | undefined): boolean {
+export function planAccruesCharges(plan: ApiPlan | null | undefined): boolean {
     if (!plan) {
         return false;
     }
-    return SHOWS_SPEND_TOOLTIP[plan.name];
+    return PLAN_ACCRUES_CHARGES[plan.name];
 }

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -57,9 +57,9 @@ const SHOWS_SPEND_HEADLINE: Record<DBPlan['name'], boolean> = {
     'growth-legacy': false
 };
 
-// Plans whose spend figure has components worth explaining. The startup deal has no base fee and
-// never bills overage, so the tooltip would name charges that don't exist.
-const SHOWS_SPEND_TOOLTIP: Record<DBPlan['name'], boolean> = {
+// Whether the plan can put a charge on the invoice at all. The startup deal has no base fee and
+// never bills overage, so nothing accrues until it converts.
+const PLAN_ACCRUES_CHARGES: Record<DBPlan['name'], boolean> = {
     'starter-v2': true,
     'growth-v2': true,
     'startup-deal': false,
@@ -95,9 +95,9 @@ export function showsSpendHeadline(plan: ApiPlan | null | undefined): boolean {
     return SHOWS_SPEND_HEADLINE[plan.name];
 }
 
-export function showsSpendTooltip(plan: ApiPlan | null | undefined): boolean {
+export function planAccruesCharges(plan: ApiPlan | null | undefined): boolean {
     if (!plan) {
         return false;
     }
-    return SHOWS_SPEND_TOOLTIP[plan.name];
+    return PLAN_ACCRUES_CHARGES[plan.name];
 }

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -75,6 +75,23 @@ const PLAN_IS_BILLED: Record<DBPlan['name'], boolean> = {
     'free-uncapped': false
 };
 
+// Plans whose spend figure has components worth explaining. The startup deal has no base fee and
+// never bills overage, so the tooltip would name charges that don't exist.
+const SHOWS_SPEND_TOOLTIP: Record<DBPlan['name'], boolean> = {
+    'starter-v2': true,
+    'growth-v2': true,
+    'startup-deal': false,
+    free: false,
+    'free-uncapped': false,
+    enterprise: false,
+    'enterprise-cloud-hosted': false,
+    starter: false,
+    growth: false,
+    'starter-legacy': false,
+    'scale-legacy': false,
+    'growth-legacy': false
+};
+
 export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {
     if (!plan) {
         return false;
@@ -102,4 +119,11 @@ export function isBilledPlan(plan: ApiPlan | null | undefined): boolean {
         return false;
     }
     return PLAN_IS_BILLED[plan.name];
+}
+
+export function showsSpendTooltip(plan: ApiPlan | null | undefined): boolean {
+    if (!plan) {
+        return false;
+    }
+    return SHOWS_SPEND_TOOLTIP[plan.name];
 }

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -1,6 +1,6 @@
 import { formatBillingDate, nextUsageResetDate } from './billingPeriod';
 import { formatMoneyFromCents } from './money';
-import { showsSpendHeadline } from './planVisibility';
+import { showsSpendHeadline, showsSpendTooltip } from './planVisibility';
 
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
@@ -73,7 +73,7 @@ function buildHeadline({
     }
 
     return {
-        headline: { label: 'CURRENT PERIOD SPEND', value: formatted, tooltip: SPEND_TOOLTIP },
+        headline: { label: 'CURRENT PERIOD SPEND', value: formatted, tooltip: showsSpendTooltip(plan) ? SPEND_TOOLTIP : undefined },
         plan: { value: planTitle }
     };
 }

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -9,15 +9,13 @@ export const SPEND_TOOLTIP =
 
 export interface SummaryStripHeadline {
     label: string;
-    /** Null while the value is still resolving — the strip skeletons it in place. */
-    value: string | null;
+    value: string;
     /** Info tooltip beside the label. Only the spend headline carries one. */
     tooltip?: string;
 }
 
 /** Current-period spend as the caller's query holds it. A null amount means "no figure to show". */
 export interface SummarySpend {
-    pending: boolean;
     amountInCents: number | null;
     currency: string | null;
 }
@@ -69,18 +67,15 @@ function buildHeadline({
         return asPlan;
     }
 
-    const spendSlots = (value: string | null) => ({
-        headline: { label: 'CURRENT PERIOD SPEND', value, tooltip: SPEND_TOOLTIP },
-        plan: { value: planTitle }
-    });
-
-    if (spend.pending) {
-        // The label needs only the plan, so it renders final while the figure resolves — no reflow.
-        return spendSlots(null);
+    const formatted = spend.amountInCents === null ? null : formatMoneyFromCents(spend.amountInCents, spend.currency);
+    if (formatted === null) {
+        return asPlan;
     }
 
-    const formatted = spend.amountInCents === null ? null : formatMoneyFromCents(spend.amountInCents, spend.currency);
-    return formatted === null ? asPlan : spendSlots(formatted);
+    return {
+        headline: { label: 'CURRENT PERIOD SPEND', value: formatted, tooltip: SPEND_TOOLTIP },
+        plan: { value: planTitle }
+    };
 }
 
 /**

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -1,11 +1,15 @@
 import { formatBillingDate, nextUsageResetDate } from './billingPeriod';
 import { formatMoneyFromCents } from './money';
-import { showsSpendHeadline, showsSpendTooltip } from './planVisibility';
+import { planAccruesCharges, showsSpendHeadline } from './planVisibility';
 
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
-export const SPEND_TOOLTIP =
-    "Next month's base fee plus this period's usage beyond your plan's included quota. Any account credit is applied when the invoice is issued. Usage syncs daily, so this can be up to 24 hours behind.";
+const SPEND_CAVEATS = 'Any account credit is applied when the invoice is issued. Usage syncs daily, so this can be up to 24 hours behind.';
+
+export const SPEND_TOOLTIP = `Next month's base fee plus this period's usage beyond your plan's included quota. ${SPEND_CAVEATS}`;
+
+/** Drops the opening sentence for plans with no base fee and no billable overage. */
+export const SPEND_TOOLTIP_WITHOUT_CHARGES = SPEND_CAVEATS;
 
 export interface SummaryStripHeadline {
     label: string;
@@ -73,7 +77,7 @@ function buildHeadline({
     }
 
     return {
-        headline: { label: 'CURRENT PERIOD SPEND', value: formatted, tooltip: showsSpendTooltip(plan) ? SPEND_TOOLTIP : undefined },
+        headline: { label: 'CURRENT PERIOD SPEND', value: formatted, tooltip: planAccruesCharges(plan) ? SPEND_TOOLTIP : SPEND_TOOLTIP_WITHOUT_CHARGES },
         plan: { value: planTitle }
     };
 }

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { showsSpendHeadline, showsSummaryStrip } from './planVisibility.js';
+import { showsSpendHeadline, showsSpendTooltip, showsSummaryStrip } from './planVisibility.js';
 import { buildSummaryState, SPEND_TOOLTIP } from './summaryState.js';
 
 import type { SummarySpend } from './summaryState.js';
@@ -92,6 +92,18 @@ describe('showsSpendHeadline', () => {
     });
 });
 
+describe('showsSpendTooltip', () => {
+    it('explains the figure on plans that have charges to explain', () => {
+        for (const name of ['starter-v2', 'growth-v2'] as const) {
+            expect(showsSpendTooltip(planOf(name))).toBe(true);
+        }
+    });
+
+    it('stays quiet on the startup deal, whose figure has no base fee or overage behind it', () => {
+        expect(showsSpendTooltip(planOf('startup-deal'))).toBe(false);
+    });
+});
+
 describe('buildSummaryState headline', () => {
     it('leads with the formatted spend and demotes the plan to its own slot', () => {
         const state = build(planOf('growth-v2'), { spend: spendOf(128430) });
@@ -102,7 +114,7 @@ describe('buildSummaryState headline', () => {
     it('reports $0.00 on the startup deal rather than treating it as missing', () => {
         // The deal rates to $0.00 at any volume, so zero is the answer, not a gap.
         const state = build(planOf('startup-deal'), { spend: spendOf(0) });
-        expect(state.headline.value).toBe('$0.00');
+        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: undefined });
         expect(state.plan).toEqual({ value: 'Startup deal' });
     });
 

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isBilledPlan, isLegacyPlan, showsSpendHeadline, showsSummaryStrip } from './planVisibility.js';
+import { isBilledPlan, isLegacyPlan, showsSpendHeadline, showsSpendTooltip, showsSummaryStrip } from './planVisibility.js';
 import { buildSummaryState, pendingPlanChange, SPEND_TOOLTIP } from './summaryState.js';
 
 import type { SummarySpend } from './summaryState.js';
@@ -92,6 +92,18 @@ describe('showsSpendHeadline', () => {
     });
 });
 
+describe('showsSpendTooltip', () => {
+    it('explains the figure on plans that have charges to explain', () => {
+        for (const name of ['starter-v2', 'growth-v2'] as const) {
+            expect(showsSpendTooltip(planOf(name))).toBe(true);
+        }
+    });
+
+    it('stays quiet on the startup deal, whose figure has no base fee or overage behind it', () => {
+        expect(showsSpendTooltip(planOf('startup-deal'))).toBe(false);
+    });
+});
+
 describe('buildSummaryState headline', () => {
     it('leads with the formatted spend and demotes the plan to its own slot', () => {
         const state = build(planOf('growth-v2'), { spend: spendOf(128430) });
@@ -102,7 +114,7 @@ describe('buildSummaryState headline', () => {
     it('reports $0.00 on the startup deal rather than treating it as missing', () => {
         // The deal rates to $0.00 at any volume, so zero is the answer, not a gap.
         const state = build(planOf('startup-deal'), { spend: spendOf(0) });
-        expect(state.headline.value).toBe('$0.00');
+        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: undefined });
         expect(state.plan).toEqual({ value: 'Startup deal' });
     });
 

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { isBilledPlan, isLegacyPlan, showsSpendHeadline, showsSpendTooltip, showsSummaryStrip } from './planVisibility.js';
-import { buildSummaryState, pendingPlanChange, SPEND_TOOLTIP } from './summaryState.js';
+import { isBilledPlan, isLegacyPlan, planAccruesCharges, showsSpendHeadline, showsSummaryStrip } from './planVisibility.js';
+import { buildSummaryState, pendingPlanChange, SPEND_TOOLTIP, SPEND_TOOLTIP_WITHOUT_CHARGES } from './summaryState.js';
 
 import type { SummarySpend } from './summaryState.js';
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
@@ -92,15 +92,21 @@ describe('showsSpendHeadline', () => {
     });
 });
 
-describe('showsSpendTooltip', () => {
-    it('explains the figure on plans that have charges to explain', () => {
+describe('planAccruesCharges', () => {
+    it('is true for the plans with a base fee and billable overage', () => {
         for (const name of ['starter-v2', 'growth-v2'] as const) {
-            expect(showsSpendTooltip(planOf(name))).toBe(true);
+            expect(planAccruesCharges(planOf(name))).toBe(true);
         }
     });
 
-    it('stays quiet on the startup deal, whose figure has no base fee or overage behind it', () => {
-        expect(showsSpendTooltip(planOf('startup-deal'))).toBe(false);
+    it('is false for the startup deal, which has neither until it converts', () => {
+        expect(planAccruesCharges(planOf('startup-deal'))).toBe(false);
+    });
+
+    it('drops only the breakdown sentence from the deal tooltip, keeping the caveats', () => {
+        expect(SPEND_TOOLTIP).toContain("Next month's base fee");
+        expect(SPEND_TOOLTIP_WITHOUT_CHARGES).not.toContain("Next month's base fee");
+        expect(SPEND_TOOLTIP).toContain(SPEND_TOOLTIP_WITHOUT_CHARGES);
     });
 });
 
@@ -114,7 +120,7 @@ describe('buildSummaryState headline', () => {
     it('reports $0.00 on the startup deal rather than treating it as missing', () => {
         // The deal rates to $0.00 at any volume, so zero is the answer, not a gap.
         const state = build(planOf('startup-deal'), { spend: spendOf(0) });
-        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: undefined });
+        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP_WITHOUT_CHARGES });
         expect(state.plan).toEqual({ value: 'Startup deal' });
     });
 

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -33,7 +33,7 @@ function build(plan: ApiPlan, opts: { paymentMethod?: StripePaymentMethod | null
 
 /** A resolved spend read, as `Summary` would hand it over. */
 function spendOf(amountInCents: number | null, currency: string | null = 'USD'): SummarySpend {
-    return { pending: false, amountInCents, currency };
+    return { amountInCents, currency };
 }
 
 describe('showsSummaryStrip', () => {
@@ -97,12 +97,6 @@ describe('buildSummaryState headline', () => {
         const state = build(planOf('growth-v2'), { spend: spendOf(128430) });
         expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: '$1,284.30', tooltip: SPEND_TOOLTIP });
         expect(state.plan).toEqual({ value: 'Growth' });
-    });
-
-    it('shows the label with no value while the read is in flight', () => {
-        const state = build(planOf('starter-v2'), { spend: { pending: true, amountInCents: null, currency: null } });
-        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: null, tooltip: SPEND_TOOLTIP });
-        expect(state.plan).toEqual({ value: 'Starter' });
     });
 
     it('reports $0.00 on the startup deal rather than treating it as missing', () => {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { showsSpendHeadline, showsSpendTooltip, showsSummaryStrip } from './planVisibility.js';
-import { buildSummaryState, SPEND_TOOLTIP } from './summaryState.js';
+import { planAccruesCharges, showsSpendHeadline, showsSummaryStrip } from './planVisibility.js';
+import { buildSummaryState, SPEND_TOOLTIP, SPEND_TOOLTIP_WITHOUT_CHARGES } from './summaryState.js';
 
 import type { SummarySpend } from './summaryState.js';
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
@@ -92,15 +92,21 @@ describe('showsSpendHeadline', () => {
     });
 });
 
-describe('showsSpendTooltip', () => {
-    it('explains the figure on plans that have charges to explain', () => {
+describe('planAccruesCharges', () => {
+    it('is true for the plans with a base fee and billable overage', () => {
         for (const name of ['starter-v2', 'growth-v2'] as const) {
-            expect(showsSpendTooltip(planOf(name))).toBe(true);
+            expect(planAccruesCharges(planOf(name))).toBe(true);
         }
     });
 
-    it('stays quiet on the startup deal, whose figure has no base fee or overage behind it', () => {
-        expect(showsSpendTooltip(planOf('startup-deal'))).toBe(false);
+    it('is false for the startup deal, which has neither until it converts', () => {
+        expect(planAccruesCharges(planOf('startup-deal'))).toBe(false);
+    });
+
+    it('drops only the breakdown sentence from the deal tooltip, keeping the caveats', () => {
+        expect(SPEND_TOOLTIP).toContain("Next month's base fee");
+        expect(SPEND_TOOLTIP_WITHOUT_CHARGES).not.toContain("Next month's base fee");
+        expect(SPEND_TOOLTIP).toContain(SPEND_TOOLTIP_WITHOUT_CHARGES);
     });
 });
 
@@ -114,7 +120,7 @@ describe('buildSummaryState headline', () => {
     it('reports $0.00 on the startup deal rather than treating it as missing', () => {
         // The deal rates to $0.00 at any volume, so zero is the answer, not a gap.
         const state = build(planOf('startup-deal'), { spend: spendOf(0) });
-        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: undefined });
+        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: '$0.00', tooltip: SPEND_TOOLTIP_WITHOUT_CHARGES });
         expect(state.plan).toEqual({ value: 'Startup deal' });
     });
 


### PR DESCRIPTION
## Problem

Two follow-ups to NAN-6246, which shipped the spend figure itself.

The strip revealed itself in three steps: the spend label appeared with a skeletoned figure, the plan slot filled in, then the label changed once the Orb read landed. On the fallback path the label and the plan slot both changed, which reads as the card correcting itself.

Separately, the tooltip opens by breaking the figure into a base fee plus usage beyond the plan's quota. A startup deal has neither — no base fee until it converts, and it rates to $0.00 at any volume — so that sentence named charges that don't exist.

## Solution

- Hold one skeleton until spend resolves, then reveal the card at once.
- Spend decides both the headline *and* whether the plan gets its own slot, so there was never a partial state worth showing. `SummarySpend` loses `pending` and the headline value is no longer nullable, making the half-resolved state unrepresentable; the spend-loading story folds into the whole-card one.
- Drop that opening sentence on `startup-deal` and keep the rest, which still applies. Which plans accrue charges is classified in `planVisibility.ts` beside the other plan maps, so a new plan has to be given an answer rather than inheriting copy that may not describe it.

## Testing

Sampled the DOM every 50ms through a real load against the dev API, on both paths:

| | before | after |
|---|---|---|
| figure arrives | 3 states | `skeleton` → `CURRENT PERIOD SPEND $x` |
| falls back | 3 states, label flips | `skeleton` → `CURRENT PLAN` |

329 webapp tests pass, including new cases asserting the deal headline carries no tooltip.
