### PR TITLE
feat(usage): read all function metrics from v2 table

### DIFF
--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -117,7 +117,6 @@ export function tableForMetric(metric: UsageMetric): string {
         case 'function_executions':
         case 'function_logs':
         case 'function_compute_gbms':
-            return `daily_function_executions`;
         case 'function_duration_seconds':
             return `daily_function_executions_v2`;
         case 'webhook_forwards':

--- a/packages/usage/lib/clickhouse/clickhouse.query.unit.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { BREAKDOWN_DIMENSIONS, isAllowedDimensionFor } from './clickhouse.query.js';
+import { BREAKDOWN_DIMENSIONS, isAllowedDimensionFor, tableForMetric } from './clickhouse.query.js';
 
 import type { UsageMetric } from '@nangohq/types';
 
@@ -28,4 +28,13 @@ describe('isAllowedDimensionFor', () => {
         expect(isAllowedDimensionFor('records', 'NONE')).toBe(false);
         expect(isAllowedDimensionFor('records', ' none ')).toBe(false);
     });
+});
+
+describe('tableForMetric', () => {
+    it.each(['function_executions', 'function_logs', 'function_compute_gbms', 'function_duration_seconds'] as const)(
+        'reads %s from the v2 function-executions aggregate',
+        (metric) => {
+            expect(tableForMetric(metric)).toBe('daily_function_executions_v2');
+        }
+    );
 });


### PR DESCRIPTION
Route function executions, logs, and compute GB-ms queries through daily_function_executions_v2 now that the v2 history backfill is complete.

Add a regression test covering all function metrics served by the v2 table.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

