### PR TITLE
feat(mcp): add deployment status tool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -13011,13 +13011,14 @@ The tool accepts JSON and UTF-8 text responses up to 5 MB (5,000,000 bytes). Uns
 
 ### Functions
 
-Use the Functions tools to inspect and deploy functions in the authenticated Nango environment. `deploy_function` and `deploy_template` start distinct deployment paths.
+Use the Functions tools to inspect and deploy functions in the authenticated Nango environment. `deploy_function` and `deploy_template` start distinct deployment paths. Use `get_deployment_status` to check whether a deployment has finished.
 
-| Tool              | Description                                                                    | Required API key scope        |
-| ----------------- | ------------------------------------------------------------------------------ | ----------------------------- |
-| `functions_list`  | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
-| `deploy_function` | Start a code function deployment.                                              | `environment:deploy`          |
-| `deploy_template` | Deploy a function template.                                                    | `environment:deploy`          |
+| Tool                    | Description                                                                    | Required API key scope        |
+| ----------------------- | ------------------------------------------------------------------------------ | ----------------------------- |
+| `functions_list`        | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+| `deploy_function`       | Start a code function deployment.                                              | `environment:deploy`          |
+| `deploy_template`       | Deploy a function template.                                                    | `environment:deploy`          |
+| `get_deployment_status` | Retrieve a deployment's current status and result.                             | `environment:deploy`          |
 
 ### Logs
 

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -87,13 +87,14 @@ The tool accepts JSON and UTF-8 text responses up to 5 MB (5,000,000 bytes). Uns
 
 ### Functions
 
-Use the Functions tools to inspect and deploy functions in the authenticated Nango environment. `deploy_function` and `deploy_template` start distinct deployment paths.
+Use the Functions tools to inspect and deploy functions in the authenticated Nango environment. `deploy_function` and `deploy_template` start distinct deployment paths. Use `get_deployment_status` to check whether a deployment has finished.
 
-| Tool              | Description                                                                    | Required API key scope        |
-| ----------------- | ------------------------------------------------------------------------------ | ----------------------------- |
-| `functions_list`  | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
-| `deploy_function` | Start a code function deployment.                                              | `environment:deploy`          |
-| `deploy_template` | Deploy a function template.                                                    | `environment:deploy`          |
+| Tool                    | Description                                                                    | Required API key scope        |
+| ----------------------- | ------------------------------------------------------------------------------ | ----------------------------- |
+| `functions_list`        | List and filter deployed syncs, actions, and on-event scripts by integration. | `environment:functions:list` |
+| `deploy_function`       | Start a code function deployment.                                              | `environment:deploy`          |
+| `deploy_template`       | Deploy a function template.                                                    | `environment:deploy`          |
+| `get_deployment_status` | Retrieve a deployment's current status and result.                             | `environment:deploy`          |
 
 ### Logs
 

