### PR TITLE
feat(mcp): add functions deploy tool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -12974,11 +12974,12 @@ The tool accepts JSON and UTF-8 text responses up to 5 MB (5,000,000 bytes). Uns
 
 ### Functions
 
-Use the Functions tools to inspect functions deployed to an integration in the authenticated Nango environment.
+Use the Functions tools to inspect and deploy functions in the authenticated Nango environment. `functions_deploy` starts a deployment and returns its initial job status without waiting for completion. Use `functions_get_deployment` to retrieve the final status.
 
-| Tool             | Description                                                                    | Required API key scope        |
-| ---------------- | ------------------------------------------------------------------------------ | ----------------------------- |
-| `functions_list` | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+| Tool               | Description                                                                    | Required API key scope        |
+| ------------------ | ------------------------------------------------------------------------------ | ----------------------------- |
+| `functions_list`   | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+| `functions_deploy` | Start a code or template function deployment.                                  | `environment:deploy`          |
 
 ### Logs
 

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -76,11 +76,12 @@ The tool accepts JSON and UTF-8 text responses up to 5 MB (5,000,000 bytes). Uns
 
 ### Functions
 
-Use the Functions tools to inspect functions deployed to an integration in the authenticated Nango environment.
+Use the Functions tools to inspect and deploy functions in the authenticated Nango environment. `functions_deploy` starts a deployment and returns its initial job status without waiting for completion. Use `functions_get_deployment` to retrieve the final status.
 
-| Tool             | Description                                                                    | Required API key scope        |
-| ---------------- | ------------------------------------------------------------------------------ | ----------------------------- |
-| `functions_list` | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+| Tool               | Description                                                                    | Required API key scope        |
+| ------------------ | ------------------------------------------------------------------------------ | ----------------------------- |
+| `functions_list`   | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+| `functions_deploy` | Start a code or template function deployment.                                  | `environment:deploy`          |
 
 ### Logs
 

--- a/packages/server/lib/controllers/functions/deployments/helpers.ts
+++ b/packages/server/lib/controllers/functions/deployments/helpers.ts
@@ -1,31 +1,5 @@
-import db from '@nangohq/database';
-import { deploySandboxTimeoutMs, FunctionError, sandboxApiKeyService } from '@nangohq/sandbox';
-import { stringifyError } from '@nangohq/utils';
-
 import type { RequestLocals } from '../../../utils/express.js';
-import type { FunctionDeploymentError } from '@nangohq/sandbox';
 import type { Response } from 'express';
