### PR TITLE
feat: show per-metric charges for paid plans

### DIFF
--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -10,6 +10,7 @@ import type {
     BillingEvent,
     BillingInvoicingDetails,
     BillingOverdueInvoices,
+    BillingPeriodCosts,
     BillingPlan,
     BillingSpendAlert,
     BillingSubscription,
@@ -97,6 +98,10 @@ export class Billing {
 
     async getUpcomingInvoice(subscriptionId: string): Promise<Result<BillingUpcomingInvoice | null>> {
         return await this.client.getUpcomingInvoice(subscriptionId);
+    }
+
+    async getPeriodCosts(subscriptionId: string): Promise<Result<BillingPeriodCosts | null>> {
+        return await this.client.getPeriodCosts(subscriptionId);
     }
 
     async getSpendAlert(subscriptionId: string): Promise<Result<BillingSpendAlert | null>> {

--- a/packages/billing/lib/clients/noop/client.ts
+++ b/packages/billing/lib/clients/noop/client.ts
@@ -6,6 +6,7 @@ import type {
     BillingEvent,
     BillingInvoicingDetails,
     BillingOverdueInvoices,
+    BillingPeriodCosts,
     BillingPlan,
     BillingSpendAlert,
     BillingSubscription,
@@ -70,6 +71,10 @@ export class NoopBillingClient implements BillingClient {
     }
 
     getUpcomingInvoice(_subscriptionId: string): Promise<Result<BillingUpcomingInvoice | null>> {
+        return Promise.resolve(Ok(null));
+    }
+
+    getPeriodCosts(_subscriptionId: string): Promise<Result<BillingPeriodCosts | null>> {
         return Promise.resolve(Ok(null));
     }
 

--- a/packages/billing/lib/clients/noop/client.ts
+++ b/packages/billing/lib/clients/noop/client.ts
@@ -19,7 +19,7 @@ import type { Result } from '@nangohq/utils';
 
 /**
  * Stub billing client for local dev / self-hosted setups with no Orb configured.
- * Selected in index.ts when `ORB_API_KEY` is unset. Calls return a benign
+ * Selected in index.ts when `ORB_API_KEY` is unset. Every call returns a benign
  * success so flows that touch billing (e.g. the billing-usage dashboard, which
  * still reads its actual numbers from ClickHouse) don't fail on the missing Orb
  * dependency. Deployed environments always set `ORB_API_KEY` and use OrbClient.

--- a/packages/billing/lib/clients/noop/client.ts
+++ b/packages/billing/lib/clients/noop/client.ts
@@ -19,7 +19,7 @@ import type { Result } from '@nangohq/utils';
 
 /**
  * Stub billing client for local dev / self-hosted setups with no Orb configured.
- * Selected in index.ts when `ORB_API_KEY` is unset. Every call returns a benign
+ * Selected in index.ts when `ORB_API_KEY` is unset. Calls return a benign
  * success so flows that touch billing (e.g. the billing-usage dashboard, which
  * still reads its actual numbers from ClickHouse) don't fail on the missing Orb
  * dependency. Deployed environments always set `ORB_API_KEY` and use OrbClient.

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -65,8 +65,9 @@ export function fromOrbUpcomingInvoice(invoice: { amount_due: string; currency: 
 }
 
 /**
- * Prod and test mode share no billable-metric ids, so both sets live here. Names can't be the key:
- * one metric bills under several of them.
+ * Keyed on billable-metric id, not price name: a price's name can change (verified — four of these
+ * metrics bill under two different names each) while its id stays put. Ids are environment-specific
+ * though, and prod and test mode share none, so both sets live here.
  */
 const orbBillableMetricToUsageMetric: Record<string, UsageMetric> = {
     // prod
@@ -90,12 +91,12 @@ const orbBillableMetricToUsageMetric: Record<string, UsageMetric> = {
 interface OrbCostBucket {
     timeframe_end: string;
     per_price_costs: {
+        price_id: string;
         total: string;
-        price: { price_type: string; currency?: string | null; billable_metric?: { id: string } | null };
+        price: { price_type: string; name: string; currency?: string | null; billable_metric?: { id: string } | null };
     }[];
 }
 
-/** Fixed prices are excluded, so the metrics never sum to the period's invoice total. */
 export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date): BillingPeriodCosts | null {
     // Cumulative buckets accumulate over the period, so the one ending last spans all of it.
     const period = costs.data.reduce<OrbCostBucket | null>(
@@ -111,31 +112,43 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date):
     }
 
     const metrics: Partial<Record<UsageMetric, number>> = {};
-    let unattributedInCents = 0;
+    const malformedMetrics: UsageMetric[] = [];
+    const flagged: BillingPeriodCosts['flagged'] = [];
+    let fullyAttributed = true;
     let currency: string | null = null;
 
     for (const priceCost of period.per_price_costs) {
         const { price } = priceCost;
+        // Excluded, so the metrics never sum to the period's invoice total — the base fee isn't split
+        // across rows.
         if (price.price_type === 'fixed_price') {
             continue;
         }
 
+        const metric = price.billable_metric ? (orbBillableMetricToUsageMetric[price.billable_metric.id] ?? null) : null;
         const priceCurrency = normalizeIsoCurrency(price.currency);
-        if (!priceCurrency || (currency && priceCurrency !== currency)) {
-            return null;
+        const amountInCents = orbAmountToCents(priceCost.total);
+        const readable = priceCurrency !== null && (currency === null || priceCurrency === currency) && amountInCents !== null;
+
+        if (!readable) {
+            // A real price we couldn't read (unparseable amount, or a currency other prices don't
+            // share). Its own metric, if we know one, can't claim a number — but every other price in
+            // the bucket is independent and still trustworthy, so only that metric is affected.
+            if (metric) {
+                malformedMetrics.push(metric);
+            } else {
+                fullyAttributed = false;
+            }
+            flagged.push({ priceId: priceCost.price_id, priceName: price.name, metric, amountInCents });
+            continue;
         }
         currency = priceCurrency;
 
-        // One unparseable amount makes the whole response untrustworthy: the metrics that did parse
-        // would understate the period.
-        const amountInCents = orbAmountToCents(priceCost.total);
-        if (amountInCents === null) {
-            return null;
-        }
-
-        const metric = price.billable_metric ? orbBillableMetricToUsageMetric[price.billable_metric.id] : undefined;
         if (!metric) {
-            unattributedInCents += amountInCents;
+            // A priced metric we don't recognise: an unpriced row can't safely claim $0, since this
+            // money might be one of theirs.
+            fullyAttributed = false;
+            flagged.push({ priceId: priceCost.price_id, priceName: price.name, metric: null, amountInCents });
             continue;
         }
 
@@ -147,7 +160,7 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date):
         return null;
     }
 
-    return { metrics, unattributedInCents, currency };
+    return { metrics, malformedMetrics, fullyAttributed, flagged, currency };
 }
 
 /**

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -44,6 +44,12 @@ export function orbAmountToCents(amount: string): number | null {
     return match[1] === '-' ? -cents : cents;
 }
 
+/** Uppercased ISO 4217 code, or null for anything else — including Orb's `credits` unit. */
+export function normalizeIsoCurrency(currency: string | null | undefined): string | null {
+    const code = currency?.trim().toUpperCase();
+    return code && /^[A-Z]{3}$/.test(code) ? code : null;
+}
+
 /**
  * The parts of an upcoming invoice the billing summary needs, or null when the amount can't be
  * stated: an unparseable amount, or a currency that isn't ISO 4217. Orb returns the literal
@@ -55,8 +61,8 @@ export function fromOrbUpcomingInvoice(invoice: { amount_due: string; currency: 
         return null;
     }
 
-    const currency = invoice.currency.trim().toUpperCase();
-    if (!/^[A-Z]{3}$/.test(currency)) {
+    const currency = normalizeIsoCurrency(invoice.currency);
+    if (!currency) {
         return null;
     }
 
@@ -125,8 +131,8 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date):
             continue;
         }
 
-        const priceCurrency = price.currency?.trim().toUpperCase();
-        if (!priceCurrency || !/^[A-Z]{3}$/.test(priceCurrency) || (currency && priceCurrency !== currency)) {
+        const priceCurrency = normalizeIsoCurrency(price.currency);
+        if (!priceCurrency || (currency && priceCurrency !== currency)) {
             return null;
         }
         currency = priceCurrency;
@@ -166,14 +172,12 @@ export function fromOrbAlert(alert: { id: string; currency: string | null; thres
         return null;
     }
 
-    const currency = (alert.currency ?? '').trim().toUpperCase();
-
     return {
         id: alert.id,
         // Rounded, not truncated: we wrote this value ourselves as whole cents, so any fractional
         // remainder is float drift from the round-trip, not a real amount.
         thresholdInCents: Math.round(threshold.value * 100),
-        currency: /^[A-Z]{3}$/.test(currency) ? currency : null
+        currency: normalizeIsoCurrency(alert.currency)
     };
 }
 

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -131,9 +131,12 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date):
         }
         currency = priceCurrency;
 
+        // An unparseable amount on a real, priced metric means we can't trust the response — treated
+        // the same as a currency mismatch above, not silently dropped: rendering the other metrics
+        // while this one reads $0.00 would present malformed data as a real answer.
         const amountInCents = orbAmountToCents(priceCost.total);
         if (amountInCents === null) {
-            continue;
+            return null;
         }
 
         const metric = price.billable_metric ? orbBillableMetricToUsageMetric[price.billable_metric.id] : undefined;

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -10,6 +10,7 @@ import type {
     BillingCustomer,
     BillingEvent,
     BillingInvoicingDetails,
+    BillingPeriodCosts,
     BillingSpendAlert,
     BillingUpcomingInvoice,
     Result,
@@ -60,6 +61,96 @@ export function fromOrbUpcomingInvoice(invoice: { amount_due: string; currency: 
     }
 
     return { amountInCents, currency };
+}
+
+/**
+ * Orb billable-metric id -> our metric. Ids are per Orb mode and prod shares none with test mode, so
+ * both sets live here; names are not usable as the key because the same metric bills under several
+ * (`Sync records`/`Stored records`, `Webhook forwards`/`Processed webhooks`, and so on).
+ */
+const orbBillableMetricToUsageMetric: Record<string, UsageMetric> = {
+    // prod
+    '8aAyMTG6HafmZpqJ': 'connections',
+    bydJcn2HUaYSGQ9S: 'proxy',
+    AinLoHESvrXqhEig: 'records',
+    j46jUSMMya8jqhkR: 'webhook_forwards',
+    S6QcTddptFM8tvFc: 'function_executions',
+    SuusTqcXhhZVq2w4: 'function_compute_gbms',
+    '7TXEdbnT3gWPqkns': 'function_logs',
+    // test mode, shared by dev, staging and local
+    QFf9VosRcMWkZvZq: 'connections',
+    T9MRaCkFi4SEf2ku: 'proxy',
+    FTTFTvuqDr7YbcRB: 'records',
+    D8Gu4UPEJ3tUWJJ3: 'webhook_forwards',
+    '29oZqvoENLmauqkY': 'function_executions',
+    '4jYMmFPKUQAKKL2T': 'function_compute_gbms',
+    '62CoZikHXhPoS6yt': 'function_logs'
+};
+
+interface OrbCostBucket {
+    timeframe_end: string;
+    per_price_costs: {
+        total: string;
+        price: { price_type: string; currency?: string | null; billable_metric?: { id: string } | null };
+    }[];
+}
+
+/**
+ * Per-metric charges for the subscription's current billing period, or null when they can't be stated:
+ * no cost data, a period that has already closed, or a currency that isn't ISO 4217 (Orb returns the
+ * literal `credits` for credit-denominated subscriptions, which has no dollar meaning).
+ *
+ * Fixed prices are excluded, so the metrics never sum to the period's invoice total.
+ */
+export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date): BillingPeriodCosts | null {
+    // Cumulative buckets accumulate over the period, so the one ending last spans all of it. Compared
+    // as instants, not strings, since the offsets need not match.
+    const period = costs.data.reduce<OrbCostBucket | null>(
+        (latest, bucket) => (latest && Date.parse(latest.timeframe_end) >= Date.parse(bucket.timeframe_end) ? latest : bucket),
+        null
+    );
+    // An ended subscription still answers with its final period rather than erroring, and those costs
+    // are not what is being billed now.
+    if (!period || Date.parse(period.timeframe_end) <= now.getTime()) {
+        return null;
+    }
+
+    const metrics: Partial<Record<UsageMetric, number>> = {};
+    let unattributedInCents = 0;
+    let currency: string | null = null;
+
+    for (const priceCost of period.per_price_costs) {
+        const { price } = priceCost;
+        if (price.price_type === 'fixed_price') {
+            continue;
+        }
+
+        const priceCurrency = price.currency?.trim().toUpperCase();
+        if (!priceCurrency || !/^[A-Z]{3}$/.test(priceCurrency) || (currency && priceCurrency !== currency)) {
+            return null;
+        }
+        currency = priceCurrency;
+
+        const amountInCents = orbAmountToCents(priceCost.total);
+        if (amountInCents === null) {
+            continue;
+        }
+
+        const metric = price.billable_metric ? orbBillableMetricToUsageMetric[price.billable_metric.id] : undefined;
+        if (!metric) {
+            unattributedInCents += amountInCents;
+            continue;
+        }
+
+        // Orb allows several prices on one metric, so accumulate rather than assign.
+        metrics[metric] = (metrics[metric] ?? 0) + amountInCents;
+    }
+
+    if (!currency) {
+        return null;
+    }
+
+    return { metrics, unattributedInCents, currency };
 }
 
 /**

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -44,16 +44,12 @@ export function orbAmountToCents(amount: string): number | null {
     return match[1] === '-' ? -cents : cents;
 }
 
-/** Uppercased ISO 4217 code, or null for anything else — including Orb's `credits` unit. */
+/** Orb denominates some invoices in a `credits` unit rather than an ISO 4217 currency. */
 export function normalizeIsoCurrency(currency: string | null | undefined): string | null {
     const code = currency?.trim().toUpperCase();
     return code && /^[A-Z]{3}$/.test(code) ? code : null;
 }
 
-/**
- * The parts of an upcoming invoice the billing summary needs, or null when the amount can't be
- * stated: an unparseable amount, or a currency that isn't ISO 4217.
- */
 export function fromOrbUpcomingInvoice(invoice: { amount_due: string; currency: string }): BillingUpcomingInvoice | null {
     const amountInCents = orbAmountToCents(invoice.amount_due);
     if (amountInCents === null) {
@@ -69,9 +65,8 @@ export function fromOrbUpcomingInvoice(invoice: { amount_due: string; currency: 
 }
 
 /**
- * Orb billable-metric id -> our metric. Ids are per Orb mode and prod shares none with test mode, so
- * both sets live here; names are not usable as the key because the same metric bills under several
- * (`Sync records`/`Stored records`, `Webhook forwards`/`Processed webhooks`, and so on).
+ * Prod and test mode share no billable-metric ids, so both sets live here. Names can't be the key:
+ * one metric bills under several of them.
  */
 const orbBillableMetricToUsageMetric: Record<string, UsageMetric> = {
     // prod
@@ -100,12 +95,7 @@ interface OrbCostBucket {
     }[];
 }
 
-/**
- * Per-metric charges for the subscription's current billing period, or null when they can't be stated:
- * no cost data, a period that has already closed, or a currency that isn't ISO 4217.
- *
- * Fixed prices are excluded, so the metrics never sum to the period's invoice total.
- */
+/** Fixed prices are excluded, so the metrics never sum to the period's invoice total. */
 export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date): BillingPeriodCosts | null {
     // Cumulative buckets accumulate over the period, so the one ending last spans all of it.
     const period = costs.data.reduce<OrbCostBucket | null>(
@@ -134,8 +124,8 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date):
         }
         currency = priceCurrency;
 
-        // An unparseable amount on a priced metric means we can't trust the response — bail entirely
-        // rather than let the other metrics render as if this one had been accounted for.
+        // One unparseable amount makes the whole response untrustworthy: the metrics that did parse
+        // would understate the period.
         const amountInCents = orbAmountToCents(priceCost.total);
         if (amountInCents === null) {
             return null;
@@ -147,7 +137,7 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date):
             continue;
         }
 
-        // Orb allows several prices on one metric, so accumulate rather than assign.
+        // Orb allows several prices on one metric.
         metrics[metric] = (metrics[metric] ?? 0) + amountInCents;
     }
 

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -52,8 +52,7 @@ export function normalizeIsoCurrency(currency: string | null | undefined): strin
 
 /**
  * The parts of an upcoming invoice the billing summary needs, or null when the amount can't be
- * stated: an unparseable amount, or a currency that isn't ISO 4217. Orb returns the literal
- * `credits` for credit-denominated invoices, which has no dollar meaning to show a customer.
+ * stated: an unparseable amount, or a currency that isn't ISO 4217.
  */
 export function fromOrbUpcomingInvoice(invoice: { amount_due: string; currency: string }): BillingUpcomingInvoice | null {
     const amountInCents = orbAmountToCents(invoice.amount_due);
@@ -103,14 +102,12 @@ interface OrbCostBucket {
 
 /**
  * Per-metric charges for the subscription's current billing period, or null when they can't be stated:
- * no cost data, a period that has already closed, or a currency that isn't ISO 4217 (Orb returns the
- * literal `credits` for credit-denominated subscriptions, which has no dollar meaning).
+ * no cost data, a period that has already closed, or a currency that isn't ISO 4217.
  *
  * Fixed prices are excluded, so the metrics never sum to the period's invoice total.
  */
 export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date): BillingPeriodCosts | null {
-    // Cumulative buckets accumulate over the period, so the one ending last spans all of it. Compared
-    // as instants, not strings, since the offsets need not match.
+    // Cumulative buckets accumulate over the period, so the one ending last spans all of it.
     const period = costs.data.reduce<OrbCostBucket | null>(
         (latest, bucket) => (latest && Date.parse(latest.timeframe_end) >= Date.parse(bucket.timeframe_end) ? latest : bucket),
         null
@@ -137,9 +134,8 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date):
         }
         currency = priceCurrency;
 
-        // An unparseable amount on a real, priced metric means we can't trust the response — treated
-        // the same as a currency mismatch above, not silently dropped: rendering the other metrics
-        // while this one reads $0.00 would present malformed data as a real answer.
+        // An unparseable amount on a priced metric means we can't trust the response — bail entirely
+        // rather than let the other metrics render as if this one had been accounted for.
         const amountInCents = orbAmountToCents(priceCost.total);
         if (amountInCents === null) {
             return null;

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -103,8 +103,10 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date):
         null
     );
     // An ended subscription still answers with its final period rather than erroring, and those costs
-    // are not what is being billed now.
-    if (!period || Date.parse(period.timeframe_end) <= now.getTime()) {
+    // are not what is being billed now. A NaN from a malformed timeframe_end must reject explicitly —
+    // NaN <= now.getTime() is always false, so it would otherwise read as a current period.
+    const periodEnd = period ? Date.parse(period.timeframe_end) : NaN;
+    if (!period || Number.isNaN(periodEnd) || periodEnd <= now.getTime()) {
         return null;
     }
 

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -488,7 +488,7 @@ describe('fromOrbPeriodCosts', () => {
     });
 
     it('maps on the id, not the name, so a renamed price still lands', () => {
-        // 29 prod subscriptions bill webhook forwarding under this name; matching on the name drops it.
+        // Prod subscriptions bill webhook forwarding under this name; matching on the name drops it.
         const costs = { data: [bucket([usagePrice(WEBHOOKS_PROD, '2.24', 'Processed webhooks')])] };
 
         expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ webhook_forwards: 224 });

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -555,6 +555,13 @@ describe('fromOrbPeriodCosts', () => {
         expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
     });
 
+    it('returns null rather than reading a malformed timeframe_end as current', () => {
+        // NaN <= now.getTime() is always false, so an unguarded comparison would treat this as open.
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '40.00')], 'not-a-date')] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
+    });
+
     it('returns null when there are no cost buckets', () => {
         expect(fromOrbPeriodCosts({ data: [] }, NOW)).toBeNull();
     });

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -593,9 +593,9 @@ describe('fromOrbPeriodCosts', () => {
         expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 0 });
     });
 