--- a/packages/server/lib/controllers/mcp/functions/deployFunction.ts
+++ b/packages/server/lib/controllers/mcp/functions/deployFunction.ts
@@ -8,7 +8,8 @@ import type { DeploymentCreateOutput } from './schema.js';
 
 export const deployFunctionTool = defineManagementMcpTool<typeof deployFunctionArgumentsSchema, DeploymentCreateOutput>({
     name: 'deploy_function',
-    description: 'Start a code function deployment and return its initial job status. This tool does not wait for the deployment to complete.',
+    description:
+        'Start a code function deployment and return its initial job status. This tool does not wait for completion; use get_deployment_status to retrieve the final status.',
     inputSchema: deployFunctionArgumentsSchema,
     outputSchema: deploymentCreateOutputSchema,
     requiredScopes: { every: ['environment:deploy'] },

--- a/packages/server/lib/controllers/mcp/functions/errors.ts
+++ b/packages/server/lib/controllers/mcp/functions/errors.ts
@@ -2,7 +2,7 @@ import { getLogger } from '@nangohq/utils';
 
 import { InternalMcpError, PublicMcpError } from '../utils.js';
 
-import type { DeployFunctionServiceError, DeployTemplateServiceError } from '../../../services/functionDeployment.service.js';
+import type { DeployFunctionServiceError, DeployTemplateServiceError, GetDeploymentStatusServiceError } from '../../../services/functionDeployment.service.js';
 import type { ListFunctionsError } from '@nangohq/shared';
 
 const logger = getLogger('Server.MCP.Functions');
@@ -61,6 +61,22 @@ export function deployTemplateServiceErrorToMcp(error: DeployTemplateServiceErro
         default: {
             const exhaustiveCheck: never = code;
             logger.error('Unexpected DeployTemplateServiceError code while deploying template', { code: exhaustiveCheck });
+            return new InternalMcpError();
+        }
+    }
+}
+
+export function getDeploymentStatusServiceErrorToMcp(error: GetDeploymentStatusServiceError): Error {
+    const code = error.code;
+    switch (code) {
+        case 'deployment_not_found':
+            return new PublicMcpError(error.message);
+        case 'deployment_status_failed':
+            logger.error('Failed to retrieve function deployment status', { err: error });
+            return new InternalMcpError();
+        default: {
+            const exhaustiveCheck: never = code;
+            logger.error('Unexpected GetDeploymentStatusServiceError code while retrieving deployment status', { code: exhaustiveCheck });
             return new InternalMcpError();
         }
     }

--- a/packages/server/lib/controllers/mcp/functions/getDeploymentStatus.ts
+++ b/packages/server/lib/controllers/mcp/functions/getDeploymentStatus.ts
@@ -1,0 +1,26 @@
+import * as functionDeploymentService from '../../../services/functionDeployment.service.js';
+import { defineManagementMcpTool } from '../managementTool.js';
+import { getDeploymentStatusServiceErrorToMcp } from './errors.js';
+import { deploymentStatusOutputSchema, getDeploymentStatusArgumentsSchema } from './schema.js';
+
+import type { DeploymentStatusOutput } from './schema.js';
+
+export const getDeploymentStatusTool = defineManagementMcpTool<typeof getDeploymentStatusArgumentsSchema, DeploymentStatusOutput>({
+    name: 'get_deployment_status',
+    description: 'Retrieve a function deployment by ID to check whether it is still running, succeeded, or failed.',
+    inputSchema: getDeploymentStatusArgumentsSchema,
+    outputSchema: deploymentStatusOutputSchema,
+    requiredScopes: { every: ['environment:deploy'] },
+    audit: { kind: 'no-audit', reason: 'read-only' },
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
+    },
+    async handler({ args, environment }) {
+        return (await functionDeploymentService.getDeploymentStatus({ environment, id: args.id })).mapError((error) =>
+            getDeploymentStatusServiceErrorToMcp(error)
+        );
+    }
+});

--- a/packages/server/lib/controllers/mcp/functions/getDeploymentStatus.ts
+++ b/packages/server/lib/controllers/mcp/functions/getDeploymentStatus.ts
@@ -1,15 +1,15 @@
 import * as functionDeploymentService from '../../../services/functionDeployment.service.js';
 import { defineManagementMcpTool } from '../managementTool.js';
 import { getDeploymentStatusServiceErrorToMcp } from './errors.js';
-import { deploymentStatusOutputSchema, getDeploymentStatusArgumentsSchema } from './schema.js';
+import { getDeploymentStatusArgumentsSchema, getDeploymentStatusOutputSchema } from './schema.js';
 
-import type { DeploymentStatusOutput } from './schema.js';
+import type { GetDeploymentStatusOutput } from './schema.js';
 
-export const getDeploymentStatusTool = defineManagementMcpTool<typeof getDeploymentStatusArgumentsSchema, DeploymentStatusOutput>({
+export const getDeploymentStatusTool = defineManagementMcpTool<typeof getDeploymentStatusArgumentsSchema, GetDeploymentStatusOutput>({
     name: 'get_deployment_status',
     description: 'Retrieve a function deployment by ID to check whether it is still running, succeeded, or failed.',
     inputSchema: getDeploymentStatusArgumentsSchema,
-    outputSchema: deploymentStatusOutputSchema,
+    outputSchema: getDeploymentStatusOutputSchema,
     requiredScopes: { every: ['environment:deploy'] },
     audit: { kind: 'no-audit', reason: 'read-only' },
     annotations: {

--- a/packages/server/lib/controllers/mcp/functions/getDeploymentStatus.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/functions/getDeploymentStatus.unit.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import * as functionDeploymentService from '../../../services/functionDeployment.service.js';
+import { InternalMcpError, PublicMcpError } from '../utils.js';
+import { getDeploymentStatusTool } from './getDeploymentStatus.js';
+
+import type { ManagementMcpContext } from '../managementTool.js';
+
+describe('getDeploymentStatusTool', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the current deployment status', async () => {
+        const response = {
+            id: deploymentId,
+            status: 'success' as const,
+            integration_id: 'github',
+            function_name: 'sync-issues',
+            function_type: 'sync' as const,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:01:00.000Z',
+            completed_at: '2026-01-01T00:01:00.000Z',
+            deployed: true,
+            deployed_functions: [{ name: 'sync-issues', version: '1.0.0' }]
+        };
+        const getSpy = vi.spyOn(functionDeploymentService, 'getDeploymentStatus').mockResolvedValue(Ok(response));
+
+        const result = await getDeploymentStatusTool.handler({ id: deploymentId }, context);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual(response);
+        }
+        expect(getSpy).toHaveBeenCalledWith({ environment: context.environment, id: deploymentId });
+    });
+
+    it('rejects an invalid deployment ID before calling the service', async () => {
+        const getSpy = vi.spyOn(functionDeploymentService, 'getDeploymentStatus');
+
+        const result = await getDeploymentStatusTool.handler({ id: 'not-a-uuid' }, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toContain('Invalid get_deployment_status arguments:');
+        }
+        expect(getSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns a missing deployment as a public MCP error', async () => {
+        vi.spyOn(functionDeploymentService, 'getDeploymentStatus').mockResolvedValue(
+            Err(
+                new functionDeploymentService.FunctionDeploymentServiceError({
+                    code: 'deployment_not_found',
+                    message: `Deployment '${deploymentId}' was not found`
+                })
+            )
+        );
+
+        const result = await getDeploymentStatusTool.handler({ id: deploymentId }, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toBe(`Deployment '${deploymentId}' was not found`);
+        }
+    });
+
+    it('maps status lookup failures to an internal MCP error', async () => {
+        vi.spyOn(functionDeploymentService, 'getDeploymentStatus').mockResolvedValue(
+            Err(
+                new functionDeploymentService.FunctionDeploymentServiceError({
+                    code: 'deployment_status_failed',
+                    message: 'Failed to retrieve deployment status',
+                    cause: new Error('sensitive database failure')
+                })
+            )
+        );
+
+        const result = await getDeploymentStatusTool.handler({ id: deploymentId }, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(InternalMcpError);
+        }
+    });
+});
+
+const deploymentId = '3c66291f-6247-47a6-a100-f4d621d751f7';
+const context = {
+    account: { id: 1 },
+    environment: { id: 42 },
+    plan: null,
+    customerApiKeyId: 7,
+    grantedScopes: ['environment:deploy']
+} as ManagementMcpContext;

--- a/packages/server/lib/controllers/mcp/functions/schema.ts
+++ b/packages/server/lib/controllers/mcp/functions/schema.ts
@@ -32,7 +32,7 @@ export const deploymentCreateOutputSchema = z
     })
     .strict();
 
-export const deploymentStatusOutputSchema = z
+export const getDeploymentStatusOutputSchema = z
     .object({
         id: z.string().uuid(),
         status: z.enum(['waiting', 'running', 'success', 'failed']),
@@ -128,4 +128,4 @@ export const listFunctionsOutputSchema = z
 
 export type ListFunctionsOutput = z.infer<typeof listFunctionsOutputSchema>;
 export type DeploymentCreateOutput = z.infer<typeof deploymentCreateOutputSchema>;
-export type DeploymentStatusOutput = z.infer<typeof deploymentStatusOutputSchema>;
+export type GetDeploymentStatusOutput = z.infer<typeof getDeploymentStatusOutputSchema>;

--- a/packages/server/lib/controllers/mcp/functions/schema.ts
+++ b/packages/server/lib/controllers/mcp/functions/schema.ts
@@ -22,11 +22,39 @@ export const deployTemplateArgumentsSchema = z
     })
     .strict();
 
+export const getDeploymentStatusArgumentsSchema = z.object({ id: z.string().uuid() }).strict();
+
 export const deploymentCreateOutputSchema = z
     .object({
         id: z.string().uuid(),
         status: z.enum(['waiting', 'running', 'success', 'failed']),
         created_at: z.iso.datetime()
+    })
+    .strict();
+
+export const deploymentStatusOutputSchema = z
+    .object({
+        id: z.string().uuid(),
+        status: z.enum(['waiting', 'running', 'success', 'failed']),
+        integration_id: z.string(),
+        function_name: z.string(),
+        function_type: runnableFunctionTypeSchema,
+        created_at: z.iso.datetime(),
+        updated_at: z.iso.datetime(),
+        started_at: z.iso.datetime().optional(),
+        completed_at: z.iso.datetime().optional(),
+        duration_ms: z.number().int().nonnegative().optional(),
+        deployed: z.boolean().optional(),
+        deployed_functions: z.array(z.object({ name: z.string(), version: z.string() }).strict()).optional(),
+        output: z.string().optional(),
+        error: z
+            .object({
+                code: z.string(),
+                message: z.string().optional(),
+                payload: z.unknown().optional()
+            })
+            .strict()
+            .optional()
     })
     .strict();
 
@@ -100,3 +128,4 @@ export const listFunctionsOutputSchema = z
 
 export type ListFunctionsOutput = z.infer<typeof listFunctionsOutputSchema>;
 export type DeploymentCreateOutput = z.infer<typeof deploymentCreateOutputSchema>;
+export type DeploymentStatusOutput = z.infer<typeof deploymentStatusOutputSchema>;

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -420,7 +420,7 @@ describe('POST /mcp management server', () => {
         ]);
     });
 
