### PR TITLE
feat(persist): enforce connection-to-environment ownership on all routes

### DIFF
--- a/packages/persist/lib/middleware/connectionOwnership.middleware.ts
+++ b/packages/persist/lib/middleware/connectionOwnership.middleware.ts
@@ -1,0 +1,20 @@
+import { connectionService } from '@nangohq/shared';
+
+import type { AuthLocals } from './auth.middleware.js';
+import type { NextFunction, Request, Response } from 'express';
+
+export const connectionOwnershipMiddleware = async (req: Request, res: Response<any, AuthLocals>, next: NextFunction) => {
+    const nangoConnectionId = Number(req.params['nangoConnectionId']);
+    if (!Number.isInteger(nangoConnectionId) || nangoConnectionId <= 0) {
+        res.status(400).json({ error: { code: 'invalid_connection_id', message: 'Invalid or missing connection id' } });
+        return;
+    }
+
+    const exists = await connectionService.connectionExistsForEnvironment(nangoConnectionId, res.locals.environment.id);
+    if (!exists) {
+        res.status(404).json({ error: { code: 'connection_not_found', message: 'Connection not found' } });
+        return;
+    }
+
+    next();
+};

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -46,12 +46,15 @@ describe('Persist API', () => {
     const serverUrl = `http://localhost:${port}`;
     let httpServer: Server | undefined;
     let seed: testSeed;
+    let otherTenantSeed: testSeed;
+    const mockOtherTenantSecretKey = 'other-tenant-secret-key';
 
     beforeAll(async () => {
         await multipleMigrations();
         await records.migrate();
         await migrateLogsMapping();
         seed = await initDb();
+        otherTenantSeed = await initDb();
         httpServer = await new Promise<Server>((resolve) => {
             const listener = server.listen(port, () => resolve(listener));
         });
@@ -63,6 +66,19 @@ describe('Persist API', () => {
                         account: { id: seed.account.id },
                         environment: { id: seed.env.id, name: seed.env.name },
                         plan: { id: seed.plan.id, name: seed.plan.name, records_store: seed.plan.records_store }
+                    })
+                );
+            }
+            if (key === mockOtherTenantSecretKey) {
+                return Promise.resolve(
+                    Ok({
+                        account: { id: otherTenantSeed.account.id },
+                        environment: { id: otherTenantSeed.env.id, name: otherTenantSeed.env.name },
+                        plan: {
+                            id: otherTenantSeed.plan.id,
+                            name: otherTenantSeed.plan.name,
+                            records_store: otherTenantSeed.plan.records_store
+                        }
                     })
                 );
             }
@@ -748,6 +764,119 @@ describe('Persist API', () => {
             });
             expect(response.status).toEqual(409);
             expect(await response.json()).toMatchObject({ error: { code: 'checkpoint_conflict' } });
+        });
+    });
+
+    describe('connection ownership', () => {
+        const authHeaders = { Authorization: `Bearer ${mockSecretKey}`, 'Content-Type': 'application/json' };
+
+        it("rejects a read on another tenant's connection (getRecords)", async () => {
+            const response = await fetch(
+                `${serverUrl}/environment/${seed.env.id}/connection/${otherTenantSeed.connection.id}/records?model=Account&limit=100`,
+                { headers: authHeaders }
+            );
+            expect(response.status).toEqual(404);
+            expect(await response.json()).toMatchObject({ error: { code: 'connection_not_found' } });
+        });
+
+        it("rejects a cursor lookup on another tenant's connection (getCursor)", async () => {
+            const response = await fetch(
+                `${serverUrl}/environment/${seed.env.id}/connection/${otherTenantSeed.connection.id}/cursor?model=Account&offset=first`,
+                { headers: authHeaders }
+            );
+            expect(response.status).toEqual(404);
+            expect(await response.json()).toMatchObject({ error: { code: 'connection_not_found' } });
+        });
+
+        it("rejects a checkpoint write on another tenant's connection (putCheckpoint)", async () => {
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${otherTenantSeed.connection.id}/checkpoint`, {
+                method: 'PUT',
+                body: JSON.stringify({ key: 'k', checkpoint: {}, expectedVersion: 1 }),
+                headers: authHeaders
+            });
+            expect(response.status).toEqual(404);
+            expect(await response.json()).toMatchObject({ error: { code: 'connection_not_found' } });
+        });
+
+        it("rejects a soft-delete of another tenant's outdated records (deleteOutdatedRecords)", async () => {
+            const response = await fetch(
+                `${serverUrl}/environment/${seed.env.id}/connection/${otherTenantSeed.connection.id}/sync/x/job/${Number.MAX_SAFE_INTEGER}/outdated`,
+                {
+                    method: 'DELETE',
+                    body: JSON.stringify({ model: 'Account', activityLogId: seed.activityLogId }),
+                    headers: authHeaders
+                }
+            );
+            expect(response.status).toEqual(404);
+            expect(await response.json()).toMatchObject({ error: { code: 'connection_not_found' } });
+        });
+
+        it("rejects a permanent hard-delete of another tenant's records (deleteHardRecords)", async () => {
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${otherTenantSeed.connection.id}/sync/x/job/1/records/hard`, {
+                method: 'DELETE',
+                body: JSON.stringify({ model: 'Account' }),
+                headers: authHeaders
+            });
+            expect(response.status).toEqual(404);
+            expect(await response.json()).toMatchObject({ error: { code: 'connection_not_found' } });
+        });
+
+        it("rejects a write of records onto another tenant's connection (postRecords, the shared recordsPath route)", async () => {
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${otherTenantSeed.connection.id}/sync/x/job/1/records`, {
+                method: 'POST',
+                body: JSON.stringify({
+                    model: 'Account',
+                    records: [{ id: '1' }],
+                    providerConfigKey: 'provider-test',
+                    connectionId: otherTenantSeed.connection.connection_id,
+                    activityLogId: seed.activityLogId,
+                    merging: { strategy: 'override' }
+                }),
+                headers: authHeaders
+            });
+            expect(response.status).toEqual(404);
+            expect(await response.json()).toMatchObject({ error: { code: 'connection_not_found' } });
+        });
+
+        it('rejects a nonexistent connection id with the same 404, not a different error', async () => {
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/999999999/records?model=Account&limit=100`, {
+                headers: authHeaders
+            });
+            expect(response.status).toEqual(404);
+            expect(await response.json()).toMatchObject({ error: { code: 'connection_not_found' } });
+        });
+
+        it('parses a scientific-notation connection id the same way the route\'s own zod schema does (regression: parseInt and Number disagree on "1e2")', async () => {
+            // Under parseInt, "<id>e2" is just <id> — the caller's own real connection. Under
+            // Number (what the route's z.coerce.number().int().positive() schema uses
+            // downstream), it's <id> * 100 — a different, near-certainly nonexistent id. If this
+            // middleware parsed with parseInt, it would authorize against the caller's own real
+            // connection while the route handler went on to act on a completely different
+            // numeric id, defeating the ownership check entirely.
+            const scientificNotationId = `${seed.connection.id}e2`;
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${scientificNotationId}/records?model=Account&limit=100`, {
+                headers: authHeaders
+            });
+            expect(response.status).toEqual(404);
+            expect(await response.json()).toMatchObject({ error: { code: 'connection_not_found' } });
+        });
+
+        it('still allows a tenant to access its own connection (no regression)', async () => {
+            const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/records?model=Account&limit=100`, {
+                headers: authHeaders
+            });
+            expect(response.status).toEqual(200);
+        });
+
+        it("also rejects the other tenant reaching into this seed's connection, using its own valid credentials", async () => {
+            const response = await fetch(
+                `${serverUrl}/environment/${otherTenantSeed.env.id}/connection/${seed.connection.id}/records?model=Account&limit=100`,
+                {
+                    headers: { Authorization: `Bearer ${mockOtherTenantSecretKey}`, 'Content-Type': 'application/json' }
+                }
+            );
+            expect(response.status).toEqual(404);
+            expect(await response.json()).toMatchObject({ error: { code: 'connection_not_found' } });
         });
     });
 });

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -4,6 +4,7 @@ import qs from 'qs';
 import { createRoute } from '@nangohq/utils';
 
 import { authMiddleware } from './middleware/auth.middleware.js';
