### PR TITLE
feat: add documentation tools to management MCP

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -12959,6 +12959,17 @@ Keep the API key server-side and only configure it in MCP clients you trust. Do 
 
 ## Tools
 
+### Documentation
+
+Use the Documentation tools to search the Nango documentation and read complete pages from Mintlify's virtual documentation filesystem. Start with `docs_search` for broad or conceptual queries, then use `docs_query_filesystem` to read a relevant `.mdx` path or perform an exact text search.
+
+These tools require a valid Management MCP API key but no additional environment operation scope. If Mintlify rate-limits a request, the tool error points to the public Nango documentation MCP at `https://nango.dev/docs/mcp` so you can connect to it directly.
+
+| Tool                    | Description                                                               | Required API key scope |
+| ----------------------- | ------------------------------------------------------------------------- | ---------------------- |
+| `docs_search`           | Search the Nango documentation and return contextual snippets and links. | None                   |
+| `docs_query_filesystem` | Read and query Mintlify's virtual Nango documentation filesystem.         | None                   |
+
 ### Connect sessions
 
 Use the Connect Session tools to start an authorization flow for an end user.

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -35,6 +35,17 @@ Keep the API key server-side and only configure it in MCP clients you trust. Do 
 
 ## Tools
 
+### Documentation
+
+Use the Documentation tools to search the Nango documentation and read complete pages from Mintlify's virtual documentation filesystem. Start with `docs_search` for broad or conceptual queries, then use `docs_query_filesystem` to read a relevant `.mdx` path or perform an exact text search.
+
+These tools require a valid Management MCP API key but no additional environment operation scope. If Mintlify rate-limits a request, the tool error points to the public Nango documentation MCP at `https://nango.dev/docs/mcp` so you can connect to it directly.
+
+| Tool                    | Description                                                               | Required API key scope |
+| ----------------------- | ------------------------------------------------------------------------- | ---------------------- |
+| `docs_search`           | Search the Nango documentation and return contextual snippets and links. | None                   |
+| `docs_query_filesystem` | Read and query Mintlify's virtual Nango documentation filesystem.         | None                   |
+
 ### Connect sessions
 
 Use the Connect Session tools to start an authorization flow for an end user.

--- a/packages/server/lib/controllers/mcp/docs/client.ts
+++ b/packages/server/lib/controllers/mcp/docs/client.ts
@@ -1,0 +1,106 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+
+import { Err, getLogger, Ok } from '@nangohq/utils';
+
+import { PublicMcpError } from '../utils.js';
+
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { Result } from '@nangohq/utils';
+
+const logger = getLogger('Server.ManagementMcp.DocsClient');
+const docsMcpUrl = new URL('https://nango.dev/docs/mcp');
+const docsMcpTimeoutMs = 60_000;
+const docsMcpDirectAccessMessage = `Connect to the Nango documentation MCP directly at ${docsMcpUrl.toString()}`;
+
+export type DocsMcpToolName = 'search_nango_docs' | 'query_docs_filesystem_nango_docs';
+
+export interface ConnectedDocsMcpClient {
+    callTool(name: DocsMcpToolName, args: Record<string, unknown>, signal: AbortSignal): Promise<CallToolResult>;
+}
+
+export type ConnectDocsMcpClient = (signal: AbortSignal) => Promise<ConnectedDocsMcpClient>;
+
+export class DocsMcpClient {
+    private clientPromise: Promise<ConnectedDocsMcpClient> | undefined;
+
+    constructor(private readonly connect: ConnectDocsMcpClient = connectDocsMcpClient) {}
+
+    async callTool(name: DocsMcpToolName, args: Record<string, unknown>): Promise<Result<string[]>> {
+        const signal = AbortSignal.timeout(docsMcpTimeoutMs);
+
+        try {
+            const client = await this.getClient(signal);
+            const result = await client.callTool(name, args, signal);
+            const textContent = result.content.filter((content) => content.type === 'text').map((content) => content.text);
+
+            if (result.isError) {
+                const message = textContent.join('\n').trim();
+                if (isRateLimitError(message)) {
+                    return Err(rateLimitError());
+                }
+
+                return Err(new PublicMcpError(message || 'The Nango documentation request failed.'));
+            }
+
+            return Ok(textContent);
+        } catch (err) {
+            if (isRateLimitError(err)) {
+                return Err(rateLimitError());
+            }
+
+            logger.error('Nango documentation MCP request failed', { err, toolName: name });
+            return Err(new PublicMcpError('The Nango documentation service is temporarily unavailable.'));
+        }
+    }
+
+    private async getClient(signal: AbortSignal): Promise<ConnectedDocsMcpClient> {
+        if (this.clientPromise) {
+            return await this.clientPromise;
+        }
+
+        const clientPromise = this.connect(signal);
+        this.clientPromise = clientPromise;
+        try {
+            return await clientPromise;
+        } catch (err) {
+            if (this.clientPromise === clientPromise) {
+                this.clientPromise = undefined;
+            }
+            throw err;
+        }
+    }
+}
+
+export const docsMcpClient = new DocsMcpClient();
+
+async function connectDocsMcpClient(signal: AbortSignal): Promise<ConnectedDocsMcpClient> {
+    const client = new Client({ name: 'Nango Management MCP docs proxy', version: '1.0.0' });
+    const transport = new StreamableHTTPClientTransport(docsMcpUrl);
+    await client.connect(transport as Transport, { signal, timeout: docsMcpTimeoutMs, maxTotalTimeout: docsMcpTimeoutMs });
+
+    return {
+        async callTool(name, args, callSignal) {
+            return (await client.callTool({ name, arguments: args }, CallToolResultSchema, {
+                signal: callSignal,
+                timeout: docsMcpTimeoutMs,
+                maxTotalTimeout: docsMcpTimeoutMs
+            })) as CallToolResult;
+        }
+    };
+}
+
+function isRateLimitError(error: unknown): boolean {
+    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 429) {
+        return true;
+    }
+
+    const message = typeof error === 'string' ? error : error instanceof Error ? error.message : '';
+    return /\b429\b|rate[ -]?limit|too many requests/i.test(message);
+}
+
+function rateLimitError(): PublicMcpError {
+    return new PublicMcpError(`The Nango documentation MCP returned 429 Too Many Requests. ${docsMcpDirectAccessMessage}.`);
+}