-    it('deploys a function template and returns the deployment job without polling', async () => {
+    it('deploys a function template and retrieves its completed deployment', async () => {
         vi.spyOn(remoteFileService, 'copy').mockResolvedValue('_LOCAL_FILE_');
         const { secret, env, account } = await createKeyWithScopes(['environment:deploy']);
         await seeders.createConfigSeed(env, 'airtable', 'airtable');

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -176,6 +176,7 @@ describe('POST /mcp management server', () => {
             'functions_list',
             'deploy_function',
             'deploy_template',
+            'get_deployment_status',
             'logs_list_operations',
             'logs_get_operation'
         ]);
@@ -207,6 +208,7 @@ describe('POST /mcp management server', () => {
             'functions_list',
             'deploy_function',
             'deploy_template',
+            'get_deployment_status',
             'logs_list_operations',
             'logs_get_operation'
         ];
@@ -394,7 +396,7 @@ describe('POST /mcp management server', () => {
         });
     });
 
-    it('lists separate deployment tools with deploy scope', async () => {
+    it('lists separate deployment and status tools with deploy scope', async () => {
         const { secret } = await createKeyWithScopes(['environment:deploy']);
         const res = await mcpPost({
             token: secret,
@@ -410,6 +412,10 @@ describe('POST /mcp management server', () => {
             {
                 name: 'deploy_template',
                 annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
+            },
+            {
+                name: 'get_deployment_status',
+                annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }
             }
         ]);
     });
@@ -435,6 +441,24 @@ describe('POST /mcp management server', () => {
             id: expect.any(String),
             status: 'success',
             created_at: expect.any(String)
+        });
+
+        const status = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 2,
+                method: 'tools/call',
+                params: { name: 'get_deployment_status', arguments: { id: res.json.result.structuredContent.id } }
+            }
+        });
+        expect(parseToolText(status)).toStrictEqual(status.json.result.structuredContent);
+        expect(status.json.result.structuredContent).toMatchObject({
+            id: res.json.result.structuredContent.id,
+            status: 'success',
+            integration_id: 'airtable',
+            function_name: 'tables',
+            function_type: 'sync'
         });
 
         await vi.waitFor(() => {
@@ -491,6 +515,20 @@ describe('POST /mcp management server', () => {
         });
         expect(missing.json.result).toStrictEqual({
             content: [{ type: 'text', text: "Integration 'missing' was not found" }],
+            isError: true
+        });
+
+        const missingStatus = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 3,
+                method: 'tools/call',
+                params: { name: 'get_deployment_status', arguments: { id: '3c66291f-6247-47a6-a100-f4d621d751f7' } }
+            }
+        });
+        expect(missingStatus.json.result).toStrictEqual({
+            content: [{ type: 'text', text: "Deployment '3c66291f-6247-47a6-a100-f4d621d751f7' was not found" }],
             isError: true
         });
     });

