### PR TITLE
fix(server): harden pre/post connection proxy request

### DIFF
--- a/packages/server/lib/hooks/connection/internal-nango.ts
+++ b/packages/server/lib/hooks/connection/internal-nango.ts
@@ -1,4 +1,12 @@
-import { configService, connectionService, getProxyConfiguration, makeDataTransferEvent, ProxyRequest, pubsub } from '@nangohq/shared';
+import {
+    configService,
+    connectionService,
+    getProxyConfiguration,
+    getServerOutboundUrlPolicy,
+    makeDataTransferEvent,
+    ProxyRequest,
+    pubsub
+} from '@nangohq/shared';
 
 import type { Config } from '@nangohq/shared';
 import type { ConnectionConfig, DBConnectionDecrypted, InternalProxyConfiguration, Provider, UserProvidedProxyConfiguration } from '@nangohq/types';
@@ -41,6 +49,7 @@ export function getInternalNango(connection: DBConnectionDecrypted, providerName
                     /* TODO: structured logging here if needed */
                 },
                 proxyConfig: proxyConfigUnwrapped,
+                outboundPolicy: getServerOutboundUrlPolicy(),
                 getConnection: () => connection,
                 getIntegrationConfig: async () => {
                     const integration = await configService.getProviderConfig(connection.provider_config_key, connection.environment_id);

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -6,6 +6,7 @@ import configService from '../config.service.js';
 import connectionService from '../connection.service.js';
 import { refreshOrTestCredentials } from '../connections/credentials/refresh.js';
 import environmentService from '../environment.service.js';
+import { getServerOutboundUrlPolicy } from '../proxy/outbound-policy.js';
 import { ProxyRequest } from '../proxy/request.js';
 import { getProxyConfiguration } from '../proxy/utils.js';
 
@@ -697,6 +698,7 @@ export class SlackService {
             const proxy = new ProxyRequest({
                 logger: () => {},
                 proxyConfig: proxyConfig.value,
+                outboundPolicy: getServerOutboundUrlPolicy(),
                 getConnection: () => slackConnection,
                 getIntegrationConfig: () => ({
                     oauth_client_id: integration.oauth_client_id,
@@ -770,6 +772,7 @@ export class SlackService {
             const proxy = new ProxyRequest({
                 logger: () => {},
                 proxyConfig: proxyConfig.value,
+                outboundPolicy: getServerOutboundUrlPolicy(),
                 getConnection: () => slackConnection,
                 getIntegrationConfig: () => ({
                     oauth_client_id: integration.oauth_client_id,

--- a/packages/shared/lib/services/proxy/byte-metering.unit.test.ts
+++ b/packages/shared/lib/services/proxy/byte-metering.unit.test.ts
@@ -1,13 +1,29 @@
 import http from 'node:http';
+import https from 'node:https';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getTestConnection } from '../../seeders/connection.seeder.js';
 import { ProxyRequest } from './request.js';
-import { getDefaultProxy } from './utils.test.js';
+import { getDefaultProxy, permissiveTestOutboundPolicy } from './utils.test.js';
 
 import type { MeteredBytes } from './byte-metering-transport.js';
+import type * as EgressModule from '@nangohq/egress';
 import type { AddressInfo } from 'node:net';
+
+// Loopback is always blocked by the real policy. These tests measure socket bytes
+// against an in-process HTTP server, so skip the SSRF guards here only.
+vi.mock('@nangohq/egress', async (importOriginal) => {
+    const actual = await importOriginal<typeof EgressModule>();
+    return {
+        ...actual,
+        assertSafeOutboundUrlSync: (url: string) => new URL(url),
+        getSafeHttpAgents: () => ({
+            httpAgent: new http.Agent({ keepAlive: true }),
+            httpsAgent: new https.Agent({ keepAlive: true })
+        })
+    };
+});
 
 interface ServerHandle {
     server: http.Server;
@@ -55,6 +71,7 @@ describe('ProxyRequest onBytes (socket metering)', () => {
             }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy,
             onBytes
         });
 
@@ -84,6 +101,7 @@ describe('ProxyRequest onBytes (socket metering)', () => {
             }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy,
             onBytes
         });
 
@@ -117,6 +135,7 @@ describe('ProxyRequest onBytes (socket metering)', () => {
             }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy,
             onBytes: (c) => {
                 fires.push({ ...c });
             }
@@ -153,6 +172,7 @@ describe('ProxyRequest onBytes (socket metering)', () => {
             }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy,
             onBytes: (c) => {
                 fires.push({ ...c });
             }
@@ -189,6 +209,7 @@ describe('ProxyRequest onBytes (socket metering)', () => {
             }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy,
             onBytes
         });
 
@@ -222,6 +243,7 @@ describe('ProxyRequest onBytes (socket metering)', () => {
             }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy,
             onBytes
         });
 
@@ -245,7 +267,8 @@ describe('ProxyRequest onBytes (socket metering)', () => {
                 endpoint: '/'
             }),
             getConnection: () => getTestConnection(),
-            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy
         });
 
         const result = (await proxy.request()).unwrap();
@@ -279,6 +302,7 @@ describe('ProxyRequest onBytes (socket metering)', () => {
             }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy,
             onBytes
         });
 
@@ -308,6 +332,7 @@ describe('ProxyRequest onBytes (socket metering)', () => {
             }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy,
             onBytes
         });
 
@@ -342,6 +367,7 @@ describe('ProxyRequest onBytes (socket metering)', () => {
             }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy,
             onBytes
         });
 
@@ -372,6 +398,7 @@ describe('ProxyRequest onBytes (socket metering)', () => {
             }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            outboundPolicy: permissiveTestOutboundPolicy,
             onBytes
         });
 

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -24,7 +24,7 @@ interface Props {
     onBytes?: (bytes: MeteredBytes) => MaybePromise<void>;
     getConnection: () => MaybePromise<ConnectionForProxy>;
     getIntegrationConfig: () => MaybePromise<IntegrationConfigForProxy>;
-    outboundPolicy?: OutboundUrlPolicy | undefined;
+    outboundPolicy: OutboundUrlPolicy;
 }
 
 /**
@@ -75,8 +75,9 @@ export class ProxyRequest {
 
     /**
      * Outbound URL SSRF policy applied to every request attempt (incl. redirect hops).
+     * Required so customer-reachable callers cannot omit the egress guard.
      */
-    outboundPolicy?: Props['outboundPolicy'];
+    outboundPolicy: Props['outboundPolicy'];
 
     constructor(props: Props) {
         this.config = props.proxyConfig;

--- a/packages/shared/lib/services/proxy/request.unit.test.ts
+++ b/packages/shared/lib/services/proxy/request.unit.test.ts
@@ -1,5 +1,4 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import assert from 'node:assert';
 
 import { AxiosError } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
@@ -11,45 +10,6 @@ import { ProxyRequest } from './request.js';
 import { getDefaultProxy } from './utils.test.js';
 
 import type { InternalAxiosRequestConfig } from 'axios';
-
-const productionProxyRequestFiles = [
-    'packages/server/lib/hooks/connection/internal-nango.ts',
-    'packages/server/lib/hooks/connection/credentials-verification-script.ts',
-    'packages/server/lib/hooks/hooks.ts',
-    'packages/server/lib/controllers/auth/postAwsSigV4.ts',
-    'packages/server/lib/services/proxy.service.ts',
-    'packages/shared/lib/services/notification/slack.service.ts',
-    'packages/runner/lib/sdk/sdk.ts'
-];
-
-function extractProxyRequestConstructorArgs(source: string): string[] {
-    const results: string[] = [];
-    const needle = 'new ProxyRequest(';
-    let searchFrom = 0;
-    while (true) {
-        const start = source.indexOf(needle, searchFrom);
-        if (start === -1) {
-            break;
-        }
-        const openParen = start + needle.length - 1;
-        let depth = 0;
-        let end = openParen;
-        for (; end < source.length; end++) {
-            const char = source[end];
-            if (char === '(') {
-                depth++;
-            } else if (char === ')') {
-                depth--;
-                if (depth === 0) {
-                    break;
-                }
-            }
-        }
-        results.push(source.slice(openParen, end + 1));
-        searchFrom = end + 1;
-    }
-    return results;
-}
 
 function makeAxiosError(status: number): AxiosError {
     const err = new AxiosError(`Request failed with status code ${status}`);
@@ -185,23 +145,7 @@ describe('call', () => {
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
         });
         const result = await proxy.request();
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
-            expect(result.error).toBeInstanceOf(OutboundUrlError);
-        }
-    });
-
-    it('every production ProxyRequest construction supplies outboundPolicy', () => {
-        let constructionCount = 0;
-        for (const relativePath of productionProxyRequestFiles) {
-            const source = readFileSync(join(process.cwd(), relativePath), 'utf8');
-            const argsList = extractProxyRequestConstructorArgs(source);
-            expect(argsList.length, `${relativePath} should construct ProxyRequest`).toBeGreaterThan(0);
-            for (const [index, args] of argsList.entries()) {
-                expect(args, `${relativePath} construction #${index + 1} missing outboundPolicy`).toMatch(/outboundPolicy\s*:/);
-                constructionCount += 1;
-            }
-        }
-        expect(constructionCount).toBeGreaterThanOrEqual(8);
+        assert(result.isErr());
+        expect(result.error).toBeInstanceOf(OutboundUrlError);
     });
 });