--- a/packages/server/lib/controllers/mcp/docs/client.ts
+++ b/packages/server/lib/controllers/mcp/docs/client.ts
@@ -37,12 +37,13 @@ export class DocsMcpClient {
             const textContent = result.content.filter((content) => content.type === 'text').map((content) => content.text);
 
             if (result.isError) {
-                const message = textContent.join('\n').trim();
-                if (isRateLimitError(message)) {
+                const message = textContent.join('\n');
+                const normalizedMessage = message.trim();
+                if (isRateLimitError(normalizedMessage)) {
                     return Err(rateLimitError());
                 }
 
-                return Err(new PublicMcpError(message || 'The Nango documentation request failed.'));
+                return Err(new PublicMcpError(normalizedMessage ? message : 'The Nango documentation request failed.'));
             }
 
             return Ok(textContent);

--- a/packages/server/lib/controllers/mcp/docs/client.ts
+++ b/packages/server/lib/controllers/mcp/docs/client.ts
@@ -19,20 +19,20 @@ export type DocsMcpToolName = 'search_nango_docs' | 'query_docs_filesystem_nango
 
 export interface ConnectedDocsMcpClient {
     callTool(name: DocsMcpToolName, args: Record<string, unknown>, signal: AbortSignal): Promise<CallToolResult>;
+    close: () => Promise<void>;
 }
 
 export type ConnectDocsMcpClient = (signal: AbortSignal) => Promise<ConnectedDocsMcpClient>;
 
 export class DocsMcpClient {
-    private clientPromise: Promise<ConnectedDocsMcpClient> | undefined;
-
     constructor(private readonly connect: ConnectDocsMcpClient = connectDocsMcpClient) {}
 
     async callTool(name: DocsMcpToolName, args: Record<string, unknown>): Promise<Result<string[]>> {
         const signal = AbortSignal.timeout(docsMcpTimeoutMs);
+        let client: ConnectedDocsMcpClient | undefined;
 
         try {
-            const client = await this.getClient(signal);
+            client = await this.connect(signal);
             const result = await client.callTool(name, args, signal);
             const textContent = result.content.filter((content) => content.type === 'text').map((content) => content.text);
 
@@ -53,23 +53,14 @@ export class DocsMcpClient {
 
             logger.error('Nango documentation MCP request failed', { err, toolName: name });
             return Err(new PublicMcpError('The Nango documentation service is temporarily unavailable.'));
-        }
-    }
-
-    private async getClient(signal: AbortSignal): Promise<ConnectedDocsMcpClient> {
-        if (this.clientPromise) {
-            return await this.clientPromise;
-        }
-
-        const clientPromise = this.connect(signal);
-        this.clientPromise = clientPromise;
-        try {
-            return await clientPromise;
-        } catch (err) {
-            if (this.clientPromise === clientPromise) {
-                this.clientPromise = undefined;
+        } finally {
+            if (client) {
+                try {
+                    await client.close();
+                } catch (err) {
+                    logger.error('Failed to close Nango documentation MCP client', { err, toolName: name });
+                }
             }
-            throw err;
         }
     }
 }
@@ -88,6 +79,9 @@ async function connectDocsMcpClient(signal: AbortSignal): Promise<ConnectedDocsM
                 timeout: docsMcpTimeoutMs,
                 maxTotalTimeout: docsMcpTimeoutMs
             })) as CallToolResult;
+        },
+        async close() {
+            await client.close();
         }
     };
 }