--- a/packages/server/lib/controllers/mcp/managementServer.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.ts
@@ -13,6 +13,7 @@ import { queryDocsFilesystemTool } from './docs/queryFilesystem.js';
 import { searchDocsTool } from './docs/search.js';
 import { deployFunctionTool } from './functions/deployFunction.js';
 import { deployTemplateTool } from './functions/deployTemplate.js';
+import { getDeploymentStatusTool } from './functions/getDeploymentStatus.js';
 import { listFunctionsTool } from './functions/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { deleteIntegrationsTool } from './integrations/delete.js';
@@ -47,6 +48,7 @@ const managementMcpTools: ManagementMcpTool[] = [
     listFunctionsTool,
     deployFunctionTool,
     deployTemplateTool,
+    getDeploymentStatusTool,
     listLogOperationsTool,
     getLogOperationTool
 ];

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -10,6 +10,7 @@ import { getConnectionsTool } from './connections/get.js';
 import { listConnectionsTool } from './connections/list.js';
 import { createConnectSessionTool } from './connectSessions/create.js';
 import { deployFunctionTool } from './functions/deployFunction.js';
+import { getDeploymentStatusTool } from './functions/getDeploymentStatus.js';
 import { listFunctionsTool } from './functions/list.js';
 import { createIntegrationsTool } from './integrations/create.js';
 import { deleteIntegrationsTool } from './integrations/delete.js';