-    it('skips a metric whose amount cannot be parsed', () => {
+    it('returns null for the whole period rather than a metric with a malformed amount', () => {
         const costs = { data: [bucket([usagePrice(RECORDS_PROD, 'n/a')])] };
 
-        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({});
+        expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
     });
 });

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -5,6 +5,7 @@ import {
     fromOrbAddress,
     fromOrbAlert,
     fromOrbCustomer,
+    fromOrbPeriodCosts,
     fromOrbUpcomingInvoice,
     orbAmountToCents,
     orbMetricToUsageMetric,
@@ -453,5 +454,148 @@ describe('fromOrbAlert', () => {
             currency: null
         });
         expect(fromOrbAlert({ id: 'alert_1', currency: null, thresholds: [{ value: 50 }] })?.currency).toBeNull();
+    });
+});
+
+// ─── fromOrbPeriodCosts ───────────────────────────────────────────────────────
+
+const NOW = new Date('2026-08-21T12:00:00Z');
+/** Ids are real: the prod and test-mode `Sync records` metrics, which share no id. */
+const RECORDS_PROD = 'AinLoHESvrXqhEig';
+const RECORDS_TEST = 'FTTFTvuqDr7YbcRB';
+const WEBHOOKS_PROD = 'j46jUSMMya8jqhkR';
+
+function usagePrice(metricId: string | null, total: string, name = 'Some price') {
+    return {
+        total,
+        price: { price_type: 'usage_price', currency: 'USD', name, billable_metric: metricId ? { id: metricId } : null }
+    };
+}
+
+function bucket(perPriceCosts: ReturnType<typeof usagePrice>[], timeframeEnd = '2026-09-01T00:00:00+00:00') {
+    return { timeframe_end: timeframeEnd, per_price_costs: perPriceCosts };
+}
+
+describe('fromOrbPeriodCosts', () => {
+    it('maps a price to its metric and converts the amount to cents', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '23.17', 'Sync records')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)).toEqual({ metrics: { records: 2317 }, unattributedInCents: 0, currency: 'USD' });
+    });
+
+    it('maps test-mode ids too, so the figures are not prod-only', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_TEST, '1.00', 'Sync records')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 100 });
+    });
+
+    it('maps on the id, not the name, so a renamed price still lands', () => {
+        // 29 prod subscriptions bill webhook forwarding under this name; matching on the name drops it.
+        const costs = { data: [bucket([usagePrice(WEBHOOKS_PROD, '2.24', 'Processed webhooks')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ webhook_forwards: 224 });
+    });
+
+    it('keeps a zero charge as zero rather than omitting the metric', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '0.00')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 0 });
+    });
+
+    it('omits a metric the subscription carries no price for', () => {
+        // Real state: sync-record charges have been removed by hand for some accounts.
+        const costs = { data: [bucket([usagePrice(WEBHOOKS_PROD, '2.00')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).not.toHaveProperty('records');
+    });
+
+    it('excludes fixed prices, so the metrics exclude the base fee', () => {
+        const costs = {
+            data: [
+                bucket([
+                    usagePrice(RECORDS_PROD, '23.17'),
+                    { total: '500.00', price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null } }
+                ])
+            ]
+        };
+
+        expect(fromOrbPeriodCosts(costs, NOW)).toEqual({ metrics: { records: 2317 }, unattributedInCents: 0, currency: 'USD' });
+    });
+
+    it('counts a price it cannot map as unattributed instead of dropping it silently', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '1.00'), usagePrice('unknown-metric-id', '7.50', 'Data transfer')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)).toEqual({ metrics: { records: 100 }, unattributedInCents: 750, currency: 'USD' });
+    });
+
+    it('leaves unattributed at zero when an unmapped price carries no charge', () => {
+        const costs = { data: [bucket([usagePrice('unknown-metric-id', '0.00')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.unattributedInCents).toBe(0);
+    });
+
+    it('sums several prices on the same metric', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '1.00'), usagePrice(RECORDS_PROD, '2.50')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 350 });
+    });
+
+    it('reads the bucket that ends last, not the one listed last', () => {
+        const costs = {
+            data: [
+                bucket([usagePrice(RECORDS_PROD, '99.00')], '2026-09-01T00:00:00+00:00'),
+                bucket([usagePrice(RECORDS_PROD, '1.00')], '2026-08-02T00:00:00+00:00')
+            ]
+        };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 9900 });
+    });
+
+    it('returns null for a period that has already closed', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '40.00')], '2026-08-17T00:00:00+00:00')] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
+    });
+
+    it('returns null when there are no cost buckets', () => {
+        expect(fromOrbPeriodCosts({ data: [] }, NOW)).toBeNull();
+    });
+
+    it('returns null for a credit-denominated subscription', () => {
+        const costs = { data: [{ ...bucket([usagePrice(RECORDS_PROD, '1.00')]) }] };
+        costs.data[0]!.per_price_costs[0]!.price.currency = 'credits';
+
+        expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
+    });
+
+    it('returns null when prices disagree on the currency', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '1.00')])] };
+        costs.data[0]!.per_price_costs.push({
+            total: '1.00',
+            price: { price_type: 'usage_price', currency: 'EUR', name: 'Proxy requests', billable_metric: { id: WEBHOOKS_PROD } }
+        });
+
+        expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
+    });
+
+    it('returns null when every price is fixed, so no currency can be stated', () => {
+        const costs = {
+            data: [bucket([{ total: '500.00', price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null } }])]
+        };
+
+        expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
+    });
+
+    it('truncates a sub-cent charge to zero', () => {
+        // Per-unit rates run to 1e-7, so this is the ordinary state on a low-usage account.
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '0.004')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 0 });
+    });
+
+    it('skips a metric whose amount cannot be parsed', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, 'n/a')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({});
     });
 });

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -463,8 +463,9 @@ const RECORDS_PROD = 'AinLoHESvrXqhEig';
 const RECORDS_TEST = 'FTTFTvuqDr7YbcRB';
 const WEBHOOKS_PROD = 'j46jUSMMya8jqhkR';
 