--- a/packages/server/lib/controllers/mcp/docs/client.ts
+++ b/packages/server/lib/controllers/mcp/docs/client.ts
@@ -17,6 +17,24 @@ const docsMcpDirectAccessMessage = `Connect to the Nango documentation MCP direc
 
 export type DocsMcpToolName = 'search_nango_docs' | 'query_docs_filesystem_nango_docs';
 
+export class DocsMcpClientTransport extends StreamableHTTPClientTransport {
+    private closePromise: Promise<void> | undefined;
+
+    override close(): Promise<void> {
+        this.closePromise ??= this.terminateSessionAndClose();
+        return this.closePromise;
+    }
+
+    private async terminateSessionAndClose(): Promise<void> {
+        try {
+            await this.terminateSession();
+        } catch (err) {
+            logger.error('Failed to terminate Nango documentation MCP session', { err });
+        }
+        await super.close();
+    }
+}
+
 export interface ConnectedDocsMcpClient {
     callTool(name: DocsMcpToolName, args: Record<string, unknown>, signal: AbortSignal): Promise<CallToolResult>;
     close: () => Promise<void>;
@@ -70,8 +88,15 @@ export const docsMcpClient = new DocsMcpClient();
 
 async function connectDocsMcpClient(signal: AbortSignal): Promise<ConnectedDocsMcpClient> {
     const client = new Client({ name: 'Nango Management MCP docs proxy', version: '1.0.0' });
-    const transport = new StreamableHTTPClientTransport(docsMcpUrl);
-    await client.connect(transport as Transport, { signal, timeout: docsMcpTimeoutMs, maxTotalTimeout: docsMcpTimeoutMs });
+    const transport = new DocsMcpClientTransport(docsMcpUrl);
+    try {
+        await client.connect(transport as Transport, { signal, timeout: docsMcpTimeoutMs, maxTotalTimeout: docsMcpTimeoutMs });
+    } catch (err) {
+        // Client.connect starts closing the transport without awaiting it when initialization fails.
+        // Await the same idempotent close operation so an allocated upstream session is terminated before returning.
+        await transport.close();
+        throw err;
+    }
 
     return {
         async callTool(name, args, callSignal) {

--- a/packages/server/lib/controllers/mcp/docs/client.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/docs/client.unit.test.ts
@@ -13,7 +13,8 @@ describe('DocsMcpClient', () => {
                 { type: 'text', text: 'second result' }
             ]
         });
-        const connect = vi.fn<ConnectDocsMcpClient>().mockResolvedValue({ callTool });
+        const connectedClient = mockConnectedClient(callTool);
+        const connect = vi.fn<ConnectDocsMcpClient>().mockResolvedValue(connectedClient);
         const client = new DocsMcpClient(connect);
 
         const result = await client.callTool('search_nango_docs', { query: 'authentication' });
@@ -23,18 +24,21 @@ describe('DocsMcpClient', () => {
             expect(result.value).toStrictEqual(['first result', 'second result']);
         }
         expect(callTool).toHaveBeenCalledWith('search_nango_docs', { query: 'authentication' }, expect.any(AbortSignal));
+        expect(connectedClient.close).toHaveBeenCalledOnce();
     });
 
-    it('reuses its initialized MCP client', async () => {
+    it('initializes and closes an MCP client for every tool call', async () => {
         const callTool = vi.fn<ConnectedDocsMcpClient['callTool']>().mockResolvedValue({ content: [{ type: 'text', text: 'result' }] });
-        const connect = vi.fn<ConnectDocsMcpClient>().mockResolvedValue({ callTool });
+        const connectedClient = mockConnectedClient(callTool);
+        const connect = vi.fn<ConnectDocsMcpClient>().mockResolvedValue(connectedClient);
         const client = new DocsMcpClient(connect);
 
         await client.callTool('search_nango_docs', { query: 'authentication' });
         await client.callTool('query_docs_filesystem_nango_docs', { command: 'head -20 /quickstart.mdx' });
 
-        expect(connect).toHaveBeenCalledOnce();
+        expect(connect).toHaveBeenCalledTimes(2);
         expect(callTool).toHaveBeenCalledTimes(2);
+        expect(connectedClient.close).toHaveBeenCalledTimes(2);
     });
 
     it('returns upstream tool errors as public errors', async () => {
@@ -42,7 +46,8 @@ describe('DocsMcpClient', () => {
             content: [{ type: 'text', text: 'Invalid documentation query' }],
             isError: true
         });
-        const client = new DocsMcpClient(() => Promise.resolve({ callTool }));
+        const connectedClient = mockConnectedClient(callTool);
+        const client = new DocsMcpClient(() => Promise.resolve(connectedClient));
 
         const result = await client.callTool('search_nango_docs', { query: 'authentication' });
 
@@ -51,13 +56,15 @@ describe('DocsMcpClient', () => {
             expect(result.error).toBeInstanceOf(PublicMcpError);
             expect(result.error.message).toBe('Invalid documentation query');
         }
+        expect(connectedClient.close).toHaveBeenCalledOnce();
     });
 
     it.each([new Error('429 Too Many Requests'), new Error('Search rate limit exceeded'), Object.assign(new Error('Upstream request failed'), { code: 429 })])(
         'adds direct MCP guidance to rate limit errors',
         async (error) => {
             const callTool = vi.fn<ConnectedDocsMcpClient['callTool']>().mockRejectedValue(error);
-            const client = new DocsMcpClient(() => Promise.resolve({ callTool }));
+            const connectedClient = mockConnectedClient(callTool);
+            const client = new DocsMcpClient(() => Promise.resolve(connectedClient));
 
             const result = await client.callTool('search_nango_docs', { query: 'authentication' });
 
@@ -68,6 +75,7 @@ describe('DocsMcpClient', () => {
                     'The Nango documentation MCP returned 429 Too Many Requests. Connect to the Nango documentation MCP directly at https://nango.dev/docs/mcp.'
                 );
             }
+            expect(connectedClient.close).toHaveBeenCalledOnce();
         }
     );
 
@@ -76,7 +84,8 @@ describe('DocsMcpClient', () => {
             content: [{ type: 'text', text: 'Rate limit exceeded' }],
             isError: true
         });
-        const client = new DocsMcpClient(() => Promise.resolve({ callTool }));
+        const connectedClient = mockConnectedClient(callTool);
+        const client = new DocsMcpClient(() => Promise.resolve(connectedClient));
 
         const result = await client.callTool('query_docs_filesystem_nango_docs', { command: 'tree / -L 2' });
 
@@ -85,11 +94,13 @@ describe('DocsMcpClient', () => {
             expect(result.error.message).toContain('429 Too Many Requests');
             expect(result.error.message).toContain('https://nango.dev/docs/mcp');
         }
+        expect(connectedClient.close).toHaveBeenCalledOnce();
     });
 
-    it('retries initialization after the connector fails', async () => {
+    it('can initialize on a later call after the connector fails', async () => {
         const callTool = vi.fn<ConnectedDocsMcpClient['callTool']>().mockResolvedValue({ content: [{ type: 'text', text: 'result' }] });
-        const connect = vi.fn<ConnectDocsMcpClient>().mockRejectedValueOnce(new Error('Initialization failed')).mockResolvedValueOnce({ callTool });
+        const connectedClient = mockConnectedClient(callTool);
+        const connect = vi.fn<ConnectDocsMcpClient>().mockRejectedValueOnce(new Error('Initialization failed')).mockResolvedValueOnce(connectedClient);
         const client = new DocsMcpClient(connect);
 
         const firstResult = await client.callTool('search_nango_docs', { query: 'authentication' });
@@ -98,5 +109,13 @@ describe('DocsMcpClient', () => {
         expect(firstResult.isErr()).toBe(true);
         expect(secondResult.isOk()).toBe(true);
         expect(connect).toHaveBeenCalledTimes(2);
+        expect(connectedClient.close).toHaveBeenCalledOnce();
     });
 });
+
+function mockConnectedClient(callTool: ConnectedDocsMcpClient['callTool']): ConnectedDocsMcpClient {
+    return {
+        callTool,
+        close: vi.fn<ConnectedDocsMcpClient['close']>().mockResolvedValue(undefined)
+    };
+}

--- a/packages/server/lib/controllers/mcp/docs/client.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/docs/client.unit.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { PublicMcpError } from '../utils.js';
+import { DocsMcpClient } from './client.js';
+
+import type { ConnectDocsMcpClient, ConnectedDocsMcpClient } from './client.js';
+
+describe('DocsMcpClient', () => {
+    it('returns every text block without limiting its size', async () => {
+        const callTool = vi.fn<ConnectedDocsMcpClient['callTool']>().mockResolvedValue({
+            content: [
+                { type: 'text', text: 'first result' },
+                { type: 'text', text: 'second result' }
+            ]
+        });
+        const connect = vi.fn<ConnectDocsMcpClient>().mockResolvedValue({ callTool });
+        const client = new DocsMcpClient(connect);
+
+        const result = await client.callTool('search_nango_docs', { query: 'authentication' });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual(['first result', 'second result']);
+        }
+        expect(callTool).toHaveBeenCalledWith('search_nango_docs', { query: 'authentication' }, expect.any(AbortSignal));
+    });
+
+    it('reuses its initialized MCP client', async () => {
+        const callTool = vi.fn<ConnectedDocsMcpClient['callTool']>().mockResolvedValue({ content: [{ type: 'text', text: 'result' }] });
+        const connect = vi.fn<ConnectDocsMcpClient>().mockResolvedValue({ callTool });
+        const client = new DocsMcpClient(connect);
+
+        await client.callTool('search_nango_docs', { query: 'authentication' });
+        await client.callTool('query_docs_filesystem_nango_docs', { command: 'head -20 /quickstart.mdx' });
+
+        expect(connect).toHaveBeenCalledOnce();
+        expect(callTool).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns upstream tool errors as public errors', async () => {
+        const callTool = vi.fn<ConnectedDocsMcpClient['callTool']>().mockResolvedValue({
+            content: [{ type: 'text', text: 'Invalid documentation query' }],
+            isError: true
+        });
+        const client = new DocsMcpClient(() => Promise.resolve({ callTool }));
+
+        const result = await client.callTool('search_nango_docs', { query: 'authentication' });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toBe('Invalid documentation query');
+        }
+    });
+
+    it.each([new Error('429 Too Many Requests'), new Error('Search rate limit exceeded'), Object.assign(new Error('Upstream request failed'), { code: 429 })])(
+        'adds direct MCP guidance to rate limit errors',
+        async (error) => {
+            const callTool = vi.fn<ConnectedDocsMcpClient['callTool']>().mockRejectedValue(error);
+            const client = new DocsMcpClient(() => Promise.resolve({ callTool }));
+
+            const result = await client.callTool('search_nango_docs', { query: 'authentication' });
+
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error).toBeInstanceOf(PublicMcpError);
+                expect(result.error.message).toBe(
+                    'The Nango documentation MCP returned 429 Too Many Requests. Connect to the Nango documentation MCP directly at https://nango.dev/docs/mcp.'
+                );
+            }
+        }
+    );
+
+    it('adds direct MCP guidance when an upstream tool result reports a rate limit', async () => {
+        const callTool = vi.fn<ConnectedDocsMcpClient['callTool']>().mockResolvedValue({
+            content: [{ type: 'text', text: 'Rate limit exceeded' }],
+            isError: true
+        });
+        const client = new DocsMcpClient(() => Promise.resolve({ callTool }));
+
+        const result = await client.callTool('query_docs_filesystem_nango_docs', { command: 'tree / -L 2' });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.message).toContain('429 Too Many Requests');
+            expect(result.error.message).toContain('https://nango.dev/docs/mcp');
+        }
+    });
+
+    it('retries initialization after the connector fails', async () => {
+        const callTool = vi.fn<ConnectedDocsMcpClient['callTool']>().mockResolvedValue({ content: [{ type: 'text', text: 'result' }] });
+        const connect = vi.fn<ConnectDocsMcpClient>().mockRejectedValueOnce(new Error('Initialization failed')).mockResolvedValueOnce({ callTool });
+        const client = new DocsMcpClient(connect);
+
+        const firstResult = await client.callTool('search_nango_docs', { query: 'authentication' });
+        const secondResult = await client.callTool('search_nango_docs', { query: 'authentication' });
+
+        expect(firstResult.isErr()).toBe(true);
+        expect(secondResult.isOk()).toBe(true);
+        expect(connect).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/server/lib/controllers/mcp/docs/client.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/docs/client.unit.test.ts
@@ -41,9 +41,9 @@ describe('DocsMcpClient', () => {
         expect(connectedClient.close).toHaveBeenCalledTimes(2);
     });
 
-    it('returns upstream tool errors as public errors', async () => {
+    it('returns upstream tool error payloads verbatim', async () => {
         const callTool = vi.fn<ConnectedDocsMcpClient['callTool']>().mockResolvedValue({
-            content: [{ type: 'text', text: 'Invalid documentation query' }],
+            content: [{ type: 'text', text: '  Invalid documentation query\n' }],
             isError: true
         });
         const connectedClient = mockConnectedClient(callTool);
@@ -54,7 +54,7 @@ describe('DocsMcpClient', () => {
         expect(result.isErr()).toBe(true);
         if (result.isErr()) {
             expect(result.error).toBeInstanceOf(PublicMcpError);
-            expect(result.error.message).toBe('Invalid documentation query');
+            expect(result.error.message).toBe('  Invalid documentation query\n');
         }
         expect(connectedClient.close).toHaveBeenCalledOnce();
     });

--- a/packages/server/lib/controllers/mcp/docs/client.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/docs/client.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { PublicMcpError } from '../utils.js';
-import { DocsMcpClient } from './client.js';
+import { DocsMcpClient, DocsMcpClientTransport } from './client.js';
 
 import type { ConnectDocsMcpClient, ConnectedDocsMcpClient } from './client.js';
 
@@ -110,6 +110,30 @@ describe('DocsMcpClient', () => {
         expect(secondResult.isOk()).toBe(true);
         expect(connect).toHaveBeenCalledTimes(2);
         expect(connectedClient.close).toHaveBeenCalledOnce();
+    });
+});
+
+describe('DocsMcpClientTransport', () => {
+    it('terminates the upstream session before closing the local transport', async () => {
+        let resolveTermination: (() => void) | undefined;
+        const termination = new Promise<void>((resolve) => {
+            resolveTermination = resolve;
+        });
+        const transport = new DocsMcpClientTransport(new URL('https://example.com/mcp'));
+        await transport.start();
+        const terminateSession = vi.spyOn(transport, 'terminateSession').mockReturnValue(termination);
+        const onclose = vi.fn();
+        transport.onclose = onclose;
+
+        const close = transport.close();
+
+        expect(terminateSession).toHaveBeenCalledOnce();
+        expect(onclose).not.toHaveBeenCalled();
+        resolveTermination?.();
+        await close;
+        await transport.close();
+        expect(onclose).toHaveBeenCalledOnce();
+        expect(terminateSession).toHaveBeenCalledOnce();
     });
 });
 

--- a/packages/server/lib/controllers/mcp/docs/queryFilesystem.ts
+++ b/packages/server/lib/controllers/mcp/docs/queryFilesystem.ts
@@ -10,7 +10,7 @@ export const queryDocsFilesystemTool = defineManagementMcpTool<typeof queryDocsF
         "Run a read-only shell-like command against Mintlify's virtual Nango documentation filesystem. Use this to read full pages, browse the documentation structure, or perform exact text searches. Supported commands include rg, grep, find, tree, ls, cat, head, tail, sed, awk, and jq. The filesystem is an isolated documentation sandbox, not the Nango server or the caller's computer.",
     inputSchema: queryDocsFilesystemInputSchema,
     outputSchema: queryDocsFilesystemOutputSchema,
-    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     requiredScopes: { none: true },
     audit: { kind: 'no-audit', reason: 'read-only' },
     async handler({ args }) {

--- a/packages/server/lib/controllers/mcp/docs/queryFilesystem.ts
+++ b/packages/server/lib/controllers/mcp/docs/queryFilesystem.ts
@@ -1,0 +1,21 @@
+import { defineManagementMcpTool } from '../managementTool.js';
+import { docsMcpClient } from './client.js';
+import { queryDocsFilesystemInputSchema, queryDocsFilesystemOutputSchema } from './schema.js';
+
+import type { QueryDocsFilesystemOutput } from './schema.js';
+
+export const queryDocsFilesystemTool = defineManagementMcpTool<typeof queryDocsFilesystemInputSchema, QueryDocsFilesystemOutput>({
+    name: 'docs_query_filesystem',
+    description:
+        "Run a read-only shell-like command against Mintlify's virtual Nango documentation filesystem. Use this to read full pages, browse the documentation structure, or perform exact text searches. Supported commands include rg, grep, find, tree, ls, cat, head, tail, sed, awk, and jq. The filesystem is an isolated documentation sandbox, not the Nango server or the caller's computer.",
+    inputSchema: queryDocsFilesystemInputSchema,
+    outputSchema: queryDocsFilesystemOutputSchema,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    requiredScopes: { none: true },
+    audit: { kind: 'no-audit', reason: 'read-only' },
+    async handler({ args }) {
+        return (await docsMcpClient.callTool('query_docs_filesystem_nango_docs', { command: args.command })).map((content) => ({
+            output: content.join('\n\n')
+        }));
+    }
+});

--- a/packages/server/lib/controllers/mcp/docs/schema.ts
+++ b/packages/server/lib/controllers/mcp/docs/schema.ts
@@ -1,0 +1,31 @@
+import * as z from 'zod/v4';
+
+export const searchDocsInputSchema = z
+    .object({
+        query: z.string().min(1).describe('Search query')
+    })
+    .strict();
+
+export const searchDocsOutputSchema = z
+    .object({
+        results: z.array(z.string())
+    })
+    .strict();
+
+export const queryDocsFilesystemInputSchema = z
+    .object({
+        command: z
+            .string()
+            .min(1)
+            .describe('A read-only shell command to run against the virtual Nango documentation filesystem, such as `head -80 /quickstart.mdx`.')
+    })
+    .strict();
+
+export const queryDocsFilesystemOutputSchema = z
+    .object({
+        output: z.string()
+    })
+    .strict();
+
+export type SearchDocsOutput = z.infer<typeof searchDocsOutputSchema>;
+export type QueryDocsFilesystemOutput = z.infer<typeof queryDocsFilesystemOutputSchema>;

--- a/packages/server/lib/controllers/mcp/docs/search.ts
+++ b/packages/server/lib/controllers/mcp/docs/search.ts
@@ -10,7 +10,7 @@ export const searchDocsTool = defineManagementMcpTool<typeof searchDocsInputSche
         'Search the Nango documentation for relevant guides, API references, and examples. Returns contextual snippets with titles and links. Use docs_query_filesystem to read the full content of a page returned by this tool.',
     inputSchema: searchDocsInputSchema,
     outputSchema: searchDocsOutputSchema,
-    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     requiredScopes: { none: true },
     audit: { kind: 'no-audit', reason: 'read-only' },
     async handler({ args }) {

--- a/packages/server/lib/controllers/mcp/docs/search.ts
+++ b/packages/server/lib/controllers/mcp/docs/search.ts
@@ -1,0 +1,19 @@
+import { defineManagementMcpTool } from '../managementTool.js';
+import { docsMcpClient } from './client.js';
+import { searchDocsInputSchema, searchDocsOutputSchema } from './schema.js';
+
+import type { SearchDocsOutput } from './schema.js';
+
+export const searchDocsTool = defineManagementMcpTool<typeof searchDocsInputSchema, SearchDocsOutput>({
+    name: 'docs_search',
+    description:
+        'Search the Nango documentation for relevant guides, API references, and examples. Returns contextual snippets with titles and links. Use docs_query_filesystem to read the full content of a page returned by this tool.',
+    inputSchema: searchDocsInputSchema,
+    outputSchema: searchDocsOutputSchema,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    requiredScopes: { none: true },
+    audit: { kind: 'no-audit', reason: 'read-only' },
+    async handler({ args }) {
+        return (await docsMcpClient.callTool('search_nango_docs', { query: args.query })).map((results) => ({ results }));
+    }
+});

--- a/packages/server/lib/controllers/mcp/docs/tools.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/docs/tools.unit.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Ok } from '@nangohq/utils';
+
+import { docsMcpClient } from './client.js';
+import { queryDocsFilesystemTool } from './queryFilesystem.js';
+import { searchDocsTool } from './search.js';
+
+import type { ManagementMcpContext } from '../managementTool.js';
+
+const context = {
+    account: {},
+    environment: {},
+    plan: null,
+    grantedScopes: ['environment:mcp']
+} as ManagementMcpContext;
+
+describe('Management MCP documentation tools', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('forwards documentation searches to Mintlify', async () => {
+        const callTool = vi.spyOn(docsMcpClient, 'callTool').mockResolvedValue(Ok(['first result', 'second result']));
+
+        const result = await searchDocsTool.handler({ query: 'authentication' }, context);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({ results: ['first result', 'second result'] });
+        }
+        expect(callTool).toHaveBeenCalledWith('search_nango_docs', { query: 'authentication' });
+    });
+
+    it('forwards filesystem queries and preserves all returned text', async () => {
+        const callTool = vi.spyOn(docsMcpClient, 'callTool').mockResolvedValue(Ok(['first block', 'second block']));
+
+        const result = await queryDocsFilesystemTool.handler({ command: 'head -80 /quickstart.mdx' }, context);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({ output: 'first block\n\nsecond block' });
+        }
+        expect(callTool).toHaveBeenCalledWith('query_docs_filesystem_nango_docs', { command: 'head -80 /quickstart.mdx' });
+    });
+
+    it('rejects invalid input before calling Mintlify', async () => {
+        const callTool = vi.spyOn(docsMcpClient, 'callTool');
+
+        const searchResult = await searchDocsTool.handler({ query: '' }, context);
+        const queryResult = await queryDocsFilesystemTool.handler({ command: '' }, context);
+
+        expect(searchResult.isErr()).toBe(true);
+        expect(queryResult.isErr()).toBe(true);
+        expect(callTool).not.toHaveBeenCalled();
+    });
+});

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -179,7 +179,7 @@ describe('POST /mcp management server', () => {
         ]);
     });
 
-    it('lists documentation tools without an environment operation scope', async () => {
+    it('lists only documentation tools with the legacy mcp scope', async () => {
         const { secret } = await createKeyWithScopes(['environment:mcp']);
         const res = await mcpPost({
             token: secret,
@@ -922,17 +922,6 @@ describe('POST /mcp management server', () => {
             },
             id: null
         });
-    });
-
-    it('does not grant scoped management tools with only the legacy mcp scope', async () => {
-        const { secret } = await createKeyWithScopes(['environment:mcp']);
-        const res = await mcpPost({
-            token: secret,
-            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
-        });
-
-        expect(res.status).toBe(200);
-        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['docs_search', 'docs_query_filesystem']);
     });
 
     it('does not intercept the existing public API MCP hosts', async () => {

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -10,6 +10,7 @@ import { Ok } from '@nangohq/utils';
 
 import { audit } from '../../audit.js';
 import { authenticateUser, runServer } from '../../utils/tests.js';
+import { withoutDocsTools } from './testUtils.js';
 
 import type { ApiKeyScope } from '@nangohq/types';
 import type { InternalAxiosRequestConfig } from 'axios';
@@ -134,10 +135,6 @@ async function createKeyWithScopes(scopes: ApiKeyScope[]) {
 
 function parseToolText(res: any) {
     return JSON.parse(res.json.result.content[0].text);
-}
-
-function withoutDocsTools<T extends { name: string }>(tools: T[]): T[] {
-    return tools.filter((tool) => tool.name !== 'docs_search' && tool.name !== 'docs_query_filesystem');
 }
 
 describe('POST /mcp management server', () => {
@@ -306,8 +303,9 @@ describe('POST /mcp management server', () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.json.result.tools).toHaveLength(1);
-        expect(res.json.result.tools[0]).toMatchObject({
+        const scopedTools = withoutDocsTools(res.json.result.tools);
+        expect(scopedTools).toHaveLength(1);
+        expect(scopedTools[0]).toMatchObject({
             name: 'functions_list',
             annotations: { readOnlyHint: true }
         });

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -136,6 +136,10 @@ function parseToolText(res: any) {
     return JSON.parse(res.json.result.content[0].text);
 }
 
+function withoutDocsTools<T extends { name: string }>(tools: T[]): T[] {
+    return tools.filter((tool) => tool.name !== 'docs_search' && tool.name !== 'docs_query_filesystem');
+}
+
 describe('POST /mcp management server', () => {
     beforeAll(async () => {
         api = await runServer();
@@ -161,6 +165,8 @@ describe('POST /mcp management server', () => {
 
         expect(res.status).toBe(200);
         expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual([
+            'docs_search',
+            'docs_query_filesystem',
             'connect_session_create',
             'integrations_list',
             'integrations_get',
@@ -174,6 +180,17 @@ describe('POST /mcp management server', () => {
             'logs_list_operations',
             'logs_get_operation'
         ]);
+    });
+
+    it('lists documentation tools without an environment operation scope', async () => {
+        const { secret } = await createKeyWithScopes(['environment:mcp']);
+        const res = await mcpPost({
+            token: secret,
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['docs_search', 'docs_query_filesystem']);
     });
 
     it('rejects each management tool when its required scope is missing', async () => {
@@ -264,7 +281,10 @@ describe('POST /mcp management server', () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['logs_list_operations', 'logs_get_operation']);
+        expect(withoutDocsTools(res.json.result.tools).map((tool: { name: string }) => tool.name)).toStrictEqual([
+            'logs_list_operations',
+            'logs_get_operation'
+        ]);
     });
 
     it('lists integration tools with integrations:list scope', async () => {
@@ -275,7 +295,7 @@ describe('POST /mcp management server', () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['integrations_list']);
+        expect(withoutDocsTools(res.json.result.tools).map((tool: { name: string }) => tool.name)).toStrictEqual(['integrations_list']);
     });
 
     it('lists the functions tool with functions:list scope', async () => {
@@ -380,8 +400,9 @@ describe('POST /mcp management server', () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.json.result.tools).toHaveLength(1);
-        expect(res.json.result.tools[0]).toMatchObject({
+        const scopedTools = withoutDocsTools(res.json.result.tools);
+        expect(scopedTools).toHaveLength(1);
+        expect(scopedTools[0]).toMatchObject({
             name: 'connections_list',
             annotations: { readOnlyHint: true }
         });
@@ -395,8 +416,9 @@ describe('POST /mcp management server', () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.json.result.tools).toHaveLength(1);
-        expect(res.json.result.tools[0]).toMatchObject({ name: 'connections_get', annotations: { readOnlyHint: false } });
+        const scopedTools = withoutDocsTools(res.json.result.tools);
+        expect(scopedTools).toHaveLength(1);
+        expect(scopedTools[0]).toMatchObject({ name: 'connections_get', annotations: { readOnlyHint: false } });
     });
 
     it('gets a connection without credentials using the read scope', async () => {
@@ -657,8 +679,9 @@ describe('POST /mcp management server', () => {
                 token: secret,
                 body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
             });
-            expect(listed.json.result.tools).toHaveLength(1);
-            expect(listed.json.result.tools[0]).toMatchObject({
+            const scopedTools = withoutDocsTools(listed.json.result.tools);
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools[0]).toMatchObject({
                 name: 'proxy_request',
                 annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
             });
@@ -752,8 +775,9 @@ describe('POST /mcp management server', () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.json.result.tools).toHaveLength(1);
-        expect(res.json.result.tools[0]).toMatchObject({
+        const scopedTools = withoutDocsTools(res.json.result.tools);
+        expect(scopedTools).toHaveLength(1);
+        expect(scopedTools[0]).toMatchObject({
             name: 'integrations_get',
             annotations: { readOnlyHint: true }
         });
@@ -767,7 +791,7 @@ describe('POST /mcp management server', () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['integrations_create']);
+        expect(withoutDocsTools(res.json.result.tools).map((tool: { name: string }) => tool.name)).toStrictEqual(['integrations_create']);
     });
 
     it('lists and executes the integration update tool with integrations:update scope', async () => {
@@ -778,7 +802,7 @@ describe('POST /mcp management server', () => {
             token: secret,
             body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
         });
-        expect(listed.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['integrations_update']);
+        expect(withoutDocsTools(listed.json.result.tools).map((tool: { name: string }) => tool.name)).toStrictEqual(['integrations_update']);
 
         const res = await mcpPost({
             token: secret,
@@ -902,7 +926,7 @@ describe('POST /mcp management server', () => {
         });
     });
 
-    it('does not grant management tools with only the legacy mcp scope', async () => {
+    it('does not grant scoped management tools with only the legacy mcp scope', async () => {
         const { secret } = await createKeyWithScopes(['environment:mcp']);
         const res = await mcpPost({
             token: secret,
@@ -910,7 +934,7 @@ describe('POST /mcp management server', () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.json.result.tools).toStrictEqual([]);
+        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['docs_search', 'docs_query_filesystem']);
     });
 
     it('does not intercept the existing public API MCP hosts', async () => {

--- a/packages/server/lib/controllers/mcp/managementServer.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.ts
@@ -9,6 +9,8 @@ import { recordManagementMcpAudit } from './audit.js';
 import { getConnectionsTool } from './connections/get.js';
 import { listConnectionsTool } from './connections/list.js';
 import { createConnectSessionTool } from './connectSessions/create.js';
+import { queryDocsFilesystemTool } from './docs/queryFilesystem.js';
+import { searchDocsTool } from './docs/search.js';
 import { listFunctionsTool } from './functions/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { deleteIntegrationsTool } from './integrations/delete.js';
@@ -29,6 +31,8 @@ const jsonSchema202012 = 'https://json-schema.org/draft/2020-12/schema';
 const emptyObjectJsonSchema: Tool['inputSchema'] = { type: 'object', properties: {} };
 
 const managementMcpTools: ManagementMcpTool[] = [
+    searchDocsTool,
+    queryDocsFilesystemTool,
     createConnectSessionTool,
     listIntegrationsTool,
     getIntegrationsTool,
@@ -157,6 +161,10 @@ function auditDeniedCallsForTool({ requestBody, context, tool }: { requestBody: 
 }
 
 function hasRequiredScopes({ grantedScopes, requiredScopes }: { grantedScopes: string[] | undefined; requiredScopes: ManagementMcpRequiredScopes }): boolean {
+    if ('none' in requiredScopes) {
+        return true;
+    }
+
     const hasRequiredScope = (scope: ApiKeyScope) => hasApiKeyScope({ grantedScopes, requiredScope: scope });
     return 'every' in requiredScopes ? requiredScopes.every.every(hasRequiredScope) : requiredScopes.anyOf.some(hasRequiredScope);
 }

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -37,11 +37,11 @@ describe('createManagementMcpServer', () => {
             expect(result.tools.map(({ name, annotations }) => ({ name, annotations }))).toStrictEqual([
                 {
                     name: 'docs_search',
-                    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }
+                    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true }
                 },
                 {
                     name: 'docs_query_filesystem',
-                    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }
+                    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true }
                 },
                 {
                     name: 'connect_session_create',

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -16,6 +16,7 @@ import { updateIntegrationsTool } from './integrations/update.js';
 import { listLogOperationsTool } from './logs/listOperations.js';
 import { createManagementMcpServer } from './managementServer.js';
 import { proxyRequestTool } from './proxy/request.js';
+import { withoutDocsTools } from './testUtils.js';
 import { PublicMcpError } from './utils.js';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -518,9 +519,10 @@ describe('createManagementMcpServer', () => {
 
         try {
             const result = await client.listTools();
+            const scopedTools = withoutDocsTools(result.tools);
 
-            expect(result.tools).toHaveLength(1);
-            expect(result.tools[0]).toMatchObject({
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools[0]).toMatchObject({
                 name: 'functions_list',
                 annotations: { readOnlyHint: true }
             });
@@ -826,10 +828,6 @@ async function createTestClient(grantedScopes: string[]): Promise<{ client: Clie
     await client.connect(clientTransport);
 
     return { client, server };
-}
-
-function withoutDocsTools<T extends { name: string }>(tools: T[]): T[] {
-    return tools.filter((tool) => tool.name !== 'docs_search' && tool.name !== 'docs_query_filesystem');
 }
 
 function fakeAccount(): DBTeam {

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -35,6 +35,14 @@ describe('createManagementMcpServer', () => {
 
             expect(result.tools.map(({ name, annotations }) => ({ name, annotations }))).toStrictEqual([
                 {
+                    name: 'docs_search',
+                    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }
+                },
+                {
+                    name: 'docs_query_filesystem',
+                    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }
+                },
+                {
                     name: 'connect_session_create',
                     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
                 },
@@ -71,6 +79,19 @@ describe('createManagementMcpServer', () => {
         }
     });
 
+    it('exposes documentation tools without an environment operation scope', async () => {
+        const { client, server } = await createTestClient(['environment:mcp']);
+
+        try {
+            const result = await client.listTools();
+
+            expect(result.tools.map((tool) => tool.name)).toStrictEqual(['docs_search', 'docs_query_filesystem']);
+        } finally {
+            await client.close();
+            await server.close();
+        }
+    });
+
     it('advertises tool schemas using the default MCP JSON Schema dialect', async () => {
         const { client, server } = await createTestClient(['environment:*']);
 
@@ -91,8 +112,9 @@ describe('createManagementMcpServer', () => {
         const authorized = await createTestClient(['environment:connect_sessions:write']);
         try {
             const result = await authorized.client.listTools();
-            expect(result.tools).toHaveLength(1);
-            expect(result.tools[0]).toMatchObject({
+            const scopedTools = withoutDocsTools(result.tools);
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools[0]).toMatchObject({
                 name: 'connect_session_create',
                 annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
             });
@@ -143,7 +165,7 @@ describe('createManagementMcpServer', () => {
         try {
             const result = await client.listTools();
 
-            expect(result.tools.map((tool) => tool.name)).toStrictEqual(['integrations_list']);
+            expect(withoutDocsTools(result.tools).map((tool) => tool.name)).toStrictEqual(['integrations_list']);
         } finally {
             await client.close();
             await server.close();
@@ -156,8 +178,9 @@ describe('createManagementMcpServer', () => {
         try {
             const result = await client.listTools();
 
-            expect(result.tools).toHaveLength(1);
-            expect(result.tools[0]).toMatchObject({
+            const scopedTools = withoutDocsTools(result.tools);
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools[0]).toMatchObject({
                 name: 'integrations_get',
                 annotations: { readOnlyHint: true }
             });
@@ -173,8 +196,9 @@ describe('createManagementMcpServer', () => {
         try {
             const result = await client.listTools();
 
-            expect(result.tools).toHaveLength(1);
-            expect(result.tools[0]).toMatchObject({
+            const scopedTools = withoutDocsTools(result.tools);
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools[0]).toMatchObject({
                 name: 'integrations_create',
                 inputSchema: {
                     type: 'object',
@@ -216,7 +240,7 @@ describe('createManagementMcpServer', () => {
         try {
             const result = await client.listTools();
 
-            expect(result.tools.map((tool) => tool.name)).toStrictEqual([
+            expect(withoutDocsTools(result.tools).map((tool) => tool.name)).toStrictEqual([
                 'integrations_list',
                 'integrations_get',
                 'integrations_create',
@@ -233,8 +257,9 @@ describe('createManagementMcpServer', () => {
         const authorized = await createTestClient(['environment:integrations:update']);
         try {
             const result = await authorized.client.listTools();
-            expect(result.tools).toHaveLength(1);
-            expect(result.tools[0]).toMatchObject({
+            const scopedTools = withoutDocsTools(result.tools);
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools[0]).toMatchObject({
                 name: 'integrations_update',
                 annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
             });
@@ -260,8 +285,9 @@ describe('createManagementMcpServer', () => {
         const authorized = await createTestClient(['environment:integrations:delete']);
         try {
             const result = await authorized.client.listTools();
-            expect(result.tools).toHaveLength(1);
-            expect(result.tools[0]).toMatchObject({
+            const scopedTools = withoutDocsTools(result.tools);
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools[0]).toMatchObject({
                 name: 'integrations_delete',
                 annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false }
             });
@@ -291,8 +317,9 @@ describe('createManagementMcpServer', () => {
             try {
                 const result = await client.listTools();
 
-                expect(result.tools).toHaveLength(1);
-                expect(result.tools[0]).toMatchObject({
+                const scopedTools = withoutDocsTools(result.tools);
+                expect(scopedTools).toHaveLength(1);
+                expect(scopedTools[0]).toMatchObject({
                     name: 'connections_list',
                     annotations: { readOnlyHint: true }
                 });
@@ -307,8 +334,9 @@ describe('createManagementMcpServer', () => {
         const authorized = await createTestClient(['environment:proxy']);
         try {
             const result = await authorized.client.listTools();
-            expect(result.tools).toHaveLength(1);
-            expect(result.tools[0]).toMatchObject({
+            const scopedTools = withoutDocsTools(result.tools);
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools[0]).toMatchObject({
                 name: 'proxy_request',
                 annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
             });
@@ -339,7 +367,7 @@ describe('createManagementMcpServer', () => {
         try {
             const result = await client.listTools();
 
-            expect(result.tools.map((tool) => tool.name)).toStrictEqual(['connections_list', 'connections_get']);
+            expect(withoutDocsTools(result.tools).map((tool) => tool.name)).toStrictEqual(['connections_list', 'connections_get']);
         } finally {
             await client.close();
             await server.close();
@@ -352,8 +380,9 @@ describe('createManagementMcpServer', () => {
         try {
             const result = await client.listTools();
 
-            expect(result.tools).toHaveLength(1);
-            expect(result.tools[0]).toMatchObject({
+            const scopedTools = withoutDocsTools(result.tools);
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools[0]).toMatchObject({
                 name: 'connections_get',
                 annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true }
             });
@@ -653,12 +682,14 @@ describe('createManagementMcpServer', () => {
         }
     });
 
-    it('disables tools when required scopes are missing', async () => {
+    it('disables scoped tools when required scopes are missing', async () => {
         const handlerSpy = vi.spyOn(listLogOperationsTool, 'handler');
         const { client, server } = await createTestClient(['environment:mcp']);
 
         try {
-            await expect(client.listTools()).resolves.toStrictEqual({ tools: [] });
+            await expect(client.listTools()).resolves.toMatchObject({
+                tools: [{ name: 'docs_search' }, { name: 'docs_query_filesystem' }]
+            });
             const result = await client.callTool({ name: 'logs_list_operations', arguments: {} });
 
             expect(result).toStrictEqual({
@@ -795,6 +826,10 @@ async function createTestClient(grantedScopes: string[]): Promise<{ client: Clie
     await client.connect(clientTransport);
 
     return { client, server };
+}
+
+function withoutDocsTools<T extends { name: string }>(tools: T[]): T[] {
+    return tools.filter((tool) => tool.name !== 'docs_search' && tool.name !== 'docs_query_filesystem');
 }
 
 function fakeAccount(): DBTeam {

--- a/packages/server/lib/controllers/mcp/managementTool.ts
+++ b/packages/server/lib/controllers/mcp/managementTool.ts
@@ -20,7 +20,7 @@ export interface ManagementMcpContext {
 }
 
 export type ManagementMcpSchema = AnySchema | z.ZodType;
-export type ManagementMcpRequiredScopes = { every: ApiKeyScope[] } | { anyOf: ApiKeyScope[] };
+export type ManagementMcpRequiredScopes = { none: true } | { every: ApiKeyScope[] } | { anyOf: ApiKeyScope[] };
 
 export interface ManagementMcpTool<TResponse extends object = object> {
     name: string;

--- a/packages/server/lib/controllers/mcp/testUtils.ts
+++ b/packages/server/lib/controllers/mcp/testUtils.ts
@@ -1,0 +1,3 @@
+export function withoutDocsTools<T extends { name: string }>(tools: T[]): T[] {
+    return tools.filter((tool) => tool.name !== 'docs_search' && tool.name !== 'docs_query_filesystem');
+}


### PR DESCRIPTION
Adds `docs_search` and `docs_query_filesystem` to the Management MCP. Both tools proxy the Mintlify-hosted Nango documentation MCP. It still requires an API key, but it doesn't matter which scopes it has.

[NAN-6631](https://linear.app/nango/issue/NAN-6631/mcp-tool-docs).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

