### PR TITLE
fix(connect-ui): pre-bundle react/jsx-runtime in vitest config

### DIFF
--- a/packages/connect-ui/vitest.config.ts
+++ b/packages/connect-ui/vitest.config.ts
@@ -7,6 +7,12 @@ export default mergeConfig(
     // Resolve the vite config function with 'serve' so tests get the root base, not the relative build base.
     viteConfig({ command: 'serve', mode: 'test' }),
     defineConfig({
+        // SWC injects the `react/jsx-runtime` import at transform time, so Vite's esbuild dep
+        // scanner never sees it and discovers it mid-run — re-optimizing and reloading the page,
+        // which kills whichever test file is importing at that moment. Not fixable by a
+        // plugin/Vite version bump: this is the maintainer-endorsed workaround for a known,
+        // by-design scanner gap (https://github.com/vitejs/vite/issues/19343).
+        optimizeDeps: { include: ['react/jsx-runtime'] },
         test: {
             include: ['src/**/*.test.tsx'],
             setupFiles: ['./src/test/setup.ts'],


### PR DESCRIPTION
## Problem
`tests-connect-ui`, which is required on `master` via the merge queue, occasionally fails with `Failed to fetch dynamically imported module` for a test file. Root cause: `@vitejs/plugin-react-swc` injects the `react/jsx-runtime` import at transform time, so Vite's dep scanner never sees it and discovers it mid-run, triggering a page reload that cancels whatever module was mid-import. This happens on every run of the suite (visible as a "Vite unexpectedly reloaded a test" warning in the logs) but only fails the suite when the reload lands during a test file's import.

## Solution
- Pre-bundle `react/jsx-runtime` via `optimizeDeps.include` in `packages/connect-ui/vitest.config.ts` so Vite has it up front and never needs to re-optimize mid-run

Fixes [NAN-6714](https://linear.app/nango/issue/NAN-6714/fix-rare-flake-in-tests-connect-ui-ci-job)

## Testing
- Ran `vitest run` locally with a cold Vite cache (`rm -rf node_modules/.vite`) repeatedly — the reload warning no longer appears and the suite passes each time, versus appearing on every run before the fix