@@ -79,6 +80,10 @@ describe('createManagementMcpServer', () => {
                 {
                     name: 'deploy_template',
                     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
+                },
+                {
+                    name: 'get_deployment_status',
+                    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }
                 },
                 { name: 'logs_list_operations', annotations: { readOnlyHint: true } },
                 { name: 'logs_get_operation', annotations: { readOnlyHint: true } }
@@ -594,12 +599,12 @@ describe('createManagementMcpServer', () => {
         }
     });
 
-    it('exposes separate function and template deployment tools', async () => {
+    it('exposes separate deployment tools and a read-only status tool', async () => {
         const authorized = await createTestClient(['environment:deploy']);
         try {
             const result = await authorized.client.listTools();
             const scopedTools = withoutDocsTools(result.tools);
-            expect(scopedTools).toHaveLength(2);
+            expect(scopedTools).toHaveLength(3);
             expect(scopedTools).toMatchObject([
                 {
                     name: 'deploy_function',
@@ -619,6 +624,19 @@ describe('createManagementMcpServer', () => {
                     inputSchema: {
                         type: 'object',
                         required: ['integration_id', 'template'],
+                        additionalProperties: false
+                    }
+                },
+                {
+                    name: 'get_deployment_status',
+                    inputSchema: {
+                        type: 'object',
+                        required: ['id'],
+                        additionalProperties: false
+                    },
+                    outputSchema: {
+                        type: 'object',
+                        required: ['id', 'status', 'integration_id', 'function_name', 'function_type', 'created_at', 'updated_at'],
                         additionalProperties: false
                     }
                 }
@@ -667,6 +685,35 @@ describe('createManagementMcpServer', () => {
                     code: 'export default {}'
                 }
             });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],
+                structuredContent: response
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('returns deployment statuses as JSON text and structured content', async () => {
+        const response = {
+            id: '3c66291f-6247-47a6-a100-f4d621d751f7',
+            status: 'success' as const,
+            integration_id: 'github',
+            function_name: 'sync-issues',
+            function_type: 'sync' as const,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:01:00.000Z',
+            completed_at: '2026-01-01T00:01:00.000Z'
+        };
+        const handlerSpy = vi.spyOn(getDeploymentStatusTool, 'handler').mockResolvedValueOnce(Ok(response));
+        const { client, server } = await createTestClient(['environment:deploy']);
+
+        try {
+            const result = await client.callTool({ name: 'get_deployment_status', arguments: { id: response.id } });
 
             expect(result).toStrictEqual({
                 content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],

--- a/packages/server/lib/services/functionDeployment.service.ts
+++ b/packages/server/lib/services/functionDeployment.service.ts
@@ -4,6 +4,7 @@ import {
     createSucceededFunctionDeployment,
     deploySandboxTimeoutMs,
     FunctionError,
+    getFunctionDeployment as getStoredFunctionDeployment,
     markFunctionDeploymentFailed,
     markFunctionDeploymentRunning,
     prepareAsyncDeploy,
@@ -24,6 +25,7 @@ import type {
     DBUser,
     FunctionDeploymentCodeBody,
     FunctionDeploymentCreateSuccess,
+    FunctionDeploymentResultSuccess,
     FunctionDeploymentTemplateBody
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -48,7 +50,9 @@ export type DeployTemplateServiceErrorCode =
     | 'template_deployment_failed'
     | 'deployment_record_creation_failed';
 
-type FunctionDeploymentServiceErrorCode = DeployFunctionServiceErrorCode | DeployTemplateServiceErrorCode;
+export type GetDeploymentStatusServiceErrorCode = 'deployment_not_found' | 'deployment_status_failed';
+
+type FunctionDeploymentServiceErrorCode = DeployFunctionServiceErrorCode | DeployTemplateServiceErrorCode | GetDeploymentStatusServiceErrorCode;
 
 export class FunctionDeploymentServiceError<TCode extends FunctionDeploymentServiceErrorCode = FunctionDeploymentServiceErrorCode> extends Error {
     public readonly code: TCode;
@@ -62,6 +66,7 @@ export class FunctionDeploymentServiceError<TCode extends FunctionDeploymentServ
 
 export type DeployFunctionServiceError = FunctionDeploymentServiceError<DeployFunctionServiceErrorCode>;
 export type DeployTemplateServiceError = FunctionDeploymentServiceError<DeployTemplateServiceErrorCode>;
+export type GetDeploymentStatusServiceError = FunctionDeploymentServiceError<GetDeploymentStatusServiceErrorCode>;
 
 export interface DeployFunctionParams {
     environment: DBEnvironment;
@@ -75,6 +80,11 @@ export interface DeployTemplateParams {
     plan: DBPlan | null;
     user?: Pick<DBUser, 'id' | 'email' | 'name'> | undefined;
     body: FunctionDeploymentTemplateBody;
+}
+
+export interface GetDeploymentStatusParams {
+    environment: DBEnvironment;
+    id: string;
 }
 
 export async function deployFunction({
@@ -295,6 +305,33 @@ export async function deployTemplate({
     }
 
     return Ok(deployment.value);
+}
+
+export async function getDeploymentStatus({
+    environment,
+    id
+}: GetDeploymentStatusParams): Promise<Result<FunctionDeploymentResultSuccess, GetDeploymentStatusServiceError>> {
+    try {
+        const deployment = await getStoredFunctionDeployment({ environmentId: environment.id, id });
+        if (!deployment) {
+            return Err(
+                new FunctionDeploymentServiceError({
+                    code: 'deployment_not_found',
+                    message: `Deployment '${id}' was not found`
+                })
+            );
+        }
+
+        return Ok(deployment);
+    } catch (err) {
+        return Err(
+            new FunctionDeploymentServiceError({
+                code: 'deployment_status_failed',
+                message: 'Failed to retrieve deployment status',
+                cause: err
+            })
+        );
+    }
 }
 
 export function toFunctionDeploymentError(err: unknown): FunctionDeploymentError {

--- a/packages/server/lib/services/functionDeployment.service.unit.test.ts
+++ b/packages/server/lib/services/functionDeployment.service.unit.test.ts
@@ -4,7 +4,7 @@ import * as sandbox from '@nangohq/sandbox';
 import * as shared from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
-import { deployFunction, deployTemplate } from './functionDeployment.service.js';
+import { deployFunction, deployTemplate, getDeploymentStatus } from './functionDeployment.service.js';
 import * as integrationTemplateService from './integrationTemplate.service.js';
 
 import type { DBFunctionDeployment } from '@nangohq/sandbox';
@@ -350,6 +350,52 @@ describe('functionDeploymentService', () => {
                 code: 'ambiguous_function',
                 message: "'settings' exists as both a sync and an action; specify 'function_type' to disambiguate"
             });
+        }
+    });
+
+    it('retrieves a deployment status from the authenticated environment', async () => {
+        const deployment = {
+            id: deploymentId,
+            status: 'success' as const,
+            integration_id: 'github',
+            function_name: 'sync-issues',
+            function_type: 'sync' as const,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:01:00.000Z',
+            completed_at: '2026-01-01T00:01:00.000Z',
+            deployed: true
+        };
+        const getSpy = vi.spyOn(sandbox, 'getFunctionDeployment').mockResolvedValue(deployment);
+
+        const result = await getDeploymentStatus({ environment, id: deploymentId });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual(deployment);
+        }
+        expect(getSpy).toHaveBeenCalledWith({ environmentId: 42, id: deploymentId });
+    });
+
+    it('returns a transport-neutral error when the deployment does not exist', async () => {
+        vi.spyOn(sandbox, 'getFunctionDeployment').mockResolvedValue(null);
+
+        const result = await getDeploymentStatus({ environment, id: deploymentId });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({ code: 'deployment_not_found', message: `Deployment '${deploymentId}' was not found` });
+        }
+    });
+
+    it('wraps deployment status storage failures', async () => {
+        const cause = new Error('database unavailable');
+        vi.spyOn(sandbox, 'getFunctionDeployment').mockRejectedValue(cause);
+
+        const result = await getDeploymentStatus({ environment, id: deploymentId });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({ code: 'deployment_status_failed', cause });
         }
     });
 });


### PR DESCRIPTION
Adds the read-only get_deployment_status Management MCP tool for polling deployment completion and retrieving the full result. Extends the reusable deployment service with an environment-scoped status lookup and documents the polling flow from both deployment tools.

NAN-6315

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