+import { connectionOwnershipMiddleware } from './middleware/connectionOwnership.middleware.js';
 import { recordsPath } from './records.js';
 import { routeHandler as deleteCheckpointHandler } from './routes/environment/environmentId/connection/connectionId/checkpoint/deleteCheckpoint.js';
 import {
@@ -51,6 +52,7 @@ server.set('query parser', (str: string) => {
 });
 
 server.use('/environment/:environmentId/*splat', authMiddleware);
+server.use('/environment/:environmentId/connection/:nangoConnectionId/*splat', connectionOwnershipMiddleware);
 server.use('/environment/:environmentId/log', express.json({ limit: maxSizeJsonLog }));
 server.use(recordsPath, express.json({ limit: maxSizeJsonRecords }));
 server.use(getCursorRoute.path, express.json());

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -522,6 +522,12 @@ export class ConnectionService {
         return result || null;
     }
 
+    public async connectionExistsForEnvironment(id: number, environmentId: number): Promise<boolean> {
+        const result = await db.knex.from<DBConnection>('_nango_connections').select('id').where({ id, environment_id: environmentId, deleted: false }).first();
+
+        return Boolean(result);
+    }
+
     public async checkIfConnectionExists(
         db: Knex,
         { connectionId, providerConfigKey, environmentId }: { connectionId: string; providerConfigKey: string; environmentId: number }


### PR DESCRIPTION
## Describe the problem and your solution

- enforce `connection-to-environment` ownership on all persist routes

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

