### PR TITLE
fix(node-client): fix array query param serialization and sync validation error

### DIFF
--- a/packages/node-client/lib/utils.ts
+++ b/packages/node-client/lib/utils.ts
@@ -29,7 +29,7 @@ export const validateSyncRecordConfiguration = (config: ListRecordsRequestConfig
 
     requiredParams.forEach((param) => {
         if (typeof config[param] === 'undefined') {
-            throw new Error(`${param} is missing and is required to make a proxy call!`);
+            throw new Error(`${param} is missing and is required to fetch sync records!`);
         }
     });
 };
@@ -50,7 +50,7 @@ export function addQueryParams(url: URL, queries?: Record<string, any>) {
     Object.entries(queries).forEach(([name, value]) => {
         if (Array.isArray(value)) {
             for (const el of value) {
-                url.searchParams.set(name, el);
+                url.searchParams.append(name, el);
             }
         } else if (value !== null && value !== undefined) {
             url.searchParams.set(name, value);

--- a/packages/node-client/lib/utils.unit.test.ts
+++ b/packages/node-client/lib/utils.unit.test.ts
@@ -1,13 +1,76 @@
 import { describe, expect, it } from 'vitest';
 
-import { getUserAgent } from './utils.js';
+import { addQueryParams, getUserAgent, validateProxyConfiguration, validateSyncRecordConfiguration } from './utils.js';
 
-const regex = 'nango-node-client/[0-9.]+ .[a-z0-9]+/[0-9a-zA-Z.-]+; node.js/[0-9.]+.';
+import type { ListRecordsRequestConfig, ProxyConfiguration } from './types.js';
+
+const regex = /^nango-node-client\/[0-9.]+ \([a-z0-9_]+\/[0-9a-zA-Z._-]+; node\.js\/[0-9.]+\)$/;
 describe('getUserAgent', () => {
     it('should output default user agent', () => {
-        expect(getUserAgent()).toMatch(new RegExp(regex));
+        expect(getUserAgent()).toMatch(regex);
     });
     it('should output additional user agent ', () => {
-        expect(getUserAgent('cli')).toMatch(new RegExp(`${regex}; cli`));
+        expect(getUserAgent('cli')).toMatch(/^nango-node-client\/[0-9.]+ \([a-z0-9_]+\/[0-9a-zA-Z._-]+; node\.js\/[0-9.]+\); cli$/);
+    });
+});
+
+describe('validateProxyConfiguration', () => {
+    it('should not throw when all required parameters are provided', () => {
+        const config: ProxyConfiguration = {
+            endpoint: '/users',
+            providerConfigKey: 'github',
+            connectionId: 'conn-123'
+        };
+        expect(() => validateProxyConfiguration(config)).not.toThrow();
+    });
+
+    it('should throw an informative error when a required parameter is missing', () => {
+        const config = {
+            providerConfigKey: 'github',
+            connectionId: 'conn-123'
+        } as ProxyConfiguration;
+        expect(() => validateProxyConfiguration(config)).toThrow('endpoint is missing and is required to make a proxy call!');
+    });
+});
+
+describe('validateSyncRecordConfiguration', () => {
+    it('should not throw when all required parameters are provided', () => {
+        const config: ListRecordsRequestConfig = {
+            model: 'Contact',
+            providerConfigKey: 'hubspot',
+            connectionId: 'conn-456'
+        };
+        expect(() => validateSyncRecordConfiguration(config)).not.toThrow();
+    });
+
+    it('should throw an informative error when a required parameter is missing', () => {
+        const config = {
+            providerConfigKey: 'hubspot',
+            connectionId: 'conn-456'
+        } as ListRecordsRequestConfig;
+        expect(() => validateSyncRecordConfiguration(config)).toThrow('model is missing and is required to fetch sync records!');
+    });
+});
+
+describe('addQueryParams', () => {
+    it('should correctly append scalar and array query parameters', () => {
+        const url = new URL('https://api.example.com/data');
+        addQueryParams(url, {
+            filter: 'active',
+            tags: ['tag1', 'tag2'],
+            empty: undefined,
+            nullValue: null
+        });
+
+        expect(url.searchParams.get('filter')).toBe('active');
+        expect(url.searchParams.getAll('tags')).toEqual(['tag1', 'tag2']);
+        expect(url.searchParams.has('empty')).toBe(false);
+        expect(url.searchParams.has('nullValue')).toBe(false);
+    });
+
+    it('should do nothing when queries is undefined', () => {
+        const url = new URL('https://api.example.com/data');
+        addQueryParams(url, undefined);
+        expect(url.search).toBe('');
     });
 });


### PR DESCRIPTION
This PR addresses two bugs and improves test coverage in @nangohq/node-client:

1. **Array Query Parameter Serialization**

   * In `addQueryParams()`, iterating over array query values was calling `url.searchParams.set(name, el)` instead of `url.searchParams.append(name, el)`. This caused multi-value array query parameters (e.g. `tags: ['tag1', 'tag2']`) to overwrite earlier values, retaining only the last item.
   * Changed to `url.searchParams.append(name, el)` so all array elements are preserved as repeated query parameters on the URL.

2. **Sync Validation Error Message**

   * Fixed a copy-paste error in `validateSyncRecordConfiguration()` where missing parameters threw:

     * `"${param} is missing and is required to make a proxy call!"`
   * Updated the error message to accurately state:

     * `"${param} is missing and is required to fetch sync records!"`

3. **Test Suite & Regex Compatibility**

   * Updated the `getUserAgent()` unit test regex to support dots and underscores in Linux/Unix OS kernel release strings (e.g. `6.19.7-200.fc43.x86_64`).
   * Added comprehensive unit tests in `packages/node-client/lib/utils.unit.test.ts` covering `validateProxyConfiguration`, `validateSyncRecordConfiguration`, and `addQueryParams` (scalars, arrays, null/undefined handling).

---

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] Tests / Documentation

---

## Verification & Testing

* Ran unit tests: `npx vitest run packages/node-client/` (all 30 tests passed).
* Ran TypeScript monorepo build: `npm run ts-build` (clean compilation with project references).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