--- a/packages/shared/lib/services/proxy/request.unit.test.ts
+++ b/packages/shared/lib/services/proxy/request.unit.test.ts
@@ -186,7 +186,9 @@ describe('call', () => {
         });
         const result = await proxy.request();
         expect(result.isErr()).toBe(true);
-        expect(result.error).toBeInstanceOf(OutboundUrlError);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(OutboundUrlError);
+        }
     });
 
     it('every production ProxyRequest construction supplies outboundPolicy', () => {

--- a/packages/shared/lib/services/proxy/request.unit.test.ts
+++ b/packages/shared/lib/services/proxy/request.unit.test.ts
@@ -1,11 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { AxiosError } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_OUTBOUND_URL_POLICY, OutboundUrlError } from '@nangohq/egress';
 
 import { getTestConnection } from '../../seeders/connection.seeder.js';
 import { ProxyRequest } from './request.js';
 import { getDefaultProxy } from './utils.test.js';
 
 import type { InternalAxiosRequestConfig } from 'axios';
+
+const productionProxyRequestFiles = [
+    'packages/server/lib/hooks/connection/internal-nango.ts',
+    'packages/server/lib/hooks/connection/credentials-verification-script.ts',
+    'packages/server/lib/hooks/hooks.ts',
+    'packages/server/lib/controllers/auth/postAwsSigV4.ts',
+    'packages/server/lib/services/proxy.service.ts',
+    'packages/shared/lib/services/notification/slack.service.ts',
+    'packages/runner/lib/sdk/sdk.ts'
+];
+
+function extractProxyRequestConstructorArgs(source: string): string[] {
+    const results: string[] = [];
+    const needle = 'new ProxyRequest(';
+    let searchFrom = 0;
+    while (true) {
+        const start = source.indexOf(needle, searchFrom);
+        if (start === -1) {
+            break;
+        }
+        const openParen = start + needle.length - 1;
+        let depth = 0;
+        let end = openParen;
+        for (; end < source.length; end++) {
+            const char = source[end];
+            if (char === '(') {
+                depth++;
+            } else if (char === ')') {
+                depth--;
+                if (depth === 0) {
+                    break;
+                }
+            }
+        }
+        results.push(source.slice(openParen, end + 1));
+        searchFrom = end + 1;
+    }
+    return results;
+}
 
 function makeAxiosError(status: number): AxiosError {
     const err = new AxiosError(`Request failed with status code ${status}`);
@@ -25,6 +69,7 @@ describe('call', () => {
         const proxy = new ProxyRequest({
             logger: fn,
             proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'https://httpstatuses.maor.io' } }, endpoint: '/200' }),
+            outboundPolicy: DEFAULT_OUTBOUND_URL_POLICY,
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
         });