-function usagePrice(metricId: string | null, total: string, name = 'Some price') {
+function usagePrice(metricId: string | null, total: string, name = 'Some price', priceId = 'price_1') {
     return {
+        price_id: priceId,
         total,
         price: { price_type: 'usage_price', currency: 'USD', name, billable_metric: metricId ? { id: metricId } : null }
     };
@@ -478,7 +479,13 @@ describe('fromOrbPeriodCosts', () => {
     it('maps a price to its metric and converts the amount to cents', () => {
         const costs = { data: [bucket([usagePrice(RECORDS_PROD, '23.17', 'Sync records')])] };
 
-        expect(fromOrbPeriodCosts(costs, NOW)).toEqual({ metrics: { records: 2317 }, unattributedInCents: 0, currency: 'USD' });
+        expect(fromOrbPeriodCosts(costs, NOW)).toEqual({
+            metrics: { records: 2317 },
+            malformedMetrics: [],
+            fullyAttributed: true,
+            flagged: [],
+            currency: 'USD'
+        });
     });
 
     it('maps test-mode ids too, so the figures are not prod-only', () => {
@@ -512,24 +519,34 @@ describe('fromOrbPeriodCosts', () => {
             data: [
                 bucket([
                     usagePrice(RECORDS_PROD, '23.17'),
-                    { total: '500.00', price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null } }
+                    { price_id: 'price_fixed', total: '500.00', price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null } }
                 ])
             ]
         };
 
-        expect(fromOrbPeriodCosts(costs, NOW)).toEqual({ metrics: { records: 2317 }, unattributedInCents: 0, currency: 'USD' });
+        expect(fromOrbPeriodCosts(costs, NOW)).toEqual({
+            metrics: { records: 2317 },
+            malformedMetrics: [],
+            fullyAttributed: true,
+            flagged: [],
+            currency: 'USD'
+        });
     });
 
-    it('counts a price it cannot map as unattributed instead of dropping it silently', () => {
+    it('marks a price it cannot map as unattributed instead of dropping it silently', () => {
         const costs = { data: [bucket([usagePrice(RECORDS_PROD, '1.00'), usagePrice('unknown-metric-id', '7.50', 'Data transfer')])] };
 
-        expect(fromOrbPeriodCosts(costs, NOW)).toEqual({ metrics: { records: 100 }, unattributedInCents: 750, currency: 'USD' });
+        const result = fromOrbPeriodCosts(costs, NOW);
+        expect(result?.metrics).toEqual({ records: 100 });
+        expect(result?.fullyAttributed).toBe(false);
+        expect(result?.flagged).toEqual([{ priceId: 'price_1', priceName: 'Data transfer', metric: null, amountInCents: 750 }]);
     });
 
-    it('leaves unattributed at zero when an unmapped price carries no charge', () => {
+    it('stays fully attributed when an unmapped price carries no charge', () => {
         const costs = { data: [bucket([usagePrice('unknown-metric-id', '0.00')])] };
 
-        expect(fromOrbPeriodCosts(costs, NOW)?.unattributedInCents).toBe(0);
+        // Still unattributed — a $0 unmapped price is not the same as no unmapped price at all.
+        expect(fromOrbPeriodCosts(costs, NOW)?.fullyAttributed).toBe(false);
     });
 
     it('sums several prices on the same metric', () => {
@@ -566,26 +583,57 @@ describe('fromOrbPeriodCosts', () => {
         expect(fromOrbPeriodCosts({ data: [] }, NOW)).toBeNull();
     });
 
-    it('returns null for a credit-denominated subscription', () => {
-        const costs = { data: [{ ...bucket([usagePrice(RECORDS_PROD, '1.00')]) }] };
-        costs.data[0]!.per_price_costs[0]!.price.currency = 'credits';
+    it('scopes a malformed price to its own metric, leaving every other metric untouched', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, 'n/a'), usagePrice(WEBHOOKS_PROD, '2.24')])] };
 
-        expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
+        const result = fromOrbPeriodCosts(costs, NOW);
+        expect(result?.metrics).toEqual({ webhook_forwards: 224 });
+        expect(result?.malformedMetrics).toEqual(['records']);
+        // Its metric is known, so no other row is thrown into doubt.
+        expect(result?.fullyAttributed).toBe(true);
     });
 
-    it('returns null when prices disagree on the currency', () => {
+    it('scopes a currency-mismatched price to its own metric the same way', () => {
         const costs = { data: [bucket([usagePrice(RECORDS_PROD, '1.00')])] };
         costs.data[0]!.per_price_costs.push({
+            price_id: 'price_2',
             total: '1.00',
             price: { price_type: 'usage_price', currency: 'EUR', name: 'Proxy requests', billable_metric: { id: WEBHOOKS_PROD } }
         });
 
-        expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
+        const result = fromOrbPeriodCosts(costs, NOW);
+        expect(result?.metrics).toEqual({ records: 100 });
+        expect(result?.malformedMetrics).toEqual(['webhook_forwards']);
+        expect(result?.currency).toBe('USD');
+    });
+
+    it('scopes a credit-denominated price to its own metric — Orb behaving as designed, not bad data', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '1.00'), usagePrice(WEBHOOKS_PROD, '2.00')])] };
+        costs.data[0]!.per_price_costs[1]!.price.currency = 'credits';
+
+        const result = fromOrbPeriodCosts(costs, NOW);
+        expect(result?.metrics).toEqual({ records: 100 });
+        expect(result?.malformedMetrics).toEqual(['webhook_forwards']);
+    });
+
+    it('cannot pin down which unpriced metric a price with no known metric and no readable amount belongs to', () => {
+        // Worst case: neither the metric nor the amount is known, so no metric-specific dash is possible —
+        // fullyAttributed still covers it, same as any other unattributed price.
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '1.00'), usagePrice('unknown-metric-id', 'n/a')])] };
+
+        const result = fromOrbPeriodCosts(costs, NOW);
+        expect(result?.metrics).toEqual({ records: 100 });
+        expect(result?.malformedMetrics).toEqual([]);
+        expect(result?.fullyAttributed).toBe(false);
     });
 
     it('returns null when every price is fixed, so no currency can be stated', () => {
         const costs = {
-            data: [bucket([{ total: '500.00', price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null } }])]
+            data: [
+                bucket([
+                    { price_id: 'price_fixed', total: '500.00', price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null } }
+                ])
+            ]
         };
 
         expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
@@ -596,11 +644,5 @@ describe('fromOrbPeriodCosts', () => {
         const costs = { data: [bucket([usagePrice(RECORDS_PROD, '0.004')])] };
 
         expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 0 });
-    });
-
-    it('returns null for the whole period rather than a metric with a malformed amount', () => {
-        const costs = { data: [bucket([usagePrice(RECORDS_PROD, 'n/a')])] };
-
-        expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
     });
 });

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -457,8 +457,6 @@ describe('fromOrbAlert', () => {
     });
 });
 
-// ─── fromOrbPeriodCosts ───────────────────────────────────────────────────────
-
 const NOW = new Date('2026-08-21T12:00:00Z');
 /** Ids are real: the prod and test-mode `Sync records` metrics, which share no id. */
 const RECORDS_PROD = 'AinLoHESvrXqhEig';

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -1,6 +1,6 @@
 import Orb from 'orb-billing';
 
-import { Err, metrics, Ok, retry } from '@nangohq/utils';
+import { Err, metrics, Ok, report, retry } from '@nangohq/utils';
 
 import { envs } from '../../envs.js';
 import {
@@ -242,7 +242,19 @@ export class OrbClient implements BillingClient {
                 }
             );
 
-            return Ok(fromOrbPeriodCosts(costs, new Date()));
+            const result = fromOrbPeriodCosts(costs, new Date());
+            if (result && result.flagged.length > 0) {
+                // A price we couldn't cleanly turn into a metric's charge: nothing else would signal
+                // that a figure is missing, or that another metric's $0 can no longer be trusted.
+                metrics.increment(metrics.Types.BILLING_PERIOD_COSTS_UNATTRIBUTED);
+                report(new Error('billing_period_costs_unattributed'), {
+                    subscriptionId,
+                    malformedMetrics: result.malformedMetrics,
+                    fullyAttributed: result.fullyAttributed,
+                    flagged: result.flagged
+                });
+            }
+            return Ok(result);
         } catch (err) {
             if (isOrbNotFoundError(err)) {
                 return Ok(null);

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -3,7 +3,15 @@ import Orb from 'orb-billing';
 import { Err, metrics, Ok, retry } from '@nangohq/utils';
 
 import { envs } from '../../envs.js';
-import { fromOrbAlert, fromOrbCustomer, fromOrbUpcomingInvoice, orbMetricToUsageMetric, toOrbEvent, toOrbPutCustomerPayload } from './adapters.js';
+import {
+    fromOrbAlert,
+    fromOrbCustomer,
+    fromOrbPeriodCosts,
+    fromOrbUpcomingInvoice,
+    orbMetricToUsageMetric,
+    toOrbEvent,
+    toOrbPutCustomerPayload
+} from './adapters.js';
 
 import type {
     BillingClient,
@@ -11,6 +19,7 @@ import type {
     BillingEvent,
     BillingInvoicingDetails,
     BillingOverdueInvoices,
+    BillingPeriodCosts,
     BillingSpendAlert,
     BillingSubscription,
     BillingUpcomingInvoice,
@@ -215,6 +224,30 @@ export class OrbClient implements BillingClient {
                 return Ok(null);
             }
             return Err(new Error('failed_to_get_upcoming_invoice', { cause: err }));
+        }
+    }
+
+    async getPeriodCosts(subscriptionId: string): Promise<Result<BillingPeriodCosts | null>> {
+        try {
+            // No timeframe: Orb defaults to the current billing period. Cumulative so the last bucket
+            // carries the period-to-date figure rather than a single day's.
+            const costs = await this.orbSDK.subscriptions.fetchCosts(
+                subscriptionId,
+                { view_mode: 'cumulative' },
+                {
+                    headers: {
+                        'Orb-Cache-Control': 'cache',
+                        'Orb-Cache-Max-Age-Seconds': '300'
+                    }
+                }
+            );
+
+            return Ok(fromOrbPeriodCosts(costs, new Date()));
+        } catch (err) {
+            if (isOrbNotFoundError(err)) {
+                return Ok(null);
+            }
+            return Err(new Error('failed_to_get_period_costs', { cause: err }));
         }
     }
 

--- a/packages/billing/lib/clients/orb/client.unit.test.ts
+++ b/packages/billing/lib/clients/orb/client.unit.test.ts
@@ -101,3 +101,35 @@ describe('OrbClient.getUpcomingInvoice', () => {
         expect((await clientRejecting(err).getUpcomingInvoice('sub_gone')).unwrap()).toBeNull();
     });
 });
+
+function clientWithCosts(fetchCosts: ReturnType<typeof vi.fn>) {
+    const client = new OrbClient();
+    (client as unknown as { orbSDK: { subscriptions: { fetchCosts: typeof fetchCosts } } }).orbSDK = { subscriptions: { fetchCosts } };
+    return client;
+}
+
+describe('OrbClient.getPeriodCosts', () => {
+    it('asks for the cumulative view of the current period, cached', () => {
+        const fetchCosts = vi.fn().mockResolvedValue({ data: [] });
+
+        void clientWithCosts(fetchCosts).getPeriodCosts('sub_1');
+
+        expect(fetchCosts).toHaveBeenCalledWith(
+            'sub_1',
+            { view_mode: 'cumulative' },
+            { headers: { 'Orb-Cache-Control': 'cache', 'Orb-Cache-Max-Age-Seconds': '300' } }
+        );
+    });
+
+    it('reports a missing subscription as no figure', async () => {
+        const fetchCosts = vi.fn().mockRejectedValue(new Orb.NotFoundError(404, { status: 404 }, 'not found', {}));
+
+        expect((await clientWithCosts(fetchCosts).getPeriodCosts('sub_gone')).unwrap()).toBeNull();
+    });
+
+    it('errors on anything else, rather than reading as no charges', async () => {
+        const fetchCosts = vi.fn().mockRejectedValue(new Orb.BadRequestError(400, { status: 400 }, 'bad', {}));
+
+        expect((await clientWithCosts(fetchCosts).getPeriodCosts('sub_1')).isErr()).toBe(true);
+    });
+});

--- a/packages/billing/lib/clients/orb/client.unit.test.ts
+++ b/packages/billing/lib/clients/orb/client.unit.test.ts
@@ -132,4 +132,51 @@ describe('OrbClient.getPeriodCosts', () => {
 
         expect((await clientWithCosts(fetchCosts).getPeriodCosts('sub_1')).isErr()).toBe(true);
     });