-
-const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
-
-export async function createDeploySandboxApiKey(parentApiKeyId: number, environmentId: number, deploymentId: string) {
-    return await sandboxApiKeyService.createSandboxApiKey(db.knex, {
-        parentApiKeyId,
-        environmentId,
-        purpose: 'deploy',
-        deploymentId,
-        expiresAt: new Date(Date.now() + deploySandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
-    });
-}
-
-export function requireCustomerKeyId<T>(res: Response<T, RequestLocals>, message: string): number | null {
-    if (res.locals['apiKeyAuthSource'] !== 'customer_key' || !res.locals['apiKeyId']) {
-        res.status(403).send({ error: { code: 'forbidden', message } } as T);
-        return null;
-    }
-
-    return res.locals['apiKeyId'];
-}
 
 export function verifyDeploymentResultSandboxToken<T>(res: Response<T, RequestLocals>, deploymentId: string): boolean {
     if (res.locals['sandboxTokenPurpose'] !== 'deploy' || res.locals['sandboxTokenDeploymentId'] !== deploymentId) {
@@ -34,19 +8,4 @@ export function verifyDeploymentResultSandboxToken<T>(res: Response<T, RequestLo
     }
 
     return true;
-}
-
-export function toFunctionDeploymentError(err: unknown): FunctionDeploymentError {
-    if (err instanceof FunctionError) {
-        return {
-            code: err.code,
-            message: err.message,
-            ...(err.payload !== undefined ? { payload: err.payload } : {})
-        };
-    }
-
-    return {
-        code: 'deployment_error',
-        message: stringifyError(err)
-    };
 }

--- a/packages/server/lib/controllers/functions/deployments/postDeployment.ts
+++ b/packages/server/lib/controllers/functions/deployments/postDeployment.ts
@@ -3,220 +3,50 @@
 // - move template deployment to its own endpoint `POST /functions/deployments/template`.
 // - move sandbox deployment to its own endpoint alongside the other deployment endpoints.
 
-import {
-    createFunctionDeployment,
-    createSucceededFunctionDeployment,
-    FunctionError,
-    markFunctionDeploymentFailed,
-    markFunctionDeploymentRunning,
-    prepareAsyncDeploy,
-    toFunctionDeploymentCreate
-} from '@nangohq/sandbox';
-import { configService, getSyncConfigRaw } from '@nangohq/shared';
 import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import * as functionDeploymentService from '../../../services/functionDeployment.service.js';
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
-import { deployIntegrationTemplate } from '../../v1/flows/preBuilt/helpers.js';
 import { sendStepError } from '../errors.js';
-import { getFunctionCallbackBaseUrl } from '../helpers.js';
 import { functionDeploymentBodySchema } from '../validation.js';
-import { createDeploySandboxApiKey, requireCustomerKeyId, toFunctionDeploymentError } from './helpers.js';
 
+import type { DeployFunctionServiceError, DeployTemplateServiceError } from '../../../services/functionDeployment.service.js';
 import type { RequestLocalsWithEnvironment } from '../../../utils/express.js';
-import type { DBSyncConfig, FunctionDeploymentCodeBody, FunctionDeploymentTemplateBody, PostFunctionDeployment } from '@nangohq/types';
+import type { FunctionDeploymentCodeBody, FunctionDeploymentTemplateBody, PostFunctionDeployment } from '@nangohq/types';
 import type { Response } from 'express';
 
 type DeploymentResponse = Response<PostFunctionDeployment['Reply'], RequestLocalsWithEnvironment>;
 
-function isProtectedExistingFunction(existingSyncConfig: Pick<DBSyncConfig, 'source'> | null): boolean {
-    return Boolean(existingSyncConfig && existingSyncConfig.source !== 'standalone');
-}
-
-function shouldAllowDestructiveDeploy(existingSyncConfig: Pick<DBSyncConfig, 'source'> | null, allowDestructive: boolean): boolean {
-    return Boolean(allowDestructive && existingSyncConfig?.source === 'standalone');
-}
-
-/**
- * Deploy a catalog template onto an integration. Runs synchronously but records a deployment async job in a
- * terminal 'success' state, so the 202 response and `GET /functions/deployments/:id` mirrors the asynchronous
- * code-deploy path.
- */
 async function handleDeployTemplate(res: DeploymentResponse, body: FunctionDeploymentTemplateBody): Promise<void> {
     const { environment, account, plan, user } = res.locals;
-
-    const outcome = await deployIntegrationTemplate({
+    const result = await functionDeploymentService.deployTemplate({
         environment,
         account,
         plan,
         user,
-        providerConfigKey: body.integration_id,
-        name: body.template,
-        type: body.function_type
+        body
     });
-
-    if (!outcome.ok) {
-        switch (outcome.reason) {
-            case 'integration_not_found':
-                res.status(404).send({ error: { code: 'integration_not_found', message: `Integration '${body.integration_id}' was not found` } });
-                return;
-            case 'template_not_found':
-                res.status(404).send({ error: { code: 'template_not_found', message: `No template named '${body.template}' exists for this integration` } });
-                return;
-            case 'ambiguous_template':
-                res.status(409).send({
-                    error: {
-                        code: 'ambiguous_function',
-                        message: `'${body.template}' exists as both a sync and an action; specify 'function_type' to disambiguate`
-                    }
-                });
-                return;
-            case 'plan_limit':
-                res.status(400).send({ error: { code: 'plan_limit', message: "Can't enable more functions, upgrade or extend your trial period" } });
-                return;
-            case 'template_already_deployed':
-                res.status(409).send({ error: { code: 'template_already_deployed', message: `'${body.template}' is already deployed on this integration` } });
-                return;
-            case 'non_runnable_type':
-                if (outcome.cause) {
-                    report(outcome.cause);
-                }
-                res.status(500).send({ error: { code: 'server_error', message: `Template '${body.template}' cannot be deployed as a function` } });
-                return;
-            default:
-                if (outcome.cause) {
-                    report(outcome.cause);
-                }
-                res.status(500).send({ error: { code: 'deployment_error', message: 'Failed to deploy the template' } });
-                return;
-        }
-    }
-
-    const { result, type } = outcome;
-    const version = result.version ?? '';
-    const deployment = await createSucceededFunctionDeployment({
-        environmentId: environment.id,
-        request: {
-            type: 'template',
-            integration_id: body.integration_id,
-            template: body.template,
-            function_name: result.name,
-            function_type: type
-        },
-        output: `Successfully deployed the functions:\n- ${result.name}@${version}`,
-        deployedFunctions: [{ name: result.name, version }]
-    });
-    if (deployment.isErr()) {
-        report(deployment.error);
-        res.status(500).send({ error: { code: 'server_error', message: 'Template was deployed but its deployment record could not be created' } });
+    if (result.isErr()) {
+        sendDeployTemplateError(res, result.error);
         return;
     }
 
-    res.status(202).send(deployment.value);
+    res.status(202).send(result.value);
 }
 
-/**
- * Deploy submitted TypeScript source code. Runs asynchronously in a sandbox: returns a waiting/running
- * deployment status
- */
 async function handleDeployCode(res: DeploymentResponse, body: FunctionDeploymentCodeBody): Promise<void> {
     const { environment } = res.locals;
-
-    const parentCustomerKeyId = requireCustomerKeyId(res, 'Function deployments can only be started from a customer API key');
-    if (!parentCustomerKeyId) {
-        return;
-    }
-
-    const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
-    if (!providerConfig || !providerConfig.id) {
-        res.status(404).send({ error: { code: 'integration_not_found', message: `Integration '${body.integration_id}' was not found` } });
-        return;
-    }
-
-    const existingSyncConfig = await getSyncConfigRaw({
-        environmentId: environment.id,
-        config_id: providerConfig.id,
-        name: body.function_name,
-        isAction: body.function_type === 'action'
+    const result = await functionDeploymentService.deployFunction({
+        environment,
+        body,
+        ...(res.locals.apiKeyAuthSource === 'customer_key' && res.locals.apiKeyId ? { parentCustomerApiKeyId: res.locals.apiKeyId } : {})
     });
-
-    if (isProtectedExistingFunction(existingSyncConfig)) {
-        res.status(400).send({
-            error: {
-                code: 'invalid_request',
-                message: `Cannot overwrite existing function '${body.function_name}'`
-            }
-        });
+    if (result.isErr()) {
+        sendDeployFunctionError(res, result.error);
         return;
     }
 
-    const allowDestructiveDeploy = shouldAllowDestructiveDeploy(existingSyncConfig, body.allow_destructive ?? false);
-    const deploymentResult = await createFunctionDeployment({
-        environmentId: environment.id,
-        request: {
-            type: 'function',
-            integration_id: body.integration_id,
-            function_name: body.function_name,
-            function_type: body.function_type,
-            code: body.code,
-            ...(body.version ? { version: body.version } : {}),
-            allow_destructive: allowDestructiveDeploy
-        }
-    });
-    if (deploymentResult.isErr()) {
-        sendStepError({ res, status: 500, error: deploymentResult.error });
-        return;
-    }
-
-    const deployment = deploymentResult.value;
-    let prepared: Awaited<ReturnType<typeof prepareAsyncDeploy>> | null = null;
-    try {
-        const nangoHost = getFunctionCallbackBaseUrl();
-        const sandboxApiKey = await createDeploySandboxApiKey(parentCustomerKeyId, environment.id, deployment.id);
-        if (sandboxApiKey.isErr()) {
-            throw sandboxApiKey.error;
-        }
-
-        const callbackUrl = new URL(`/functions/deployments/${deployment.id}/result`, nangoHost).toString();
-        prepared = await prepareAsyncDeploy({
-            integration_id: body.integration_id,
-            function_name: body.function_name,
-            function_type: body.function_type,
-            code: body.code,
-            environment_name: environment.name,
-            nango_secret_key: sandboxApiKey.value,
-            nango_host: nangoHost,
-            deployment_id: deployment.id,
-            callback_url: callbackUrl,
-            ...(body.version ? { version: body.version } : {}),
-            allow_destructive: allowDestructiveDeploy
-        });
-
-        const running = await markFunctionDeploymentRunning({
-            environmentId: environment.id,
-            id: deployment.id,
-            sandboxId: prepared.sandboxId,
-            startedAt: prepared.startedAt,
-            executionTimeoutAt: prepared.executionTimeoutAt
-        });
-        if (!running) {
-            await prepared.kill();
-            throw new Error(`Failed to mark function deployment '${deployment.id}' as running`);
-        }
-
-        await prepared.start();
-
-        res.status(202).send(toFunctionDeploymentCreate(running));
-    } catch (err) {
-        await prepared?.kill().catch(() => {
-            // Still mark the deployment as failed if sandbox cleanup fails.
-        });
-        await markFunctionDeploymentFailed({
-            environmentId: environment.id,
-            id: deployment.id,
-            error: toFunctionDeploymentError(err)
-        });
-        sendStepError({ res, error: err, ...(err instanceof FunctionError ? {} : { status: 500 }) });
-    }
+    res.status(202).send(result.value);
 }
 
 export const postFunctionDeployment = asyncWrapperWithEnvironment<PostFunctionDeployment>(async (req, res) => {
@@ -240,3 +70,70 @@ export const postFunctionDeployment = asyncWrapperWithEnvironment<PostFunctionDe
 
     await handleDeployCode(res, body);
 });
+
+function sendDeployFunctionError(res: DeploymentResponse, error: DeployFunctionServiceError): void {
+    switch (error.code) {
+        case 'customer_api_key_required':
+            res.status(403).send({ error: { code: 'forbidden', message: error.message } });
+            return;
+        case 'integration_not_found':
+            res.status(404).send({ error: { code: 'integration_not_found', message: error.message } });
+            return;
+        case 'invalid_request':
+            res.status(400).send({ error: { code: 'invalid_request', message: error.message } });
+            return;
+        case 'function_error':
+            sendStepError({ res, error: error.cause });
+            return;
+        case 'deployment_creation_failed':
+        case 'deployment_failed':
+            sendStepError({ res, status: 500, error: error.cause });
+            return;
+        default: {
+            const exhaustiveCheck: never = error.code;
+            report(new Error('Unexpected function deployment service error', { cause: exhaustiveCheck }));
+            res.status(500).send({ error: { code: 'server_error', message: 'Internal error' } });
+        }
+    }
+}
+
+function sendDeployTemplateError(res: DeploymentResponse, error: DeployTemplateServiceError): void {
+    switch (error.code) {
+        case 'integration_not_found':
+            res.status(404).send({ error: { code: 'integration_not_found', message: error.message } });
+            return;
+        case 'template_not_found':
+            res.status(404).send({ error: { code: 'template_not_found', message: error.message } });
+            return;
+        case 'ambiguous_function':
+        case 'template_already_deployed':
+            res.status(409).send({ error: { code: error.code, message: error.message } });
+            return;
+        case 'plan_limit':
+            res.status(400).send({ error: { code: error.code, message: error.message } });
+            return;
+        case 'non_runnable_template':
+            if (error.cause) {
+                report(error.cause);
+            }
+            res.status(500).send({ error: { code: 'server_error', message: error.message } });
+            return;
+        case 'template_deployment_failed':
+            if (error.cause) {
+                report(error.cause);
+            }
+            res.status(500).send({ error: { code: 'deployment_error', message: error.message } });
+            return;
+        case 'deployment_record_creation_failed':
+            if (error.cause) {
+                report(error.cause);
+            }
+            res.status(500).send({ error: { code: 'server_error', message: error.message } });
+            return;
+        default: {
+            const exhaustiveCheck: never = error.code;
+            report(new Error('Unexpected template deployment service error', { cause: exhaustiveCheck }));
+            res.status(500).send({ error: { code: 'server_error', message: 'Internal error' } });
+        }
+    }
+}

--- a/packages/server/lib/controllers/functions/deployments/postDeploymentResult.ts
+++ b/packages/server/lib/controllers/functions/deployments/postDeploymentResult.ts
@@ -7,10 +7,11 @@ import {
 } from '@nangohq/sandbox';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { toFunctionDeploymentError } from '../../../services/functionDeployment.service.js';
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { normalizeFunctionErrorCode } from '../errors.js';
 import { functionDeploymentParamsSchema, functionDeploymentResultBodySchema } from '../validation.js';
-import { toFunctionDeploymentError, verifyDeploymentResultSandboxToken } from './helpers.js';
+import { verifyDeploymentResultSandboxToken } from './helpers.js';
 
 import type { PostFunctionDeploymentResult } from '@nangohq/types';
 

--- a/packages/server/lib/controllers/functions/validation.ts
+++ b/packages/server/lib/controllers/functions/validation.ts
@@ -2,9 +2,11 @@ import { z } from 'zod';
 
 import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../helpers/validation.js';
 
-const integrationIdSchema = providerConfigKeySchema.refine((value) => value !== '.' && value !== '..', {
+export const functionIntegrationIdSchema = providerConfigKeySchema.refine((value) => value !== '.' && value !== '..', {
     message: 'Integration id cannot be "." or ".."'
 });
+
+export const runnableFunctionTypeSchema = z.enum(['action', 'sync']);
 
 export const functionCompileBodySchema = z
     .object({
@@ -14,8 +16,8 @@ export const functionCompileBodySchema = z
 
 export const functionDryrunBodySchema = z
     .object({
-        integration_id: integrationIdSchema,
-        function_type: z.enum(['action', 'sync']),
+        integration_id: functionIntegrationIdSchema,
+        function_type: runnableFunctionTypeSchema,
         code: z.string().min(1),
         connection_id: connectionIdSchema,
         input: z.unknown().optional(),
@@ -62,9 +64,9 @@ export const functionDeploymentBodySchema = z.discriminatedUnion('type', [
     z
         .object({
             type: z.literal('function'),
-            integration_id: integrationIdSchema,
+            integration_id: functionIntegrationIdSchema,
             function_name: syncNameSchema,
-            function_type: z.enum(['action', 'sync']),
+            function_type: runnableFunctionTypeSchema,
             code: z.string().min(1),
             version: z.string().optional(),
             allow_destructive: z.boolean().default(false)
@@ -73,10 +75,10 @@ export const functionDeploymentBodySchema = z.discriminatedUnion('type', [
     z
         .object({
             type: z.literal('template'),
-            integration_id: integrationIdSchema,
+            integration_id: functionIntegrationIdSchema,
             template: syncNameSchema,
             // Optional: inferred from the template name unless a sync and an action share it.
-            function_type: z.enum(['action', 'sync']).optional()
+            function_type: runnableFunctionTypeSchema.optional()
         })
         .strict()
 ]);

--- a/packages/server/lib/controllers/mcp/functions/deploy.ts
+++ b/packages/server/lib/controllers/mcp/functions/deploy.ts
@@ -1,0 +1,49 @@
+import { makeAuditTarget } from '../../../audit.js';
+import * as functionDeploymentService from '../../../services/functionDeployment.service.js';
+import { defineManagementMcpTool } from '../managementTool.js';
+import { deployFunctionServiceErrorToMcp, deployTemplateServiceErrorToMcp } from './errors.js';
+import { deployFunctionsArgumentsSchema, deployFunctionsOutputSchema, toFunctionDeploymentBody } from './schema.js';
+
+import type { DeployFunctionsOutput } from './schema.js';
+
+export const deployFunctionsTool = defineManagementMcpTool<typeof deployFunctionsArgumentsSchema, DeployFunctionsOutput>({
+    name: 'functions_deploy',
+    description:
+        'Start a code or template function deployment and return its initial job status. This tool does not wait for completion; use functions_get_deployment to retrieve the final status.',
+    inputSchema: deployFunctionsArgumentsSchema,
+    outputSchema: deployFunctionsOutputSchema,
+    requiredScopes: { every: ['environment:deploy'] },
+    audit: {
+        kind: 'audit',
+        resource: 'function',
+        action: 'deployed',
+        scope: 'environment',
+        metadata: ({ args }) => ({
+            providerConfigKey: args.integration_id,
+            ...(args.function_type ? { type: args.function_type } : {})
+        }),
+        targetFromOutput: ({ args }) => makeAuditTarget('function', args.type === 'function' ? args.function_name : args.template)
+    },
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false
+    },
+    async handler({ args, account, environment, plan, customerApiKeyId }) {
+        const body = toFunctionDeploymentBody(args);
+        if (body.type === 'template') {
+            return (await functionDeploymentService.deployTemplate({ account, environment, plan, body })).mapError((error) =>
+                deployTemplateServiceErrorToMcp(error)
+            );
+        }
+
+        return (
+            await functionDeploymentService.deployFunction({
+                environment,
+                body,
+                ...(customerApiKeyId ? { parentCustomerApiKeyId: customerApiKeyId } : {})
+            })
+        ).mapError((error) => deployFunctionServiceErrorToMcp(error));
+    }
+});

--- a/packages/server/lib/controllers/mcp/functions/deploy.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/functions/deploy.unit.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import * as functionDeploymentService from '../../../services/functionDeployment.service.js';
+import { InternalMcpError, PublicMcpError } from '../utils.js';
+import { deployFunctionsTool } from './deploy.js';
+
+import type { ManagementMcpContext } from '../managementTool.js';
+
+describe('deployFunctionsTool', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('starts a single function deployment with the authenticated customer API key', async () => {
+        const response = { id: '3c66291f-6247-47a6-a100-f4d621d751f7', status: 'running' as const, created_at: '2026-01-01T00:00:00.000Z' };
+        const deploySpy = vi.spyOn(functionDeploymentService, 'deployFunction').mockResolvedValue(Ok(response));
+        const templateSpy = vi.spyOn(functionDeploymentService, 'deployTemplate');
+
+        const result = await deployFunctionsTool.handler(
+            {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}',
+                version: '1.0.0',
+                allow_destructive: true
+            },
+            context
+        );
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual(response);
+        }
+        expect(deploySpy).toHaveBeenCalledWith({
+            environment: context.environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}',
+                version: '1.0.0',
+                allow_destructive: true
+            }
+        });
+        expect(templateSpy).not.toHaveBeenCalled();
+    });
+
+    it('starts a template deployment without calling the single function path', async () => {
+        const response = { id: '3c66291f-6247-47a6-a100-f4d621d751f7', status: 'success' as const, created_at: '2026-01-01T00:00:00.000Z' };
+        const deploySpy = vi.spyOn(functionDeploymentService, 'deployFunction');
+        const templateSpy = vi.spyOn(functionDeploymentService, 'deployTemplate').mockResolvedValue(Ok(response));
+
+        const result = await deployFunctionsTool.handler({ type: 'template', integration_id: 'airtable', template: 'tables', function_type: 'sync' }, context);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual(response);
+        }
+        expect(templateSpy).toHaveBeenCalledWith({
+            account: context.account,
+            environment: context.environment,
+            plan: context.plan,
+            body: { type: 'template', integration_id: 'airtable', template: 'tables', function_type: 'sync' }
+        });
+        expect(deploySpy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        { name: 'missing type', args: { integration_id: 'github' } },
+        { name: 'unknown argument', args: { type: 'template', integration_id: 'github', template: 'issues', unexpected: true } },
+        { name: 'missing function name', args: { type: 'function', integration_id: 'github', function_type: 'sync', code: 'code' } },
+        { name: 'missing function type', args: { type: 'function', integration_id: 'github', function_name: 'issues', code: 'code' } },
+        { name: 'empty code', args: { type: 'function', integration_id: 'github', function_name: 'issues', function_type: 'sync', code: '' } },
+        {
+            name: 'template field on function deployment',
+            args: { type: 'function', integration_id: 'github', function_name: 'issues', function_type: 'sync', code: 'code', template: 'issues' }
+        },
+        { name: 'missing template', args: { type: 'template', integration_id: 'github' } },
+        { name: 'code on template deployment', args: { type: 'template', integration_id: 'github', template: 'issues', code: 'code' } },
+        { name: 'on-event function type', args: { type: 'template', integration_id: 'github', template: 'issues', function_type: 'on-event' } },
+        { name: 'invalid integration ID', args: { type: 'template', integration_id: '..', template: 'issues' } }
+    ])('rejects $name before calling a deployment service', async ({ args }) => {
+        const deploySpy = vi.spyOn(functionDeploymentService, 'deployFunction');
+        const templateSpy = vi.spyOn(functionDeploymentService, 'deployTemplate');
+
+        const result = await deployFunctionsTool.handler(args, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toContain('Invalid functions_deploy arguments:');
+        }
+        expect(deploySpy).not.toHaveBeenCalled();
+        expect(templateSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns expected deployment errors as public MCP errors', async () => {
+        vi.spyOn(functionDeploymentService, 'deployFunction').mockResolvedValue(
+            Err(
+                new functionDeploymentService.FunctionDeploymentServiceError({
+                    code: 'integration_not_found',
+                    message: "Integration 'missing' was not found"
+                })
+            )
+        );
+
+        const result = await deployFunctionsTool.handler(
+            {
+                type: 'function',
+                integration_id: 'missing',
+                function_name: 'issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            },
+            context
+        );
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toBe("Integration 'missing' was not found");
+        }
+    });
+
+    it('maps infrastructure deployment failures to an internal MCP error', async () => {
+        vi.spyOn(functionDeploymentService, 'deployFunction').mockResolvedValue(
+            Err(
+                new functionDeploymentService.FunctionDeploymentServiceError({
+                    code: 'deployment_failed',
+                    message: 'Failed to start function deployment',
+                    cause: new Error('sensitive sandbox failure')
+                })
+            )
+        );
+
+        const result = await deployFunctionsTool.handler(
+            {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            },
+            context
+        );
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(InternalMcpError);
+        }
+    });
+});
+
+const context = {
+    account: { id: 1 },
+    environment: { id: 42 },
+    plan: null,
+    customerApiKeyId: 7,
+    grantedScopes: ['environment:deploy']
+} as ManagementMcpContext;

--- a/packages/server/lib/controllers/mcp/functions/errors.ts
+++ b/packages/server/lib/controllers/mcp/functions/errors.ts
@@ -2,6 +2,7 @@ import { getLogger } from '@nangohq/utils';
 
 import { InternalMcpError, PublicMcpError } from '../utils.js';
 
+import type { DeployFunctionServiceError, DeployTemplateServiceError } from '../../../services/functionDeployment.service.js';
 import type { ListFunctionsError } from '@nangohq/shared';
 
 const logger = getLogger('Server.MCP.Functions');
@@ -18,6 +19,48 @@ export function listFunctionsServiceErrorToMcp(error: ListFunctionsError): Error
         default: {
             const exhaustiveCheck: never = code;
             logger.error('Unexpected ListFunctionsError code while listing functions', { code: exhaustiveCheck });
+            return new InternalMcpError();
+        }
+    }
+}
+
+export function deployFunctionServiceErrorToMcp(error: DeployFunctionServiceError): Error {
+    const code = error.code;
+    switch (code) {
+        case 'customer_api_key_required':
+        case 'integration_not_found':
+        case 'invalid_request':
+        case 'function_error':
+            return new PublicMcpError(error.message);
+        case 'deployment_creation_failed':
+        case 'deployment_failed':
+            logger.error('Failed to deploy function', { err: error });
+            return new InternalMcpError();
+        default: {
+            const exhaustiveCheck: never = code;
+            logger.error('Unexpected DeployFunctionServiceError code while deploying function', { code: exhaustiveCheck });
+            return new InternalMcpError();
+        }
+    }
+}
+
+export function deployTemplateServiceErrorToMcp(error: DeployTemplateServiceError): Error {
+    const code = error.code;
+    switch (code) {
+        case 'integration_not_found':
+        case 'template_not_found':
+        case 'ambiguous_function':
+        case 'plan_limit':
+        case 'template_already_deployed':
+            return new PublicMcpError(error.message);
+        case 'non_runnable_template':
+        case 'template_deployment_failed':
+        case 'deployment_record_creation_failed':
+            logger.error('Failed to deploy function template', { err: error });
+            return new InternalMcpError();
+        default: {
+            const exhaustiveCheck: never = code;
+            logger.error('Unexpected DeployTemplateServiceError code while deploying template', { code: exhaustiveCheck });
             return new InternalMcpError();
         }
     }

--- a/packages/server/lib/controllers/mcp/functions/schema.ts
+++ b/packages/server/lib/controllers/mcp/functions/schema.ts
@@ -1,6 +1,84 @@
 import * as z from 'zod/v4';
 
-import { functionTypeSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
+import { functionTypeSchema, providerConfigKeySchema, syncNameSchema } from '../../../helpers/validation.js';
+import { functionIntegrationIdSchema, runnableFunctionTypeSchema } from '../../functions/validation.js';
+
+import type { FunctionDeploymentBody } from '@nangohq/types';
+
+// The MCP SDK only advertises top-level Zod object schemas. Model the public deployment union as a strict
+// object, publish its conditional shape through JSON Schema metadata, and enforce the same conditions at runtime.
+export const deployFunctionsArgumentsSchema = z
+    .object({
+        type: z.enum(['function', 'template']),
+        integration_id: functionIntegrationIdSchema,
+        function_name: syncNameSchema.optional(),
+        function_type: runnableFunctionTypeSchema.optional(),
+        code: z.string().min(1).optional(),
+        version: z.string().optional(),
+        allow_destructive: z.boolean().optional(),
+        template: syncNameSchema.optional()
+    })
+    .strict()
+    .superRefine((args, ctx) => {
+        if (args.type === 'function') {
+            requireArgument(args.function_name, 'function_name', 'function', ctx);
+            requireArgument(args.function_type, 'function_type', 'function', ctx);
+            requireArgument(args.code, 'code', 'function', ctx);
+            rejectArgument(args.template, 'template', 'function', ctx);
+            return;
+        }
+
+        requireArgument(args.template, 'template', 'template', ctx);
+        rejectArgument(args.function_name, 'function_name', 'template', ctx);
+        rejectArgument(args.code, 'code', 'template', ctx);
+        rejectArgument(args.version, 'version', 'template', ctx);
+        rejectArgument(args.allow_destructive, 'allow_destructive', 'template', ctx);
+    })
+    .meta({
+        oneOf: [
+            {
+                properties: { type: { const: 'function' } },
+                required: ['function_name', 'function_type', 'code'],
+                not: { required: ['template'] }
+            },
+            {
+                properties: { type: { const: 'template' } },
+                required: ['template'],
+                not: {
+                    anyOf: [{ required: ['function_name'] }, { required: ['code'] }, { required: ['version'] }, { required: ['allow_destructive'] }]
+                }
+            }
+        ]
+    });
+
+export const deployFunctionsOutputSchema = z
+    .object({
+        id: z.string().uuid(),
+        status: z.enum(['waiting', 'running', 'success', 'failed']),
+        created_at: z.iso.datetime()
+    })
+    .strict();
+
+export function toFunctionDeploymentBody(args: z.output<typeof deployFunctionsArgumentsSchema>): FunctionDeploymentBody {
+    if (args.type === 'function') {
+        return {
+            type: 'function',
+            integration_id: args.integration_id,
+            function_name: getRequiredDeploymentArgument(args.function_name, 'function_name'),
+            function_type: getRequiredDeploymentArgument(args.function_type, 'function_type'),
+            code: getRequiredDeploymentArgument(args.code, 'code'),
+            ...(args.version !== undefined ? { version: args.version } : {}),
+            ...(args.allow_destructive !== undefined ? { allow_destructive: args.allow_destructive } : {})
+        };
+    }
+
+    return {
+        type: 'template',
+        integration_id: args.integration_id,
+        template: getRequiredDeploymentArgument(args.template, 'template'),
+        ...(args.function_type !== undefined ? { function_type: args.function_type } : {})
+    };
+}
 
 export const listFunctionsArgumentsSchema = z
     .object({
@@ -71,3 +149,25 @@ export const listFunctionsOutputSchema = z
     .strict();
 
 export type ListFunctionsOutput = z.infer<typeof listFunctionsOutputSchema>;
+export type DeployFunctionsOutput = z.infer<typeof deployFunctionsOutputSchema>;
+
+function getRequiredDeploymentArgument<T>(value: T | undefined, field: string): T {
+    if (value === undefined) {
+        throw new Error(`Validated functions_deploy arguments are missing '${field}'`);
+    }
+    return value;
+}
+
+function requireArgument(value: unknown, field: string, type: 'function' | 'template', ctx: z.RefinementCtx): void {
+    if (value !== undefined) {
+        return;
+    }
+    ctx.addIssue({ code: 'custom', path: [field], message: `${field} is required when type is ${type}` });
+}
+
+function rejectArgument(value: unknown, field: string, type: 'function' | 'template', ctx: z.RefinementCtx): void {
+    if (value === undefined) {
+        return;
+    }
+    ctx.addIssue({ code: 'custom', path: [field], message: `${field} is not allowed when type is ${type}` });
+}

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 
 import * as featureFlags from '@nangohq/feature-flags';
 import { logContextGetter } from '@nangohq/logs';
-import { getGlobalWebhookReceiveUrl, ProxyRequest, seeders } from '@nangohq/shared';
+import { getGlobalWebhookReceiveUrl, ProxyRequest, remoteFileService, seeders } from '@nangohq/shared';
 import { Ok } from '@nangohq/utils';
 
 import { audit } from '../../audit.js';
@@ -171,6 +171,7 @@ describe('POST /mcp management server', () => {
             'connections_get',
             'proxy_request',
             'functions_list',
+            'functions_deploy',
             'logs_list_operations',
             'logs_get_operation'
         ]);
@@ -189,6 +190,7 @@ describe('POST /mcp management server', () => {
             'connections_get',
             'proxy_request',
             'functions_list',
+            'functions_deploy',
             'logs_list_operations',
             'logs_get_operation'
         ];
@@ -368,6 +370,103 @@ describe('POST /mcp management server', () => {
         });
         expect(missing.json.result).toStrictEqual({
             content: [{ type: 'text', text: 'Integration does not exist' }],
+            isError: true
+        });
+    });
+
+    it('lists the function deployment tool with deploy scope', async () => {
+        const { secret } = await createKeyWithScopes(['environment:deploy']);
+        const res = await mcpPost({
+            token: secret,
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools).toHaveLength(1);
+        expect(res.json.result.tools[0]).toMatchObject({
+            name: 'functions_deploy',
+            annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false }
+        });
+    });
+
+    it('deploys a function template and returns the deployment job without polling', async () => {
+        vi.spyOn(remoteFileService, 'copy').mockResolvedValue('_LOCAL_FILE_');
+        const { secret, env, account } = await createKeyWithScopes(['environment:deploy']);
+        await seeders.createConfigSeed(env, 'airtable', 'airtable');
+
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: { name: 'functions_deploy', arguments: { type: 'template', integration_id: 'airtable', template: 'tables' } }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        expect(parseToolText(res)).toStrictEqual(res.json.result.structuredContent);
+        expect(res.json.result.structuredContent).toStrictEqual({
+            id: expect.any(String),
+            status: 'success',
+            created_at: expect.any(String)
+        });
+
+        await vi.waitFor(() => {
+            const event = auditSpy.mock.calls
+                .map((call) => call[0])
+                .find((candidate) => candidate.accountId === account.id && candidate.resource === 'function' && candidate.action === 'deployed');
+            expect(event).toMatchObject({
+                accountId: account.id,
+                environment: { id: env.id, display: env.name },
+                resource: 'function',
+                action: 'deployed',
+                targets: [{ type: 'function', id: 'tables' }],
+                metadata: { providerConfigKey: 'airtable' },
+                context: { interface: 'mcp' },
+                outcome: 'success'
+            });
+        });
+    });
+
+    it('returns public errors for invalid deployment arguments and missing integrations', async () => {
+        const { secret } = await createKeyWithScopes(['environment:deploy']);
+
+        const invalid = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'functions_deploy',
+                    arguments: { type: 'template', integration_id: 'airtable', template: 'tables', code: 'not allowed' }
+                }
+            }
+        });
+        expect(invalid.json.result).toMatchObject({ isError: true });
+        expect(invalid.json.result.content[0].text).toContain('Invalid arguments for tool functions_deploy');
+
+        const missing = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 2,
+                method: 'tools/call',
+                params: {
+                    name: 'functions_deploy',
+                    arguments: {
+                        type: 'function',
+                        integration_id: 'missing',
+                        function_name: 'sync-issues',
+                        function_type: 'sync',
+                        code: 'export default {}'
+                    }
+                }
+            }
+        });
+        expect(missing.json.result).toStrictEqual({
+            content: [{ type: 'text', text: "Integration 'missing' was not found" }],
             isError: true
         });
     });

--- a/packages/server/lib/controllers/mcp/management.ts
+++ b/packages/server/lib/controllers/mcp/management.ts
@@ -14,6 +14,7 @@ export const postManagementMcp = asyncWrapperWithEnvironment<PostManagementMcp>(
         environment,
         plan,
         grantedScopes: res.locals['apiKeyPrincipal']?.scopes,
+        ...(res.locals['apiKeyAuthSource'] === 'customer_key' && res.locals['apiKeyId'] ? { customerApiKeyId: res.locals['apiKeyId'] } : {}),
         audit: resolveAuditAttribution(req, res.locals)
     };
     const server = createManagementMcpServer(context, req.body);

--- a/packages/server/lib/controllers/mcp/managementServer.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.ts
@@ -9,6 +9,7 @@ import { recordManagementMcpAudit } from './audit.js';
 import { getConnectionsTool } from './connections/get.js';
 import { listConnectionsTool } from './connections/list.js';
 import { createConnectSessionTool } from './connectSessions/create.js';
+import { deployFunctionsTool } from './functions/deploy.js';
 import { listFunctionsTool } from './functions/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { deleteIntegrationsTool } from './integrations/delete.js';
@@ -39,6 +40,7 @@ const managementMcpTools: ManagementMcpTool[] = [
     getConnectionsTool,
     proxyRequestTool,
     listFunctionsTool,
+    deployFunctionsTool,
     listLogOperationsTool,
     getLogOperationTool
 ];

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -9,6 +9,7 @@ import { audit } from '../../audit.js';
 import { getConnectionsTool } from './connections/get.js';
 import { listConnectionsTool } from './connections/list.js';
 import { createConnectSessionTool } from './connectSessions/create.js';
+import { deployFunctionsTool } from './functions/deploy.js';
 import { listFunctionsTool } from './functions/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { deleteIntegrationsTool } from './integrations/delete.js';
@@ -62,6 +63,10 @@ describe('createManagementMcpServer', () => {
                     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
                 },
                 { name: 'functions_list', annotations: { readOnlyHint: true } },
+                {
+                    name: 'functions_deploy',
+                    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false }
+                },
                 { name: 'logs_list_operations', annotations: { readOnlyHint: true } },
                 { name: 'logs_get_operation', annotations: { readOnlyHint: true } }
             ]);
@@ -541,6 +546,94 @@ describe('createManagementMcpServer', () => {
 
         try {
             const result = await client.callTool({ name: 'functions_list', arguments: { integration_id: 'github' } });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],
+                structuredContent: response
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('exposes and authorizes non-idempotent function deployments', async () => {
+        const authorized = await createTestClient(['environment:deploy']);
+        try {
+            const result = await authorized.client.listTools();
+            expect(result.tools).toHaveLength(1);
+            expect(result.tools[0]).toMatchObject({
+                name: 'functions_deploy',
+                inputSchema: {
+                    type: 'object',
+                    required: ['type', 'integration_id'],
+                    additionalProperties: false,
+                    oneOf: [
+                        {
+                            properties: { type: { const: 'function' } },
+                            required: ['function_name', 'function_type', 'code'],
+                            not: { required: ['template'] }
+                        },
+                        {
+                            properties: { type: { const: 'template' } },
+                            required: ['template']
+                        }
+                    ]
+                },
+                outputSchema: {
+                    type: 'object',
+                    required: ['id', 'status', 'created_at'],
+                    additionalProperties: false
+                },
+                annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false }
+            });
+        } finally {
+            await authorized.client.close();
+            await authorized.server.close();
+        }
+
+        const handlerSpy = vi.spyOn(deployFunctionsTool, 'handler');
+        const unauthorized = await createTestClient(['environment:functions:*']);
+        try {
+            const result = await unauthorized.client.callTool({
+                name: 'functions_deploy',
+                arguments: { type: 'template', integration_id: 'airtable', template: 'tables' }
+            });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: 'MCP error -32602: Tool functions_deploy disabled' }],
+                isError: true
+            });
+            expect(handlerSpy).not.toHaveBeenCalled();
+        } finally {
+            handlerSpy.mockRestore();
+            await unauthorized.client.close();
+            await unauthorized.server.close();
+        }
+    });
+
+    it('returns function deployment results as JSON text and structured content', async () => {
+        const response = {
+            id: '3c66291f-6247-47a6-a100-f4d621d751f7',
+            status: 'running' as const,
+            created_at: '2026-01-01T00:00:00.000Z'
+        };
+        const handlerSpy = vi.spyOn(deployFunctionsTool, 'handler').mockResolvedValueOnce(Ok(response));
+        const { client, server } = await createTestClient(['environment:deploy']);
+
+        try {
+            const result = await client.callTool({
+                name: 'functions_deploy',
+                arguments: {
+                    type: 'function',
+                    integration_id: 'github',
+                    function_name: 'sync-issues',
+                    function_type: 'sync',
+                    code: 'export default {}'
+                }
+            });
 
             expect(result).toStrictEqual({
                 content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],

--- a/packages/server/lib/controllers/mcp/managementTool.ts
+++ b/packages/server/lib/controllers/mcp/managementTool.ts
@@ -16,6 +16,7 @@ export interface ManagementMcpContext {
     environment: DBEnvironment;
     plan: DBPlan | null;
     grantedScopes: string[] | undefined;
+    customerApiKeyId?: number | undefined;
     audit?: AuditAttribution | undefined;
 }
 

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.ts
@@ -3,9 +3,9 @@ import * as z from 'zod';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
+import { deployIntegrationTemplate } from '../../../../services/integrationTemplate.service.js';
 import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { flowConfig } from '../../../sync/deploy/validation.js';
-import { deployIntegrationTemplate } from './helpers.js';
 
 import type { PostPreBuiltDeploy } from '@nangohq/types';
 

--- a/packages/server/lib/services/functionDeployment.service.ts
+++ b/packages/server/lib/services/functionDeployment.service.ts
@@ -1,0 +1,331 @@
+import db from '@nangohq/database';
+import {
+    createFunctionDeployment,
+    createSucceededFunctionDeployment,
+    deploySandboxTimeoutMs,
+    FunctionError,
+    markFunctionDeploymentFailed,
+    markFunctionDeploymentRunning,
+    prepareAsyncDeploy,
+    sandboxApiKeyService,
+    toFunctionDeploymentCreate
+} from '@nangohq/sandbox';
+import { configService, getSyncConfigRaw } from '@nangohq/shared';
+import { baseUrl, Err, Ok, stringifyError } from '@nangohq/utils';
+
+import { deployIntegrationTemplate } from './integrationTemplate.service.js';
+
+import type { FunctionDeploymentError } from '@nangohq/sandbox';
+import type {
+    DBEnvironment,
+    DBPlan,
+    DBSyncConfig,
+    DBTeam,
+    DBUser,
+    FunctionDeploymentCodeBody,
+    FunctionDeploymentCreateSuccess,
+    FunctionDeploymentTemplateBody
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
+
+export type DeployFunctionServiceErrorCode =
+    | 'customer_api_key_required'
+    | 'integration_not_found'
+    | 'invalid_request'
+    | 'deployment_creation_failed'
+    | 'function_error'
+    | 'deployment_failed';
+
+export type DeployTemplateServiceErrorCode =
+    | 'integration_not_found'
+    | 'template_not_found'
+    | 'ambiguous_function'
+    | 'plan_limit'
+    | 'template_already_deployed'
+    | 'non_runnable_template'
+    | 'template_deployment_failed'
+    | 'deployment_record_creation_failed';
+
+type FunctionDeploymentServiceErrorCode = DeployFunctionServiceErrorCode | DeployTemplateServiceErrorCode;
+
+export class FunctionDeploymentServiceError<TCode extends FunctionDeploymentServiceErrorCode = FunctionDeploymentServiceErrorCode> extends Error {
+    public readonly code: TCode;
+
+    constructor({ code, message, cause }: { code: TCode; message: string; cause?: unknown }) {
+        super(message, { cause });
+        this.name = 'FunctionDeploymentServiceError';
+        this.code = code;
+    }
+}
+
+export type DeployFunctionServiceError = FunctionDeploymentServiceError<DeployFunctionServiceErrorCode>;
+export type DeployTemplateServiceError = FunctionDeploymentServiceError<DeployTemplateServiceErrorCode>;
+
+export interface DeployFunctionParams {
+    environment: DBEnvironment;
+    body: FunctionDeploymentCodeBody;
+    parentCustomerApiKeyId?: number | undefined;
+}
+
+export interface DeployTemplateParams {
+    account: DBTeam;
+    environment: DBEnvironment;
+    plan: DBPlan | null;
+    user?: Pick<DBUser, 'id' | 'email' | 'name'> | undefined;
+    body: FunctionDeploymentTemplateBody;
+}
+
+export async function deployFunction({
+    environment,
+    body,
+    parentCustomerApiKeyId
+}: DeployFunctionParams): Promise<Result<FunctionDeploymentCreateSuccess, DeployFunctionServiceError>> {
+    if (!parentCustomerApiKeyId) {
+        return Err(
+            new FunctionDeploymentServiceError({
+                code: 'customer_api_key_required',
+                message: 'Function deployments can only be started from a customer API key'
+            })
+        );
+    }
+
+    const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
+    if (!providerConfig?.id) {
+        return Err(
+            new FunctionDeploymentServiceError({
+                code: 'integration_not_found',
+                message: `Integration '${body.integration_id}' was not found`
+            })
+        );
+    }
+
+    const existingSyncConfig = await getSyncConfigRaw({
+        environmentId: environment.id,
+        config_id: providerConfig.id,
+        name: body.function_name,
+        isAction: body.function_type === 'action'
+    });
+
+    if (isProtectedExistingFunction(existingSyncConfig)) {
+        return Err(
+            new FunctionDeploymentServiceError({
+                code: 'invalid_request',
+                message: `Cannot overwrite existing function '${body.function_name}'`
+            })
+        );
+    }
+
+    const allowDestructiveDeploy = shouldAllowDestructiveDeploy(existingSyncConfig, body.allow_destructive ?? false);
+    const deploymentResult = await createFunctionDeployment({
+        environmentId: environment.id,
+        request: {
+            type: 'function',
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            code: body.code,
+            ...(body.version ? { version: body.version } : {}),
+            allow_destructive: allowDestructiveDeploy
+        }
+    });
+    if (deploymentResult.isErr()) {
+        return Err(
+            new FunctionDeploymentServiceError({
+                code: 'deployment_creation_failed',
+                message: 'Failed to create function deployment',
+                cause: deploymentResult.error
+            })
+        );
+    }
+
+    const deployment = deploymentResult.value;
+    let prepared: Awaited<ReturnType<typeof prepareAsyncDeploy>> | null = null;
+    try {
+        const sandboxApiKey = await createDeploySandboxApiKey(parentCustomerApiKeyId, environment.id, deployment.id);
+        if (sandboxApiKey.isErr()) {
+            throw sandboxApiKey.error;
+        }
+
+        const callbackUrl = new URL(`/functions/deployments/${deployment.id}/result`, baseUrl).toString();
+        prepared = await prepareAsyncDeploy({
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            code: body.code,
+            environment_name: environment.name,
+            nango_secret_key: sandboxApiKey.value,
+            nango_host: baseUrl,
+            deployment_id: deployment.id,
+            callback_url: callbackUrl,
+            ...(body.version ? { version: body.version } : {}),
+            allow_destructive: allowDestructiveDeploy
+        });
+
+        const running = await markFunctionDeploymentRunning({
+            environmentId: environment.id,
+            id: deployment.id,
+            sandboxId: prepared.sandboxId,
+            startedAt: prepared.startedAt,
+            executionTimeoutAt: prepared.executionTimeoutAt
+        });
+        if (!running) {
+            throw new Error(`Failed to mark function deployment '${deployment.id}' as running`);
+        }
+
+        await prepared.start();
+        return Ok(toFunctionDeploymentCreate(running));
+    } catch (err) {
+        await prepared?.kill().catch(() => {
+            // Still mark the deployment as failed if sandbox cleanup fails.
+        });
+        await markFunctionDeploymentFailed({
+            environmentId: environment.id,
+            id: deployment.id,
+            error: toFunctionDeploymentError(err)
+        });
+
+        if (err instanceof FunctionError) {
+            return Err(new FunctionDeploymentServiceError({ code: 'function_error', message: err.message, cause: err }));
+        }
+        return Err(new FunctionDeploymentServiceError({ code: 'deployment_failed', message: 'Failed to start function deployment', cause: err }));
+    }
+}
+
+export async function deployTemplate({
+    account,
+    environment,
+    plan,
+    user,
+    body
+}: DeployTemplateParams): Promise<Result<FunctionDeploymentCreateSuccess, DeployTemplateServiceError>> {
+    const outcome = await deployIntegrationTemplate({
+        environment,
+        account,
+        plan,
+        user,
+        providerConfigKey: body.integration_id,
+        name: body.template,
+        type: body.function_type
+    });
+
+    if (!outcome.ok) {
+        switch (outcome.reason) {
+            case 'integration_not_found':
+                return Err(
+                    new FunctionDeploymentServiceError({
+                        code: 'integration_not_found',
+                        message: `Integration '${body.integration_id}' was not found`
+                    })
+                );
+            case 'template_not_found':
+                return Err(
+                    new FunctionDeploymentServiceError({
+                        code: 'template_not_found',
+                        message: `No template named '${body.template}' exists for this integration`
+                    })
+                );
+            case 'ambiguous_template':
+                return Err(
+                    new FunctionDeploymentServiceError({
+                        code: 'ambiguous_function',
+                        message: `'${body.template}' exists as both a sync and an action; specify 'function_type' to disambiguate`
+                    })
+                );
+            case 'plan_limit':
+                return Err(
+                    new FunctionDeploymentServiceError({
+                        code: 'plan_limit',
+                        message: "Can't enable more functions, upgrade or extend your trial period"
+                    })
+                );
+            case 'template_already_deployed':
+                return Err(
+                    new FunctionDeploymentServiceError({
+                        code: 'template_already_deployed',
+                        message: `'${body.template}' is already deployed on this integration`
+                    })
+                );
+            case 'non_runnable_type':
+                return Err(
+                    new FunctionDeploymentServiceError({
+                        code: 'non_runnable_template',
+                        message: `Template '${body.template}' cannot be deployed as a function`,
+                        cause: outcome.cause
+                    })
+                );
+            case 'failed_to_deploy':
+                return Err(
+                    new FunctionDeploymentServiceError({
+                        code: 'template_deployment_failed',
+                        message: 'Failed to deploy the template',
+                        cause: outcome.cause
+                    })
+                );
+            default: {
+                const exhaustiveCheck: never = outcome.reason;
+                return exhaustiveCheck;
+            }
+        }
+    }
+
+    const { result, type } = outcome;
+    const version = result.version ?? '';
+    const deployment = await createSucceededFunctionDeployment({
+        environmentId: environment.id,
+        request: {
+            type: 'template',
+            integration_id: body.integration_id,
+            template: body.template,
+            function_name: result.name,
+            function_type: type
+        },
+        output: `Successfully deployed the functions:\n- ${result.name}@${version}`,
+        deployedFunctions: [{ name: result.name, version }]
+    });
+    if (deployment.isErr()) {
+        return Err(
+            new FunctionDeploymentServiceError({
+                code: 'deployment_record_creation_failed',
+                message: 'Template was deployed but its deployment record could not be created',
+                cause: deployment.error
+            })
+        );
+    }
+
+    return Ok(deployment.value);
+}
+
+export function toFunctionDeploymentError(err: unknown): FunctionDeploymentError {
+    if (err instanceof FunctionError) {
+        return {
+            code: err.code,
+            message: err.message,
+            ...(err.payload !== undefined ? { payload: err.payload } : {})
+        };
+    }
+
+    return {
+        code: 'deployment_error',
+        message: stringifyError(err)
+    };
+}
+
+function isProtectedExistingFunction(existingSyncConfig: Pick<DBSyncConfig, 'source'> | null): boolean {
+    return Boolean(existingSyncConfig && existingSyncConfig.source !== 'standalone');
+}
+
+function shouldAllowDestructiveDeploy(existingSyncConfig: Pick<DBSyncConfig, 'source'> | null, allowDestructive: boolean): boolean {
+    return Boolean(allowDestructive && existingSyncConfig?.source === 'standalone');
+}
+
+async function createDeploySandboxApiKey(parentApiKeyId: number, environmentId: number, deploymentId: string) {
+    return await sandboxApiKeyService.createSandboxApiKey(db.knex, {
+        parentApiKeyId,
+        environmentId,
+        purpose: 'deploy',
+        deploymentId,
+        expiresAt: new Date(Date.now() + deploySandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
+    });
+}

--- a/packages/server/lib/services/functionDeployment.service.unit.test.ts
+++ b/packages/server/lib/services/functionDeployment.service.unit.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as sandbox from '@nangohq/sandbox';
+import * as shared from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import { deployFunction, deployTemplate } from './functionDeployment.service.js';
+import * as integrationTemplateService from './integrationTemplate.service.js';
+
+import type { DBFunctionDeployment } from '@nangohq/sandbox';
+import type { Config } from '@nangohq/shared';
+import type { DBEnvironment, DBSyncConfig, DBTeam, SyncDeploymentResult } from '@nangohq/types';
+
+describe('functionDeploymentService', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('starts a single function deployment and returns its initial job state', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
+        vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue(null);
+        const createSpy = vi
+            .spyOn(sandbox, 'createFunctionDeployment')
+            .mockResolvedValue(Ok({ id: deploymentId, status: 'waiting', created_at: '2026-01-01T00:00:00.000Z' }));
+        vi.spyOn(sandbox.sandboxApiKeyService, 'createSandboxApiKey').mockResolvedValue(Ok('sandbox-api-key'));
+        const start = vi.fn().mockResolvedValue(undefined);
+        const kill = vi.fn().mockResolvedValue(undefined);
+        const startedAt = new Date('2026-01-01T00:00:01.000Z');
+        const executionTimeoutAt = new Date('2026-01-01T00:05:31.000Z');
+        const prepareSpy = vi.spyOn(sandbox, 'prepareAsyncDeploy').mockResolvedValue({
+            sandboxId: 'sandbox-id',
+            startedAt,
+            executionTimeoutAt,
+            start,
+            kill
+        });
+        const runningRow = { id: deploymentId, job_type: 'deployment', status: 'running' } as DBFunctionDeployment;
+        const runningSpy = vi.spyOn(sandbox, 'markFunctionDeploymentRunning').mockResolvedValue(runningRow);
+        vi.spyOn(sandbox, 'toFunctionDeploymentCreate').mockReturnValue({
+            id: deploymentId,
+            status: 'running',
+            created_at: '2026-01-01T00:00:00.000Z'
+        });
+
+        const result = await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}',
+                version: '1.0.0',
+                allow_destructive: true
+            }
+        });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({
+                id: deploymentId,
+                status: 'running',
+                created_at: '2026-01-01T00:00:00.000Z'
+            });
+        }
+        expect(createSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            request: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}',
+                version: '1.0.0',
+                allow_destructive: false
+            }
+        });
+        expect(prepareSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                deployment_id: deploymentId,
+                nango_secret_key: 'sandbox-api-key',
+                allow_destructive: false
+            })
+        );
+        expect(runningSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            id: deploymentId,
+            sandboxId: 'sandbox-id',
+            startedAt,
+            executionTimeoutAt
+        });
+        expect(start).toHaveBeenCalledOnce();
+        expect(kill).not.toHaveBeenCalled();
+    });
+
+    it('allows a destructive deployment only for an existing standalone function', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
+        vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue({ source: 'standalone' } as DBSyncConfig);
+        const createSpy = vi.spyOn(sandbox, 'createFunctionDeployment').mockResolvedValue(Err(new Error('stop after request assertion')));
+
+        await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}',
+                allow_destructive: true
+            }
+        });
+
+        expect(createSpy).toHaveBeenCalledOnce();
+        expect(createSpy.mock.calls.at(0)?.[0]).toMatchObject({ environmentId: 42, request: { allow_destructive: true } });
+    });
+
+    it('rejects repo-managed functions before creating a deployment job', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
+        vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue({ source: 'repo' } as DBSyncConfig);
+        const createSpy = vi.spyOn(sandbox, 'createFunctionDeployment');
+
+        const result = await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({ code: 'invalid_request', message: "Cannot overwrite existing function 'sync-issues'" });
+        }
+        expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it('requires a customer API key before starting a single function deployment', async () => {
+        const configSpy = vi.spyOn(shared.configService, 'getProviderConfig');
+
+        const result = await deployFunction({
+            environment,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.code).toBe('customer_api_key_required');
+        }
+        expect(configSpy).not.toHaveBeenCalled();
+    });
+
+    it('marks the deployment failed and cleans up when the sandbox cannot start', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
+        vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue(null);
+        vi.spyOn(sandbox, 'createFunctionDeployment').mockResolvedValue(Ok({ id: deploymentId, status: 'waiting', created_at: '2026-01-01T00:00:00.000Z' }));
+        vi.spyOn(sandbox.sandboxApiKeyService, 'createSandboxApiKey').mockResolvedValue(Ok('sandbox-api-key'));
+        const failure = new Error('sandbox failed');
+        const start = vi.fn().mockRejectedValue(failure);
+        const kill = vi.fn().mockResolvedValue(undefined);
+        vi.spyOn(sandbox, 'prepareAsyncDeploy').mockResolvedValue({
+            sandboxId: 'sandbox-id',
+            startedAt: new Date(),
+            executionTimeoutAt: new Date(),
+            start,
+            kill
+        });
+        vi.spyOn(sandbox, 'markFunctionDeploymentRunning').mockResolvedValue({ id: deploymentId } as DBFunctionDeployment);
+        const failedSpy = vi.spyOn(sandbox, 'markFunctionDeploymentFailed').mockResolvedValue(null);
+
+        const result = await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({ code: 'deployment_failed', cause: failure });
+        }
+        expect(kill).toHaveBeenCalledOnce();
+        expect(failedSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            id: deploymentId,
+            error: { code: 'deployment_error', message: '{"name":"Error","message":"sandbox failed"}' }
+        });
+    });
+
+    it('deploys a template and records a terminal deployment job', async () => {
+        vi.spyOn(integrationTemplateService, 'deployIntegrationTemplate').mockResolvedValue({
+            ok: true,
+            type: 'sync',
+            result: { name: 'tables', version: '1.2.3' } as SyncDeploymentResult
+        });
+        const createSpy = vi
+            .spyOn(sandbox, 'createSucceededFunctionDeployment')
+            .mockResolvedValue(Ok({ id: deploymentId, status: 'success', created_at: '2026-01-01T00:00:00.000Z' }));
+
+        const result = await deployTemplate({
+            account,
+            environment,
+            plan: null,
+            body: { type: 'template', integration_id: 'airtable', template: 'tables' }
+        });
+
+        expect(result.isOk()).toBe(true);
+        expect(createSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            request: {
+                type: 'template',
+                integration_id: 'airtable',
+                template: 'tables',
+                function_name: 'tables',
+                function_type: 'sync'
+            },
+            output: 'Successfully deployed the functions:\n- tables@1.2.3',
+            deployedFunctions: [{ name: 'tables', version: '1.2.3' }]
+        });
+    });
+
+    it('maps template deployment outcomes to transport-neutral errors', async () => {
+        vi.spyOn(integrationTemplateService, 'deployIntegrationTemplate').mockResolvedValue({ ok: false, reason: 'ambiguous_template' });
+
+        const result = await deployTemplate({
+            account,
+            environment,
+            plan: null,
+            body: { type: 'template', integration_id: 'google-calendar', template: 'settings' }
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({
+                code: 'ambiguous_function',
+                message: "'settings' exists as both a sync and an action; specify 'function_type' to disambiguate"
+            });
+        }
+    });
+});
+
+const deploymentId = '3c66291f-6247-47a6-a100-f4d621d751f7';
+const account = { id: 1, name: 'Test account' } as DBTeam;
+const environment = { id: 42, name: 'dev' } as DBEnvironment;