@@ -55,6 +100,7 @@ describe('call', () => {
         const proxy = new ProxyRequest({
             logger: fn,
             proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'https://httpstatuses.maor.io' } }, endpoint: '/400', retries: 1 }),
+            outboundPolicy: DEFAULT_OUTBOUND_URL_POLICY,
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
         });
@@ -89,6 +135,7 @@ describe('call', () => {
         const proxy = new ProxyRequest({
             logger: fn,
             proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'https://httpstatuses.maor.io' } }, endpoint: '/500', retries: 1 }),
+            outboundPolicy: DEFAULT_OUTBOUND_URL_POLICY,
             getConnection,
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
         });
@@ -127,5 +174,32 @@ describe('call', () => {
 
         // should dynamically rebuild proxy config on each iteration
         expect(getConnection).toHaveBeenCalledTimes(2);
+    });
+
+    it('blocks private IP-literal targets when outboundPolicy is set', async () => {
+        const proxy = new ProxyRequest({
+            logger: vi.fn(),
+            proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'http://127.0.0.1' } }, endpoint: '/' }),
+            outboundPolicy: DEFAULT_OUTBOUND_URL_POLICY,
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
+        });
+        const result = await proxy.request();
+        expect(result.isErr()).toBe(true);
+        expect(result.error).toBeInstanceOf(OutboundUrlError);
+    });
+
+    it('every production ProxyRequest construction supplies outboundPolicy', () => {
+        let constructionCount = 0;
+        for (const relativePath of productionProxyRequestFiles) {
+            const source = readFileSync(join(process.cwd(), relativePath), 'utf8');
+            const argsList = extractProxyRequestConstructorArgs(source);
+            expect(argsList.length, `${relativePath} should construct ProxyRequest`).toBeGreaterThan(0);
+            for (const [index, args] of argsList.entries()) {
+                expect(args, `${relativePath} construction #${index + 1} missing outboundPolicy`).toMatch(/outboundPolicy\s*:/);
+                constructionCount += 1;
+            }
+        }
+        expect(constructionCount).toBeGreaterThanOrEqual(8);
     });
 });

