### PR TITLE
feat(server): Add webhook for recovered oauth connection

### DIFF
--- a/docs/guides/auth/token-refreshing.mdx
+++ b/docs/guides/auth/token-refreshing.mdx
@@ -19,18 +19,20 @@ Token refresh can fail for various reasons:
 
 When a refresh fails, Nango can [notify your app via webhook](/guides/platform/webhooks-from-nango) so you can prompt the user to reconnect.
 
+Nango automatically retries failed refreshes on its periodic cycle, so a single failure doesn't necessarily mean the connection is broken — transient provider outages often resolve on the next retry. When a connection recovers, Nango sends a follow-up webhook with `"success": true` so you know it's healthy again without having to poll the connection. Nango only gives up on a connection (and stops retrying) after several consecutive days of failed refreshes.
+
 ## Best practices
 
 Revoked access tokens and refresh failures happen to all integrations. To handle them gracefully:
 
-1. **Monitor for failures**: Set up [webhooks from Nango](/guides/platform/webhooks-from-nango) to receive notifications when token refresh fails
+1. **Monitor for failures and recoveries**: Set up [webhooks from Nango](/guides/platform/webhooks-from-nango) to receive notifications when token refresh fails, and again if/when it later recovers
 2. **Handle revoked tokens**: Follow our [guide on handling revoked access tokens](/guides/platform/common-issues#token-refresh-error-from-the-external-api)
 3. **Implement re-authorization**: Make sure you have the [re-authorization flow](/guides/auth/auth-guide#re-authorize-an-existing-connection) in place so users can easily reconnect broken connections
 
 ## Related guides
 
 - [Auth guide](/guides/auth/auth-guide#re-authorize-an-existing-connection) - implement reconnect sessions for invalid credentials.
-- [Webhooks from Nango](/guides/platform/webhooks-from-nango) - receive refresh failure notifications.
+- [Webhooks from Nango](/guides/platform/webhooks-from-nango) - receive refresh failure and recovery notifications.
 - [Common issues](/guides/platform/common-issues#token-refresh-error-from-the-external-api) - troubleshoot revoked tokens.
 
 <Tip>

--- a/docs/guides/platform/webhooks-from-nango.mdx
+++ b/docs/guides/platform/webhooks-from-nango.mdx
@@ -258,7 +258,7 @@ All `operation` values are:
 
 - `creation`: a new connection has been created
 - `override`: a connection has been re-authorized
-- `refresh`: an OAuth connection's access token has failed to refresh
+- `refresh`: an OAuth connection's access token has failed to refresh, or has recovered after a previous failure
 
 Payload received following a refresh token error:
 
@@ -286,6 +286,30 @@ Payload received following a refresh token error:
 
 <Note>
   Webhooks are only sent for certain connection creation errors. For example, during the OAuth flow, some errors are reported locally in the OAuth modal by the external API. Since Nango does not receive these errors, it cannot trigger a webhook for them.
+</Note>
+
+Nango retries refreshing on its periodic cycle, so a single refresh failure doesn't necessarily mean the connection needs re-authorization. When a connection recovers — i.e. a refresh succeeds after a previous refresh failure — Nango sends a follow-up webhook with `"success": true`:
+
+```json
+{
+    "type": "auth",
+    "operation": "refresh",
+    "connectionId": "<your-connection-id>",
+    "authMode": "OAUTH2 | BASIC | API_KEY | ...",
+    "providerConfigKey": "<your-integration-id>",
+    "provider": "<your-provider-key>",
+    "environment": "DEV | PROD | ...",
+    "success": true,
+    "tags": {
+        "end_user_id": "<your-end-user-id>",
+        "end_user_email": "<your-end-user-email>",
+        "organization_id": "<your-organization-id>"
+    }
+}
+```
+
+<Note>
+  This recovery webhook is only sent when a refresh succeeds after a previous refresh failure — not on every routine successful refresh. It's gated by the same webhook setting as refresh failures.
 </Note>
 
 ### Sync webhooks

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2169,18 +2169,20 @@ Token refresh can fail for various reasons:
 
 When a refresh fails, Nango can [notify your app via webhook](/guides/platform/webhooks-from-nango) so you can prompt the user to reconnect.
 
+Nango automatically retries failed refreshes on its periodic cycle, so a single failure doesn't necessarily mean the connection is broken — transient provider outages often resolve on the next retry. When a connection recovers, Nango sends a follow-up webhook with `"success": true` so you know it's healthy again without having to poll the connection. Nango only gives up on a connection (and stops retrying) after several consecutive days of failed refreshes.
+
 ## Best practices
 
 Revoked access tokens and refresh failures happen to all integrations. To handle them gracefully:
 
-1. **Monitor for failures**: Set up [webhooks from Nango](/guides/platform/webhooks-from-nango) to receive notifications when token refresh fails
+1. **Monitor for failures and recoveries**: Set up [webhooks from Nango](/guides/platform/webhooks-from-nango) to receive notifications when token refresh fails, and again when it later recovers
 2. **Handle revoked tokens**: Follow our [guide on handling revoked access tokens](/guides/platform/common-issues#token-refresh-error-from-the-external-api)
 3. **Implement re-authorization**: Make sure you have the [re-authorization flow](/guides/auth/auth-guide#re-authorize-an-existing-connection) in place so users can easily reconnect broken connections
 
 ## Related guides
 
 - [Auth guide](/guides/auth/auth-guide#re-authorize-an-existing-connection) - implement reconnect sessions for invalid credentials.
-- [Webhooks from Nango](/guides/platform/webhooks-from-nango) - receive refresh failure notifications.
+- [Webhooks from Nango](/guides/platform/webhooks-from-nango) - receive refresh failure and recovery notifications.
 - [Common issues](/guides/platform/common-issues#token-refresh-error-from-the-external-api) - troubleshoot revoked tokens.
 
 <Tip>
@@ -7559,7 +7561,7 @@ All `operation` values are:
 
 - `creation`: a new connection has been created
 - `override`: a connection has been re-authorized
-- `refresh`: an OAuth connection's access token has failed to refresh
+- `refresh`: an OAuth connection's access token has failed to refresh, or has recovered after a previous failure
 
 Payload received following a refresh token error:
 
@@ -7587,6 +7589,30 @@ Payload received following a refresh token error:
 
 <Note>
   Webhooks are only sent for certain connection creation errors. For example, during the OAuth flow, some errors are reported locally in the OAuth modal by the external API. Since Nango does not receive these errors, it cannot trigger a webhook for them.
+</Note>
+
+Nango retries refreshing on its periodic cycle, so a single refresh failure doesn't necessarily mean the connection needs re-authorization. When a connection recovers — i.e. a refresh succeeds after a previous refresh failure — Nango sends a follow-up webhook with `"success": true` so you don't have to poll the connection to find out:
+
+```json
+{
+    "type": "auth",
+    "operation": "refresh",
+    "connectionId": "<your-connection-id>",
+    "authMode": "OAUTH2 | BASIC | API_KEY | ...",
+    "providerConfigKey": "<your-integration-id>",
+    "provider": "<your-provider-key>",
+    "environment": "DEV | PROD | ...",
+    "success": true,
+    "tags": {
+        "end_user_id": "<your-end-user-id>",
+        "end_user_email": "<your-end-user-email>",
+        "organization_id": "<your-organization-id>"
+    }
+}
+```
+
+<Note>
+  This recovery webhook is only sent when a refresh succeeds after a previous refresh failure — not on every routine successful refresh. It's gated by the same webhook setting as refresh failures.
 </Note>
 
 ### Sync webhooks

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2175,7 +2175,7 @@ Nango automatically retries failed refreshes on its periodic cycle, so a single 
 
 Revoked access tokens and refresh failures happen to all integrations. To handle them gracefully:
 
-1. **Monitor for failures and recoveries**: Set up [webhooks from Nango](/guides/platform/webhooks-from-nango) to receive notifications when token refresh fails, and again when it later recovers
+1. **Monitor for failures and recoveries**: Set up [webhooks from Nango](/guides/platform/webhooks-from-nango) to receive notifications when token refresh fails, and again if/when it later recovers
 2. **Handle revoked tokens**: Follow our [guide on handling revoked access tokens](/guides/platform/common-issues#token-refresh-error-from-the-external-api)
 3. **Implement re-authorization**: Make sure you have the [re-authorization flow](/guides/auth/auth-guide#re-authorize-an-existing-connection) in place so users can easily reconnect broken connections
 
@@ -7591,7 +7591,7 @@ Payload received following a refresh token error:
   Webhooks are only sent for certain connection creation errors. For example, during the OAuth flow, some errors are reported locally in the OAuth modal by the external API. Since Nango does not receive these errors, it cannot trigger a webhook for them.
 </Note>
 
-Nango retries refreshing on its periodic cycle, so a single refresh failure doesn't necessarily mean the connection needs re-authorization. When a connection recovers — i.e. a refresh succeeds after a previous refresh failure — Nango sends a follow-up webhook with `"success": true` so you don't have to poll the connection to find out:
+Nango retries refreshing on its periodic cycle, so a single refresh failure doesn't necessarily mean the connection needs re-authorization. When a connection recovers — i.e. a refresh succeeds after a previous refresh failure — Nango sends a follow-up webhook with `"success": true`:
 
 ```json
 {

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -263,17 +263,12 @@ export const connectionRefreshSuccess = async ({
     environment?: DBEnvironment;
     provider?: Provider;
 }): Promise<void> => {
-    let hadActiveAuthError = false;
+    let clearedActiveAuthError = false;
     try {
-        hadActiveAuthError = Boolean(await errorNotificationService.auth.get(connection.id));
-    } catch (err) {
-        report(new Error('refresh_success_hook_failed', { cause: err }), { id: connection.id });
-    }
-
-    try {
-        await errorNotificationService.auth.clear({
+        const deletedCount = await errorNotificationService.auth.clear({
             connection_id: connection.id
         });
+        clearedActiveAuthError = deletedCount > 0;
     } catch (err) {
         report(new Error('refresh_success_hook_failed', { cause: err }), { id: connection.id });
     }
@@ -290,7 +285,7 @@ export const connectionRefreshSuccess = async ({
         report(new Error('refresh_success_hook_failed', { cause: err }), { id: connection.id });
     }
 
-    if (hadActiveAuthError && account && environment && provider) {
+    if (clearedActiveAuthError && account && environment && provider) {
         try {
             const webhookSettings = await externalWebhookService.get(environment.id);
 

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -252,11 +252,24 @@ export const reconnectionFailed = async ({
 
 export const connectionRefreshSuccess = async ({
     connection,
-    config
+    config,
+    account,
+    environment,
+    provider
 }: {
     connection: Pick<DBConnectionDecrypted, 'id' | 'connection_id' | 'provider_config_key' | 'environment_id'>;
     config: IntegrationConfig;
+    account?: DBTeam;
+    environment?: DBEnvironment;
+    provider?: Provider;
 }): Promise<void> => {
+    let hadActiveAuthError = false;
+    try {
+        hadActiveAuthError = Boolean(await errorNotificationService.auth.get(connection.id));
+    } catch (err) {
+        report(new Error('refresh_success_hook_failed', { cause: err }), { id: connection.id });
+    }
+
     try {
         await errorNotificationService.auth.clear({
             connection_id: connection.id
@@ -275,6 +288,33 @@ export const connectionRefreshSuccess = async ({
         });
     } catch (err) {
         report(new Error('refresh_success_hook_failed', { cause: err }), { id: connection.id });
+    }
+
+    if (hadActiveAuthError && account && environment && provider) {
+        try {
+            const webhookSettings = await externalWebhookService.get(environment.id);
+
+            if (webhookSettings) {
+                const webhookSigningKey = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);
+                if (webhookSigningKey.isErr()) {
+                    throw webhookSigningKey.error;
+                }
+
+                void sendAuthWebhook({
+                    connection,
+                    environment,
+                    secret: webhookSigningKey.value,
+                    webhookSettings,
+                    auth_mode: provider.auth_mode,
+                    operation: 'refresh',
+                    success: true,
+                    providerConfig: config,
+                    account
+                });
+            }
+        } catch (err) {
+            report(new Error('refresh_recovery_webhook_failed', { cause: err }), { id: connection.id });
+        }
     }
 };
 

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -36,7 +36,13 @@ interface RefreshProps {
     integration: IntegrationConfig;
     logContextGetter: LogContextGetter;
     instantRefresh: boolean;
-    onRefreshSuccess: (args: { connection: DBConnectionDecrypted; environment: DBEnvironment; config: ProviderConfig }) => Promise<void>;
+    onRefreshSuccess: (args: {
+        connection: DBConnectionDecrypted;
+        environment: DBEnvironment;
+        config: ProviderConfig;
+        account: DBTeam;
+        provider: Provider;
+    }) => Promise<void>;
     onRefreshFailed: (args: {
         connection: DBConnectionDecrypted;
         logCtx: LogContext;
@@ -251,7 +257,9 @@ async function refreshCredentials(
         await onRefreshSuccess({
             connection: value.connection,
             environment,
-            config: integration as ProviderConfig
+            config: integration as ProviderConfig,
+            account,
+            provider
         });
     } else {
         metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FRESH, 1, { providerConfigKey: integration.unique_key });
@@ -342,7 +350,9 @@ async function testCredentials(
         await onRefreshSuccess({
             connection: oldConnection,
             environment,
-            config: integration as ProviderConfig
+            config: integration as ProviderConfig,
+            account,
+            provider
         });
 
         return Ok(connection);

--- a/packages/shared/lib/services/notification/error.service.ts
+++ b/packages/shared/lib/services/notification/error.service.ts
@@ -37,8 +37,9 @@ export const errorNotificationService = {
         get: async (id: number): Promise<ActiveLog | null> => {
             return await db.knex.from<ActiveLog>(DB_TABLE).where({ type: 'auth', connection_id: id, active: true }).first();
         },
-        clear: async ({ connection_id, trx = db.knex }: { connection_id: ActiveLog['connection_id']; trx?: Knex.Transaction | Knex }): Promise<void> => {
-            await trx.from<ActiveLog>(DB_TABLE).where({ type: 'auth', connection_id }).delete();
+        clear: async ({ connection_id, trx = db.knex }: { connection_id: ActiveLog['connection_id']; trx?: Knex.Transaction | Knex }): Promise<number> => {
+            const deletedCount = await trx.from<ActiveLog>(DB_TABLE).where({ type: 'auth', connection_id, active: true }).delete();
+            return deletedCount;
         }
     },
     sync: {

--- a/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { permissions } from '@nangohq/authz';
 
 import { PermissionGate } from '@/components/patterns/PermissionGate';
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { Switch } from '@/components/ui/Switch';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useEnvironment, usePatchWebhook } from '../../../../hooks/useEnvironment';
@@ -87,11 +88,14 @@ export const WebhookCheckboxes: React.FC<CheckboxFormProps> = ({ env, checkboxSt
 
     return (
         <div className="flex flex-col gap-10">
-            {checkboxesConfig.map(({ label, stateKey }) => (
+            {checkboxesConfig.map(({ label, tooltip, stateKey }) => (
                 <div className="flex items-center justify-between" key={stateKey}>
-                    <label htmlFor={stateKey} className={`text-sm font-medium`}>
-                        {label}
-                    </label>
+                    <div className="flex gap-2 items-center">
+                        <label htmlFor={stateKey} className={`text-sm font-medium`}>
+                            {label}
+                        </label>
+                        <InfoTooltip>{tooltip}</InfoTooltip>
+                    </div>
 
                     <div className="flex gap-2 items-center">
                         {loading === stateKey && <Loader2 className="size-4 animate-spin" />}

--- a/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
@@ -24,8 +24,8 @@ const checkboxesConfig: CheckboxConfig[] = [
         stateKey: 'on_auth_creation'
     },
     {
-        label: 'Auth: token refresh error webhooks',
-        tooltip: 'If checked, a webhook will be sent on connection refresh failure.',
+        label: 'Auth: token refresh webhooks',
+        tooltip: 'If checked, a webhook will be sent on connection refresh failure, and again if the connection later recovers.',
         stateKey: 'on_auth_refresh_error'
     },
     {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Sends a webhook with `{"type": "auth", "operation": "refresh", "success": true }` on `connectionRefreshSuccess`, _only_ if the connection had previously errored. This closes the loop for customers who receive a webhook on refresh failures that may resolve themselves on next refresh attempt.

Also updated the webhook settings page to actually display the tooltip content defined there:
<img width="1178" height="317" alt="Screenshot 2026-08-21 at 2 53 41 PM" src="https://github.com/user-attachments/assets/683f6b25-a781-4d63-9537-d1abefc032b3" />

<!-- Issue ticket number and link (if applicable) -->
[NAN-6686: feat(server): Add webhook for connection refresh success after error](https://linear.app/nango/issue/NAN-6686/featserver-add-webhook-for-connection-refresh-success-after-error)

<!-- Testing instructions (skip if just adding/editing providers) -->
1. Configure your webhooks locally to point somewhere like [webhook.site](https://webhook.site/) or a local server for testing
2. Simulate a connection error on an existing OAuth connection with something like:

```
INSERT INTO _nango_active_logs (type, action, connection_id, active) VALUES ('auth', 'token_refresh', <connection_id>, true);
```

3. See connection as having auth error from UI
4. Trigger refresh
5. Should see auth error go away and receive webhook:

```
{
  "operation": "refresh",
  "success": true,
  "type": "auth",
  ...
}
```
6. Trigger refresh again
7. Should not receive another webhook

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

