### PR TITLE
feat(audit): record the scopes an API key was granted, on every route

### DIFF
--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -364,7 +364,6 @@ describe('audit middleware — live-stack contract', () => {
                 method: 'POST',
                 session,
                 query: { env: env.name },
-                // No scopes in the request: the recorded set can only come from what was granted.
                 body: { display_name: 'ci-runner' }
             });
 
@@ -373,7 +372,6 @@ describe('audit middleware — live-stack contract', () => {
             await vi.waitFor(() => {
                 expect(auditEvent('api_key', 'created')).toBeDefined();
             });
-            // Same metadata keys as the public route's event, so a reader can compare the two surfaces.
             expect(auditEvent('api_key', 'created')).toMatchObject({
                 resource: 'api_key',
                 action: 'created',

--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -9,6 +9,7 @@ import { audit } from '../audit.js';
 import { authenticateUser, isSuccess, runServer } from '../utils/tests.js';
 
 import type { AuditAction, AuditResource } from '@nangohq/audit';
+import type { ApiKeyScope } from '@nangohq/types';
 import type { MockInstance } from 'vitest';
 
 // The single audit integration suite: only the cases that genuinely need the live stack. Everything
@@ -355,7 +356,10 @@ describe('audit middleware — live-stack contract', () => {
             });
         });
 
-        it('records the granted scopes when the dashboard creates an environment API key', async () => {
+        it.each<{ requested: ApiKeyScope[] | undefined; granted: ApiKeyScope[]; name: string }>([
+            { requested: undefined, granted: ['environment:*'], name: 'ci-default' },
+            { requested: ['environment:integrations:list'], granted: ['environment:integrations:list'], name: 'ci-scoped' }
+        ])('records the scopes the dashboard granted an environment API key ($name)', async ({ requested, granted, name }) => {
             const { account, env, user } = await seeders.seedAccountEnvAndUser({ plan: { has_audit_trail_control_plane: true } });
             const session = await authenticateUser(api, user);
             auditSpy.mockClear();
@@ -365,7 +369,7 @@ describe('audit middleware — live-stack contract', () => {
                 session,
                 // @ts-expect-error querystring is not typed on this endpoint
                 query: { env: env.name },
-                body: { display_name: 'ci-runner' }
+                body: { display_name: name, ...(requested ? { scopes: requested } : {}) }
             });
 
             expect(create.res.status).toBe(200);
@@ -379,8 +383,8 @@ describe('audit middleware — live-stack contract', () => {
                 outcome: 'success',
                 accountId: account.id,
                 actor: { type: 'user', id: String(user.id), display: user.email },
-                targets: [{ type: 'api_key', id: String(create.json.data.id), display: 'ci-runner' }],
-                metadata: { displayName: 'ci-runner', scopes: ['environment:*'] }
+                targets: [{ type: 'api_key', id: String(create.json.data.id), display: name }],
+                metadata: { displayName: name, scopes: granted }
             });
             expect(JSON.stringify(auditEvent('api_key', 'created'))).not.toContain(create.json.data.secret);
         });

--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -363,6 +363,7 @@ describe('audit middleware — live-stack contract', () => {
             const create = await api.fetch('/api/v1/environment/api-keys', {
                 method: 'POST',
                 session,
+                // @ts-expect-error querystring is not typed on this endpoint
                 query: { env: env.name },
                 body: { display_name: 'ci-runner' }
             });

--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -355,6 +355,37 @@ describe('audit middleware — live-stack contract', () => {
             });
         });
 
+        it('records the granted scopes when the dashboard creates an environment API key', async () => {
+            const { account, env, user } = await seeders.seedAccountEnvAndUser({ plan: { has_audit_trail_control_plane: true } });
+            const session = await authenticateUser(api, user);
+            auditSpy.mockClear();
+
+            const create = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                session,
+                query: { env: env.name },
+                // No scopes in the request: the recorded set can only come from what was granted.
+                body: { display_name: 'ci-runner' }
+            });
+
+            expect(create.res.status).toBe(200);
+            isSuccess(create.json);
+            await vi.waitFor(() => {
+                expect(auditEvent('api_key', 'created')).toBeDefined();
+            });
+            // Same metadata keys as the public route's event, so a reader can compare the two surfaces.
+            expect(auditEvent('api_key', 'created')).toMatchObject({
+                resource: 'api_key',
+                action: 'created',
+                outcome: 'success',
+                accountId: account.id,
+                actor: { type: 'user', id: String(user.id), display: user.email },
+                targets: [{ type: 'api_key', id: String(create.json.data.id), display: 'ci-runner' }],
+                metadata: { displayName: 'ci-runner', scopes: ['environment:*'] }
+            });
+            expect(JSON.stringify(auditEvent('api_key', 'created'))).not.toContain(create.json.data.secret);
+        });
+
         it('records public environment API key creation and deletion with an Account API key', async () => {
             const { account, env } = await seeders.seedAccountEnvAndUser({ plan: { has_audit_trail_control_plane: true } });
             const accountKey = (
@@ -386,7 +417,7 @@ describe('audit middleware — live-stack contract', () => {
                 environment: null,
                 actor: { type: 'api_key', id: String(accountKey.id), display: 'Key automation' },
                 targets: [{ type: 'api_key', id: createdId, display: 'provisioned-ci' }],
-                metadata: { displayName: 'provisioned-ci', environmentId: env.id }
+                metadata: { displayName: 'provisioned-ci', environmentId: env.id, scopes: ['environment:*'] }
             });
             expect(JSON.stringify(auditEvent('api_key', 'created'))).not.toContain(secret);
 

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -878,16 +878,12 @@ export const auditApiKeyCreated = auditable<CreateApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'created', scope: 'environment' }),
     // Never read the secret from the response — only the id and display name identify the key.
     targetFromResponse: (response) => makeTarget('api_key', response.data.id, response.data.display_name),
-    // The name is taken from the request so a refused attempt still records what was asked for; the scopes
-    // come from the response because the request's are optional and the service fills in the rest.
     metadata: (req) => omitUndefined({ displayName: req.body.display_name }),
     metadataFromResponse: (response) => omitUndefined({ scopes: response.data.scopes })
 });
 export const auditPublicApiKeyCreated = auditable<PostPublicApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'created', scope: 'account' }),
     targetFromResponse: (response) => makeTarget('api_key', response.data.id, response.data.display_name),