--- a/packages/shared/lib/services/proxy/utils.test.ts
+++ b/packages/shared/lib/services/proxy/utils.test.ts
@@ -1,4 +1,16 @@
+import type { OutboundUrlPolicy } from '@nangohq/egress';
 import type { ApplicationConstructedProxyConfiguration, Provider } from '@nangohq/types';
+
+/** Localhost-friendly policy for unit tests that talk to an in-process HTTP server. */
+export const permissiveTestOutboundPolicy: OutboundUrlPolicy = {
+    mode: 'permissive',
+    denylist: new Set(),
+    allowlist: [],
+    blockPrivateIps: false,
+    blockLinkLocal: false,
+    allowedSchemes: new Set(['http:', 'https:']),
+    maxRedirects: 5
+};
 
 export function getDefaultProxy(
     override: Omit<Partial<ApplicationConstructedProxyConfiguration>, 'connection' | 'provider'> &


### PR DESCRIPTION
**Title:** Harden pre/post-connection proxy requests

## Summary
- Apply the same outbound URL policy used by other server proxy callers to pre- and post-connection scripts.
- Make `outboundPolicy` a required `ProxyRequest` argument so every construction site, including Slack notifications, supplies one.
- Add tests that every production `ProxyRequest` construction passes a policy, and that the policy is enforced on the request path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

