### PR TITLE
feat(mfa): record why an MFA verification was rejected (NAN-6615)

### DIFF
--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -52,7 +52,7 @@ export async function verifyPendingMfaLogin(req: Request, credential: PostMFALog
     // Account state can change while the user completes the MFA challenge.
     const currentUser = await loadEligibleUser(pending.userId);
     if (!currentUser) {
-        recordMFALoginRefused({ method, reason: 'user_not_eligible' });
+        recordMFALoginRefused({ method });
         return { error: 'invalid' };
     }
 

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -1,6 +1,6 @@
 import db from '@nangohq/database';
 import { getFlags } from '@nangohq/feature-flags';
-import { accountService, mfaService, recordMFAVerifyFailure, userService } from '@nangohq/shared';
+import { accountService, mfaService, recordMFALoginRefused, recordMFAVerifyFailure, userService } from '@nangohq/shared';
 
 import { safeReturnTo } from '../returnTo.js';
 import { markMfaVerified } from './elevation.js';
@@ -52,7 +52,7 @@ export async function verifyPendingMfaLogin(req: Request, credential: PostMFALog
     // Account state can change while the user completes the MFA challenge.
     const currentUser = await loadEligibleUser(pending.userId);
     if (!currentUser) {
-        recordMFAVerifyFailure({ context: 'login', method, reason: 'user_not_eligible' });
+        recordMFALoginRefused({ method, reason: 'user_not_eligible' });
         return { error: 'invalid' };
     }
 

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -1,6 +1,6 @@
 import db from '@nangohq/database';
 import { getFlags } from '@nangohq/feature-flags';
-import { accountService, mfaService, userService } from '@nangohq/shared';
+import { accountService, mfaService, recordMFAVerifyFailure, userService } from '@nangohq/shared';
 
 import { safeReturnTo } from '../returnTo.js';
 import { markMfaVerified } from './elevation.js';
@@ -26,21 +26,24 @@ export async function loginOrStartPendingMfa(req: Request, user: DBUser, returnT
 }
 
 export async function verifyPendingMfaLogin(req: Request, credential: PostMFALoginVerification['Body']): Promise<PendingMFALoginResult> {
+    const method = credential.type === 'recoveryCode' ? 'recovery_code' : 'totp';
     const pending = req.session.pendingMfaLogin;
     if (!pending || Date.now() - pending.createdAt > MFA_LOGIN_TTL_MS) {
         delete req.session.pendingMfaLogin;
         await saveSession(req);
+        recordMFAVerifyFailure({ context: 'login', method, reason: 'challenge_expired' });
         return { error: 'expired' };
     }
 
     const user = await loadEligibleUser(pending.userId);
     if (!user) {
+        recordMFAVerifyFailure({ context: 'login', method, reason: 'user_not_eligible' });
         return { error: 'invalid' };
     }
     const verified = (
         credential.type === 'recoveryCode'
-            ? await mfaService.consumeRecoveryCode(user.id, credential.recoveryCode)
-            : await mfaService.verifyTotp(user.id, credential.code)
+            ? await mfaService.consumeRecoveryCode(user.id, credential.recoveryCode, { context: 'login' })
+            : await mfaService.verifyTotp(user.id, credential.code, { context: 'login' })
     ).unwrap();
     if (!verified) {
         return { error: 'invalid' };
@@ -49,6 +52,7 @@ export async function verifyPendingMfaLogin(req: Request, credential: PostMFALog
     // Account state can change while the user completes the MFA challenge.
     const currentUser = await loadEligibleUser(pending.userId);
     if (!currentUser) {
+        recordMFAVerifyFailure({ context: 'login', method, reason: 'user_not_eligible' });
         return { error: 'invalid' };
     }
 

--- a/packages/server/lib/controllers/v1/account/mfa/mfa.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/mfa.ts
@@ -140,7 +140,7 @@ export const postMFARecoveryCodes = asyncWrapper<PostMFARecoveryCodes>(async (re
         res.status(400).send({ error: { code: 'mfa_not_enabled' } });
         return;
     }
-    const verified = await mfaService.verifyTotp(user.id, code);
+    const verified = await mfaService.verifyTotp(user.id, code, { context: 'recovery_codes_regenerate' });
     if (verified.isErr()) {
         throw verified.error;
     }
@@ -175,7 +175,7 @@ export const deleteMFA = asyncWrapper<DeleteMFA>(async (req, res) => {
         res.status(400).send({ error: { code: 'mfa_not_enabled' } });
         return;
     }
-    const verified = await mfaService.verifyTotp(user.id, code);
+    const verified = await mfaService.verifyTotp(user.id, code, { context: 'disable' });
     if (verified.isErr()) {
         throw verified.error;
     }

--- a/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/stepUp.ts
@@ -65,8 +65,8 @@ export async function verifyStepUpMfa(
 
     const verified = (
         credential.type === 'recoveryCode'
-            ? await mfaService.consumeRecoveryCode(user.id, credential.recoveryCode, trx)
-            : await mfaService.verifyTotp(user.id, credential.code, trx)
+            ? await mfaService.consumeRecoveryCode(user.id, credential.recoveryCode, { trx, context: 'step_up' })
+            : await mfaService.verifyTotp(user.id, credential.code, { trx, context: 'step_up' })
     ).unwrap();
 
     return verified ? 'verified' : 'invalid';

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.ts
@@ -67,7 +67,7 @@ async function challengeAdmin({
         return false;
     }
 
-    const verified = await mfaService.verifyTotp(adminUser.id, code);
+    const verified = await mfaService.verifyTotp(adminUser.id, code, { context: 'impersonation' });
     if (verified.isErr()) {
         throw verified.error;
     }

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -40,7 +40,7 @@ export type { CreateEnvironmentError } from './services/environment.service.js';
 export * from './services/tags.service.js';
 export * from './services/tags/schema.js';
 export * as gettingStartedService from './services/getting-started.service.js';
-export { MFAError } from './services/mfa.service.js';
+export { MFAError, recordMFAVerifyFailure, recordMFAVerifySuccess } from './services/mfa.service.js';
 export { CustomerKeyError, MAX_API_KEYS_PER_ACCOUNT } from './services/customerKey.service.js';
 export { GetConnectionError, type ConnectionWithDetails, type GetConnectionErrorCode, type RetrievedConnection } from './services/connection.service.js';
 export * from './services/invitations.js';

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -40,7 +40,7 @@ export type { CreateEnvironmentError } from './services/environment.service.js';
 export * from './services/tags.service.js';
 export * from './services/tags/schema.js';
 export * as gettingStartedService from './services/getting-started.service.js';
-export { MFAError, recordMFAVerifyFailure, recordMFAVerifySuccess } from './services/mfa.service.js';
+export { MFAError, recordMFALoginRefused, recordMFAVerifyFailure, recordMFAVerifySuccess } from './services/mfa.service.js';
 export { CustomerKeyError, MAX_API_KEYS_PER_ACCOUNT } from './services/customerKey.service.js';
 export { GetConnectionError, type ConnectionWithDetails, type GetConnectionErrorCode, type RetrievedConnection } from './services/connection.service.js';
 export * from './services/invitations.js';

--- a/packages/shared/lib/services/mfa.service.integration.test.ts
+++ b/packages/shared/lib/services/mfa.service.integration.test.ts
@@ -2,6 +2,7 @@ import * as OTPAuth from 'otpauth';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { multipleMigrations } from '@nangohq/database';
+import { metrics } from '@nangohq/utils';
 
 import { createAccount } from '../seeders/account.seeder.js';
 import { seedUser } from '../seeders/user.seeder.js';
@@ -169,6 +170,106 @@ describe('MFA service', () => {
         expect(enabledIds).toEqual(new Set([enabledUser.id]));
 
         expect(await mfaService.getEnabledUserIds([])).toEqual(new Set());
+    });
+
+    describe('verification metrics', () => {
+        function spyOnMetrics() {
+            const increment = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+            return {
+                failures: () => increment.mock.calls.filter(([name]) => name === metrics.Types.MFA_VERIFY_FAILURE).map(([, , dimensions]) => dimensions),
+                successes: () => increment.mock.calls.filter(([name]) => name === metrics.Types.MFA_VERIFY_SUCCESS).map(([, , dimensions]) => dimensions)
+            };
+        }
+
+        async function seedActiveFactor() {
+            const account = await createAccount();
+            const user = await seedUser(account.id);
+            const enrollment = (await mfaService.startEnrollment(user.id, user.email)).unwrap();
+            const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
+            (await mfaService.activateEnrollment(user.id, totp.generate())).unwrap();
+            return { user, totp };
+        }
+
+        it('tells clock drift apart from a genuinely wrong code', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
+
+            const { user, totp } = await seedActiveFactor();
+            const { failures } = spyOnMetrics();
+
+            // right secret, 5 steps out, so past TOTP_WINDOW but inside the diagnostic window
+            const drifted = totp.generate({ timestamp: Date.now() + 5 * STEP_MS });
+            expect((await mfaService.verifyTotp(user.id, drifted, { context: 'login' })).unwrap()).toBe(false);
+
+            // a different secret's code is wrong at any offset
+            const otherTotp = new OTPAuth.TOTP({ period: 30, digits: 6, secret: new OTPAuth.Secret({ size: 20 }) });
+            expect((await mfaService.verifyTotp(user.id, otherTotp.generate(), { context: 'login' })).unwrap()).toBe(false);
+
+            expect(failures()).toEqual([
+                { context: 'login', method: 'totp', reason: 'clock_drift' },
+                { context: 'login', method: 'totp', reason: 'wrong_code' }
+            ]);
+        });
+
+        it('records a replayed code as reuse rather than a wrong code', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
+
+            const { user, totp } = await seedActiveFactor();
+            vi.setSystemTime(new Date('2026-08-14T12:00:30Z'));
+            const { failures, successes } = spyOnMetrics();
+
+            const token = totp.generate();
+            expect((await mfaService.verifyTotp(user.id, token, { context: 'step_up' })).unwrap()).toBe(true);
+            expect((await mfaService.verifyTotp(user.id, token, { context: 'step_up' })).unwrap()).toBe(false);
+
+            expect(successes()).toEqual([{ context: 'step_up', method: 'totp', drift: 0 }]);
+            expect(failures()).toEqual([{ context: 'step_up', method: 'totp', reason: 'code_reuse' }]);
+        });
+
+        it('tags an accepted code with the clock offset it was accepted at', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
+
+            const { user, totp } = await seedActiveFactor();
+            const { successes } = spyOnMetrics();
+
+            const twoStepsAhead = totp.generate({ timestamp: Date.now() + 2 * STEP_MS });
+            expect((await mfaService.verifyTotp(user.id, twoStepsAhead, { context: 'login' })).unwrap()).toBe(true);
+
+            expect(successes()).toEqual([{ context: 'login', method: 'totp', drift: 2 }]);
+        });
+
+        it('separates a malformed code, an unenrolled user and a spent recovery code', async () => {
+            const account = await createAccount();
+            const noFactorUser = await seedUser(account.id);
+            const enrollment = (await mfaService.startEnrollment(noFactorUser.id, noFactorUser.email)).unwrap();
+            const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
+            const activated = (await mfaService.activateEnrollment(noFactorUser.id, totp.generate())).unwrap();
+            const { failures } = spyOnMetrics();
+
+            expect((await mfaService.verifyTotp(noFactorUser.id, '12345', { context: 'disable' })).unwrap()).toBe(false);
+            expect((await mfaService.consumeRecoveryCode(noFactorUser.id, activated.recoveryCodes[0]!, { context: 'login' })).unwrap()).toBe(true);
+            expect((await mfaService.consumeRecoveryCode(noFactorUser.id, activated.recoveryCodes[0]!, { context: 'login' })).unwrap()).toBe(false);
+
+            (await mfaService.disable(noFactorUser.id)).unwrap();
+            expect((await mfaService.verifyTotp(noFactorUser.id, totp.generate(), { context: 'login' })).unwrap()).toBe(false);
+
+            expect(failures()).toEqual([
+                { context: 'disable', method: 'totp', reason: 'malformed_code' },
+                { context: 'login', method: 'recovery_code', reason: 'unknown_recovery_code' },
+                { context: 'login', method: 'totp', reason: 'not_enrolled' }
+            ]);
+        });
+
+        it('defaults the context when a caller does not pass one', async () => {
+            const { user } = await seedActiveFactor();
+            const { failures } = spyOnMetrics();
+
+            expect((await mfaService.verifyTotp(user.id, '000')).unwrap()).toBe(false);
+
+            expect(failures()).toEqual([{ context: 'unknown', method: 'totp', reason: 'malformed_code' }]);
+        });
     });
 
     it('returns encryption setup failures instead of rejecting', async () => {

--- a/packages/shared/lib/services/mfa.service.integration.test.ts
+++ b/packages/shared/lib/services/mfa.service.integration.test.ts
@@ -10,6 +10,25 @@ import * as encryptionManager from '../utils/encryption.manager.js';
 import mfaService from './mfa.service.js';
 
 const STEP_MS = 30 * 1000;
+// Wider than the service's drift diagnostic window, so a code rejected here is wrong at any offset it probes.
+const WRONG_CODE_PROBE_STEPS = 25;
+
+/** A six-digit code this factor does not accept at any offset the service checks. */
+function wrongCodeFor(totp: OTPAuth.TOTP, timestamp: number): string {
+    const accepted = new Set<string>();
+    for (let step = -WRONG_CODE_PROBE_STEPS; step <= WRONG_CODE_PROBE_STEPS; step++) {
+        accepted.add(totp.generate({ timestamp: timestamp + step * STEP_MS }));
+    }
+
+    for (let candidate = 0; candidate <= accepted.size; candidate++) {
+        const code = String(candidate).padStart(6, '0');
+        if (!accepted.has(code)) {
+            return code;
+        }
+    }
+
+    throw new Error('no wrong code available');
+}
 
 describe('MFA service', () => {
     beforeAll(async () => {
@@ -201,9 +220,8 @@ describe('MFA service', () => {
             const drifted = totp.generate({ timestamp: Date.now() + 5 * STEP_MS });
             expect((await mfaService.verifyTotp(user.id, drifted, { context: 'login' })).unwrap()).toBe(false);
 
-            // a different secret's code is wrong at any offset
-            const otherTotp = new OTPAuth.TOTP({ period: 30, digits: 6, secret: new OTPAuth.Secret({ size: 20 }) });
-            expect((await mfaService.verifyTotp(user.id, otherTotp.generate(), { context: 'login' })).unwrap()).toBe(false);
+            // a code this factor never produces, so it is wrong rather than drifted
+            expect((await mfaService.verifyTotp(user.id, wrongCodeFor(totp, Date.now()), { context: 'login' })).unwrap()).toBe(false);
 
             expect(failures()).toEqual([
                 { context: 'login', method: 'totp', reason: 'clock_drift' },
@@ -238,6 +256,29 @@ describe('MFA service', () => {
             expect((await mfaService.verifyTotp(user.id, twoStepsAhead, { context: 'login' })).unwrap()).toBe(true);
 
             expect(successes()).toEqual([{ context: 'login', method: 'totp', drift: 2 }]);
+        });
+
+        it('reports the real drift once it climbs past the stored ceiling', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-08-14T12:00:00Z'));
+
+            const account = await createAccount();
+            const user = await seedUser(account.id);
+            const enrollment = (await mfaService.startEnrollment(user.id, user.email)).unwrap();
+            const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
+
+            // activation is lenient enough to seed 5, then each verify walks the window 2 further out
+            (await mfaService.activateEnrollment(user.id, totp.generate({ timestamp: Date.now() + 5 * STEP_MS }))).unwrap();
+            const { successes } = spyOnMetrics();
+
+            for (const steps of [7, 9, 11]) {
+                const code = totp.generate({ timestamp: Date.now() + steps * STEP_MS });
+                expect((await mfaService.verifyTotp(user.id, code, { context: 'login' })).unwrap()).toBe(true);
+            }
+
+            // the column stays bounded by MAX_CLOCK_OFFSET_STEPS, the metric reports what actually matched
+            expect((await mfaService.getActiveFactor(user.id))?.clock_offset_steps).toBe(10);
+            expect(successes().map((dimensions) => dimensions?.['drift'])).toEqual([7, 9, 11]);
         });
 
         it('separates a malformed code, an unenrolled user and a spent recovery code', async () => {

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -26,29 +26,19 @@ const DRIFT_DIAGNOSTIC_WINDOW = 20;
 
 export type MFAErrorCode = 'encryption_unavailable' | 'already_enabled' | 'enrollment_not_found' | 'invalid_code' | 'not_enabled';
 
-/** Which flow asked for the second factor. */
 export type MFAVerifyContext = 'login' | 'step_up' | 'activation' | 'recovery_codes_regenerate' | 'disable' | 'impersonation' | 'unknown';
 
 export type MFAVerifyMethod = 'totp' | 'recovery_code';
 
 export type MFAVerifyFailureReason =
-    /** No enabled factor for this user, so there was nothing to check against. */
     | 'not_enrolled'
-    /** Not six digits, so it never reached the TOTP check. */
     | 'malformed_code'
-    /** Correct for this secret, but outside the accepted window. The authenticator's clock is off. */
     | 'clock_drift'
-    /** Correct and in window, but at or behind a counter we already accepted. */
     | 'code_reuse'
-    /** Lost the race to another request spending the same counter. */
     | 'concurrent_use'
-    /** No recovery code matched, or the one sent was already consumed. */
     | 'unknown_recovery_code'
-    /** Wrong for this secret at any plausible clock offset. */
     | 'wrong_code'
-    /** The challenge itself timed out before a code arrived. */
     | 'challenge_expired'
-    /** The user became ineligible (suspended, or MFA turned off) while the challenge was open. */
     | 'user_not_eligible';
 
 type TokenCheck =
@@ -188,8 +178,6 @@ class MFAService {
     /**
      * Pass `trx` to consume the factor in the caller's transaction, so rolling that back
      * un-burns the code rather than leaving it spent on an action that never happened.
-     *
-     * `context` only labels the metric, so a rejection can be read back per flow.
      */
     public async verifyTotp(userId: number, token: string, { trx: parentTrx, context = 'unknown' }: MFAVerifyOptions = {}): Promise<Result<boolean>> {
         try {

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -54,10 +54,6 @@ export function recordMFAVerifySuccess({ context, method, driftSteps = 0 }: { co
     metrics.increment(metrics.Types.MFA_VERIFY_SUCCESS, 1, { context, method, drift: Math.abs(driftSteps) });
 }
 
-/**
- * A login turned away after the factor was already accepted. Kept off the verify metrics so their
- * success and failure counts stay one per attempt.
- */
 export function recordMFALoginRefused({ method, reason }: { method: MFAVerifyMethod; reason: Extract<MFAVerifyFailureReason, 'user_not_eligible'> }): void {
     metrics.increment(metrics.Types.MFA_LOGIN_REFUSED, 1, { method, reason });
 }

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import * as OTPAuth from 'otpauth';
 
 import db from '@nangohq/database';
-import { Err, Ok } from '@nangohq/utils';
+import { Err, metrics, Ok } from '@nangohq/utils';
 
 import { getEncryptionManager } from '../utils/encryption.manager.js';
 
@@ -18,8 +18,63 @@ const TOTP_PERIOD_SECONDS = 30;
 const TOTP_WINDOW = 2;
 const TOTP_ENROLLMENT_WINDOW = 5;
 const MAX_CLOCK_OFFSET_STEPS = 10;
+/**
+ * Only ever used to explain a rejection we have already decided on. A code that lands here is still
+ * refused, we just get to say it was drift rather than a wrong code.
+ */
+const DRIFT_DIAGNOSTIC_WINDOW = 20;
 
 export type MFAErrorCode = 'encryption_unavailable' | 'already_enabled' | 'enrollment_not_found' | 'invalid_code' | 'not_enabled';
+
+/** Which flow asked for the second factor. */
+export type MFAVerifyContext = 'login' | 'step_up' | 'activation' | 'recovery_codes_regenerate' | 'disable' | 'impersonation' | 'unknown';
+
+export type MFAVerifyMethod = 'totp' | 'recovery_code';
+
+export type MFAVerifyFailureReason =
+    /** No enabled factor for this user, so there was nothing to check against. */
+    | 'not_enrolled'
+    /** Not six digits, so it never reached the TOTP check. */
+    | 'malformed_code'
+    /** Correct for this secret, but outside the accepted window. The authenticator's clock is off. */
+    | 'clock_drift'
+    /** Correct and in window, but at or behind a counter we already accepted. */
+    | 'code_reuse'
+    /** Lost the race to another request spending the same counter. */
+    | 'concurrent_use'
+    /** No recovery code matched, or the one sent was already consumed. */
+    | 'unknown_recovery_code'
+    /** Wrong for this secret at any plausible clock offset. */
+    | 'wrong_code'
+    /** The challenge itself timed out before a code arrived. */
+    | 'challenge_expired'
+    /** The user became ineligible (suspended, or MFA turned off) while the challenge was open. */
+    | 'user_not_eligible';
+
+type TokenCheck =
+    | { ok: true; counter: bigint; offsetSteps: number }
+    | { ok: false; reason: Extract<MFAVerifyFailureReason, 'malformed_code' | 'clock_drift' | 'wrong_code'> };
+
+export interface MFAVerifyOptions {
+    trx?: Knex;
+    context?: MFAVerifyContext;
+}
+
+export function recordMFAVerifySuccess({ context, method, driftSteps = 0 }: { context: MFAVerifyContext; method: MFAVerifyMethod; driftSteps?: number }): void {
+    metrics.increment(metrics.Types.MFA_VERIFY_SUCCESS, 1, { context, method, drift: Math.abs(driftSteps) });
+}
+
+export function recordMFAVerifyFailure({
+    context,
+    method,
+    reason
+}: {
+    context: MFAVerifyContext;
+    method: MFAVerifyMethod;
+    reason: MFAVerifyFailureReason;
+}): void {
+    metrics.increment(metrics.Types.MFA_VERIFY_FAILURE, 1, { context, method, reason });
+}
 
 export class MFAError extends Error {
     constructor(
@@ -87,9 +142,11 @@ class MFAService {
                 }
 
                 const verified = this.verifyToken(factor, token, TOTP_ENROLLMENT_WINDOW);
-                if (verified === null) {
+                if (!verified.ok) {
+                    recordMFAVerifyFailure({ context: 'activation', method: 'totp', reason: verified.reason });
                     throw new MFAError('invalid_code');
                 }
+                recordMFAVerifySuccess({ context: 'activation', method: 'totp', driftSteps: verified.offsetSteps });
 
                 const recoveryCodes = this.createRecoveryCodes();
                 await trx<DBMFAFactor>(FACTORS_TABLE)
@@ -129,19 +186,27 @@ class MFAService {
     }
 
     /**
-     * Pass `parentTrx` to consume the factor in the caller's transaction, so rolling that back
+     * Pass `trx` to consume the factor in the caller's transaction, so rolling that back
      * un-burns the code rather than leaving it spent on an action that never happened.
+     *
+     * `context` only labels the metric, so a rejection can be read back per flow.
      */
-    public async verifyTotp(userId: number, token: string, parentTrx?: Knex): Promise<Result<boolean>> {
+    public async verifyTotp(userId: number, token: string, { trx: parentTrx, context = 'unknown' }: MFAVerifyOptions = {}): Promise<Result<boolean>> {
         try {
             const verified = await this.inTransaction(parentTrx, async (trx) => {
                 const factor = await trx<DBMFAFactor>(FACTORS_TABLE).where({ user_id: userId }).whereNotNull('enabled_at').forUpdate().first();
                 if (!factor) {
+                    recordMFAVerifyFailure({ context, method: 'totp', reason: 'not_enrolled' });
                     return false;
                 }
 
                 const verified = this.verifyToken(factor, token, TOTP_WINDOW);
-                if (verified === null || (factor.last_accepted_counter !== null && verified.counter <= BigInt(factor.last_accepted_counter))) {
+                if (!verified.ok) {
+                    recordMFAVerifyFailure({ context, method: 'totp', reason: verified.reason });
+                    return false;
+                }
+                if (factor.last_accepted_counter !== null && verified.counter <= BigInt(factor.last_accepted_counter)) {
+                    recordMFAVerifyFailure({ context, method: 'totp', reason: 'code_reuse' });
                     return false;
                 }
 
@@ -160,7 +225,13 @@ class MFAService {
                         updated_at: trx.fn.now() as unknown as Date
                     });
 
-                return updated === 1;
+                if (updated !== 1) {
+                    recordMFAVerifyFailure({ context, method: 'totp', reason: 'concurrent_use' });
+                    return false;
+                }
+
+                recordMFAVerifySuccess({ context, method: 'totp', driftSteps: verified.offsetSteps });
+                return true;
             });
             return Ok(verified);
         } catch (err) {
@@ -168,13 +239,14 @@ class MFAService {
         }
     }
 
-    /** See {@link verifyTotp} for `parentTrx`. */
-    public async consumeRecoveryCode(userId: number, code: string, parentTrx?: Knex): Promise<Result<boolean>> {
+    /** See {@link verifyTotp} for the options. */
+    public async consumeRecoveryCode(userId: number, code: string, { trx: parentTrx, context = 'unknown' }: MFAVerifyOptions = {}): Promise<Result<boolean>> {
         try {
             const codeHash = this.hashRecoveryCode(code);
             const consumed = await this.inTransaction(parentTrx, async (trx) => {
                 const factor = await trx<DBMFAFactor>(FACTORS_TABLE).where({ user_id: userId }).whereNotNull('enabled_at').forUpdate().first();
                 if (!factor) {
+                    recordMFAVerifyFailure({ context, method: 'recovery_code', reason: 'not_enrolled' });
                     return false;
                 }
 
@@ -183,7 +255,13 @@ class MFAService {
                     .whereNull('consumed_at')
                     .update({ consumed_at: trx.fn.now() as unknown as Date });
 
-                return updated === 1;
+                if (updated !== 1) {
+                    recordMFAVerifyFailure({ context, method: 'recovery_code', reason: 'unknown_recovery_code' });
+                    return false;
+                }
+
+                recordMFAVerifySuccess({ context, method: 'recovery_code' });
+                return true;
             });
             return Ok(consumed);
         } catch (err) {
@@ -233,9 +311,9 @@ class MFAService {
         });
     }
 
-    private verifyToken(factor: DBMFAFactor, token: string, window: number): { counter: bigint; offsetSteps: number } | null {
+    private verifyToken(factor: DBMFAFactor, token: string, window: number): TokenCheck {
         if (!/^\d{6}$/.test(token)) {
-            return null;
+            return { ok: false, reason: 'malformed_code' };
         }
 
         const encryptionManager = getEncryptionManager();
@@ -257,12 +335,14 @@ class MFAService {
 
             const offsetSteps = center + delta;
             return {
+                ok: true,
                 counter: BigInt(totp.counter({ timestamp }) + offsetSteps),
                 offsetSteps: Math.max(-MAX_CLOCK_OFFSET_STEPS, Math.min(MAX_CLOCK_OFFSET_STEPS, offsetSteps))
             };
         }
 
-        return null;
+        const driftingDelta = totp.validate({ token, timestamp, window: DRIFT_DIAGNOSTIC_WINDOW });
+        return { ok: false, reason: driftingDelta === null ? 'wrong_code' : 'clock_drift' };
     }
 
     private createRecoveryCodes(): string[] {

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -42,7 +42,7 @@ export type MFAVerifyFailureReason =
     | 'user_not_eligible';
 
 type TokenCheck =
-    | { ok: true; counter: bigint; offsetSteps: number; storedOffsetSteps: number }
+    | { ok: true; counter: bigint; measuredOffsetSteps: number; boundedOffsetSteps: number }
     | { ok: false; reason: Extract<MFAVerifyFailureReason, 'malformed_code' | 'clock_drift' | 'wrong_code'> };
 
 export interface MFAVerifyOptions {
@@ -54,8 +54,8 @@ export function recordMFAVerifySuccess({ context, method, driftSteps = 0 }: { co
     metrics.increment(metrics.Types.MFA_VERIFY_SUCCESS, 1, { context, method, drift: Math.abs(driftSteps) });
 }
 
-export function recordMFALoginRefused({ method, reason }: { method: MFAVerifyMethod; reason: Extract<MFAVerifyFailureReason, 'user_not_eligible'> }): void {
-    metrics.increment(metrics.Types.MFA_LOGIN_REFUSED, 1, { method, reason });
+export function recordMFALoginRefused({ method }: { method: MFAVerifyMethod }): void {
+    metrics.increment(metrics.Types.MFA_LOGIN_REFUSED, 1, { method, reason: 'user_not_eligible' });
 }
 
 export function recordMFAVerifyFailure({
@@ -140,7 +140,7 @@ class MFAService {
                     recordMFAVerifyFailure({ context: 'activation', method: 'totp', reason: verified.reason });
                     throw new MFAError('invalid_code');
                 }
-                recordMFAVerifySuccess({ context: 'activation', method: 'totp', driftSteps: verified.offsetSteps });
+                recordMFAVerifySuccess({ context: 'activation', method: 'totp', driftSteps: verified.measuredOffsetSteps });
 
                 const recoveryCodes = this.createRecoveryCodes();
                 await trx<DBMFAFactor>(FACTORS_TABLE)
@@ -148,7 +148,7 @@ class MFAService {
                     .update({
                         enabled_at: trx.fn.now() as unknown as Date,
                         last_accepted_counter: verified.counter.toString(),
-                        clock_offset_steps: verified.storedOffsetSteps,
+                        clock_offset_steps: verified.boundedOffsetSteps,
                         updated_at: trx.fn.now() as unknown as Date
                     });
                 await this.replaceRecoveryCodes(trx, userId, recoveryCodes);
@@ -213,7 +213,7 @@ class MFAService {
                     })
                     .update({
                         last_accepted_counter: verified.counter.toString(),
-                        clock_offset_steps: verified.storedOffsetSteps,
+                        clock_offset_steps: verified.boundedOffsetSteps,
                         updated_at: trx.fn.now() as unknown as Date
                     });
 
@@ -222,7 +222,7 @@ class MFAService {
                     return false;
                 }
 
-                recordMFAVerifySuccess({ context, method: 'totp', driftSteps: verified.offsetSteps });
+                recordMFAVerifySuccess({ context, method: 'totp', driftSteps: verified.measuredOffsetSteps });
                 return true;
             });
             return Ok(verified);
@@ -325,12 +325,14 @@ class MFAService {
                 continue;
             }
 
-            const offsetSteps = center + delta;
+            const measuredOffsetSteps = center + delta;
+            // Only the bounded value is persisted, so a device reporting a wildly wrong clock cannot drag
+            // the accept window arbitrarily far on the next attempt.
             return {
                 ok: true,
-                counter: BigInt(totp.counter({ timestamp }) + offsetSteps),
-                offsetSteps,
-                storedOffsetSteps: Math.max(-MAX_CLOCK_OFFSET_STEPS, Math.min(MAX_CLOCK_OFFSET_STEPS, offsetSteps))
+                counter: BigInt(totp.counter({ timestamp }) + measuredOffsetSteps),
+                measuredOffsetSteps,
+                boundedOffsetSteps: Math.max(-MAX_CLOCK_OFFSET_STEPS, Math.min(MAX_CLOCK_OFFSET_STEPS, measuredOffsetSteps))
             };
         }
 

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -30,8 +30,6 @@ export type MFAVerifyContext = 'login' | 'step_up' | 'activation' | 'recovery_co
 
 export type MFAVerifyMethod = 'totp' | 'recovery_code';
 
-export type MFALoginRefusedReason = 'user_not_eligible';
-
 export type MFAVerifyFailureReason =
     | 'not_enrolled'
     | 'malformed_code'
@@ -60,7 +58,7 @@ export function recordMFAVerifySuccess({ context, method, driftSteps = 0 }: { co
  * A login turned away after the factor was already accepted. Kept off the verify metrics so their
  * success and failure counts stay one per attempt.
  */
-export function recordMFALoginRefused({ method, reason }: { method: MFAVerifyMethod; reason: MFALoginRefusedReason }): void {
+export function recordMFALoginRefused({ method, reason }: { method: MFAVerifyMethod; reason: Extract<MFAVerifyFailureReason, 'user_not_eligible'> }): void {
     metrics.increment(metrics.Types.MFA_LOGIN_REFUSED, 1, { method, reason });
 }
 

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -30,6 +30,8 @@ export type MFAVerifyContext = 'login' | 'step_up' | 'activation' | 'recovery_co
 
 export type MFAVerifyMethod = 'totp' | 'recovery_code';
 
+export type MFALoginRefusedReason = 'user_not_eligible';
+
 export type MFAVerifyFailureReason =
     | 'not_enrolled'
     | 'malformed_code'
@@ -52,6 +54,14 @@ export interface MFAVerifyOptions {
 
 export function recordMFAVerifySuccess({ context, method, driftSteps = 0 }: { context: MFAVerifyContext; method: MFAVerifyMethod; driftSteps?: number }): void {
     metrics.increment(metrics.Types.MFA_VERIFY_SUCCESS, 1, { context, method, drift: Math.abs(driftSteps) });
+}
+
+/**
+ * A login turned away after the factor was already accepted. Kept off the verify metrics so their
+ * success and failure counts stay one per attempt.
+ */
+export function recordMFALoginRefused({ method, reason }: { method: MFAVerifyMethod; reason: MFALoginRefusedReason }): void {
+    metrics.increment(metrics.Types.MFA_LOGIN_REFUSED, 1, { method, reason });
 }
 
 export function recordMFAVerifyFailure({

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -42,7 +42,7 @@ export type MFAVerifyFailureReason =
     | 'user_not_eligible';
 
 type TokenCheck =
-    | { ok: true; counter: bigint; offsetSteps: number }
+    | { ok: true; counter: bigint; offsetSteps: number; storedOffsetSteps: number }
     | { ok: false; reason: Extract<MFAVerifyFailureReason, 'malformed_code' | 'clock_drift' | 'wrong_code'> };
 
 export interface MFAVerifyOptions {
@@ -148,7 +148,7 @@ class MFAService {
                     .update({
                         enabled_at: trx.fn.now() as unknown as Date,
                         last_accepted_counter: verified.counter.toString(),
-                        clock_offset_steps: verified.offsetSteps,
+                        clock_offset_steps: verified.storedOffsetSteps,
                         updated_at: trx.fn.now() as unknown as Date
                     });
                 await this.replaceRecoveryCodes(trx, userId, recoveryCodes);
@@ -213,7 +213,7 @@ class MFAService {
                     })
                     .update({
                         last_accepted_counter: verified.counter.toString(),
-                        clock_offset_steps: verified.offsetSteps,
+                        clock_offset_steps: verified.storedOffsetSteps,
                         updated_at: trx.fn.now() as unknown as Date
                     });
 
@@ -329,7 +329,8 @@ class MFAService {
             return {
                 ok: true,
                 counter: BigInt(totp.counter({ timestamp }) + offsetSteps),
-                offsetSteps: Math.max(-MAX_CLOCK_OFFSET_STEPS, Math.min(MAX_CLOCK_OFFSET_STEPS, offsetSteps))
+                offsetSteps,
+                storedOffsetSteps: Math.max(-MAX_CLOCK_OFFSET_STEPS, Math.min(MAX_CLOCK_OFFSET_STEPS, offsetSteps))
             };
         }
 

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -27,6 +27,11 @@ export enum Types {
     CRON_TRIAL = 'nango.cron.trial',
 
     LOGS_LOG = 'nango.logs.log',
+
+    // Second factor accepted, tagged method=totp|recovery_code, context, and drift (absolute clock offset steps).
+    MFA_VERIFY_SUCCESS = 'nango.mfa.verify.success',
+    // Second factor rejected, tagged method, context, and reason so drift, reuse and a wrong code are told apart.
+    MFA_VERIFY_FAILURE = 'nango.mfa.verify.failure',
     KVSTORE_SLIDING_WINDOW_USAGE = 'nango.kvstore.sliding_window.usage',
     KVSTORE_SLIDING_WINDOW_FAIL_OPEN = 'nango.kvstore.sliding_window.fail_open',
     BILLED_RECORDS_COUNT = 'nango.billed.records.count',

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -28,9 +28,7 @@ export enum Types {
 
     LOGS_LOG = 'nango.logs.log',
 
-    // Second factor accepted, tagged method=totp|recovery_code, context, and drift (absolute clock offset steps).
     MFA_VERIFY_SUCCESS = 'nango.mfa.verify.success',
-    // Second factor rejected, tagged method, context, and reason so drift, reuse and a wrong code are told apart.
     MFA_VERIFY_FAILURE = 'nango.mfa.verify.failure',
     KVSTORE_SLIDING_WINDOW_USAGE = 'nango.kvstore.sliding_window.usage',
     KVSTORE_SLIDING_WINDOW_FAIL_OPEN = 'nango.kvstore.sliding_window.fail_open',

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -30,6 +30,7 @@ export enum Types {
 
     MFA_VERIFY_SUCCESS = 'nango.mfa.verify.success',
     MFA_VERIFY_FAILURE = 'nango.mfa.verify.failure',
+    MFA_LOGIN_REFUSED = 'nango.mfa.login.refused',
     KVSTORE_SLIDING_WINDOW_USAGE = 'nango.kvstore.sliding_window.usage',
     KVSTORE_SLIDING_WINDOW_FAIL_OPEN = 'nango.kvstore.sliding_window.fail_open',
     BILLED_RECORDS_COUNT = 'nango.billed.records.count',


### PR DESCRIPTION
NAN-6615

We had no visibility into why an MFA verification was rejected. Both problems reported so far, clock drift and code reuse, showed up as a generic invalid code and each needed a debugging round to identify.

Verification now emits:

- `nango.mfa.verify.success`, tagged `context`, `method`, `drift`
- `nango.mfa.verify.failure`, tagged `context`, `method`, `reason`
- `nango.mfa.login.refused`, tagged `method`, `reason`

`context` is the flow that asked for the factor: `login`, `step_up`, `activation`, `recovery_codes_regenerate`, `disable`, `impersonation`. `method` is `totp` or `recovery_code`. Verify reasons are `clock_drift`, `code_reuse`, `concurrent_use`, `wrong_code`, `malformed_code`, `not_enrolled`, `unknown_recovery_code`, `challenge_expired`, `user_not_eligible`.

### Test plan

- [x] `mfa.service.integration.test.ts`, 5 new cases covering drift vs wrong code, reuse, the drift tag on success, malformed / not enrolled / spent recovery code, and the default context
- [x] existing MFA controller, impersonation, signin and audit-auth suites pass
- [x] confirm the metrics land in Datadog on staging and build a panel off `reason`