--- a/packages/server/lib/services/integrationTemplate.service.ts
+++ b/packages/server/lib/services/integrationTemplate.service.ts
@@ -2,8 +2,8 @@ import db from '@nangohq/database';
 import { logContextGetter } from '@nangohq/logs';
 import { configService, deployTemplate, productTracking, startTrial, syncManager } from '@nangohq/shared';
 
-import flowService from '../../../../services/flow.service.js';
-import { getOrchestrator } from '../../../../utils/utils.js';
+import { getOrchestrator } from '../utils/utils.js';
+import flowService from './flow.service.js';
 
 import type { DBEnvironment, DBPlan, DBTeam, DBUser, RunnableFunctionType, ScriptTypeLiteral, SyncDeploymentResult } from '@nangohq/types';
 
@@ -24,9 +24,7 @@ export type DeployIntegrationTemplateOutcome =
 
 /**
  * Deploys a catalog template onto an integration: resolves the template from the catalog (keyed by the
- * integration's own provider), deploys it, and triggers it for existing connections. Shared by the private
- * `POST /api/v1/flows/pre-built/deploy` and the public `POST /integrations/:uniqueKey/functions` — each maps
- * the outcome to its own response shape.
+ * integration's own provider), deploys it, and triggers it for existing connections.
  */
 export async function deployIntegrationTemplate({
     environment,
@@ -40,7 +38,7 @@ export async function deployIntegrationTemplate({
     environment: DBEnvironment;
     account: DBTeam;
     plan: DBPlan | null;
-    user: DBUser;
+    user?: Pick<DBUser, 'id' | 'email' | 'name'> | undefined;
     providerConfigKey: string;
     name: string;
     type?: ScriptTypeLiteral | undefined;


### PR DESCRIPTION
Adds Management MCP tools for listing and deploying code or template functions, with strict schemas, scope enforcement, structured results, auditing, and public error handling.

Refactors code and template deployments into reusable service methods so the HTTP and MCP controllers share transport-neutral logic while retaining separate deployment paths. The PR also includes the stacked `functions_list` prerequisite, focused coverage, and Management MCP documentation.

NAN-6315: https://linear.app/nango/issue/NAN-6315/mcp-tool-functions-deploy

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