-    // This route takes no scopes, so the response is the only place the granted set can come from. The
-    // environment is in the metadata because the route is account-scoped and the event carries none.
     metadata: (req) => omitUndefined({ displayName: req.body.display_name, environmentId: req.body.environment_id }),
     metadataFromResponse: (response) => omitUndefined({ scopes: response.data.scopes })
 });

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -878,16 +878,18 @@ export const auditApiKeyCreated = auditable<CreateApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'created', scope: 'environment' }),
     // Never read the secret from the response — only the id and display name identify the key.
     targetFromResponse: (response) => makeTarget('api_key', response.data.id, response.data.display_name),
-    metadata: (req) =>
-        omitUndefined({
-            displayName: req.body.display_name,
-            scopes: req.body.scopes
-        })
+    // The name is taken from the request so a refused attempt still records what was asked for; the scopes
+    // come from the response because the request's are optional and the service fills in the rest.
+    metadata: (req) => omitUndefined({ displayName: req.body.display_name }),
+    metadataFromResponse: (response) => omitUndefined({ scopes: response.data.scopes })
 });
 export const auditPublicApiKeyCreated = auditable<PostPublicApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'created', scope: 'account' }),
     targetFromResponse: (response) => makeTarget('api_key', response.data.id, response.data.display_name),
-    metadata: (req) => omitUndefined({ displayName: req.body.display_name, environmentId: req.body.environment_id })
+    // This route takes no scopes, so the response is the only place the granted set can come from. The
+    // environment is in the metadata because the route is account-scoped and the event carries none.
+    metadata: (req) => omitUndefined({ displayName: req.body.display_name, environmentId: req.body.environment_id }),
+    metadataFromResponse: (response) => omitUndefined({ scopes: response.data.scopes })
 });
 export const auditAccountApiKeyCreated = auditable<CreateAccountApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'created', scope: 'account' }),


### PR DESCRIPTION
- **`api_key.created` now records the granted scopes whichever route created the key.** The three producers disagreed: the two private routes recorded scopes, the public one did not — so for a key created through the API, the access it was granted appeared nowhere in the trail. All three now read the scopes from the **response** rather than the request, which is what the account route already did. The public route carries no scopes in its body at all (the service picks them), so the response is the only possible source; and on the dashboard route the request's scopes are optional, so recording the request meant recording nothing for a key actually granted `environment:*`.
- **Adds the missing audit coverage for the dashboard route**, asserting the granted scopes for a request that names none — the case that distinguishes request-derived from response-derived. The route had no audit test at all before.

### What did not change

Neither endpoint's response shape: both already returned `scopes`, they just weren't being read.

`displayName` still comes from the request, so a refused attempt still records what was asked for. `environmentId` stays only on the two account-scoped routes — the event's own `environment` is null there, so that metadata field is the sole record of which environment the key belongs to. Removing it for symmetry would have destroyed information, which is why `api_key.deleted` is untouched.

### Known trade

`metadataFromResponse` only runs on success, so a failed or denied create no longer records the *attempted* scopes. The actor, outcome, and requested name are still recorded. This was deliberate — a `scopes` value on a row where nothing was granted reads as a grant — but if attempt-vs-grant should both be visible, the follow-up is a separate `requestedScopes` field rather than moving this one back.

## Test plan

- [x] Live-stack test for the public route tightened to assert the granted scopes; confirmed red without the change
- [x] New live-stack test for the dashboard route, with no scopes in the request; confirmed red when scopes revert to request-derived
- [x] 16 tests in `audit.integration.test.ts` pass; `npm run lint` exits 0; Prettier clean
- [ ] After deploy: create a key from the dashboard and via the API, and confirm both rows carry the granted scopes

Found while auditing symmetry across all 67 audit specs ahead of the audit-trail rollout (NAN-4530). `api_key.updated` has the same class of problem and is *not* fixed here: `PatchApiKey` responds with only `{ success: true }`, so there is nothing to read back and it still records the requested scopes. That needs either a richer response or a lookup at finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

