### PR TITLE
feat(mcp): add deploy function tool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -13011,11 +13011,12 @@ The tool accepts JSON and UTF-8 text responses up to 5 MB (5,000,000 bytes). Uns
 
 ### Functions
 
-Use the Functions tools to inspect functions deployed to an integration in the authenticated Nango environment.
+Use the Functions tools to inspect and deploy functions in the authenticated Nango environment.
 
-| Tool             | Description                                                                    | Required API key scope        |
-| ---------------- | ------------------------------------------------------------------------------ | ----------------------------- |
-| `functions_list` | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+| Tool              | Description                                                                    | Required API key scope        |
+| ----------------- | ------------------------------------------------------------------------------ | ----------------------------- |
+| `functions_list`  | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+| `deploy_function` | Start a code function deployment.                                              | `environment:deploy`          |
 
 ### Logs
 

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -87,11 +87,12 @@ The tool accepts JSON and UTF-8 text responses up to 5 MB (5,000,000 bytes). Uns
 
 ### Functions
 
-Use the Functions tools to inspect functions deployed to an integration in the authenticated Nango environment.
+Use the Functions tools to inspect and deploy functions in the authenticated Nango environment.
 
-| Tool             | Description                                                                    | Required API key scope        |
-| ---------------- | ------------------------------------------------------------------------------ | ----------------------------- |
-| `functions_list` | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+| Tool              | Description                                                                    | Required API key scope        |
+| ----------------- | ------------------------------------------------------------------------------ | ----------------------------- |
+| `functions_list`  | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+| `deploy_function` | Start a code function deployment.                                              | `environment:deploy`          |
 
 ### Logs
 

--- a/packages/sandbox/lib/api-keys/sandbox-api-key.unit.test.ts
+++ b/packages/sandbox/lib/api-keys/sandbox-api-key.unit.test.ts
@@ -197,8 +197,13 @@ describe('customer key sandbox token service', () => {
         }
     });
 