+
+    it('scopes an unparseable amount to its own metric, not the whole page — no other price to fall back on here', async () => {
+        const fetchCosts = vi.fn().mockResolvedValue({
+            data: [
+                {
+                    timeframe_end: '2026-09-01T00:00:00+00:00',
+                    per_price_costs: [
+                        {
+                            price_id: 'price_1',
+                            total: 'n/a',
+                            price: { price_type: 'usage_price', currency: 'USD', name: 'Sync records', billable_metric: { id: 'AinLoHESvrXqhEig' } }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        // Only one price in the whole bucket, and it's the malformed one, so nothing is left to state
+        // a currency in — null here, not a 500.
+        expect((await clientWithCosts(fetchCosts).getPeriodCosts('sub_1')).unwrap()).toBeNull();
+    });
+
+    it('keeps a working metric intact when a different metric on the same subscription is malformed', async () => {
+        const fetchCosts = vi.fn().mockResolvedValue({
+            data: [
+                {
+                    timeframe_end: '2026-09-01T00:00:00+00:00',
+                    per_price_costs: [
+                        {
+                            price_id: 'price_1',
+                            total: 'n/a',
+                            price: { price_type: 'usage_price', currency: 'USD', name: 'Sync records', billable_metric: { id: 'AinLoHESvrXqhEig' } }
+                        },
+                        {
+                            price_id: 'price_2',
+                            total: '2.24',
+                            price: { price_type: 'usage_price', currency: 'USD', name: 'Webhook forwards', billable_metric: { id: 'j46jUSMMya8jqhkR' } }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        const result = (await clientWithCosts(fetchCosts).getPeriodCosts('sub_1')).unwrap();
+        expect(result?.metrics).toEqual({ webhook_forwards: 224 });
+        expect(result?.malformedMetrics).toEqual(['records']);
+    });
 });

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { billing } from '@nangohq/billing';
+import db from '@nangohq/database';
+import { seeders, updatePlan } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import { isError, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../utils/tests.js';
+
+const route = '/api/v1/plans/billing/period-costs';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+let getPeriodCostsSpy: any;
+
+const NO_COSTS = { metrics: {}, unattributedInCents: null, currency: null };
+const COSTS = { metrics: { records: 2317, connections: 0 }, unattributedInCents: 0, currency: 'USD' };
+
+/** Seeds an account on `planName` with a linked Orb subscription, and returns its api key. */
+async function seedPlan(planName: string, { subscriptionId = 'orb_sub_123' }: { subscriptionId?: string | null } = {}) {
+    const seed = await seeders.seedAccountEnvAndUser();
+    // The whole suite asserts on plan gating, so a silently failed update would test the seeded
+    // default plan instead and pass for the wrong reason.
+    const updated = await updatePlan(db.knex, { id: seed.plan.id, name: planName as any, orb_subscription_id: subscriptionId });
+    if (updated.isErr()) {
+        throw updated.error;
+    }
+    return seed;
+}
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+        getPeriodCostsSpy = vi.spyOn(billing, 'getPeriodCosts');
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getPeriodCostsSpy.mockResolvedValue(Ok(COSTS));
+    });
+
+    describe('Authentication & Authorization', () => {
+        it('should be protected', async () => {
+            const res = await api.fetch(route, { method: 'GET', query: { env: 'dev' } });
+
+            shouldBeProtected(res);
+        });
+
+        it('should enforce env query param', async () => {
+            const { apiKey } = await seeders.seedAccountEnvAndUser();
+            const res = await api.fetch(route, {
+                method: 'GET',
+                token: apiKey.secret,
+                // @ts-expect-error missing env on purpose
+                query: {}
+            });
+
+            shouldRequireQueryEnv(res);
+        });
+
+        it('should reject extra params in query', async () => {
+            const { apiKey } = await seeders.seedAccountEnvAndUser();
+            const res = await api.fetch(route, {
+                method: 'GET',
+                token: apiKey.secret,
+                // @ts-expect-error extra param on purpose
+                query: { env: 'dev', foo: 'bar' }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_query_params');
+        });
+    });
+
+    describe('Plan gating', () => {
+        it.each(['free', 'free-uncapped', 'enterprise'])('should not call Orb on %s', async (planName) => {
+            const { apiKey } = await seedPlan(planName);
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+            expect(res.json.data).toStrictEqual(NO_COSTS);
+            // These plans are rated outside the standard price set, so "returned nothing" is not
+            // enough — the call must not happen at all.
+            expect(getPeriodCostsSpy).not.toHaveBeenCalled();
+        });
+
+        it.each(['starter-v2', 'growth-v2', 'startup-deal'])('should return per-metric charges on %s', async (planName) => {
+            const { apiKey } = await seedPlan(planName);
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+            expect(res.json.data).toStrictEqual(COSTS);
+            expect(getPeriodCostsSpy).toHaveBeenCalledWith('orb_sub_123');
+        });
+
+        it('should keep a zero charge as zero — the startup deal really does bill $0.00', async () => {
+            const { apiKey } = await seedPlan('startup-deal');
+            getPeriodCostsSpy.mockResolvedValue(Ok({ metrics: { records: 0 }, unattributedInCents: 0, currency: 'USD' }));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data).toStrictEqual({ metrics: { records: 0 }, unattributedInCents: 0, currency: 'USD' });
+        });
+    });
+
+    describe('Orb responses', () => {
+        it('should report no figures when Orb has no current period', async () => {
+            const { apiKey } = await seedPlan('starter-v2');
+            getPeriodCostsSpy.mockResolvedValue(Ok(null));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data).toStrictEqual(NO_COSTS);
+        });
+
+        it('should pass through an unattributed amount so the caller knows the metrics are short', async () => {
+            const { apiKey } = await seedPlan('growth-v2');
+            getPeriodCostsSpy.mockResolvedValue(Ok({ metrics: { records: 100 }, unattributedInCents: 750, currency: 'USD' }));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data).toStrictEqual({ metrics: { records: 100 }, unattributedInCents: 750, currency: 'USD' });
+        });
+
+        it('should 500 when the Orb read fails', async () => {
+            const { apiKey } = await seedPlan('starter-v2');
+            getPeriodCostsSpy.mockResolvedValue(Err(new Error('failed_to_get_period_costs')));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isError(res.json);
+            expect(res.res.status).toBe(500);
+            expect(res.json.error.code).toBe('server_error');
+        });
+
+        it('should report no figures when a spend plan has no linked subscription', async () => {
+            // Reachable before the Orb link exists, so it degrades rather than erroring.
+            const { apiKey } = await seedPlan('starter-v2', { subscriptionId: null });
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+            expect(res.json.data).toStrictEqual(NO_COSTS);
+            expect(getPeriodCostsSpy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
@@ -17,8 +17,7 @@ const COSTS = { metrics: { records: 2317, connections: 0 }, unattributedInCents:
 
 async function seedPlan(planName: string, { subscriptionId = 'orb_sub_123' }: { subscriptionId?: string | null } = {}) {
     const seed = await seeders.seedAccountEnvAndUser();
-    // The whole suite asserts on plan gating, so a silently failed update would test the seeded
-    // default plan instead and pass for the wrong reason.
+    // A silently failed update would test the seeded default plan and pass for the wrong reason.
     const updated = await updatePlan(db.knex, { id: seed.plan.id, name: planName as any, orb_subscription_id: subscriptionId });
     if (updated.isErr()) {
         throw updated.error;

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
@@ -12,8 +12,14 @@ let api: Awaited<ReturnType<typeof runServer>>;
 
 let getPeriodCostsSpy: any;
 
-const NO_COSTS = { metrics: {}, unattributedInCents: null, currency: null };
-const COSTS = { metrics: { records: 2317, connections: 0 }, unattributedInCents: 0, currency: 'USD' };
+const NO_COSTS = { metrics: {}, malformedMetrics: [], fullyAttributed: true, currency: null, noCosts: true };
+const COSTS = {
+    metrics: { records: 2317, connections: 0 },
+    malformedMetrics: [],
+    fullyAttributed: true,
+    currency: 'USD',
+    noCosts: false
+};
 
 async function seedPlan(planName: string, { subscriptionId = 'orb_sub_123' }: { subscriptionId?: string | null } = {}) {
     const seed = await seeders.seedAccountEnvAndUser();
@@ -101,12 +107,18 @@ describe(`GET ${route}`, () => {
 
         it('should keep a zero charge as zero — the startup deal really does bill $0.00', async () => {
             const { apiKey } = await seedPlan('startup-deal');
-            getPeriodCostsSpy.mockResolvedValue(Ok({ metrics: { records: 0 }, unattributedInCents: 0, currency: 'USD' }));
+            getPeriodCostsSpy.mockResolvedValue(Ok({ metrics: { records: 0 }, malformedMetrics: [], fullyAttributed: true, currency: 'USD' }));
 
             const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
 
             isSuccess(res.json);
-            expect(res.json.data).toStrictEqual({ metrics: { records: 0 }, unattributedInCents: 0, currency: 'USD' });
+            expect(res.json.data).toStrictEqual({
+                metrics: { records: 0 },
+                malformedMetrics: [],
+                fullyAttributed: true,
+                currency: 'USD',
+                noCosts: false
+            });
         });
     });
 
@@ -121,14 +133,20 @@ describe(`GET ${route}`, () => {
             expect(res.json.data).toStrictEqual(NO_COSTS);
         });
 
-        it('should pass through an unattributed amount so the caller knows the metrics are short', async () => {
+        it('passes through fullyAttributed and malformedMetrics so the caller knows which figures to trust', async () => {
             const { apiKey } = await seedPlan('growth-v2');
-            getPeriodCostsSpy.mockResolvedValue(Ok({ metrics: { records: 100 }, unattributedInCents: 750, currency: 'USD' }));
+            getPeriodCostsSpy.mockResolvedValue(Ok({ metrics: { records: 100 }, malformedMetrics: ['proxy'], fullyAttributed: false, currency: 'USD' }));
 
             const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
 
             isSuccess(res.json);
-            expect(res.json.data).toStrictEqual({ metrics: { records: 100 }, unattributedInCents: 750, currency: 'USD' });
+            expect(res.json.data).toStrictEqual({
+                metrics: { records: 100 },
+                malformedMetrics: ['proxy'],
+                fullyAttributed: false,
+                currency: 'USD',
+                noCosts: false
+            });
         });
 
         it('should 500 when the Orb read fails', async () => {

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
@@ -15,7 +15,6 @@ let getPeriodCostsSpy: any;
 const NO_COSTS = { metrics: {}, unattributedInCents: null, currency: null };
 const COSTS = { metrics: { records: 2317, connections: 0 }, unattributedInCents: 0, currency: 'USD' };
 
-/** Seeds an account on `planName` with a linked Orb subscription, and returns its api key. */
 async function seedPlan(planName: string, { subscriptionId = 'orb_sub_123' }: { subscriptionId?: string | null } = {}) {
     const seed = await seeders.seedAccountEnvAndUser();
     // The whole suite asserts on plan gating, so a silently failed update would test the seeded

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
@@ -1,0 +1,62 @@
+import { billing } from '@nangohq/billing';
+import { metrics, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { isSpendPlan } from '../../../../utils/spendPlans.js';
+
+import type { GetBillingPeriodCosts } from '@nangohq/types';
+
+const NO_COSTS = { metrics: {}, unattributedInCents: null, currency: null };
+
+export const getBillingPeriodCosts = asyncWrapper<GetBillingPeriodCosts>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const { plan } = res.locals;
+    if (!plan) {
+        res.status(400).send({ error: { code: 'feature_disabled' } });
+        return;
+    }
+
+    if (!isSpendPlan(plan)) {
+        res.status(200).send({ data: NO_COSTS });
+        return;
+    }
+
+    // A spend plan can exist before its Orb subscription is linked — granted manually, or a
+    // deployment with billing switched off. No figures to state, not a failure.
+    if (!plan.orb_subscription_id) {
+        res.status(200).send({ data: NO_COSTS });
+        return;
+    }
+
+    const costsRes = await billing.getPeriodCosts(plan.orb_subscription_id);
+    if (costsRes.isErr()) {
+        report(costsRes.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to get period costs' } });
+        return;
+    }
+
+    const costs = costsRes.value;
+    if (!costs) {
+        res.status(200).send({ data: NO_COSTS });
+        return;
+    }
+
+    if (costs.unattributedInCents > 0) {
+        // A priced metric we don't recognise. Nothing states the shortfall to the customer, so this is
+        // the only signal that the per-metric figures are understating what Orb will invoice.
+        metrics.increment(metrics.Types.BILLING_PERIOD_COSTS_UNATTRIBUTED);
+        report(new Error('billing_period_costs_unattributed'), {
+            subscriptionId: plan.orb_subscription_id,
+            unattributedInCents: costs.unattributedInCents
+        });
+    }
+
+    res.status(200).send({
+        data: { metrics: costs.metrics, unattributedInCents: costs.unattributedInCents, currency: costs.currency }
+    });
+});

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
@@ -1,12 +1,12 @@
 import { billing } from '@nangohq/billing';
-import { metrics, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { isSpendPlan } from '../../../../utils/spendPlans.js';
 
 import type { GetBillingPeriodCosts } from '@nangohq/types';
 
-const NO_COSTS = { metrics: {}, unattributedInCents: null, currency: null };
+const NO_COSTS: GetBillingPeriodCosts['Success']['data'] = { metrics: {}, malformedMetrics: [], fullyAttributed: true, currency: null, noCosts: true };
 
 export const getBillingPeriodCosts = asyncWrapper<GetBillingPeriodCosts>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
@@ -46,17 +46,13 @@ export const getBillingPeriodCosts = asyncWrapper<GetBillingPeriodCosts>(async (
         return;
     }
 
-    if (costs.unattributedInCents > 0) {
-        // A priced metric we don't recognise: nothing else would signal that the figures understate
-        // what Orb will invoice.
-        metrics.increment(metrics.Types.BILLING_PERIOD_COSTS_UNATTRIBUTED);
-        report(new Error('billing_period_costs_unattributed'), {
-            subscriptionId: plan.orb_subscription_id,
-            unattributedInCents: costs.unattributedInCents
-        });
-    }
-
     res.status(200).send({
-        data: { metrics: costs.metrics, unattributedInCents: costs.unattributedInCents, currency: costs.currency }
+        data: {
+            metrics: costs.metrics,
+            malformedMetrics: costs.malformedMetrics,
+            fullyAttributed: costs.fullyAttributed,
+            currency: costs.currency,
+            noCosts: false
+        }
     });
 });

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
@@ -27,7 +27,7 @@ export const getBillingPeriodCosts = asyncWrapper<GetBillingPeriodCosts>(async (
     }
 
     // A spend plan can exist before its Orb subscription is linked — granted manually, or a
-    // deployment with billing switched off. No figures to state, not a failure.
+    // deployment with billing switched off.
     if (!plan.orb_subscription_id) {
         res.status(200).send({ data: NO_COSTS });
         return;
@@ -47,8 +47,8 @@ export const getBillingPeriodCosts = asyncWrapper<GetBillingPeriodCosts>(async (
     }
 
     if (costs.unattributedInCents > 0) {
-        // A priced metric we don't recognise, with nothing else signalling that the per-metric
-        // figures now understate what Orb will invoice.
+        // A priced metric we don't recognise: nothing else would signal that the figures understate
+        // what Orb will invoice.
         metrics.increment(metrics.Types.BILLING_PERIOD_COSTS_UNATTRIBUTED);
         report(new Error('billing_period_costs_unattributed'), {
             subscriptionId: plan.orb_subscription_id,

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
@@ -47,8 +47,8 @@ export const getBillingPeriodCosts = asyncWrapper<GetBillingPeriodCosts>(async (
     }
 
     if (costs.unattributedInCents > 0) {
-        // A priced metric we don't recognise. Nothing states the shortfall to the customer, so this is
-        // the only signal that the per-metric figures are understating what Orb will invoice.
+        // A priced metric we don't recognise, with nothing else signalling that the per-metric
+        // figures now understate what Orb will invoice.
         metrics.increment(metrics.Types.BILLING_PERIOD_COSTS_UNATTRIBUTED);
         report(new Error('billing_period_costs_unattributed'), {
             subscriptionId: plan.orb_subscription_id,

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -104,6 +104,7 @@ import { getMeta } from './controllers/v1/meta/getMeta.js';
 import { postOrbWebhooks } from './controllers/v1/orb/postWebhooks.js';
 import { getPlainHmac } from './controllers/v1/plain/getHmac.js';
 import { deleteSpendAlert } from './controllers/v1/plans/billing/deleteSpendAlert.js';
+import { getBillingPeriodCosts } from './controllers/v1/plans/billing/getBillingPeriodCosts.js';
 import { getOverdueInvoices } from './controllers/v1/plans/billing/getOverdueInvoices.js';
 import { getSpendAlert } from './controllers/v1/plans/billing/getSpendAlert.js';
 import { getUpcomingInvoice } from './controllers/v1/plans/billing/getUpcomingInvoice.js';
@@ -297,6 +298,7 @@ web.route('/plans/billing-usage/top-dimension-values').get(webAuth, getBillingUs
 web.route('/plans/billing/invoicing').put(webAuth, auditBillingDetailsChanged, can(p.canChangePlan), putInvoicingDetails);
 web.route('/plans/billing/overdue').get(webAuth, getOverdueInvoices);
 web.route('/plans/billing/upcoming-invoice').get(webAuth, getUpcomingInvoice);
+web.route('/plans/billing/period-costs').get(webAuth, getBillingPeriodCosts);
 web.route('/plans/billing/spend-alert').get(webAuth, can(p.canManageBilling), getSpendAlert);
 web.route('/plans/billing/spend-alert').put(webAuth, auditBillingSpendAlertChanged, can(p.canManageBilling), putSpendAlert);
 web.route('/plans/billing/spend-alert').delete(webAuth, auditBillingSpendAlertRemoved, can(p.canManageBilling), deleteSpendAlert);

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -123,6 +123,7 @@ import type { DeleteMFA, GetMFAStatus, PostMFAActivation, PostMFAEnrollment, Pos
 import type { GetPlainHmac } from './plain/api.js';
 import type {
     DeleteSpendAlert,
+    GetBillingPeriodCosts,
     GetBillingUsage,
     GetBillingUsageTopDimensionValues,
     GetOverdueInvoices,
@@ -238,6 +239,7 @@ export type PrivateApiEndpoints =
     | GetBillingUsage
     | GetBillingUsageTopDimensionValues
     | GetUpcomingInvoice
+    | GetBillingPeriodCosts
     | GetSpendAlert
     | PutSpendAlert
     | DeleteSpendAlert

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -99,7 +99,6 @@ export interface BillingPeriodCosts {
     /** Cents on usage prices that map to no metric of ours, so `metrics` doesn't account for everything
      *  charged. Stays 0 while the mapping is complete. */
     unattributedInCents: number;
-    /** ISO 4217, uppercased. Orb's `credits` is rejected upstream. */
     currency: string;
 }
 

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -11,6 +11,7 @@ export interface BillingClient {
     getSubscription: (accountId: number) => Promise<Result<BillingSubscription | null>>;
     getOverdueInvoices: (accountId: number) => Promise<Result<BillingOverdueInvoices>>;
     getUpcomingInvoice: (subscriptionId: string) => Promise<Result<BillingUpcomingInvoice | null>>;
+    getPeriodCosts: (subscriptionId: string) => Promise<Result<BillingPeriodCosts | null>>;
     getSpendAlert: (subscriptionId: string) => Promise<Result<BillingSpendAlert | null>>;
     setSpendAlert: (subscriptionId: string, opts: { thresholdInCents: number }) => Promise<Result<BillingSpendAlert>>;
     removeSpendAlert: (subscriptionId: string) => Promise<Result<void>>;
@@ -89,6 +90,17 @@ export interface BillingSpendAlert {
     thresholdInCents: number;
     /** ISO 4217, uppercased. Null when Orb reports a unit that isn't a currency. */
     currency: string | null;
+}
+
+export interface BillingPeriodCosts {
+    /** Integer cents charged this billing period per metric, excluding every fixed price. A metric is
+     *  absent when the subscription carries no price for it, which is not the same as being charged 0. */
+    metrics: Partial<Record<UsageMetric, number>>;
+    /** Cents on usage prices that map to no metric of ours, so `metrics` doesn't account for everything
+     *  charged. Stays 0 while the mapping is complete. */
+    unattributedInCents: number;
+    /** ISO 4217, uppercased. Orb's `credits` is rejected upstream. */
+    currency: string;
 }
 
 export type CounterUsageMetric = Exclude<UsageMetric, 'records' | 'connections'>;

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -96,9 +96,15 @@ export interface BillingPeriodCosts {
     /** Integer cents charged this billing period per metric, excluding every fixed price. A metric is
      *  absent when the subscription carries no price for it, which is not the same as being charged 0. */
     metrics: Partial<Record<UsageMetric, number>>;
-    /** Cents on usage prices that map to no metric of ours, so `metrics` doesn't account for everything
-     *  charged. Stays 0 while the mapping is complete. */
-    unattributedInCents: number;
+    /** Metrics with a real price whose charge we couldn't read — an unparseable amount, or a currency
+     *  other prices don't share. A charge exists; we just can't state it, so it reads as a dash, not $0. */
+    malformedMetrics: UsageMetric[];
+    /** False when a price maps to no metric of ours, so an unpriced row can't safely claim $0 — the
+     *  money might be one of theirs. */
+    fullyAttributed: boolean;
+    /** The individual prices behind `malformedMetrics` and a false `fullyAttributed`, for alerting —
+     *  not sent over HTTP. */
+    flagged: { priceId: string; priceName: string; metric: UsageMetric | null; amountInCents: number | null }[];
     currency: string;
 }
 

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -180,8 +180,15 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
     Success: {
         data: {
             metrics: Partial<Record<UsageMetric, number>>;
-            unattributedInCents: number | null;
+            /** Metrics with a real price whose charge couldn't be read — show a dash, not $0. */
+            malformedMetrics: UsageMetric[];
+            /** False when some usage price mapped to no metric of ours — an absent metric can't safely
+             *  read as $0, since the money might be one of theirs. */
+            fullyAttributed: boolean;
             currency: string | null;
+            /** True when there's no billing period to report costs for — a free plan, no linked
+             *  subscription, or an ended one. `metrics`/`currency` are otherwise never empty/null. */
+            noCosts: boolean;
         };
     };
 }>;

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -179,11 +179,7 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
     Querystring: { env: string };
     Success: {
         data: {
-            /** Cents charged this billing period per metric, fixed prices excluded. Absent means the
-             *  subscription carries no price for that metric, which is not a charge of 0. */
             metrics: Partial<Record<UsageMetric, number>>;
-            /** Cents charged on usage prices that map to no metric, so `metrics` is not exhaustive.
-             *  Null when there are no figures at all. */
             unattributedInCents: number | null;
             currency: string | null;
         };

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -172,6 +172,24 @@ export type GetUpcomingInvoice = ApiEndpoint<{
     };
 }>;
 
+export type GetBillingPeriodCosts = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
+    Method: 'GET';
+    Path: '/api/v1/plans/billing/period-costs';
+    Querystring: { env: string };
+    Success: {
+        data: {
+            /** Cents charged this billing period per metric, fixed prices excluded. Absent means the
+             *  subscription carries no price for that metric, which is not a charge of 0. */
+            metrics: Partial<Record<UsageMetric, number>>;
+            /** Cents charged on usage prices that map to no metric, so `metrics` is not exhaustive.
+             *  Null when there are no figures at all. */
+            unattributedInCents: number | null;
+            currency: string | null;
+        };
+    };
+}>;
+
 // A thin proxy onto Orb's single `cost_exceeded` alert, so an account has at most one threshold.
 export type GetSpendAlert = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -145,6 +145,7 @@ export enum Types {
     BILLING_USAGE_CACHE = 'nango.billing.usage.cache',
     BILLING_USAGE_ORB_MS = 'nango.billing.usage.orb.ms',
     BILLING_USAGE_ORB_ERRORS = 'nango.billing.usage.orb.errors',
+    BILLING_PERIOD_COSTS_UNATTRIBUTED = 'nango.billing.period_costs.unattributed',
     BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_DURATION_MS = 'nango.billing.usage.clickhouse.batcher.ingest.duration_ms',
     BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_RESULT = 'nango.billing.usage.clickhouse.batcher.ingest.result',
     BILLING_USAGE_CLICKHOUSE_BATCHER_RETRY = 'nango.billing.usage.clickhouse.batcher.retry',

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -9,7 +9,7 @@ import { hasMonthlySpend } from '@/pages/Team/Billing/planVisibility';
 import { useStore } from '@/store';
 import { usePlanOverrideStore } from './planOverride';
 
-import type { SpendOverride, UsageLimitOverride } from './planOverride';
+import type { PeriodCostsOverride, SpendOverride, UsageLimitOverride } from './planOverride';
 import type { PlanDefinition } from '@nangohq/types';
 
 const REAL_PLAN_VALUE = '__real__';
@@ -21,6 +21,7 @@ const REAL_SPEND_VALUE = '__real_spend__';
 const UNAVAILABLE_SPEND_VALUE = 'unavailable';
 // A base-only Starter bill, a mid-period Growth bill, and the startup deal's real zero.
 const SPEND_PRESETS_IN_CENTS = [0, 5000, 128430];
+const REAL_PERIOD_COSTS_VALUE = '__real_period_costs__';
 // Only these 3 self-serve tiers have a real downgrade/cancellation path — legacy and Enterprise
 // plans never schedule a change in practice, so they're not offered as scheduled-change targets.
 const MAIN_PLAN_ORDER: PlanDefinition['code'][] = ['free', 'starter-v2', 'growth-v2'];
@@ -45,6 +46,10 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
     const setSpendHeadlineEnabled = usePlanOverrideStore((s) => s.setSpendHeadlineEnabled);
     const spendOverride = usePlanOverrideStore((s) => s.spendOverride);
     const setSpendOverride = usePlanOverrideStore((s) => s.setSpendOverride);
+    const metricChargesEnabled = usePlanOverrideStore((s) => s.metricChargesEnabled);
+    const setMetricChargesEnabled = usePlanOverrideStore((s) => s.setMetricChargesEnabled);
+    const periodCostsOverride = usePlanOverrideStore((s) => s.periodCostsOverride);
+    const setPeriodCostsOverride = usePlanOverrideStore((s) => s.setPeriodCostsOverride);
 
     // Plan caps are enforced on Free only, so that simulator is offered there alone. Overdue invoices
     // aren't plan-specific — a downgraded account can still owe one — so that one is always offered.
@@ -184,6 +189,39 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                                             </SelectItem>
                                         ))}
                                         <SelectItem value={UNAVAILABLE_SPEND_VALUE}>Unavailable (falls back to plan name)</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        )}
+
+                        <div className="flex flex-col gap-1.5 border-t border-border-muted pt-4">
+                            <span className="text-sm text-text-muted">Per-metric charges column (unverified — hidden from customers)</span>
+                            <Select value={metricChargesEnabled ? 'on' : 'off'} onValueChange={(value) => setMetricChargesEnabled(value === 'on')}>
+                                <SelectTrigger className="w-full text-sm px-2.5 gap-2">
+                                    <SelectValue placeholder="Hidden" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="off">Hidden</SelectItem>
+                                    <SelectItem value="on">Shown</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        {metricChargesEnabled && (
+                            <div className="flex flex-col gap-1.5">
+                                <span className="text-sm text-text-muted">Simulate per-metric charges (the local billing client returns none)</span>
+                                <Select
+                                    value={periodCostsOverride ?? REAL_PERIOD_COSTS_VALUE}
+                                    onValueChange={(value) => setPeriodCostsOverride(value === REAL_PERIOD_COSTS_VALUE ? null : (value as PeriodCostsOverride))}
+                                >
+                                    <SelectTrigger className="w-full text-sm px-2.5 gap-2">
+                                        <SelectValue placeholder="Real charges" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value={REAL_PERIOD_COSTS_VALUE}>Real charges (no override)</SelectItem>
+                                        <SelectItem value="populated">A charge on some metrics</SelectItem>
+                                        <SelectItem value="zero">$0.00 on every metric</SelectItem>
+                                        <SelectItem value="unavailable">Unavailable (no figures)</SelectItem>
                                     </SelectContent>
                                 </Select>
                             </div>

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -109,22 +109,26 @@ export function buildSpendOverride(override: SpendOverride): GetUpcomingInvoice[
  */
 export function buildPeriodCostsOverride(override: PeriodCostsOverride): GetBillingPeriodCosts['Success'] {
     if (override === 'unavailable') {
-        return { data: { metrics: {}, unattributedInCents: null, currency: null } };
+        return { data: { metrics: {}, malformedMetrics: [], fullyAttributed: true, currency: null, noCosts: true } };
     }
     if (override === 'zero') {
         return {
             data: {
                 metrics: { connections: 0, proxy: 0, function_executions: 0, function_compute_gbms: 0, function_logs: 0, webhook_forwards: 0 },
-                unattributedInCents: 0,
-                currency: 'USD'
+                malformedMetrics: [],
+                fullyAttributed: true,
+                currency: 'USD',
+                noCosts: false
             }
         };
     }
     return {
         data: {
             metrics: { connections: 11352, proxy: 1200, function_executions: 500, function_compute_gbms: 2317, function_logs: 150, webhook_forwards: 0 },
-            unattributedInCents: 0,
-            currency: 'USD'
+            malformedMetrics: [],
+            fullyAttributed: true,
+            currency: 'USD',
+            noCosts: false
         }
     };
 }

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -3,12 +3,15 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 import { LocalStorageKeys } from '@/utils/local-storage';
 
-import type { ApiPlan, GetOverdueInvoices, GetUpcomingInvoice, PlanDefinition } from '@nangohq/types';
+import type { ApiPlan, GetBillingPeriodCosts, GetOverdueInvoices, GetUpcomingInvoice, PlanDefinition } from '@nangohq/types';
 
 /** Simulated aggregate usage state, matching what `getAggregateUsageState` can return. */
 export type UsageLimitOverride = 'near' | 'over';
 
 export type SpendOverride = number | 'unavailable';
+
+/** Simulated per-metric charges: a spread of amounts, all zero, or no figures at all. */
+export type PeriodCostsOverride = 'populated' | 'zero' | 'unavailable';
 
 interface PlanOverrideState {
     /** The plan code to visually preview instead of the account's real plan, or `null` for the real plan. */
@@ -26,12 +29,21 @@ interface PlanOverrideState {
     spendHeadlineEnabled: boolean;
     /** Spend to simulate. Only meaningful with the flag on. */
     spendOverride: SpendOverride | null;
+    /**
+     * Reveals the per-metric charges column. Separate from the spend headline so the two can be
+     * verified against real invoices independently; delete this flag once it ships to everyone.
+     */
+    metricChargesEnabled: boolean;
+    /** Per-metric charges to simulate. Only meaningful with the flag on. */
+    periodCostsOverride: PeriodCostsOverride | null;
     setOverride: (code: PlanDefinition['code'] | null) => void;
     setScheduledTarget: (code: PlanDefinition['code'] | null) => void;
     setOverdueOverride: (override: boolean) => void;
     setUsageLimitOverride: (override: UsageLimitOverride | null) => void;
     setSpendHeadlineEnabled: (enabled: boolean) => void;
     setSpendOverride: (override: SpendOverride | null) => void;
+    setMetricChargesEnabled: (enabled: boolean) => void;
+    setPeriodCostsOverride: (override: PeriodCostsOverride | null) => void;
 }
 
 export const usePlanOverrideStore = create<PlanOverrideState>()(
@@ -43,17 +55,28 @@ export const usePlanOverrideStore = create<PlanOverrideState>()(
             usageLimitOverride: null,
             spendHeadlineEnabled: false,
             spendOverride: null,
+            metricChargesEnabled: false,
+            periodCostsOverride: null,
             // Reset the simulated states too — each is only valid for the plan it was picked against,
             // and the two are offered on opposite sides of the paid/free split.
             // `spendHeadlineEnabled` is deliberately not reset — it's a rollout flag, not a
             // simulated state scoped to the previewed plan.
             setOverride: (overrideCode) =>
-                set({ overrideCode, scheduledTargetCode: null, overdueOverride: false, usageLimitOverride: null, spendOverride: null }),
+                set({
+                    overrideCode,
+                    scheduledTargetCode: null,
+                    overdueOverride: false,
+                    usageLimitOverride: null,
+                    spendOverride: null,
+                    periodCostsOverride: null
+                }),
             setScheduledTarget: (scheduledTargetCode) => set({ scheduledTargetCode }),
             setOverdueOverride: (overdueOverride) => set({ overdueOverride }),
             setUsageLimitOverride: (usageLimitOverride) => set({ usageLimitOverride }),
             setSpendHeadlineEnabled: (spendHeadlineEnabled) => set({ spendHeadlineEnabled }),
-            setSpendOverride: (spendOverride) => set({ spendOverride })
+            setSpendOverride: (spendOverride) => set({ spendOverride }),
+            setMetricChargesEnabled: (metricChargesEnabled) => set({ metricChargesEnabled }),
+            setPeriodCostsOverride: (periodCostsOverride) => set({ periodCostsOverride })
         }),
         {
             name: LocalStorageKeys.DevPlanOverride,
@@ -84,6 +107,35 @@ export function buildSpendOverride(override: SpendOverride): GetUpcomingInvoice[
         return { data: { amountInCents: null, currency: null } };
     }
     return { data: { amountInCents: override, currency: 'USD' } };
+}
+
+/**
+ * Stands in for the real period-costs response when the override is on, for visual QA only.
+ *
+ * `populated` deliberately spreads charges across some metrics and leaves others at zero, and omits
+ * `records` entirely — a metric with no price is a state real accounts are in, and it renders
+ * differently from a zero charge.
+ */
+export function buildPeriodCostsOverride(override: PeriodCostsOverride): GetBillingPeriodCosts['Success'] {
+    if (override === 'unavailable') {
+        return { data: { metrics: {}, unattributedInCents: null, currency: null } };
+    }
+    if (override === 'zero') {
+        return {
+            data: {
+                metrics: { connections: 0, proxy: 0, function_executions: 0, function_compute_gbms: 0, function_logs: 0, webhook_forwards: 0 },
+                unattributedInCents: 0,
+                currency: 'USD'
+            }
+        };
+    }
+    return {
+        data: {
+            metrics: { connections: 11352, proxy: 1200, function_executions: 500, function_compute_gbms: 2317, function_logs: 150, webhook_forwards: 0 },
+            unattributedInCents: 0,
+            currency: 'USD'
+        }
+    };
 }
 
 /** Overlays a dev-tool plan override (and optional simulated scheduled change) onto a real plan, for visual QA only. */

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -10,7 +10,6 @@ export type UsageLimitOverride = 'near' | 'over';
 
 export type SpendOverride = number | 'unavailable';
 
-/** Simulated per-metric charges: a spread of amounts, all zero, or no figures at all. */
 export type PeriodCostsOverride = 'populated' | 'zero' | 'unavailable';
 
 interface PlanOverrideState {
@@ -29,12 +28,7 @@ interface PlanOverrideState {
     spendHeadlineEnabled: boolean;
     /** Spend to simulate. Only meaningful with the flag on. */
     spendOverride: SpendOverride | null;
-    /**
-     * Reveals the per-metric charges column. Separate from the spend headline so the two can be
-     * verified against real invoices independently; delete this flag once it ships to everyone.
-     */
     metricChargesEnabled: boolean;
-    /** Per-metric charges to simulate. Only meaningful with the flag on. */
     periodCostsOverride: PeriodCostsOverride | null;
     setOverride: (code: PlanDefinition['code'] | null) => void;
     setScheduledTarget: (code: PlanDefinition['code'] | null) => void;
@@ -110,11 +104,8 @@ export function buildSpendOverride(override: SpendOverride): GetUpcomingInvoice[
 }
 
 /**
- * Stands in for the real period-costs response when the override is on, for visual QA only.
- *
- * `populated` deliberately spreads charges across some metrics and leaves others at zero, and omits
- * `records` entirely — a metric with no price is a state real accounts are in, and it renders
- * differently from a zero charge.
+ * `populated` omits `records` entirely: a metric with no price at all is a state real accounts are
+ * in, and it is not the same as a zero charge.
  */
 export function buildPeriodCostsOverride(override: PeriodCostsOverride): GetBillingPeriodCosts['Success'] {
     if (override === 'unavailable') {

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 
 import { permissions } from '@nangohq/authz';
 
-import { applyPlanOverride, buildOverdueOverride, buildSpendOverride, usePlanOverrideStore } from '../features/planOverride';
+import { applyPlanOverride, buildOverdueOverride, buildPeriodCostsOverride, buildSpendOverride, usePlanOverrideStore } from '../features/planOverride';
 import { APIError, apiFetch } from '../utils/api';
 import { globalEnv } from '../utils/env';
 import { useEnvironment } from './useEnvironment';
@@ -13,6 +13,7 @@ import type {
     ApiPlan,
     BreakdownDimensions,
     DeleteSpendAlert,
+    GetBillingPeriodCosts,
     GetBillingUsage,
     GetBillingUsageTopDimensionValues,
     GetEnvironment,
@@ -216,6 +217,38 @@ export function useApiGetUpcomingInvoice(env: string, plan?: { name: string } | 
             });
 
             const json = (await res.json()) as GetUpcomingInvoice['Reply'];
+            if (res.status !== 200 || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        }
+    });
+}
+
+export const GetBillingPeriodCostsQueryKey = ['plans', 'billing', 'period-costs'];
+
+/**
+ * The current period's charge per metric. Shares the invoice's stale time deliberately: both read the
+ * same Orb figures, and different windows would let the strip and the table disagree on one screen.
+ */
+export function useApiGetBillingPeriodCosts(env: string, plan?: { name: string } | null, options?: { enabled?: boolean }) {
+    const planName = plan?.name;
+    const periodCostsOverride = usePlanOverrideStore((s) => s.periodCostsOverride);
+    return useQuery<GetBillingPeriodCosts['Success'], APIError>({
+        enabled: Boolean(env) && (options?.enabled ?? false),
+        staleTime: UPCOMING_INVOICE_STALE_TIME,
+        queryKey: [...GetBillingPeriodCostsQueryKey, env, planName, currentBillingPeriod(), periodCostsOverride],
+        queryFn: async (): Promise<GetBillingPeriodCosts['Success']> => {
+            if (periodCostsOverride !== null) {
+                return buildPeriodCostsOverride(periodCostsOverride);
+            }
+
+            const res = await apiFetch(`/api/v1/plans/billing/period-costs?env=${env}`, {
+                method: 'GET'
+            });
+
+            const json = (await res.json()) as GetBillingPeriodCosts['Reply'];
             if (res.status !== 200 || 'error' in json) {
                 throw new APIError({ res, json });
             }

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -229,8 +229,8 @@ export function useApiGetUpcomingInvoice(env: string, plan?: { name: string } | 
 export const GetBillingPeriodCostsQueryKey = ['plans', 'billing', 'period-costs'];
 
 /**
- * The current period's charge per metric. Shares the invoice's stale time deliberately: both read the
- * same Orb figures, and different windows would let the strip and the table disagree on one screen.
+ * Shares the invoice's stale time deliberately: both read the same Orb figures, and different
+ * windows would let two views of them disagree.
  */
 export function useApiGetBillingPeriodCosts(env: string, plan?: { name: string } | null, options?: { enabled?: boolean }) {
     const planName = plan?.name;

--- a/packages/webapp/src/pages/Team/Billing/components/FreeUsage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/FreeUsage.tsx
@@ -20,7 +20,7 @@ import type { UsageMetric } from '@nangohq/types';
  */
 export const FreeUsage: React.FC = () => {
     const env = useStore((state) => state.env);
-    const { selectedMonth } = useSelectedMonth();
+    const { selectedMonth, isCurrentMonth } = useSelectedMonth();
 
     const timeframe = useMemo(() => {
         const start = new Date(Date.UTC(selectedMonth.getUTCFullYear(), selectedMonth.getUTCMonth(), 1));
@@ -31,9 +31,6 @@ export const FreeUsage: React.FC = () => {
     // The caps gauge (plans/usage) is live current-period. For a past month, show that month's usage
     // from the billing series instead — counters: the month total; connections/records: the point-in-time
     // value. The cap is constant, so used / limit / % stay meaningful across months.
-    const now = new Date();
-    const isCurrentMonth = selectedMonth.getUTCFullYear() === now.getUTCFullYear() && selectedMonth.getUTCMonth() === now.getUTCMonth();
-
     const { data: caps, isLoading: capsLoading, error: capsError } = useApiGetUsage(env);
     // avgPerDay: connections/records come back as the concurrent daily count (not the billing
     // running-average), so their cap line is meaningful. No-op for the counter metrics.
@@ -75,7 +72,7 @@ export const FreeUsage: React.FC = () => {
                 env={env}
                 timeframe={timeframe}
                 chartMode="cumulative"
-                showLimits
+                variant="caps"
                 isRowOpen={(metric) => expanded.includes(metric)}
                 onRowOpenChange={(metric, open) => setRowOpen(metric, open)}
             />

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -4,10 +4,12 @@ import { useMemo } from 'react';
 import { Alert, AlertActions, AlertDescription, AlertTitle, Button } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
-import { useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
+import { usePlanOverrideStore } from '@/features/planOverride';
+import { useApiGetBillingPeriodCosts, useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
-import { isLegacyPlan } from '../planVisibility';
+import { hasMonthlySpend, isLegacyPlan } from '../planVisibility';
+import { buildUsageRowCharges } from '../usageCharges';
 import { useSelectedMonth } from '../useSelectedMonth';
 import { FreeUsage } from './FreeUsage';
 import { MonthSelector } from './MonthSelector';
@@ -16,7 +18,7 @@ import { UsageTable } from './UsageTable';
 
 export const Usage: React.FC = () => {
     const env = useStore((state) => state.env);
-    const { selectedMonth } = useSelectedMonth();
+    const { selectedMonth, isCurrentMonth } = useSelectedMonth();
     const { data: environmentData } = useCurrentPlan(env);
     const plan = environmentData?.plan;
     const isFree = plan?.name === 'free';
@@ -39,6 +41,13 @@ export const Usage: React.FC = () => {
     // billing running-average, matching what each row's drill-in chart also requests.
     const { data: usage, isLoading, error: usageError } = useApiGetBillingUsage(env, timeframe, { avgPerDay: true, enabled: plan != null && !isFree });
 
+    // Behind a dev-tool flag until the figures are checked against real Orb invoices.
+    const metricChargesEnabled = usePlanOverrideStore((s) => s.metricChargesEnabled);
+    // Orb only holds costs for the period in progress, so a past month has no charge to state.
+    const chargesEnabled = metricChargesEnabled && isCurrentMonth && hasMonthlySpend(plan);
+    const { data: periodCosts, isPending: costsPending, isError: costsError } = useApiGetBillingPeriodCosts(env, plan, { enabled: chargesEnabled });
+    const charges = buildUsageRowCharges({ enabled: chargesEnabled, isPending: costsPending, isError: costsError, data: periodCosts });
+
     if (usageError) {
         return (
             <div className="w-full flex flex-col gap-6">
@@ -59,8 +68,7 @@ export const Usage: React.FC = () => {
 
     const isLegacy = isLegacyPlan(plan);
     // Paid/legacy plans are uncapped (only `freePlan` sets real limits in `plans/definitions.ts`),
-    // so every row shows just its usage total — `UsageRow` already renders that gracefully for a
-    // `null` limit (no bar, "—" instead of a percent).
+    // so every row shows its usage total and, where we have one, what it cost.
     const rows = USAGE_METRICS.map((metric) => ({
         metric,
         label: USAGE_METRIC_LABELS[metric],
@@ -103,7 +111,15 @@ export const Usage: React.FC = () => {
                 <MonthSelector />
             </div>
 
-            <UsageTable rows={rows} isLoading={isLoading} env={env} timeframe={timeframe} chartMode="daily" showLimits={false} />
+            <UsageTable
+                rows={rows}
+                isLoading={isLoading}
+                env={env}
+                timeframe={timeframe}
+                chartMode="daily"
+                variant={charges ? 'charges' : 'usage'}
+                charges={charges}
+            />
         </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -41,7 +41,6 @@ export const Usage: React.FC = () => {
     // billing running-average, matching what each row's drill-in chart also requests.
     const { data: usage, isLoading, error: usageError } = useApiGetBillingUsage(env, timeframe, { avgPerDay: true, enabled: plan != null && !isFree });
 
-    // Behind a dev-tool flag until the figures are checked against real Orb invoices.
     const metricChargesEnabled = usePlanOverrideStore((s) => s.metricChargesEnabled);
     // Orb only holds costs for the period in progress, so a past month has no charge to state.
     const chargesEnabled = metricChargesEnabled && isCurrentMonth && hasMonthlySpend(plan);
@@ -67,8 +66,7 @@ export const Usage: React.FC = () => {
     }
 
     const isLegacy = isLegacyPlan(plan);
-    // Paid/legacy plans are uncapped (only `freePlan` sets real limits in `plans/definitions.ts`),
-    // so every row shows its usage total and, where we have one, what it cost.
+    // Paid/legacy plans are uncapped (only `freePlan` sets real limits in `plans/definitions.ts`).
     const rows = USAGE_METRICS.map((metric) => ({
         metric,
         label: USAGE_METRIC_LABELS[metric],

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -7,15 +7,21 @@ import { cn } from '@/utils/utils';
 import { UsageBar } from './UsageBar';
 import { UsageChartCard } from './UsageChartCard';
 
+import type { UsageRowCharge } from '../usageCharges';
 import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 
-/** Shared column template so the header row and each metric row line up, on both Free and paid —
- *  paid just leaves the used/limit slot blank and puts its usage figure in the last slot, so it
- *  lands in the exact same spot (rather than recomputing a different set of column widths).
- *  That last column is fixed at the design's 124px rather than a fraction: as a fraction it grew
- *  with the viewport and left the figure stranded mid-row, a long way from its caret — most visible
- *  on paid, where the used/limit column beside it is empty. */
-export const USAGE_ROW_GRID = 'grid grid-cols-[minmax(0,2fr)_minmax(0,2.2fr)_124px_20px] items-center gap-4 px-6';
+/** Shared column template so the header row and each metric row line up. The last two columns are
+ *  fixed at 124px/20px rather than a fraction, so the charge/percent figure can't drift from its
+ *  caret on a wide viewport. The middle column's share differs by variant: Free ('caps') needs room
+ *  for the used/limit bar, so metric:middle is close to even; paid has no bar, so the figure sits
+ *  right beside its charge (Figma node 562-79998: metric 566px, this-period 200px, a ~3:1 split). */
+export function usageRowGrid(variant: 'caps' | 'usage' | 'charges'): string {
+    // Tailwind's scanner needs the full bracketed class literally in source to generate it, so this
+    // picks between two complete strings rather than assembling one from a variable.
+    return variant === 'caps'
+        ? 'grid grid-cols-[minmax(0,2fr)_minmax(0,2.2fr)_124px_20px] items-center gap-4 px-6'
+        : 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_124px_20px] items-center gap-4 px-6';
+}
 
 interface UsageRowProps {
     metric: UsageMetric;
@@ -37,9 +43,12 @@ interface UsageRowProps {
     onOpenChange?: (open: boolean) => void;
     /** 'cumulative' for Free (progress toward the cap), 'daily' for paid. */
     chartMode: 'daily' | 'cumulative';
-    /** Show the used/limit pairing, bar, and % of limit column (Free). When false (paid, for now),
-     *  just the plain usage figure and no percent column — there's no limit to show it against. */
-    showLimits: boolean;
+    /** 'caps' pairs usage with the plan limit and a percentage (Free); 'charges' shows the usage
+     *  figure and what it cost this period; 'usage' shows the figure alone, for a paid plan with no
+     *  charge to state (a past period, or the rollout flag off). */
+    variant: 'caps' | 'usage' | 'charges';
+    /** This metric's charge, when the parent resolved one. Only read by the 'charges' variant. */
+    charge?: UsageRowCharge;
 }
 
 /**
@@ -60,19 +69,23 @@ export const UsageRow: React.FC<UsageRowProps> = ({
     open,
     onOpenChange,
     chartMode,
-    showLimits
+    variant,
+    charge
 }) => {
     const state = getUsageState(usage, limit);
     const percent = limit ? Math.round((usage / limit) * 100) : null;
+    const showLimits = variant === 'caps';
+    // 'usage' keeps the figure in the last column, where it sat before charges existed.
+    const usageColumn = variant === 'usage' ? 'last' : 'middle';
 
     return (
         <Collapsible open={open} onOpenChange={onOpenChange} className="border-b border-border-muted last:border-b-0 data-[state=open]:bg-surface-panel">
             <CollapsibleTrigger className="group w-full text-left py-4 transition-colors data-[state=closed]:hover:bg-surface-panel data-[state=open]:border-b data-[state=open]:border-border-muted">
-                <div className={USAGE_ROW_GRID}>
+                <div className={usageRowGrid(variant)}>
                     <div className="flex flex-col min-w-0">
                         <span className="text-text-default text-body-medium-regular truncate">{label}</span>
                     </div>
-                    {showLimits ? (
+                    {usageColumn === 'middle' ? (
                         <div className="flex flex-col gap-1.5">
                             {capsLoading ? (
                                 <Skeleton className="h-5 w-32" />
@@ -80,25 +93,31 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                                 <>
                                     <span className="text-text-default text-body-medium-regular" title={formatUsageExact(usage)}>
                                         {formatUsage(usage)}
-                                        {limit != null && <span className="text-text-muted"> / {formatLimit(limit)}</span>}
+                                        {showLimits && limit != null && <span className="text-text-muted"> / {formatLimit(limit)}</span>}
                                     </span>
-                                    {limit != null && <UsageBar usage={usage} limit={limit} className="max-w-[280px]" />}
+                                    {showLimits && limit != null && <UsageBar usage={usage} limit={limit} className="max-w-[280px]" />}
                                 </>
                             )}
                         </div>
                     ) : (
                         <div />
                     )}
-                    {capsLoading ? (
+                    {capsLoading && variant !== 'charges' ? (
                         <Skeleton className="h-4 w-12" />
                     ) : showLimits ? (
                         <div className={cn('text-body-medium-regular', getUsageStateTextColor(state))}>
                             {limit == null ? '—' : state === 'over' ? 'Limit reached' : `${percent}%`}
                         </div>
-                    ) : (
+                    ) : variant === 'usage' ? (
                         <div className="text-text-default text-body-medium-regular" title={formatUsageExact(usage)}>
                             {formatUsage(usage)}
                         </div>
+                    ) : charge?.pending ? (
+                        <Skeleton className="h-4 w-12" />
+                    ) : (
+                        // No bar and no over-limit colour: on an uncapped plan a charge is what was
+                        // billed, not a threshold crossed.
+                        <div className="text-text-default text-body-medium-regular">{charge?.formatted ?? '—'}</div>
                     )}
                     <ChevronDown className="size-5 text-text-muted transition-transform group-data-[state=open]:rotate-180" />
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -75,8 +75,9 @@ export const UsageRow: React.FC<UsageRowProps> = ({
     const state = getUsageState(usage, limit);
     const percent = limit ? Math.round((usage / limit) * 100) : null;
     const showLimits = variant === 'caps';
-    // 'usage' keeps the figure in the last column, where it sat before charges existed.
-    const usageColumn = variant === 'usage' ? 'last' : 'middle';
+    // The charges variant has its own loading source (this row's charge query) instead of the shared
+    // usage query, since the two can resolve at different times.
+    const isPending = variant === 'charges' ? charge?.pending : capsLoading;
 
     return (
         <Collapsible open={open} onOpenChange={onOpenChange} className="border-b border-border-muted last:border-b-0 data-[state=open]:bg-surface-panel">
@@ -85,7 +86,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                     <div className="flex flex-col min-w-0">
                         <span className="text-text-default text-body-medium-regular truncate">{label}</span>
                     </div>
-                    {usageColumn === 'middle' ? (
+                    {variant !== 'usage' ? (
                         <div className="flex flex-col gap-1.5">
                             {capsLoading ? (
                                 <Skeleton className="h-5 w-32" />
@@ -102,7 +103,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                     ) : (
                         <div />
                     )}
-                    {capsLoading && variant !== 'charges' ? (
+                    {isPending ? (
                         <Skeleton className="h-4 w-12" />
                     ) : showLimits ? (
                         <div className={cn('text-body-medium-regular', getUsageStateTextColor(state))}>
@@ -112,8 +113,6 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                         <div className="text-text-default text-body-medium-regular" title={formatUsageExact(usage)}>
                             {formatUsage(usage)}
                         </div>
-                    ) : charge?.pending ? (
-                        <Skeleton className="h-4 w-12" />
                     ) : (
                         // No bar and no over-limit colour: on an uncapped plan a charge is what was
                         // billed, not a threshold crossed.

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -10,11 +10,6 @@ import { UsageChartCard } from './UsageChartCard';
 import type { UsageRowCharge } from '../usageCharges';
 import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 
-/** Shared column template so the header row and each metric row line up. The last two columns are
- *  fixed at 124px/20px rather than a fraction, so the charge/percent figure can't drift from its
- *  caret on a wide viewport. The middle column's share differs by variant: Free ('caps') needs room
- *  for the used/limit bar, so metric:middle is close to even; paid has no bar, so the figure sits
- *  right beside its charge (Figma node 562-79998: metric 566px, this-period 200px, a ~3:1 split). */
 export function usageRowGrid(variant: 'caps' | 'usage' | 'charges'): string {
     // Tailwind's scanner needs the full bracketed class literally in source to generate it, so this
     // picks between two complete strings rather than assembling one from a variable.
@@ -43,11 +38,7 @@ interface UsageRowProps {
     onOpenChange?: (open: boolean) => void;
     /** 'cumulative' for Free (progress toward the cap), 'daily' for paid. */
     chartMode: 'daily' | 'cumulative';
-    /** 'caps' pairs usage with the plan limit and a percentage (Free); 'charges' shows the usage
-     *  figure and what it cost this period; 'usage' shows the figure alone, for a paid plan with no
-     *  charge to state (a past period, or the rollout flag off). */
     variant: 'caps' | 'usage' | 'charges';
-    /** This metric's charge, when the parent resolved one. Only read by the 'charges' variant. */
     charge?: UsageRowCharge;
 }
 
@@ -75,8 +66,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
     const state = getUsageState(usage, limit);
     const percent = limit ? Math.round((usage / limit) * 100) : null;
     const showLimits = variant === 'caps';
-    // The charges variant has its own loading source (this row's charge query) instead of the shared
-    // usage query, since the two can resolve at different times.
+    // The charge and usage queries resolve independently.
     const isPending = variant === 'charges' ? charge?.pending : capsLoading;
 
     return (
@@ -114,8 +104,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                             {formatUsage(usage)}
                         </div>
                     ) : (
-                        // No bar and no over-limit colour: on an uncapped plan a charge is what was
-                        // billed, not a threshold crossed.
+                        // On an uncapped plan a charge is what was billed, not a threshold crossed.
                         <div className="text-text-default text-body-medium-regular">{charge?.formatted ?? '—'}</div>
                     )}
                     <ChevronDown className="size-5 text-text-muted transition-transform group-data-[state=open]:rotate-180" />

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -1,8 +1,9 @@
 import { Info } from 'lucide-react';
 
 import { cn } from '@/utils/utils';
-import { USAGE_ROW_GRID, UsageRow } from './UsageRow';
+import { UsageRow, usageRowGrid } from './UsageRow';
 
+import type { UsageChargeLookup } from '../usageCharges';
 import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 
 export interface UsageTableRow {
@@ -21,9 +22,11 @@ interface UsageTableProps {
     timeframe: { start: string; end: string };
     /** 'cumulative' for Free (progress toward the cap), 'daily' for paid. */
     chartMode: 'daily' | 'cumulative';
-    /** Show the used/limit pairing and % of limit column (Free). Off for paid for now — there are
-     *  no limits to show against until caps/charges land there (NAN-6220). */
-    showLimits: boolean;
+    /** 'caps' pairs usage with the plan limit (Free); 'charges' adds the period's charge; 'usage'
+     *  shows the figure alone, for a paid plan with no charge to state. */
+    variant: 'caps' | 'usage' | 'charges';
+    /** Resolves each row's charge. Null keeps the column empty — see `buildUsageRowCharges`. */
+    charges?: UsageChargeLookup;
     /** Controlled expand state, keyed by metric — Free persists this in the URL. Uncontrolled
      *  (each row manages its own open state) when omitted. */
     isRowOpen?: (metric: UsageMetric) => boolean;
@@ -34,14 +37,15 @@ interface UsageTableProps {
  * The bordered per-metric usage table shared by Free and paid: a header row, then one collapsible
  * {@link UsageRow} per metric.
  */
-export const UsageTable: React.FC<UsageTableProps> = ({ rows, isLoading, env, timeframe, chartMode, showLimits, isRowOpen, onRowOpenChange }) => {
+export const UsageTable: React.FC<UsageTableProps> = ({ rows, isLoading, env, timeframe, chartMode, variant, charges, isRowOpen, onRowOpenChange }) => {
+    const showLimits = variant === 'caps';
     return (
         <div className="w-full flex flex-col gap-4">
             <div className="rounded border border-border-default overflow-hidden">
-                <div className={cn(USAGE_ROW_GRID, 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
+                <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
                     <span>Metric</span>
-                    {showLimits ? <span>Used / Limit</span> : <span />}
-                    <span>{showLimits ? '% of limit' : 'This period'}</span>
+                    <span>{variant === 'usage' ? '' : showLimits ? 'Used / Limit' : 'This period'}</span>
+                    <span>{showLimits ? '% of limit' : variant === 'usage' ? 'This period' : 'Charges'}</span>
                     <span />
                 </div>
                 {rows.map((row) => (
@@ -59,7 +63,8 @@ export const UsageTable: React.FC<UsageTableProps> = ({ rows, isLoading, env, ti
                         open={isRowOpen?.(row.metric)}
                         onOpenChange={onRowOpenChange ? (open) => onRowOpenChange(row.metric, open) : undefined}
                         chartMode={chartMode}
-                        showLimits={showLimits}
+                        variant={variant}
+                        charge={charges?.(row.metric)}
                     />
                 ))}
             </div>

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -22,10 +22,7 @@ interface UsageTableProps {
     timeframe: { start: string; end: string };
     /** 'cumulative' for Free (progress toward the cap), 'daily' for paid. */
     chartMode: 'daily' | 'cumulative';
-    /** 'caps' pairs usage with the plan limit (Free); 'charges' adds the period's charge; 'usage'
-     *  shows the figure alone, for a paid plan with no charge to state. */
     variant: 'caps' | 'usage' | 'charges';
-    /** Resolves each row's charge. Null keeps the column empty — see `buildUsageRowCharges`. */
     charges?: UsageChargeLookup;
     /** Controlled expand state, keyed by metric — Free persists this in the URL. Uncontrolled
      *  (each row manages its own open state) when omitted. */

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -30,19 +30,31 @@ interface UsageTableProps {
     onRowOpenChange?: (metric: UsageMetric, open: boolean) => void;
 }
 
+/** The two right-hand column headers, which differ by variant. */
+function usageColumnHeaders(variant: UsageTableProps['variant']): { thisPeriod: string; rightmost: string } {
+    switch (variant) {
+        case 'caps':
+            return { thisPeriod: 'Used / Limit', rightmost: '% of limit' };
+        case 'charges':
+            return { thisPeriod: 'This period', rightmost: 'Charges' };
+        case 'usage':
+            return { thisPeriod: '', rightmost: 'This period' };
+    }
+}
+
 /**
  * The bordered per-metric usage table shared by Free and paid: a header row, then one collapsible
  * {@link UsageRow} per metric.
  */
 export const UsageTable: React.FC<UsageTableProps> = ({ rows, isLoading, env, timeframe, chartMode, variant, charges, isRowOpen, onRowOpenChange }) => {
-    const showLimits = variant === 'caps';
+    const { thisPeriod, rightmost } = usageColumnHeaders(variant);
     return (
         <div className="w-full flex flex-col gap-4">
             <div className="rounded border border-border-default overflow-hidden">
                 <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
                     <span>Metric</span>
-                    <span>{variant === 'usage' ? '' : showLimits ? 'Used / Limit' : 'This period'}</span>
-                    <span>{showLimits ? '% of limit' : variant === 'usage' ? 'This period' : 'Charges'}</span>
+                    <span>{thisPeriod}</span>
+                    <span>{rightmost}</span>
                     <span />
                 </div>
                 {rows.map((row) => (

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.ts
@@ -20,11 +20,6 @@ interface BuildArgs {
 const NO_FIGURE: UsageRowCharge = { formatted: null, pending: false };
 const PENDING: UsageRowCharge = { formatted: null, pending: true };
 
-/**
- * A metric Orb returns no price for reads as zero: no price means no charge. That only holds while
- * every charge was attributed — an unattributed one could belong to any of those metrics, so once
- * `unattributedInCents` is non-zero they all state no figure rather than claiming zero.
- */
 export function buildUsageRowCharges(args: BuildArgs): UsageChargeLookup {
     if (!args.enabled) {
         return null;
@@ -39,12 +34,20 @@ export function buildUsageRowCharges(args: BuildArgs): UsageChargeLookup {
         return () => NO_FIGURE;
     }
 
-    const { metrics, unattributedInCents, currency } = args.data.data;
-    const fullyAttributed = unattributedInCents === 0;
+    const { metrics, malformedMetrics, fullyAttributed, currency, noCosts } = args.data.data;
+    if (noCosts) {
+        return () => NO_FIGURE;
+    }
 
     return (metric) => {
+        // A real price exists but its charge couldn't be read — a dash, not a $0 we can't stand behind.
+        if (malformedMetrics.includes(metric)) {
+            return NO_FIGURE;
+        }
         const amountInCents = metrics[metric];
         if (amountInCents === undefined) {
+            // No price for this metric reads as zero, unless some other price went unattributed — that
+            // money could belong to this metric, so it states no figure rather than claiming zero.
             return fullyAttributed ? { formatted: formatMoneyFromCents(0, currency), pending: false } : NO_FIGURE;
         }
         return { formatted: formatMoneyFromCents(amountInCents, currency), pending: false };

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.ts
@@ -1,0 +1,58 @@
+import { formatMoneyFromCents } from './money';
+
+import type { GetBillingPeriodCosts, UsageMetric } from '@nangohq/types';
+
+export interface UsageRowCharge {
+    /** Formatted amount, or null when there is no figure to state. */
+    formatted: string | null;
+    /** Still resolving — show a placeholder rather than a figure. */
+    pending: boolean;
+}
+
+/** Null when charges don't apply at all, so the column is absent rather than empty. */
+export type UsageChargeLookup = ((metric: UsageMetric) => UsageRowCharge) | null;
+
+interface BuildArgs {
+    /** False on Free, on a past month, or without the rollout flag. */
+    enabled: boolean;
+    isPending: boolean;
+    isError: boolean;
+    data: GetBillingPeriodCosts['Success'] | undefined;
+}
+
+const NO_FIGURE: UsageRowCharge = { formatted: null, pending: false };
+const PENDING: UsageRowCharge = { formatted: null, pending: true };
+
+/**
+ * Resolves each metric's charge for the period.
+ *
+ * A metric Orb returns no price for reads as zero, since no price means no charge — several accounts
+ * have had a metric's price removed by hand and genuinely owe nothing on it. That only holds while
+ * every charge was attributed: an unattributed one could belong to any of those metrics, so once
+ * `unattributedInCents` is non-zero they all state no figure rather than claiming zero.
+ */
+export function buildUsageRowCharges(args: BuildArgs): UsageChargeLookup {
+    if (!args.enabled) {
+        return null;
+    }
+
+    if (args.isPending) {
+        return () => PENDING;
+    }
+
+    // react-query keeps the last success on a failed refetch; a stale amount is worse than none.
+    if (args.isError || !args.data) {
+        return () => NO_FIGURE;
+    }
+
+    const { metrics, unattributedInCents, currency } = args.data.data;
+    const fullyAttributed = unattributedInCents === 0;
+
+    return (metric) => {
+        const amountInCents = metrics[metric];
+        if (amountInCents === undefined) {
+            return fullyAttributed ? { formatted: formatMoneyFromCents(0, currency), pending: false } : NO_FIGURE;
+        }
+        return { formatted: formatMoneyFromCents(amountInCents, currency), pending: false };
+    };
+}

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.ts
@@ -3,9 +3,7 @@ import { formatMoneyFromCents } from './money';
 import type { GetBillingPeriodCosts, UsageMetric } from '@nangohq/types';
 
 export interface UsageRowCharge {
-    /** Formatted amount, or null when there is no figure to state. */
     formatted: string | null;
-    /** Still resolving — show a placeholder rather than a figure. */
     pending: boolean;
 }
 
@@ -13,7 +11,6 @@ export interface UsageRowCharge {
 export type UsageChargeLookup = ((metric: UsageMetric) => UsageRowCharge) | null;
 
 interface BuildArgs {
-    /** False on Free, on a past month, or without the rollout flag. */
     enabled: boolean;
     isPending: boolean;
     isError: boolean;
@@ -24,11 +21,8 @@ const NO_FIGURE: UsageRowCharge = { formatted: null, pending: false };
 const PENDING: UsageRowCharge = { formatted: null, pending: true };
 
 /**
- * Resolves each metric's charge for the period.
- *
- * A metric Orb returns no price for reads as zero, since no price means no charge — several accounts
- * have had a metric's price removed by hand and genuinely owe nothing on it. That only holds while
- * every charge was attributed: an unattributed one could belong to any of those metrics, so once
+ * A metric Orb returns no price for reads as zero: no price means no charge. That only holds while
+ * every charge was attributed — an unattributed one could belong to any of those metrics, so once
  * `unattributedInCents` is non-zero they all state no figure rather than claiming zero.
  */
 export function buildUsageRowCharges(args: BuildArgs): UsageChargeLookup {

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildUsageRowCharges } from './usageCharges';
+
+import type { GetBillingPeriodCosts } from '@nangohq/types';
+
+function success(data: GetBillingPeriodCosts['Success']['data']): GetBillingPeriodCosts['Success'] {
+    return { data };
+}
+
+const settled = { enabled: true, isPending: false, isError: false };
+
+describe('buildUsageRowCharges', () => {
+    it('returns null when charges do not apply, so the column can be dropped', () => {
+        expect(buildUsageRowCharges({ ...settled, enabled: false, data: undefined })).toBeNull();
+    });
+
+    it('formats a charge in the response currency', () => {
+        const charges = buildUsageRowCharges({ ...settled, data: success({ metrics: { records: 2317 }, unattributedInCents: 0, currency: 'USD' }) });
+
+        expect(charges?.('records')).toEqual({ formatted: '$23.17', pending: false });
+    });
+
+    it('states a real zero as zero rather than as no figure', () => {
+        const charges = buildUsageRowCharges({ ...settled, data: success({ metrics: { records: 0 }, unattributedInCents: 0, currency: 'USD' }) });
+
+        expect(charges?.('records')).toEqual({ formatted: '$0.00', pending: false });
+    });
+
+    it('reads a metric with no price as zero when everything was attributed', () => {
+        // Real state: some accounts have had a metric's price removed by hand, so they owe nothing on it.
+        const charges = buildUsageRowCharges({ ...settled, data: success({ metrics: { proxy: 100 }, unattributedInCents: 0, currency: 'USD' }) });
+
+        expect(charges?.('records')).toEqual({ formatted: '$0.00', pending: false });
+    });
+
+    it('refuses to call an unpriced metric zero while a charge went unattributed', () => {
+        const charges = buildUsageRowCharges({ ...settled, data: success({ metrics: { proxy: 100 }, unattributedInCents: 750, currency: 'USD' }) });
+
+        expect(charges?.('records').formatted).toBeNull();
+        // The charges it did attribute are still trustworthy.
+        expect(charges?.('proxy').formatted).toBe('$1.00');
+    });
+
+    it('states no figure for a currency it cannot format', () => {
+        const charges = buildUsageRowCharges({ ...settled, data: success({ metrics: { records: 100 }, unattributedInCents: 0, currency: 'credits' }) });
+
+        expect(charges?.('records').formatted).toBeNull();
+    });
+
+    it('reports pending while the query is in flight', () => {
+        const charges = buildUsageRowCharges({ enabled: true, isPending: true, isError: false, data: undefined });
+
+        expect(charges?.('records')).toEqual({ formatted: null, pending: true });
+    });
+
+    it('drops a stale figure when the refetch failed', () => {
+        const charges = buildUsageRowCharges({
+            enabled: true,
+            isPending: false,
+            isError: true,
+            data: success({ metrics: { records: 2317 }, unattributedInCents: 0, currency: 'USD' })
+        });
+
+        expect(charges?.('records')).toEqual({ formatted: null, pending: false });
+    });
+});

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.unit.test.ts
@@ -16,36 +16,77 @@ describe('buildUsageRowCharges', () => {
     });
 
     it('formats a charge in the response currency', () => {
-        const charges = buildUsageRowCharges({ ...settled, data: success({ metrics: { records: 2317 }, unattributedInCents: 0, currency: 'USD' }) });
+        const charges = buildUsageRowCharges({
+            ...settled,
+            data: success({ metrics: { records: 2317 }, malformedMetrics: [], fullyAttributed: true, currency: 'USD', noCosts: false })
+        });
 
         expect(charges?.('records')).toEqual({ formatted: '$23.17', pending: false });
     });
 
     it('states a real zero as zero rather than as no figure', () => {
-        const charges = buildUsageRowCharges({ ...settled, data: success({ metrics: { records: 0 }, unattributedInCents: 0, currency: 'USD' }) });
+        const charges = buildUsageRowCharges({
+            ...settled,
+            data: success({ metrics: { records: 0 }, malformedMetrics: [], fullyAttributed: true, currency: 'USD', noCosts: false })
+        });
 
         expect(charges?.('records')).toEqual({ formatted: '$0.00', pending: false });
     });
 
     it('reads a metric with no price as zero when everything was attributed', () => {
         // Real state: some accounts have had a metric's price removed by hand, so they owe nothing on it.
-        const charges = buildUsageRowCharges({ ...settled, data: success({ metrics: { proxy: 100 }, unattributedInCents: 0, currency: 'USD' }) });
+        const charges = buildUsageRowCharges({
+            ...settled,
+            data: success({ metrics: { proxy: 100 }, malformedMetrics: [], fullyAttributed: true, currency: 'USD', noCosts: false })
+        });
 
         expect(charges?.('records')).toEqual({ formatted: '$0.00', pending: false });
     });
 
-    it('refuses to call an unpriced metric zero while a charge went unattributed', () => {
-        const charges = buildUsageRowCharges({ ...settled, data: success({ metrics: { proxy: 100 }, unattributedInCents: 750, currency: 'USD' }) });
+    it('refuses to call an unpriced metric zero while another charge went unattributed', () => {
+        const charges = buildUsageRowCharges({
+            ...settled,
+            data: success({ metrics: { proxy: 100 }, malformedMetrics: [], fullyAttributed: false, currency: 'USD', noCosts: false })
+        });
 
         expect(charges?.('records').formatted).toBeNull();
         // The charges it did attribute are still trustworthy.
         expect(charges?.('proxy').formatted).toBe('$1.00');
     });
 
-    it('states no figure for a currency it cannot format', () => {
-        const charges = buildUsageRowCharges({ ...settled, data: success({ metrics: { records: 100 }, unattributedInCents: 0, currency: 'credits' }) });
+    it('shows a dash for a metric whose own price came through malformed, not $0', () => {
+        // Its own price is known bad, but that says nothing about any other metric.
+        const charges = buildUsageRowCharges({
+            ...settled,
+            data: success({
+                metrics: { proxy: 100 },
+                malformedMetrics: ['records'],
+                fullyAttributed: true,
+                currency: 'USD',
+                noCosts: false
+            })
+        });
 
         expect(charges?.('records').formatted).toBeNull();
+        expect(charges?.('proxy').formatted).toBe('$1.00');
+    });
+
+    it('states no figure for a currency it cannot format', () => {
+        const charges = buildUsageRowCharges({
+            ...settled,
+            data: success({ metrics: { records: 100 }, malformedMetrics: [], fullyAttributed: true, currency: 'credits', noCosts: false })
+        });
+
+        expect(charges?.('records').formatted).toBeNull();
+    });
+
+    it('states no figure when the server reports no billing period to cost', () => {
+        const charges = buildUsageRowCharges({
+            ...settled,
+            data: success({ metrics: {}, malformedMetrics: [], fullyAttributed: true, currency: null, noCosts: true })
+        });
+
+        expect(charges?.('records')).toEqual({ formatted: null, pending: false });
     });
 
     it('reports pending while the query is in flight', () => {
@@ -59,7 +100,7 @@ describe('buildUsageRowCharges', () => {
             enabled: true,
             isPending: false,
             isError: true,
-            data: success({ metrics: { records: 2317 }, unattributedInCents: 0, currency: 'USD' })
+            data: success({ metrics: { records: 2317 }, malformedMetrics: [], fullyAttributed: true, currency: 'USD', noCosts: false })
         });
 
         expect(charges?.('records')).toEqual({ formatted: null, pending: false });

--- a/packages/webapp/src/pages/Team/Billing/useSelectedMonth.ts
+++ b/packages/webapp/src/pages/Team/Billing/useSelectedMonth.ts
@@ -12,7 +12,6 @@ interface UseSelectedMonth {
     setSelectedMonth: (date: Date) => void;
     /** False once at the current month (no future navigation). */
     canGoNext: boolean;
-    /** True when the selected month is the live one — the only month with current-period figures. */
     isCurrentMonth: boolean;
     /** False at the June-2026 ClickHouse floor — that's when the data starts. */
     canGoPrevious: boolean;

--- a/packages/webapp/src/pages/Team/Billing/useSelectedMonth.ts
+++ b/packages/webapp/src/pages/Team/Billing/useSelectedMonth.ts
@@ -12,6 +12,8 @@ interface UseSelectedMonth {
     setSelectedMonth: (date: Date) => void;
     /** False once at the current month (no future navigation). */
     canGoNext: boolean;
+    /** True when the selected month is the live one — the only month with current-period figures. */
+    isCurrentMonth: boolean;
     /** False at the June-2026 ClickHouse floor — that's when the data starts. */
     canGoPrevious: boolean;
 }
@@ -54,5 +56,5 @@ export function useSelectedMonth(): UseSelectedMonth {
 
     const canGoPrevious = useMemo(() => selectedMonth.getTime() > EARLIEST_USAGE_MONTH_MS, [selectedMonth]);
 
-    return { selectedMonth, setSelectedMonth, canGoNext, canGoPrevious };
+    return { selectedMonth, setSelectedMonth, canGoNext, canGoPrevious, isCurrentMonth: !canGoNext };
 }


### PR DESCRIPTION
## Problem

Paid plans (Starter, Growth, startup deal) show usage with no indication of what each metric costs — allowances and rates live only in Orb, and our backend has never computed or returned a dollar figure for usage.

## Solution

**Not customer-facing yet.** The Charges column is behind a dev-tool-only flag and stays off until we've verified the per-metric figures against real Orb invoices. Nothing here ships to customers on its own.

- Read Orb's per-price cost breakdown for the current billing period via `subscriptions.fetchCosts`, mapped to our metrics by billable-metric id (not price name, which is renamed per subscription)
- Add `GET /plans/billing/period-costs`, gated the same way as the upcoming-invoice endpoint
- A metric with no Orb price reads `$0.00`; an unmapped priced metric is tracked separately as `unattributedInCents` so the row shows no figure instead of a wrong one, and it's reported for visibility

Fixes [NAN-6220](https://linear.app/nango/issue/NAN-6220)

## Testing

- Unit tests for the Orb adapter's id mapping and edge cases (ended subscriptions, unattributed charges, currency mismatches), the client, and the webapp's charge-display rules
- Integration tests for the new endpoint's plan gating and Orb-response handling
- Verified end to end against live Orb (both test mode and prod-shaped fixtures) and the local dev stack: charges land on the correct row and the sum plus base fee matches the summary strip's upcoming-invoice figure

## Follow-ups

- Legacy plans, custom/enterprise pricing, and startup-deal usage credits are out of scope — deferred per the ticket

<img width="2912" height="1806" alt="image" src="https://github.com/user-attachments/assets/8ea182f0-9432-48e4-93b0-6b7b4d9a92cf" />

☝️  Note these are fake charges made on test Orb account, ignore the actual usage being 0 across all metrics.