-    it('keeps parent scopes and adds sandbox baseline scopes', () => {
-        expect(buildSandboxApiKeyScopes(['environment:functions:dryrun', 'environment:records:read'])).toStrictEqual([
+    it('keeps parent scopes and adds sandbox baseline scopes for dryruns', () => {
+        expect(
+            buildSandboxApiKeyScopes({
+                purpose: 'dryrun',
+                parentScopes: ['environment:functions:dryrun', 'environment:records:read']
+            })
+        ).toStrictEqual([
             'environment:functions:dryrun',
             'environment:records:read',
             'environment:connections:read',
@@ -207,12 +212,29 @@ describe('customer key sandbox token service', () => {
         ]);
     });
 
-    it('does not duplicate baseline scopes already present on the parent key', () => {
-        expect(buildSandboxApiKeyScopes(['environment:functions:dryrun', 'environment:proxy'])).toStrictEqual([
+    it('does not duplicate dryrun baseline scopes already present on the parent key', () => {
+        expect(buildSandboxApiKeyScopes({ purpose: 'dryrun', parentScopes: ['environment:functions:dryrun', 'environment:proxy'] })).toStrictEqual([
             'environment:functions:dryrun',
             'environment:proxy',
             'environment:connections:read',
             'environment:integrations:read'
         ]);
+    });
+
+    it('limits deploy sandbox tokens to the deploy scope', () => {
+        expect(
+            buildSandboxApiKeyScopes({
+                purpose: 'deploy',
+                parentScopes: ['environment:deploy', 'environment:connections:read', 'environment:integrations:read', 'environment:proxy']
+            })
+        ).toStrictEqual(['environment:deploy']);
+    });
+
+    it('derives the deploy scope from a parent wildcard', () => {
+        expect(buildSandboxApiKeyScopes({ purpose: 'deploy', parentScopes: ['environment:*'] })).toStrictEqual(['environment:deploy']);
+    });
+
+    it('does not grant deploy scope after it is removed from the parent key', () => {
+        expect(buildSandboxApiKeyScopes({ purpose: 'deploy', parentScopes: ['environment:records:read'] })).toStrictEqual([]);
     });
 });

--- a/packages/server/lib/controllers/functions/deployments/helpers.ts
+++ b/packages/server/lib/controllers/functions/deployments/helpers.ts
@@ -1,31 +1,5 @@
-import db from '@nangohq/database';
-import { deploySandboxTimeoutMs, FunctionError, sandboxApiKeyService } from '@nangohq/sandbox';
-import { stringifyError } from '@nangohq/utils';
-
 import type { RequestLocals } from '../../../utils/express.js';
-import type { FunctionDeploymentError } from '@nangohq/sandbox';
 import type { Response } from 'express';
-
-const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
-
-export async function createDeploySandboxApiKey(parentApiKeyId: number, environmentId: number, deploymentId: string) {
-    return await sandboxApiKeyService.createSandboxApiKey(db.knex, {
-        parentApiKeyId,
-        environmentId,
-        purpose: 'deploy',
-        deploymentId,
-        expiresAt: new Date(Date.now() + deploySandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
-    });
-}
-
-export function requireCustomerKeyId<T>(res: Response<T, RequestLocals>, message: string): number | null {
-    if (res.locals['apiKeyAuthSource'] !== 'customer_key' || !res.locals['apiKeyId']) {
-        res.status(403).send({ error: { code: 'forbidden', message } } as T);
-        return null;
-    }
-
-    return res.locals['apiKeyId'];
-}
 
 export function verifyDeploymentResultSandboxToken<T>(res: Response<T, RequestLocals>, deploymentId: string): boolean {
     if (res.locals['sandboxTokenPurpose'] !== 'deploy' || res.locals['sandboxTokenDeploymentId'] !== deploymentId) {
@@ -34,19 +8,4 @@ export function verifyDeploymentResultSandboxToken<T>(res: Response<T, RequestLo
     }
 
     return true;
-}
-
-export function toFunctionDeploymentError(err: unknown): FunctionDeploymentError {
-    if (err instanceof FunctionError) {
-        return {
-            code: err.code,
-            message: err.message,
-            ...(err.payload !== undefined ? { payload: err.payload } : {})
-        };
-    }
-
-    return {
-        code: 'deployment_error',
-        message: stringifyError(err)
-    };
 }

--- a/packages/server/lib/controllers/functions/deployments/postDeployment.ts
+++ b/packages/server/lib/controllers/functions/deployments/postDeployment.ts
@@ -3,38 +3,22 @@
 // - move template deployment to its own endpoint `POST /functions/deployments/template`.
 // - move sandbox deployment to its own endpoint alongside the other deployment endpoints.
 
-import {
-    createFunctionDeployment,
-    createSucceededFunctionDeployment,
-    FunctionError,
-    markFunctionDeploymentFailed,
-    markFunctionDeploymentRunning,
-    prepareAsyncDeploy,
-    toFunctionDeploymentCreate
-} from '@nangohq/sandbox';
-import { configService, getSyncConfigRaw } from '@nangohq/shared';
-import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { createSucceededFunctionDeployment } from '@nangohq/sandbox';
+import { getLogger, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import * as functionDeploymentService from '../../../services/functionDeployment.service.js';
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { deployIntegrationTemplate } from '../../v1/flows/preBuilt/helpers.js';
 import { sendStepError } from '../errors.js';
-import { getFunctionCallbackBaseUrl } from '../helpers.js';
 import { functionDeploymentBodySchema } from '../validation.js';
-import { createDeploySandboxApiKey, requireCustomerKeyId, toFunctionDeploymentError } from './helpers.js';
 
+import type { DeployFunctionServiceError } from '../../../services/functionDeployment.service.js';
 import type { RequestLocalsWithEnvironment } from '../../../utils/express.js';
-import type { DBSyncConfig, FunctionDeploymentCodeBody, FunctionDeploymentTemplateBody, PostFunctionDeployment } from '@nangohq/types';
+import type { FunctionDeploymentCodeBody, FunctionDeploymentTemplateBody, PostFunctionDeployment } from '@nangohq/types';
 import type { Response } from 'express';
 
 type DeploymentResponse = Response<PostFunctionDeployment['Reply'], RequestLocalsWithEnvironment>;
-
-function isProtectedExistingFunction(existingSyncConfig: Pick<DBSyncConfig, 'source'> | null): boolean {
-    return Boolean(existingSyncConfig && existingSyncConfig.source !== 'standalone');
-}
-
-function shouldAllowDestructiveDeploy(existingSyncConfig: Pick<DBSyncConfig, 'source'> | null, allowDestructive: boolean): boolean {
-    return Boolean(allowDestructive && existingSyncConfig?.source === 'standalone');
-}
+const logger = getLogger('Server.Functions.Deployments');
 
 /**
  * Deploy a catalog template onto an integration. Runs synchronously but records a deployment async job in a
@@ -120,103 +104,17 @@ async function handleDeployTemplate(res: DeploymentResponse, body: FunctionDeplo
  */
 async function handleDeployCode(res: DeploymentResponse, body: FunctionDeploymentCodeBody): Promise<void> {
     const { environment } = res.locals;
-
-    const parentCustomerKeyId = requireCustomerKeyId(res, 'Function deployments can only be started from a customer API key');
-    if (!parentCustomerKeyId) {
-        return;
-    }
-
-    const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
-    if (!providerConfig || !providerConfig.id) {
-        res.status(404).send({ error: { code: 'integration_not_found', message: `Integration '${body.integration_id}' was not found` } });
-        return;
-    }
-
-    const existingSyncConfig = await getSyncConfigRaw({
-        environmentId: environment.id,
-        config_id: providerConfig.id,
-        name: body.function_name,
-        isAction: body.function_type === 'action'
+    const result = await functionDeploymentService.deployFunction({
+        environment,
+        body,
+        ...(res.locals.apiKeyAuthSource === 'customer_key' && res.locals.apiKeyId ? { parentCustomerApiKeyId: res.locals.apiKeyId } : {})
     });
-
-    if (isProtectedExistingFunction(existingSyncConfig)) {
-        res.status(400).send({
-            error: {
-                code: 'invalid_request',
-                message: `Cannot overwrite existing function '${body.function_name}'`
-            }
-        });
+    if (result.isErr()) {
+        sendDeployFunctionError(res, result.error);
         return;
     }
 
-    const allowDestructiveDeploy = shouldAllowDestructiveDeploy(existingSyncConfig, body.allow_destructive ?? false);
-    const deploymentResult = await createFunctionDeployment({
-        environmentId: environment.id,
-        request: {
-            type: 'function',
-            integration_id: body.integration_id,
-            function_name: body.function_name,
-            function_type: body.function_type,
-            code: body.code,
-            ...(body.version ? { version: body.version } : {}),
-            allow_destructive: allowDestructiveDeploy
-        }
-    });
-    if (deploymentResult.isErr()) {
-        sendStepError({ res, status: 500, error: deploymentResult.error });
-        return;
-    }
-
-    const deployment = deploymentResult.value;
-    let prepared: Awaited<ReturnType<typeof prepareAsyncDeploy>> | null = null;
-    try {
-        const nangoHost = getFunctionCallbackBaseUrl();
-        const sandboxApiKey = await createDeploySandboxApiKey(parentCustomerKeyId, environment.id, deployment.id);
-        if (sandboxApiKey.isErr()) {
-            throw sandboxApiKey.error;
-        }
-
-        const callbackUrl = new URL(`/functions/deployments/${deployment.id}/result`, nangoHost).toString();
-        prepared = await prepareAsyncDeploy({
-            integration_id: body.integration_id,
-            function_name: body.function_name,
-            function_type: body.function_type,
-            code: body.code,
-            environment_name: environment.name,
-            nango_secret_key: sandboxApiKey.value,
-            nango_host: nangoHost,
-            deployment_id: deployment.id,
-            callback_url: callbackUrl,
-            ...(body.version ? { version: body.version } : {}),
-            allow_destructive: allowDestructiveDeploy
-        });
-
-        const running = await markFunctionDeploymentRunning({
-            environmentId: environment.id,
-            id: deployment.id,
-            sandboxId: prepared.sandboxId,
-            startedAt: prepared.startedAt,
-            executionTimeoutAt: prepared.executionTimeoutAt
-        });
-        if (!running) {
-            await prepared.kill();
-            throw new Error(`Failed to mark function deployment '${deployment.id}' as running`);
-        }
-
-        await prepared.start();
-
-        res.status(202).send(toFunctionDeploymentCreate(running));
-    } catch (err) {
-        await prepared?.kill().catch(() => {
-            // Still mark the deployment as failed if sandbox cleanup fails.
-        });
-        await markFunctionDeploymentFailed({
-            environmentId: environment.id,
-            id: deployment.id,
-            error: toFunctionDeploymentError(err)
-        });
-        sendStepError({ res, error: err, ...(err instanceof FunctionError ? {} : { status: 500 }) });
-    }
+    res.status(202).send(result.value);
 }
 
 export const postFunctionDeployment = asyncWrapperWithEnvironment<PostFunctionDeployment>(async (req, res) => {
@@ -240,3 +138,29 @@ export const postFunctionDeployment = asyncWrapperWithEnvironment<PostFunctionDe
 
     await handleDeployCode(res, body);
 });
+
+function sendDeployFunctionError(res: DeploymentResponse, error: DeployFunctionServiceError): void {
+    switch (error.code) {
+        case 'customer_api_key_required':
+            res.status(403).send({ error: { code: 'forbidden', message: error.message } });
+            return;
+        case 'integration_not_found':
+            res.status(404).send({ error: { code: 'integration_not_found', message: error.message } });
+            return;
+        case 'invalid_request':
+            res.status(400).send({ error: { code: 'invalid_request', message: error.message } });
+            return;
+        case 'function_error':
+            sendStepError({ res, error: error.cause });
+            return;
+        case 'deployment_creation_failed':
+        case 'deployment_failed':
+            sendStepError({ res, status: 500, error: error.cause });
+            return;
+        default: {
+            const exhaustiveCheck: never = error.code;
+            logger.error('Unexpected function deployment service error', { code: exhaustiveCheck });
+            res.status(500).send({ error: { code: 'server_error', message: 'Internal error' } });
+        }
+    }
+}

--- a/packages/server/lib/controllers/functions/deployments/postDeploymentResult.ts
+++ b/packages/server/lib/controllers/functions/deployments/postDeploymentResult.ts
@@ -7,10 +7,11 @@ import {
 } from '@nangohq/sandbox';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { toFunctionDeploymentError } from '../../../services/functionDeployment.service.js';
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { normalizeFunctionErrorCode } from '../errors.js';
 import { functionDeploymentParamsSchema, functionDeploymentResultBodySchema } from '../validation.js';
-import { toFunctionDeploymentError, verifyDeploymentResultSandboxToken } from './helpers.js';
+import { verifyDeploymentResultSandboxToken } from './helpers.js';
 
 import type { PostFunctionDeploymentResult } from '@nangohq/types';
 

--- a/packages/server/lib/controllers/functions/functions.integration.test.ts
+++ b/packages/server/lib/controllers/functions/functions.integration.test.ts
@@ -605,6 +605,56 @@ describe('functions public API', () => {
         expect(getRes.json).not.toHaveProperty('execution_timeout_at');
     });
 
+    it('restricts deploy sandbox tokens to deployment APIs', async () => {
+        const seed = await seedAccount(['environment:deploy']);
+        const apiKey = await createApiKeyWithScopes(seed, ['environment:deploy']);
+        const deployment = await createDeploymentSeed({ environmentId: seed.env.id, startedAt: new Date() });
+        const sandboxToken = (
+            await sandboxApiKeyService.createSandboxApiKey(db.knex, {
+                parentApiKeyId: apiKey.id,
+                environmentId: seed.env.id,
+                purpose: 'deploy',
+                deploymentId: deployment.id,
+                expiresAt: new Date(Date.now() + 60_000)
+            })
+        ).unwrap();
+        const headers = { authorization: `Bearer ${sandboxToken}` };
+
+        const proxyRes = await fetch(`${api.url}/proxy/api.github.com/user`, { headers });
+        expect(proxyRes.status).toBe(403);
+        expect(await proxyRes.json()).toStrictEqual({
+            error: { code: 'forbidden', message: 'Insufficient scope. Required: environment:proxy' }
+        });
+
+        const connectionRes = await fetch(`${api.url}/connection/connection-id`, { headers });
+        expect(connectionRes.status).toBe(403);
+        expect(await connectionRes.json()).toStrictEqual({
+            error: {
+                code: 'forbidden',
+                message: 'Insufficient scope. Required one of: environment:connections:read or environment:connections:read_credentials'
+            }
+        });
+
+        const integrationRes = await fetch(`${api.url}/integrations/integration-id`, { headers });
+        expect(integrationRes.status).toBe(403);
+        expect(await integrationRes.json()).toStrictEqual({
+            error: {
+                code: 'forbidden',
+                message: 'Insufficient scope. Required one of: environment:integrations:read or environment:integrations:read_credentials'
+            }
+        });
+
+        for (const endpoint of ['/sync/deploy/confirmation', '/sync/deploy']) {
+            const deployRes = await fetch(`${api.url}${endpoint}`, {
+                method: 'POST',
+                headers: { ...headers, 'content-type': 'application/json' },
+                body: '{}'
+            });
+            expect(deployRes.status).toBe(400);
+            expect(await deployRes.json()).toMatchObject({ error: { code: 'invalid_body' } });
+        }
+    });
+
     it('accepts POST /functions/deployments/:id/result with a sandbox token', async () => {
         const seed = await seedAccount(['environment:deploy']);
         const apiKey = await createApiKeyWithScopes(seed, ['environment:deploy']);

--- a/packages/server/lib/controllers/functions/validation.ts
+++ b/packages/server/lib/controllers/functions/validation.ts
@@ -2,9 +2,11 @@ import { z } from 'zod';
 
 import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../helpers/validation.js';
 
-const integrationIdSchema = providerConfigKeySchema.refine((value) => value !== '.' && value !== '..', {
+export const functionIntegrationIdSchema = providerConfigKeySchema.refine((value) => value !== '.' && value !== '..', {
     message: 'Integration id cannot be "." or ".."'
 });
+
+export const runnableFunctionTypeSchema = z.enum(['action', 'sync']);
 
 export const functionCompileBodySchema = z
     .object({
@@ -14,8 +16,8 @@ export const functionCompileBodySchema = z
 
 export const functionDryrunBodySchema = z
     .object({
-        integration_id: integrationIdSchema,
-        function_type: z.enum(['action', 'sync']),
+        integration_id: functionIntegrationIdSchema,
+        function_type: runnableFunctionTypeSchema,
         code: z.string().min(1),
         connection_id: connectionIdSchema,
         input: z.unknown().optional(),
@@ -62,9 +64,9 @@ export const functionDeploymentBodySchema = z.discriminatedUnion('type', [
     z
         .object({
             type: z.literal('function'),
-            integration_id: integrationIdSchema,
+            integration_id: functionIntegrationIdSchema,
             function_name: syncNameSchema,
-            function_type: z.enum(['action', 'sync']),
+            function_type: runnableFunctionTypeSchema,
             code: z.string().min(1),
             version: z.string().optional(),
             allow_destructive: z.boolean().default(false)
@@ -73,10 +75,10 @@ export const functionDeploymentBodySchema = z.discriminatedUnion('type', [
     z
         .object({
             type: z.literal('template'),
-            integration_id: integrationIdSchema,
+            integration_id: functionIntegrationIdSchema,
             template: syncNameSchema,
             // Optional: inferred from the template name unless a sync and an action share it.
-            function_type: z.enum(['action', 'sync']).optional()
+            function_type: runnableFunctionTypeSchema.optional()
         })
         .strict()
 ]);

--- a/packages/server/lib/controllers/mcp/functions/deployFunction.ts
+++ b/packages/server/lib/controllers/mcp/functions/deployFunction.ts
@@ -1,0 +1,38 @@
+import { makeAuditTarget } from '../../../audit.js';
+import * as functionDeploymentService from '../../../services/functionDeployment.service.js';
+import { defineManagementMcpTool } from '../managementTool.js';
+import { deployFunctionServiceErrorToMcp } from './errors.js';
+import { deployFunctionArgumentsSchema, deploymentCreateOutputSchema } from './schema.js';
+
+import type { DeploymentCreateOutput } from './schema.js';
+
+export const deployFunctionTool = defineManagementMcpTool<typeof deployFunctionArgumentsSchema, DeploymentCreateOutput>({
+    name: 'deploy_function',
+    description: 'Start a code function deployment and return its initial job status. This tool does not wait for the deployment to complete.',
+    inputSchema: deployFunctionArgumentsSchema,
+    outputSchema: deploymentCreateOutputSchema,
+    requiredScopes: { every: ['environment:deploy'] },
+    audit: {
+        kind: 'audit',
+        resource: 'function',
+        action: 'deployed',
+        scope: 'environment',
+        metadata: ({ args }) => ({ providerConfigKey: args.integration_id, type: args.function_type }),
+        targetFromOutput: ({ args }) => makeAuditTarget('function', args.function_name)
+    },
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false
+    },
+    async handler({ args, environment, customerApiKeyId }) {
+        return (
+            await functionDeploymentService.deployFunction({
+                environment,
+                body: { type: 'function', ...args },
+                ...(customerApiKeyId ? { parentCustomerApiKeyId: customerApiKeyId } : {})
+            })
+        ).mapError((error) => deployFunctionServiceErrorToMcp(error));
+    }
+});

--- a/packages/server/lib/controllers/mcp/functions/deployFunction.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/functions/deployFunction.unit.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import * as functionDeploymentService from '../../../services/functionDeployment.service.js';
+import { InternalMcpError, PublicMcpError } from '../utils.js';
+import { deployFunctionTool } from './deployFunction.js';
+
+import type { ManagementMcpContext } from '../managementTool.js';
+
+describe('deployFunctionTool', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('starts a function deployment with the authenticated customer API key', async () => {
+        const response = { id: deploymentId, status: 'running' as const, created_at: '2026-01-01T00:00:00.000Z' };
+        const deploySpy = vi.spyOn(functionDeploymentService, 'deployFunction').mockResolvedValue(Ok(response));
+
+        const result = await deployFunctionTool.handler(
+            {
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}',
+                version: '1.0.0',
+                allow_destructive: true
+            },
+            context
+        );
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual(response);
+        }
+        expect(deploySpy).toHaveBeenCalledWith({
+            environment: context.environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}',
+                version: '1.0.0',
+                allow_destructive: true
+            }
+        });
+    });
+
+    it.each([
+        { name: 'missing function name', args: { integration_id: 'github', function_type: 'sync', code: 'code' } },
+        { name: 'missing function type', args: { integration_id: 'github', function_name: 'issues', code: 'code' } },
+        { name: 'empty code', args: { integration_id: 'github', function_name: 'issues', function_type: 'sync', code: '' } },
+        {
+            name: 'template argument',
+            args: { integration_id: 'github', function_name: 'issues', function_type: 'sync', code: 'code', template: 'issues' }
+        },
+        { name: 'invalid integration ID', args: { integration_id: '..', function_name: 'issues', function_type: 'sync', code: 'code' } }
+    ])('rejects $name before calling the deployment service', async ({ args }) => {
+        const deploySpy = vi.spyOn(functionDeploymentService, 'deployFunction');
+
+        const result = await deployFunctionTool.handler(args, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toContain('Invalid deploy_function arguments:');
+        }
+        expect(deploySpy).not.toHaveBeenCalled();
+    });
+
+    it('returns expected deployment errors as public MCP errors', async () => {
+        vi.spyOn(functionDeploymentService, 'deployFunction').mockResolvedValue(
+            Err(
+                new functionDeploymentService.FunctionDeploymentServiceError({
+                    code: 'integration_not_found',
+                    message: "Integration 'missing' was not found"
+                })
+            )
+        );
+
+        const result = await deployFunctionTool.handler(
+            {
+                integration_id: 'missing',
+                function_name: 'issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            },
+            context
+        );
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toBe("Integration 'missing' was not found");
+        }
+    });
+
+    it('maps infrastructure deployment failures to an internal MCP error', async () => {
+        vi.spyOn(functionDeploymentService, 'deployFunction').mockResolvedValue(
+            Err(
+                new functionDeploymentService.FunctionDeploymentServiceError({
+                    code: 'deployment_failed',
+                    message: 'Failed to start function deployment',
+                    cause: new Error('sensitive sandbox failure')
+                })
+            )
+        );
+
+        const result = await deployFunctionTool.handler(
+            {
+                integration_id: 'github',
+                function_name: 'issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            },
+            context
+        );
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(InternalMcpError);
+        }
+    });
+});
+
+const deploymentId = '3c66291f-6247-47a6-a100-f4d621d751f7';
+const context = {
+    account: { id: 1 },
+    environment: { id: 42 },
+    plan: null,
+    customerApiKeyId: 7,
+    grantedScopes: ['environment:deploy']
+} as ManagementMcpContext;

--- a/packages/server/lib/controllers/mcp/functions/errors.ts
+++ b/packages/server/lib/controllers/mcp/functions/errors.ts
@@ -2,6 +2,7 @@ import { getLogger } from '@nangohq/utils';
 
 import { InternalMcpError, PublicMcpError } from '../utils.js';
 
+import type { DeployFunctionServiceError } from '../../../services/functionDeployment.service.js';
 import type { ListFunctionsError } from '@nangohq/shared';
 
 const logger = getLogger('Server.MCP.Functions');
@@ -18,6 +19,26 @@ export function listFunctionsServiceErrorToMcp(error: ListFunctionsError): Error
         default: {
             const exhaustiveCheck: never = code;
             logger.error('Unexpected ListFunctionsError code while listing functions', { code: exhaustiveCheck });
+            return new InternalMcpError();
+        }
+    }
+}
+
+export function deployFunctionServiceErrorToMcp(error: DeployFunctionServiceError): Error {
+    const code = error.code;
+    switch (code) {
+        case 'customer_api_key_required':
+        case 'integration_not_found':
+        case 'invalid_request':
+        case 'function_error':
+            return new PublicMcpError(error.message);
+        case 'deployment_creation_failed':
+        case 'deployment_failed':
+            logger.error('Failed to deploy function', { err: error });
+            return new InternalMcpError();
+        default: {
+            const exhaustiveCheck: never = code;
+            logger.error('Unexpected DeployFunctionServiceError code while deploying function', { code: exhaustiveCheck });
             return new InternalMcpError();
         }
     }

--- a/packages/server/lib/controllers/mcp/functions/schema.ts
+++ b/packages/server/lib/controllers/mcp/functions/schema.ts
@@ -1,6 +1,26 @@
 import * as z from 'zod/v4';
 
-import { functionTypeSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
+import { functionTypeSchema, providerConfigKeySchema, syncNameSchema } from '../../../helpers/validation.js';
+import { functionIntegrationIdSchema, runnableFunctionTypeSchema } from '../../functions/validation.js';
+
+export const deployFunctionArgumentsSchema = z
+    .object({
+        integration_id: functionIntegrationIdSchema,
+        function_name: syncNameSchema,
+        function_type: runnableFunctionTypeSchema,
+        code: z.string().min(1),
+        version: z.string().optional(),
+        allow_destructive: z.boolean().optional()
+    })
+    .strict();
+
+export const deploymentCreateOutputSchema = z
+    .object({
+        id: z.string().uuid(),
+        status: z.enum(['waiting', 'running', 'success', 'failed']),
+        created_at: z.iso.datetime()
+    })
+    .strict();
 
 export const listFunctionsArgumentsSchema = z
     .object({
@@ -71,3 +91,4 @@ export const listFunctionsOutputSchema = z
     .strict();
 
 export type ListFunctionsOutput = z.infer<typeof listFunctionsOutputSchema>;
+export type DeploymentCreateOutput = z.infer<typeof deploymentCreateOutputSchema>;

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -174,6 +174,7 @@ describe('POST /mcp management server', () => {
             'connections_get',
             'proxy_request',
             'functions_list',
+            'deploy_function',
             'logs_list_operations',
             'logs_get_operation'
         ]);
@@ -203,6 +204,7 @@ describe('POST /mcp management server', () => {
             'connections_get',
             'proxy_request',
             'functions_list',
+            'deploy_function',
             'logs_list_operations',
             'logs_get_operation'
         ];
@@ -386,6 +388,69 @@ describe('POST /mcp management server', () => {
         });
         expect(missing.json.result).toStrictEqual({
             content: [{ type: 'text', text: 'Integration does not exist' }],
+            isError: true
+        });
+    });
+
+    it('lists the function deployment tool with deploy scope', async () => {
+        const { secret } = await createKeyWithScopes(['environment:deploy']);
+        const res = await mcpPost({
+            token: secret,
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools).toMatchObject([
+            {
+                name: 'deploy_function',
+                annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false }
+            }
+        ]);
+    });
+
+    it('returns public errors for invalid function deployment arguments and missing integrations', async () => {
+        const { secret } = await createKeyWithScopes(['environment:deploy']);
+
+        const invalid = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'deploy_function',
+                    arguments: {
+                        integration_id: 'airtable',
+                        function_name: 'tables',
+                        function_type: 'sync',
+                        code: 'export default {}',
+                        template: 'not allowed'
+                    }
+                }
+            }
+        });
+        expect(invalid.json.result).toMatchObject({ isError: true });
+        expect(invalid.json.result.content[0].text).toContain('Invalid arguments for tool deploy_function');
+
+        const missing = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 2,
+                method: 'tools/call',
+                params: {
+                    name: 'deploy_function',
+                    arguments: {
+                        integration_id: 'missing',
+                        function_name: 'sync-issues',
+                        function_type: 'sync',
+                        code: 'export default {}'
+                    }
+                }
+            }
+        });
+        expect(missing.json.result).toStrictEqual({
+            content: [{ type: 'text', text: "Integration 'missing' was not found" }],
             isError: true
         });
     });

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -400,7 +400,7 @@ describe('POST /mcp management server', () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.json.result.tools).toMatchObject([
+        expect(withoutDocsTools(res.json.result.tools)).toMatchObject([
             {
                 name: 'deploy_function',
                 annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false }

--- a/packages/server/lib/controllers/mcp/management.ts
+++ b/packages/server/lib/controllers/mcp/management.ts
@@ -14,6 +14,7 @@ export const postManagementMcp = asyncWrapperWithEnvironment<PostManagementMcp>(
         environment,
         plan,
         grantedScopes: res.locals['apiKeyPrincipal']?.scopes,
+        ...(res.locals['apiKeyAuthSource'] === 'customer_key' && res.locals['apiKeyId'] ? { customerApiKeyId: res.locals['apiKeyId'] } : {}),
         audit: resolveAuditAttribution(req, res.locals)
     };
     const server = createManagementMcpServer(context, req.body);

--- a/packages/server/lib/controllers/mcp/management.ts
+++ b/packages/server/lib/controllers/mcp/management.ts
@@ -4,6 +4,7 @@ import { resolveAuditAttribution } from '../../middleware/audit.middleware.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { createManagementMcpServer } from './managementServer.js';
 
+import type { RequestLocalsWithEnvironment } from '../../utils/express.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { GetManagementMcp, PostManagementMcp } from '@nangohq/types';
 
@@ -14,7 +15,7 @@ export const postManagementMcp = asyncWrapperWithEnvironment<PostManagementMcp>(
         environment,
         plan,
         grantedScopes: res.locals['apiKeyPrincipal']?.scopes,
-        ...(res.locals['apiKeyAuthSource'] === 'customer_key' && res.locals['apiKeyId'] ? { customerApiKeyId: res.locals['apiKeyId'] } : {}),
+        customerApiKeyId: getCustomerApiKeyId(res.locals),
         audit: resolveAuditAttribution(req, res.locals)
     };
     const server = createManagementMcpServer(context, req.body);
@@ -42,3 +43,7 @@ export const getManagementMcp = asyncWrapperWithEnvironment<GetManagementMcp>((_
         })
     );
 });
+
+function getCustomerApiKeyId(locals: RequestLocalsWithEnvironment): number | undefined {
+    return locals.apiKeyAuthSource === 'customer_key' ? locals.apiKeyId : undefined;
+}

--- a/packages/server/lib/controllers/mcp/managementServer.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.ts
@@ -11,6 +11,7 @@ import { listConnectionsTool } from './connections/list.js';
 import { createConnectSessionTool } from './connectSessions/create.js';
 import { queryDocsFilesystemTool } from './docs/queryFilesystem.js';
 import { searchDocsTool } from './docs/search.js';
+import { deployFunctionTool } from './functions/deployFunction.js';
 import { listFunctionsTool } from './functions/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { deleteIntegrationsTool } from './integrations/delete.js';
@@ -43,6 +44,7 @@ const managementMcpTools: ManagementMcpTool[] = [
     getConnectionsTool,
     proxyRequestTool,
     listFunctionsTool,
+    deployFunctionTool,
     listLogOperationsTool,
     getLogOperationTool
 ];

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -9,6 +9,7 @@ import { audit } from '../../audit.js';
 import { getConnectionsTool } from './connections/get.js';
 import { listConnectionsTool } from './connections/list.js';
 import { createConnectSessionTool } from './connectSessions/create.js';
+import { deployFunctionTool } from './functions/deployFunction.js';
 import { listFunctionsTool } from './functions/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { deleteIntegrationsTool } from './integrations/delete.js';
@@ -71,6 +72,10 @@ describe('createManagementMcpServer', () => {
                     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
                 },
                 { name: 'functions_list', annotations: { readOnlyHint: true } },
+                {
+                    name: 'deploy_function',
+                    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false }
+                },
                 { name: 'logs_list_operations', annotations: { readOnlyHint: true } },
                 { name: 'logs_get_operation', annotations: { readOnlyHint: true } }
             ]);
@@ -572,6 +577,83 @@ describe('createManagementMcpServer', () => {
 
         try {
             const result = await client.callTool({ name: 'functions_list', arguments: { integration_id: 'github' } });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],
+                structuredContent: response
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('exposes the function deployment tool', async () => {
+        const authorized = await createTestClient(['environment:deploy']);
+        try {
+            const result = await authorized.client.listTools();
+            expect(result.tools).toHaveLength(1);
+            expect(result.tools).toMatchObject([
+                {
+                    name: 'deploy_function',
+                    inputSchema: {
+                        type: 'object',
+                        required: ['integration_id', 'function_name', 'function_type', 'code'],
+                        additionalProperties: false
+                    },
+                    outputSchema: {
+                        type: 'object',
+                        required: ['id', 'status', 'created_at'],
+                        additionalProperties: false
+                    }
+                }
+            ]);
+        } finally {
+            await authorized.client.close();
+            await authorized.server.close();
+        }
+
+        const handlerSpy = vi.spyOn(deployFunctionTool, 'handler');
+        const unauthorized = await createTestClient(['environment:functions:*']);
+        try {
+            const result = await unauthorized.client.callTool({
+                name: 'deploy_function',
+                arguments: { integration_id: 'github', function_name: 'issues', function_type: 'sync', code: 'code' }
+            });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: 'MCP error -32602: Tool deploy_function disabled' }],
+                isError: true
+            });
+            expect(handlerSpy).not.toHaveBeenCalled();
+        } finally {
+            handlerSpy.mockRestore();
+            await unauthorized.client.close();
+            await unauthorized.server.close();
+        }
+    });
+
+    it('returns function deployment results as JSON text and structured content', async () => {
+        const response = {
+            id: '3c66291f-6247-47a6-a100-f4d621d751f7',
+            status: 'running' as const,
+            created_at: '2026-01-01T00:00:00.000Z'
+        };
+        const handlerSpy = vi.spyOn(deployFunctionTool, 'handler').mockResolvedValueOnce(Ok(response));
+        const { client, server } = await createTestClient(['environment:deploy']);
+
+        try {
+            const result = await client.callTool({
+                name: 'deploy_function',
+                arguments: {
+                    integration_id: 'github',
+                    function_name: 'sync-issues',
+                    function_type: 'sync',
+                    code: 'export default {}'
+                }
+            });
 
             expect(result).toStrictEqual({
                 content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -594,8 +594,9 @@ describe('createManagementMcpServer', () => {
         const authorized = await createTestClient(['environment:deploy']);
         try {
             const result = await authorized.client.listTools();
-            expect(result.tools).toHaveLength(1);
-            expect(result.tools).toMatchObject([
+            const scopedTools = withoutDocsTools(result.tools);
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools).toMatchObject([
                 {
                     name: 'deploy_function',
                     inputSchema: {

--- a/packages/server/lib/controllers/mcp/managementTool.ts
+++ b/packages/server/lib/controllers/mcp/managementTool.ts
@@ -16,6 +16,7 @@ export interface ManagementMcpContext {
     environment: DBEnvironment;
     plan: DBPlan | null;
     grantedScopes: string[] | undefined;
+    customerApiKeyId?: number | undefined;
     audit?: AuditAttribution | undefined;
 }
 

--- a/packages/server/lib/services/functionDeployment.service.ts
+++ b/packages/server/lib/services/functionDeployment.service.ts
@@ -1,0 +1,196 @@
+import db from '@nangohq/database';
+import {
+    createFunctionDeployment,
+    deploySandboxTimeoutMs,
+    FunctionError,
+    markFunctionDeploymentFailed,
+    markFunctionDeploymentRunning,
+    prepareAsyncDeploy,
+    sandboxApiKeyService,
+    toFunctionDeploymentCreate
+} from '@nangohq/sandbox';
+import { configService, getSyncConfigRaw } from '@nangohq/shared';
+import { baseUrl, Err, Ok, stringifyError } from '@nangohq/utils';
+
+import type { FunctionDeploymentError } from '@nangohq/sandbox';
+import type { DBEnvironment, DBSyncConfig, FunctionDeploymentCodeBody, FunctionDeploymentCreateSuccess } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
+
+export type DeployFunctionServiceErrorCode =
+    | 'customer_api_key_required'
+    | 'integration_not_found'
+    | 'invalid_request'
+    | 'deployment_creation_failed'
+    | 'function_error'
+    | 'deployment_failed';
+
+type FunctionDeploymentServiceErrorCode = DeployFunctionServiceErrorCode;
+
+export class FunctionDeploymentServiceError<TCode extends FunctionDeploymentServiceErrorCode = FunctionDeploymentServiceErrorCode> extends Error {
+    public readonly code: TCode;
+
+    constructor({ code, message, cause }: { code: TCode; message: string; cause?: unknown }) {
+        super(message, { cause });
+        this.name = 'FunctionDeploymentServiceError';
+        this.code = code;
+    }
+}
+
+export type DeployFunctionServiceError = FunctionDeploymentServiceError<DeployFunctionServiceErrorCode>;
+
+export interface DeployFunctionParams {
+    environment: DBEnvironment;
+    body: FunctionDeploymentCodeBody;
+    parentCustomerApiKeyId?: number | undefined;
+}
+
+export async function deployFunction({
+    environment,
+    body,
+    parentCustomerApiKeyId
+}: DeployFunctionParams): Promise<Result<FunctionDeploymentCreateSuccess, DeployFunctionServiceError>> {
+    if (!parentCustomerApiKeyId) {
+        return Err(
+            new FunctionDeploymentServiceError({
+                code: 'customer_api_key_required',
+                message: 'Function deployments can only be started from a customer API key'
+            })
+        );
+    }
+
+    const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
+    if (!providerConfig?.id) {
+        return Err(
+            new FunctionDeploymentServiceError({
+                code: 'integration_not_found',
+                message: `Integration '${body.integration_id}' was not found`
+            })
+        );
+    }
+
+    const existingSyncConfig = await getSyncConfigRaw({
+        environmentId: environment.id,
+        config_id: providerConfig.id,
+        name: body.function_name,
+        isAction: body.function_type === 'action'
+    });
+
+    if (isProtectedExistingFunction(existingSyncConfig)) {
+        return Err(
+            new FunctionDeploymentServiceError({
+                code: 'invalid_request',
+                message: `Cannot overwrite existing function '${body.function_name}'`
+            })
+        );
+    }
+
+    const allowDestructiveDeploy = shouldAllowDestructiveDeploy(existingSyncConfig, body.allow_destructive ?? false);
+    const deploymentResult = await createFunctionDeployment({
+        environmentId: environment.id,
+        request: {
+            type: 'function',
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            code: body.code,
+            ...(body.version ? { version: body.version } : {}),
+            allow_destructive: allowDestructiveDeploy
+        }
+    });
+    if (deploymentResult.isErr()) {
+        return Err(
+            new FunctionDeploymentServiceError({
+                code: 'deployment_creation_failed',
+                message: 'Failed to create function deployment',
+                cause: deploymentResult.error
+            })
+        );
+    }
+
+    const deployment = deploymentResult.value;
+    let prepared: Awaited<ReturnType<typeof prepareAsyncDeploy>> | null = null;
+    try {
+        const sandboxApiKey = await createDeploySandboxApiKey(parentCustomerApiKeyId, environment.id, deployment.id);
+        if (sandboxApiKey.isErr()) {
+            throw sandboxApiKey.error;
+        }
+
+        const callbackUrl = new URL(`/functions/deployments/${deployment.id}/result`, baseUrl).toString();
+        prepared = await prepareAsyncDeploy({
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            code: body.code,
+            environment_name: environment.name,
+            nango_secret_key: sandboxApiKey.value,
+            nango_host: baseUrl,
+            deployment_id: deployment.id,
+            callback_url: callbackUrl,
+            ...(body.version ? { version: body.version } : {}),
+            allow_destructive: allowDestructiveDeploy
+        });
+
+        const running = await markFunctionDeploymentRunning({
+            environmentId: environment.id,
+            id: deployment.id,
+            sandboxId: prepared.sandboxId,
+            startedAt: prepared.startedAt,
+            executionTimeoutAt: prepared.executionTimeoutAt
+        });
+        if (!running) {
+            throw new Error(`Failed to mark function deployment '${deployment.id}' as running`);
+        }
+
+        await prepared.start();
+        return Ok(toFunctionDeploymentCreate(running));
+    } catch (err) {
+        await prepared?.kill().catch(() => {
+            // Still mark the deployment as failed if sandbox cleanup fails.
+        });
+        await markFunctionDeploymentFailed({
+            environmentId: environment.id,
+            id: deployment.id,
+            error: toFunctionDeploymentError(err)
+        });
+
+        if (err instanceof FunctionError) {
+            return Err(new FunctionDeploymentServiceError({ code: 'function_error', message: err.message, cause: err }));
+        }
+        return Err(new FunctionDeploymentServiceError({ code: 'deployment_failed', message: 'Failed to start function deployment', cause: err }));
+    }
+}
+
+export function toFunctionDeploymentError(err: unknown): FunctionDeploymentError {
+    if (err instanceof FunctionError) {
+        return {
+            code: err.code,
+            message: err.message,
+            ...(err.payload !== undefined ? { payload: err.payload } : {})
+        };
+    }
+
+    return {
+        code: 'deployment_error',
+        message: stringifyError(err)
+    };
+}
+
+function isProtectedExistingFunction(existingSyncConfig: Pick<DBSyncConfig, 'source'> | null): boolean {
+    return Boolean(existingSyncConfig && existingSyncConfig.source !== 'standalone');
+}
+
+function shouldAllowDestructiveDeploy(existingSyncConfig: Pick<DBSyncConfig, 'source'> | null, allowDestructive: boolean): boolean {
+    return Boolean(allowDestructive && existingSyncConfig?.source === 'standalone');
+}
+
+async function createDeploySandboxApiKey(parentApiKeyId: number, environmentId: number, deploymentId: string) {
+    return await sandboxApiKeyService.createSandboxApiKey(db.knex, {
+        parentApiKeyId,
+        environmentId,
+        purpose: 'deploy',
+        deploymentId,
+        expiresAt: new Date(Date.now() + deploySandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
+    });
+}

--- a/packages/server/lib/services/functionDeployment.service.unit.test.ts
+++ b/packages/server/lib/services/functionDeployment.service.unit.test.ts
@@ -162,6 +162,103 @@ describe('functionDeploymentService', () => {
         expect(configSpy).not.toHaveBeenCalled();
     });
 
+    it('returns integration_not_found before reading or creating deployment state', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue(null);
+        const getSyncConfigSpy = vi.spyOn(shared, 'getSyncConfigRaw');
+        const createSpy = vi.spyOn(sandbox, 'createFunctionDeployment');
+
+        const result = await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'missing',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({ code: 'integration_not_found', message: "Integration 'missing' was not found" });
+        }
+        expect(getSyncConfigSpy).not.toHaveBeenCalled();
+        expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns deployment_creation_failed without preparing a sandbox', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
+        vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue(null);
+        const failure = new Error('database unavailable');
+        vi.spyOn(sandbox, 'createFunctionDeployment').mockResolvedValue(Err(failure));
+        const createSandboxApiKeySpy = vi.spyOn(sandbox.sandboxApiKeyService, 'createSandboxApiKey');
+        const prepareSpy = vi.spyOn(sandbox, 'prepareAsyncDeploy');
+
+        const result = await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({
+                code: 'deployment_creation_failed',
+                message: 'Failed to create function deployment',
+                cause: failure
+            });
+        }
+        expect(createSandboxApiKeySpy).not.toHaveBeenCalled();
+        expect(prepareSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns function_error and preserves the function error payload in the failed deployment', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
+        vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue(null);
+        vi.spyOn(sandbox, 'createFunctionDeployment').mockResolvedValue(
+            Ok({
+                id: deploymentId,
+                status: 'waiting',
+                created_at: '2026-01-01T00:00:00.000Z'
+            })
+        );
+        vi.spyOn(sandbox.sandboxApiKeyService, 'createSandboxApiKey').mockResolvedValue(Ok('sandbox-api-key'));
+        const payload = { diagnostics: [{ line: 4, message: 'Type mismatch' }] };
+        const failure = new sandbox.FunctionError({ code: 'compilation_error', message: 'Compilation failed', status: 400, payload });
+        vi.spyOn(sandbox, 'prepareAsyncDeploy').mockRejectedValue(failure);
+        const failedSpy = vi.spyOn(sandbox, 'markFunctionDeploymentFailed').mockResolvedValue(null);
+
+        const result = await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({ code: 'function_error', message: 'Compilation failed' });
+            expect(result.error.cause).toBe(failure);
+        }
+        expect(failedSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            id: deploymentId,
+            error: { code: 'compilation_error', message: 'Compilation failed', payload }
+        });
+    });
+
     it('marks the deployment failed and cleans up when the sandbox cannot start', async () => {
         vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
         vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue(null);

--- a/packages/server/lib/services/functionDeployment.service.unit.test.ts
+++ b/packages/server/lib/services/functionDeployment.service.unit.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as sandbox from '@nangohq/sandbox';
+import * as shared from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import { deployFunction } from './functionDeployment.service.js';
+
+import type { DBFunctionDeployment } from '@nangohq/sandbox';
+import type { Config } from '@nangohq/shared';
+import type { DBEnvironment, DBSyncConfig } from '@nangohq/types';
+
+describe('functionDeploymentService', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('starts a single function deployment and returns its initial job state', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
+        vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue(null);
+        const createSpy = vi
+            .spyOn(sandbox, 'createFunctionDeployment')
+            .mockResolvedValue(Ok({ id: deploymentId, status: 'waiting', created_at: '2026-01-01T00:00:00.000Z' }));
+        vi.spyOn(sandbox.sandboxApiKeyService, 'createSandboxApiKey').mockResolvedValue(Ok('sandbox-api-key'));
+        const start = vi.fn().mockResolvedValue(undefined);
+        const kill = vi.fn().mockResolvedValue(undefined);
+        const startedAt = new Date('2026-01-01T00:00:01.000Z');
+        const executionTimeoutAt = new Date('2026-01-01T00:05:31.000Z');
+        const prepareSpy = vi.spyOn(sandbox, 'prepareAsyncDeploy').mockResolvedValue({
+            sandboxId: 'sandbox-id',
+            startedAt,
+            executionTimeoutAt,
+            start,
+            kill
+        });
+        const runningRow = { id: deploymentId, job_type: 'deployment', status: 'running' } as DBFunctionDeployment;
+        const runningSpy = vi.spyOn(sandbox, 'markFunctionDeploymentRunning').mockResolvedValue(runningRow);
+        vi.spyOn(sandbox, 'toFunctionDeploymentCreate').mockReturnValue({
+            id: deploymentId,
+            status: 'running',
+            created_at: '2026-01-01T00:00:00.000Z'
+        });
+
+        const result = await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}',
+                version: '1.0.0',
+                allow_destructive: true
+            }
+        });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({
+                id: deploymentId,
+                status: 'running',
+                created_at: '2026-01-01T00:00:00.000Z'
+            });
+        }
+        expect(createSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            request: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}',
+                version: '1.0.0',
+                allow_destructive: false
+            }
+        });
+        expect(prepareSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                deployment_id: deploymentId,
+                nango_secret_key: 'sandbox-api-key',
+                allow_destructive: false
+            })
+        );
+        expect(runningSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            id: deploymentId,
+            sandboxId: 'sandbox-id',
+            startedAt,
+            executionTimeoutAt
+        });
+        expect(start).toHaveBeenCalledOnce();
+        expect(kill).not.toHaveBeenCalled();
+    });
+
+    it('allows a destructive deployment only for an existing standalone function', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
+        vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue({ source: 'standalone' } as DBSyncConfig);
+        const createSpy = vi.spyOn(sandbox, 'createFunctionDeployment').mockResolvedValue(Err(new Error('stop after request assertion')));
+
+        await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}',
+                allow_destructive: true
+            }
+        });
+
+        expect(createSpy).toHaveBeenCalledOnce();
+        expect(createSpy.mock.calls.at(0)?.[0]).toMatchObject({ environmentId: 42, request: { allow_destructive: true } });
+    });
+
+    it('rejects repo-managed functions before creating a deployment job', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
+        vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue({ source: 'repo' } as DBSyncConfig);
+        const createSpy = vi.spyOn(sandbox, 'createFunctionDeployment');
+
+        const result = await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({ code: 'invalid_request', message: "Cannot overwrite existing function 'sync-issues'" });
+        }
+        expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it('requires a customer API key before starting a single function deployment', async () => {
+        const configSpy = vi.spyOn(shared.configService, 'getProviderConfig');
+
+        const result = await deployFunction({
+            environment,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.code).toBe('customer_api_key_required');
+        }
+        expect(configSpy).not.toHaveBeenCalled();
+    });
+
+    it('marks the deployment failed and cleans up when the sandbox cannot start', async () => {
+        vi.spyOn(shared.configService, 'getProviderConfig').mockResolvedValue({ id: 12 } as Config);
+        vi.spyOn(shared, 'getSyncConfigRaw').mockResolvedValue(null);
+        vi.spyOn(sandbox, 'createFunctionDeployment').mockResolvedValue(Ok({ id: deploymentId, status: 'waiting', created_at: '2026-01-01T00:00:00.000Z' }));
+        vi.spyOn(sandbox.sandboxApiKeyService, 'createSandboxApiKey').mockResolvedValue(Ok('sandbox-api-key'));
+        const failure = new Error('sandbox failed');
+        const start = vi.fn().mockRejectedValue(failure);
+        const kill = vi.fn().mockResolvedValue(undefined);
+        vi.spyOn(sandbox, 'prepareAsyncDeploy').mockResolvedValue({
+            sandboxId: 'sandbox-id',
+            startedAt: new Date(),
+            executionTimeoutAt: new Date(),
+            start,
+            kill
+        });
+        vi.spyOn(sandbox, 'markFunctionDeploymentRunning').mockResolvedValue({ id: deploymentId } as DBFunctionDeployment);
+        const failedSpy = vi.spyOn(sandbox, 'markFunctionDeploymentFailed').mockResolvedValue(null);
+
+        const result = await deployFunction({
+            environment,
+            parentCustomerApiKeyId: 7,
+            body: {
+                type: 'function',
+                integration_id: 'github',
+                function_name: 'sync-issues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({ code: 'deployment_failed', cause: failure });
+        }
+        expect(kill).toHaveBeenCalledOnce();
+        expect(failedSpy).toHaveBeenCalledWith({
+            environmentId: 42,
+            id: deploymentId,
+            error: { code: 'deployment_error', message: '{"name":"Error","message":"sandbox failed"}' }
+        });
+    });
+});
+
+const deploymentId = '3c66291f-6247-47a6-a100-f4d621d751f7';
+const environment = { id: 42, name: 'dev' } as DBEnvironment;

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -408,6 +408,56 @@ describe('Account service', () => {
         });
     });
 
+    it('should restrict deploy sandbox API keys to the current parent deploy scope', async () => {
+        const account = await createTestAccount();
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
+        if (!environment) {
+            throw new Error('Failed to create test environment');
+        }
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+        const parentKey = (
+            await customerKeyService.createApiKey(db.knex, {
+                accountId: account.id,
+                environmentId: environment.id,
+                displayName: `sandbox-deploy-parent-${uuid()}`,
+                scopes: ['environment:deploy', 'environment:records:read']
+            })
+        ).unwrap();
+        const signingSecret = decryptSandboxSigningSecret(parentKey);
+        if (!signingSecret) {
+            throw new Error('Failed to decrypt sandbox signing secret');
+        }
+        const deploymentId = '00000000-0000-4000-8000-000000000002';
+        const sandboxToken = createSandboxApiKeyToken({
+            parentApiKeyId: parentKey.id,
+            signingSecret,
+            purpose: 'deploy',
+            deploymentId,
+            expiresAt: new Date(Date.now() + 60 * 1000)
+        });
+
+        const bySecretKey = await accountService.getAccountContext({ secretKey: sandboxToken });
+
+        expect(bySecretKey?.auth).toStrictEqual({
+            source: 'sandbox_token',
+            scopes: ['environment:deploy'],
+            apiKeyId: parentKey.id,
+            purpose: 'deploy',
+            deploymentId
+        });
+
+        await customerKeyService.updateApiKeyScopes(db.knex, parentKey.id, ['environment:records:read'], environment.id);
+
+        const afterDeployScopeRemoval = await accountService.getAccountContext({ secretKey: sandboxToken });
+        expect(afterDeployScopeRemoval?.auth).toStrictEqual({
+            source: 'sandbox_token',
+            scopes: [],
+            apiKeyId: parentKey.id,
+            purpose: 'deploy',
+            deploymentId
+        });
+    });
+
     it('should return null when sandbox API key token is expired', async () => {
         const account = await createTestAccount();
         const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -644,18 +644,19 @@ class AccountService {
 
             const defaultSecret = getEncryptionManager().decryptAPISecret(row.default_secret);
             const pendingKey = row.pending_secret ? getEncryptionManager().decryptAPISecret(row.pending_secret) : null;
+            const scopes = buildSandboxApiKeyScopes({ purpose: verified.purpose, parentScopes: row.auth_scopes });
             const auth =
                 verified.purpose === 'dryrun'
                     ? {
                           source: 'sandbox_token' as const,
-                          scopes: buildSandboxApiKeyScopes(row.auth_scopes),
+                          scopes,
                           apiKeyId: row.auth_api_key_id,
                           purpose: verified.purpose,
                           dryrunId: verified.dryrun_id
                       }
                     : {
                           source: 'sandbox_token' as const,
-                          scopes: buildSandboxApiKeyScopes(row.auth_scopes),
+                          scopes,
                           apiKeyId: row.auth_api_key_id,
                           purpose: verified.purpose,
                           deploymentId: verified.deployment_id

--- a/packages/shared/lib/services/sandbox-api-key.ts
+++ b/packages/shared/lib/services/sandbox-api-key.ts
@@ -2,6 +2,8 @@ import crypto from 'node:crypto';
 
 import jwt from 'jsonwebtoken';
 
+import { hasApiKeyScope } from '@nangohq/utils';
+
 import { getEncryptionManager } from '../utils/encryption.manager.js';
 
 import type { ApiKeyScope, DBCustomerKey } from '@nangohq/types';
@@ -66,7 +68,21 @@ export function isSandboxApiKey(secret: string): boolean {
     return secret.startsWith(sandboxApiKeyPrefix);
 }
 
-export function buildSandboxApiKeyScopes(parentScopes: string[] | null | undefined): ApiKeyScope[] {
+export function buildSandboxApiKeyScopes({
+    purpose,
+    parentScopes
+}: {
+    purpose: SandboxApiKeyPurpose;
+    parentScopes: string[] | null | undefined;
+}): ApiKeyScope[] {
+    if (purpose === 'deploy') {
+        return hasApiKeyScope({ grantedScopes: parentScopes ?? undefined, requiredScope: 'environment:deploy' }) ? ['environment:deploy'] : [];
+    }
+
+    return buildDryrunSandboxApiKeyScopes(parentScopes);
+}
+
+function buildDryrunSandboxApiKeyScopes(parentScopes: string[] | null | undefined): ApiKeyScope[] {
     const scopes = new Set<string>();
 
     for (const scope of parentScopes ?? []) {


### PR DESCRIPTION
Adds the deploy_function Management MCP tool for starting asynchronous code deployments. Extracts the existing code-deployment flow into a reusable service shared by HTTP and MCP callers. 

NAN-6315

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

