### PR TITLE
feat(agent-sessions): resolve tenant connection selectors (NAN-6594)

### DIFF
--- a/packages/server/lib/controllers/mcp/connections/list.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/connections/list.unit.test.ts
@@ -117,6 +117,7 @@ function connectionFixture(): Awaited<ReturnType<typeof connectionService.listCo
     return {
         connection: connectionDataFixture(),
         provider: 'github',
+        integration_id: 'github',
         active_logs: [{ type: 'auth', log_id: 'log-id' }],
         end_user: endUserFixture()
     };

--- a/packages/server/lib/controllers/mcp/connections/list.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/connections/list.unit.test.ts
@@ -117,7 +117,6 @@ function connectionFixture(): Awaited<ReturnType<typeof connectionService.listCo
     return {
         connection: connectionDataFixture(),
         provider: 'github',
-        integration_id: 'github',
         active_logs: [{ type: 'auth', log_id: 'log-id' }],
         end_user: endUserFixture()
     };

--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -37,9 +37,10 @@ describe('agentSession service', () => {
 
     it('creates and retrieves an immutable session snapshot', async () => {
         const expiresAt = new Date(Date.now() + 60_000);
+        // Slack is deliberately absent: an integration the tenant selectors matched no connection
+        // for is simply not in the snapshot, and the session exposes it as not connected.
         const resolvedConnections = {
-            github: { connectionId: 'github-connection', tags: { endUser: 'customer-1' } },
-            slack: null
+            github: { integrationId: 'github', provider: 'github', connectionId: 'github-connection', internalConnectionId: 1, configId: 10 }
         } satisfies AgentSessionResolvedConnections;
         const compiledToolset = {
             github: { pinned: ['create_issue'], searchable: ['get_issue'] },

--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -37,8 +37,6 @@ describe('agentSession service', () => {
 
     it('creates and retrieves an immutable session snapshot', async () => {
         const expiresAt = new Date(Date.now() + 60_000);
-        // Slack is deliberately absent: an integration the tenant selectors matched no connection
-        // for is simply not in the snapshot, and the session exposes it as not connected.
         const resolvedConnections = {
             github: { integrationId: 'github', provider: 'github', connectionId: 'github-connection', internalConnectionId: 1, configId: 10 }
         } satisfies AgentSessionResolvedConnections;

--- a/packages/server/lib/services/agentSessionConnections.service.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.ts
@@ -9,25 +9,24 @@ import type {
     AgentSessionAmbiguousConnectionsPayload,
     AgentSessionConnectionCandidate,
     AgentSessionConnectionCandidateReport,
-    AgentSessionConnectionDisambiguation,
     AgentSessionConnectionResolutionErrorCode,
     AgentSessionConnectionSelector,
-    AgentSessionDisambiguationIssueReason,
-    AgentSessionInvalidDisambiguationPayload,
+    AgentSessionPinnedConnection,
     AgentSessionResolvedConnection,
     AgentSessionResolvedConnections,
-    AgentSessionTenantConnections
+    AgentSessionTenantConnections,
+    AgentSessionUnknownPinnedConnectionsPayload
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export const MAX_SELECTORS = 10;
-export const MAX_DISAMBIGUATION_PINS = 50;
+export const MAX_PINNED_CONNECTIONS = 50;
 
 /**
  * A tenant selector is expected to match a handful of connections, one per integration. Reading one
  * row past the limit turns a pathologically broad selector into an error instead of a truncated
  * candidate list, which could otherwise hide the second candidate of an integration and resolve a
- * connection the caller never disambiguated.
+ * connection the caller never pinned.
  */
 export const MAX_CANDIDATES_PER_SELECTOR = 200;
 
@@ -42,30 +41,37 @@ const selectorSchema = z
     });
 
 /**
- * Public shape of `tenant.connections`. `any` is an OR between selectors, and the constraints
- * within one selector are matched together.
+ * Public shape of `tenant.connections`. `any` is an OR between selectors, and the constraints within
+ * one selector are matched together. `pinned` names connections outright, both for breaking ties
+ * between selectors and for the customer who resolves connections themselves and sends ids.
  */
 export const agentSessionTenantConnectionsSchema = z
     .strictObject({
-        any: z.array(selectorSchema).min(1).max(MAX_SELECTORS),
-        disambiguation: z
+        any: z.array(selectorSchema).max(MAX_SELECTORS).optional(),
+        pinned: z
             .array(
                 z.strictObject({
                     integration_id: providerConfigKeySchema,
                     connection_id: connectionIdSchema
                 })
             )
-            .max(MAX_DISAMBIGUATION_PINS)
+            .max(MAX_PINNED_CONNECTIONS)
+            .refine((pinned) => new Set(pinned.map((pin) => pin.integration_id)).size === pinned.length, {
+                message: 'Only one connection can be pinned per integration'
+            })
             .optional()
+    })
+    .refine((connections) => (connections.any?.length ?? 0) > 0 || (connections.pinned?.length ?? 0) > 0, {
+        message: 'Provide at least one connection selector in any, or at least one pinned connection'
     })
     .transform(
         (connections): AgentSessionTenantConnections => ({
-            any: connections.any.map((selector) => ({
+            any: (connections.any ?? []).map((selector) => ({
                 tags: selector.tags,
                 endUserId: selector.end_user_id,
                 endUserOrganizationId: selector.end_user_organization_id
             })),
-            disambiguation: (connections.disambiguation ?? []).map((pin) => ({
+            pinned: (connections.pinned ?? []).map((pin) => ({
                 integrationId: pin.integration_id,
                 connectionId: pin.connection_id
             }))
@@ -117,14 +123,7 @@ export async function listTenantConnectionCandidates({
         }
 
         for (const row of rows) {
-            byInternalId.set(row.connection.id, {
-                integrationId: row.integration_id,
-                provider: row.provider,
-                connectionId: row.connection.connection_id,
-                internalConnectionId: row.connection.id,
-                configId: row.connection.config_id,
-                tags: row.connection.tags
-            });
+            byInternalId.set(row.connection.id, toCandidate(row));
         }
     }
 
@@ -132,65 +131,80 @@ export async function listTenantConnectionCandidates({
 }
 
 /**
- * Pure resolution: one connection per integration, or a report naming the candidates the caller
- * has to choose between. Zero matches is not an error, the integration is simply absent from the
- * result and the session exposes it as not connected.
+ * Looks up each pinned connection in the environment. A pin stands on its own rather than narrowing
+ * the selectors, so the connection only has to exist, be live, and belong to the integration named.
  */
-export function resolveTenantConnections({
-    candidates,
-    disambiguation
+export async function listPinnedConnections({
+    environmentId,
+    pinned
 }: {
-    candidates: AgentSessionConnectionCandidate[];
-    disambiguation: AgentSessionConnectionDisambiguation[];
-}): Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError> {
-    const candidatesByIntegration = new Map<string, AgentSessionConnectionCandidate[]>();
-    for (const candidate of candidates) {
-        const forIntegration = candidatesByIntegration.get(candidate.integrationId) ?? [];
-        forIntegration.push(candidate);
-        candidatesByIntegration.set(candidate.integrationId, forIntegration);
-    }
+    environmentId: number;
+    pinned: AgentSessionPinnedConnection[];
+}): Promise<Result<AgentSessionConnectionCandidate[], AgentSessionConnectionResolutionError>> {
+    const found: AgentSessionConnectionCandidate[] = [];
+    const unknown: AgentSessionUnknownPinnedConnectionsPayload['pinned'] = [];
 
-    const pins = new Map<string, AgentSessionConnectionCandidate>();
-    const issues: AgentSessionInvalidDisambiguationPayload['disambiguation'] = [];
+    for (const pin of pinned) {
+        const [row] = await connectionService.listConnections({
+            environmentId,
+            connectionId: pin.connectionId,
+            integrationIds: [pin.integrationId],
+            limit: 1
+        });
 
-    for (const pin of disambiguation) {
-        const forIntegration = candidatesByIntegration.get(pin.integrationId) ?? [];
-        const pinned = matchPin({ pin, candidates: forIntegration, alreadyPinned: pins.has(pin.integrationId) });
-
-        if ('reason' in pinned) {
-            issues.push({
-                integration_id: pin.integrationId,
-                connection_id: pin.connectionId,
-                reason: pinned.reason,
-                candidates: forIntegration.map(toCandidateReport)
-            });
-            continue;
+        if (row) {
+            found.push(toCandidate(row));
+        } else {
+            unknown.push({ integration_id: pin.integrationId, connection_id: pin.connectionId });
         }
-
-        pins.set(pin.integrationId, pinned.candidate);
     }
 
-    if (issues.length > 0) {
-        const payload: AgentSessionInvalidDisambiguationPayload = { disambiguation: issues };
+    if (unknown.length > 0) {
+        const payload: AgentSessionUnknownPinnedConnectionsPayload = { pinned: unknown };
         return Err(
             new AgentSessionConnectionResolutionError({
-                code: 'invalid_disambiguation',
-                message: `${issues.length} pinned ${issues.length === 1 ? 'connection does' : 'connections do'} not narrow a matched integration. A pinned connection must be one the connection selectors already matched.`,
+                code: 'unknown_pinned_connection',
+                message: `${unknown.length} pinned ${unknown.length === 1 ? 'connection does' : 'connections do'} not exist on the integration given. Check the connection id and the integration id.`,
                 payload: { ...payload }
             })
         );
     }
 
-    const resolved: Record<string, AgentSessionResolvedConnection> = {};
-    const ambiguous: Record<string, { candidates: AgentSessionConnectionCandidateReport[] }> = {};
+    return Ok(found);
+}
 
-    for (const [integrationId, forIntegration] of candidatesByIntegration) {
-        const pinned = pins.get(integrationId);
-        if (pinned) {
-            resolved[integrationId] = toResolvedConnection(pinned);
+/**
+ * Pure resolution: one connection per integration, or a report naming the candidates the caller has
+ * to choose between. A pinned connection is authoritative for its integration, whether or not the
+ * selectors matched it. Zero matches is not an error, the integration is simply absent from the
+ * result and the session exposes it as not connected.
+ */
+export function resolveTenantConnections({
+    candidates,
+    pinned
+}: {
+    candidates: AgentSessionConnectionCandidate[];
+    pinned: AgentSessionConnectionCandidate[];
+}): Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError> {
+    const resolved: Record<string, AgentSessionResolvedConnection> = {};
+    for (const connection of pinned) {
+        resolved[connection.integrationId] = toResolvedConnection(connection);
+    }
+
+    const candidatesByIntegration = new Map<string, AgentSessionConnectionCandidate[]>();
+    for (const candidate of candidates) {
+        if (resolved[candidate.integrationId]) {
             continue;
         }
 
+        const forIntegration = candidatesByIntegration.get(candidate.integrationId) ?? [];
+        forIntegration.push(candidate);
+        candidatesByIntegration.set(candidate.integrationId, forIntegration);
+    }
+
+    const ambiguous: Record<string, { candidates: AgentSessionConnectionCandidateReport[] }> = {};
+
+    for (const [integrationId, forIntegration] of candidatesByIntegration) {
         const [onlyCandidate, ...rest] = forIntegration;
         if (!onlyCandidate || rest.length > 0) {
             ambiguous[integrationId] = { candidates: forIntegration.map(toCandidateReport) };
@@ -222,36 +236,28 @@ export async function resolveTenantConnectionsForEnvironment({
     environmentId: number;
     connections: AgentSessionTenantConnections;
 }): Promise<Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError>> {
+    const pinned = await listPinnedConnections({ environmentId, pinned: connections.pinned });
+    if (pinned.isErr()) {
+        return Err(pinned.error);
+    }
+
     const candidates = await listTenantConnectionCandidates({ environmentId, selectors: connections.any });
     if (candidates.isErr()) {
         return Err(candidates.error);
     }
 
-    return resolveTenantConnections({ candidates: candidates.value, disambiguation: connections.disambiguation });
+    return resolveTenantConnections({ candidates: candidates.value, pinned: pinned.value });
 }
 
-function matchPin({
-    pin,
-    candidates,
-    alreadyPinned
-}: {
-    pin: AgentSessionConnectionDisambiguation;
-    candidates: AgentSessionConnectionCandidate[];
-    alreadyPinned: boolean;
-}): { candidate: AgentSessionConnectionCandidate } | { reason: AgentSessionDisambiguationIssueReason } {
-    if (alreadyPinned) {
-        return { reason: 'duplicate_pin' };
-    }
-    if (candidates.length === 0) {
-        return { reason: 'no_candidates' };
-    }
-
-    const candidate = candidates.find((candidate) => candidate.connectionId === pin.connectionId);
-    if (!candidate) {
-        return { reason: 'connection_not_a_candidate' };
-    }
-
-    return { candidate };
+function toCandidate(row: Awaited<ReturnType<typeof connectionService.listConnections>>[number]): AgentSessionConnectionCandidate {
+    return {
+        integrationId: row.integration_id,
+        provider: row.provider,
+        connectionId: row.connection.connection_id,
+        internalConnectionId: row.connection.id,
+        configId: row.connection.config_id,
+        tags: row.connection.tags
+    };
 }
 
 function toResolvedConnection(candidate: AgentSessionConnectionCandidate): AgentSessionResolvedConnection {

--- a/packages/server/lib/services/agentSessionConnections.service.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.ts
@@ -5,13 +5,11 @@ import { Err, Ok } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../helpers/validation.js';
 
-import type { ConnectionIntegrationMatchRow, ConnectionMatchCandidate } from '@nangohq/shared';
+import type { ConnectionIntegrationMatchRow, ConnectionMatch, ConnectionMatchCandidate } from '@nangohq/shared';
 import type {
     AgentSessionAmbiguousConnectionsPayload,
-    AgentSessionConnectionCandidate,
     AgentSessionConnectionCandidateReport,
     AgentSessionConnectionResolutionErrorCode,
-    AgentSessionIntegrationMatch,
     AgentSessionPinnedConnection,
     AgentSessionPinnedConnectionNotMatchedPayload,
     AgentSessionResolvedConnection,
@@ -79,92 +77,107 @@ export async function resolveTenantConnectionsForEnvironment({
 }): Promise<Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError>> {
     const tagSelectors = connections.any.map((selector) => selector.tags);
 
-    const groups = await connectionService.groupConnectionMatchesByIntegration({
+    const matches = await connectionService.groupConnectionMatchesByIntegration({
         environmentId,
         tagSelectors,
         candidateSampleSize: CANDIDATE_SAMPLE_SIZE
     });
 
-    const verifiedPins: AgentSessionConnectionCandidate[] = [];
-    const rejectedPins: AgentSessionPinnedConnection[] = [];
+    const verifiedPins: ConnectionMatch[] = [];
+    const unknownPins: AgentSessionPinnedConnection[] = [];
+    const notMatchedPins: AgentSessionPinnedConnection[] = [];
 
     for (const pin of connections.pinned) {
-        // Queried per pin rather than searched in the samples above, which only hold part of the set.
-        const row = await connectionService.findConnectionMatchingSelectors({
-            environmentId,
-            integrationId: pin.integrationId,
-            connectionId: pin.connectionId,
-            tagSelectors
-        });
+        const target = { environmentId, integrationId: pin.integrationId, connectionId: pin.connectionId };
 
-        if (row) {
-            verifiedPins.push(toCandidate({ integrationId: row.integration_id, provider: row.provider, candidate: row.candidate }));
+        // Queried per pin rather than searched in the samples above, which only hold part of the set.
+        const matched = await connectionService.findConnectionMatchingSelectors({ ...target, tagSelectors });
+        if (matched) {
+            verifiedPins.push(matched);
+            continue;
+        }
+
+        const exists = tagSelectors.length > 0 && (await connectionService.findConnectionMatchingSelectors({ ...target, tagSelectors: [] }));
+        if (exists) {
+            notMatchedPins.push(pin);
         } else {
-            rejectedPins.push(pin);
+            unknownPins.push(pin);
         }
     }
 
-    return resolveTenantConnections({
-        matches: groups.map(toIntegrationMatch),
-        verifiedPins,
-        rejectedPins,
-        hasSelectors: tagSelectors.length > 0
-    });
+    return resolveTenantConnections({ matches, verifiedPins, unknownPins, notMatchedPins });
 }
 
 export function resolveTenantConnections({
     matches,
     verifiedPins,
-    rejectedPins,
-    hasSelectors
+    unknownPins,
+    notMatchedPins
 }: {
-    matches: AgentSessionIntegrationMatch[];
-    verifiedPins: AgentSessionConnectionCandidate[];
-    rejectedPins: AgentSessionPinnedConnection[];
-    hasSelectors: boolean;
+    matches: ConnectionIntegrationMatchRow[];
+    verifiedPins: ConnectionMatch[];
+    unknownPins: AgentSessionPinnedConnection[];
+    notMatchedPins: AgentSessionPinnedConnection[];
 }): Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError> {
-    if (rejectedPins.length > 0) {
-        return Err(hasSelectors ? pinnedNotMatchedError(rejectedPins, matches) : unknownPinnedConnectionError(rejectedPins));
+    if (unknownPins.length > 0) {
+        return Err(unknownPinnedConnectionError(unknownPins));
     }
 
-    const resolved: Record<string, AgentSessionResolvedConnection> = {};
+    if (notMatchedPins.length > 0) {
+        return Err(pinnedNotMatchedError(notMatchedPins, matches));
+    }
+
+    // Maps rather than plain objects: an integration id of `__proto__` would not become an own
+    // property, and the integration would silently drop out of the result.
+    const resolved = new Map<string, AgentSessionResolvedConnection>();
     for (const pin of verifiedPins) {
-        resolved[pin.integrationId] = toResolvedConnection(pin);
+        resolved.set(pin.integration_id, toResolvedConnection(pin.integration_id, pin.provider, pin.candidate));
     }
 
-    const ambiguous: AgentSessionAmbiguousConnectionsPayload['integrations'] = {};
+    const ambiguous = new Map<string, AgentSessionAmbiguousConnectionsPayload['integrations'][string]>();
 
     for (const match of matches) {
-        if (resolved[match.integrationId]) {
+        if (resolved.has(match.integration_id)) {
             continue;
         }
 
         const [onlyCandidate] = match.candidates;
-        if (match.matchCount > 1 || !onlyCandidate) {
-            ambiguous[match.integrationId] = { match_count: match.matchCount, candidates: match.candidates.map(toCandidateReport) };
+        if (match.match_count > 1 || !onlyCandidate) {
+            ambiguous.set(match.integration_id, { match_count: match.match_count, candidates: match.candidates.map(toCandidateReport) });
             continue;
         }
 
-        resolved[match.integrationId] = toResolvedConnection(onlyCandidate);
+        resolved.set(match.integration_id, toResolvedConnection(match.integration_id, match.provider, onlyCandidate));
     }
 
-    const ambiguousIntegrations = Object.keys(ambiguous);
-    if (ambiguousIntegrations.length > 0) {
-        const payload: AgentSessionAmbiguousConnectionsPayload = { integrations: ambiguous };
+    if (ambiguous.size > 0) {
+        const payload: AgentSessionAmbiguousConnectionsPayload = { integrations: Object.fromEntries(ambiguous) };
         return Err(
             new AgentSessionConnectionResolutionError({
                 code: 'ambiguous_connections',
-                message: `${ambiguousIntegrations.length} ${ambiguousIntegrations.length === 1 ? 'integration' : 'integrations'} matched more than one connection. Narrow the connection tags or pin a connection id.`,
+                message: `${ambiguous.size} ${ambiguous.size === 1 ? 'integration' : 'integrations'} matched more than one connection. Narrow the connection tags or pin a connection id.`,
                 payload: { ...payload }
             })
         );
     }
 
-    return Ok(resolved);
+    return Ok(Object.fromEntries(resolved));
 }
 
-function pinnedNotMatchedError(rejected: AgentSessionPinnedConnection[], matches: AgentSessionIntegrationMatch[]): AgentSessionConnectionResolutionError {
-    const byIntegration = new Map(matches.map((match) => [match.integrationId, match]));
+function unknownPinnedConnectionError(rejected: AgentSessionPinnedConnection[]): AgentSessionConnectionResolutionError {
+    const payload: AgentSessionUnknownPinnedConnectionsPayload = {
+        pinned: rejected.map((pin) => ({ integration_id: pin.integrationId, connection_id: pin.connectionId }))
+    };
+
+    return new AgentSessionConnectionResolutionError({
+        code: 'unknown_pinned_connection',
+        message: `${rejected.length} pinned ${rejected.length === 1 ? 'connection does' : 'connections do'} not exist on the integration given. Check the connection id and the integration id.`,
+        payload: { ...payload }
+    });
+}
+
+function pinnedNotMatchedError(rejected: AgentSessionPinnedConnection[], matches: ConnectionIntegrationMatchRow[]): AgentSessionConnectionResolutionError {
+    const byIntegration = new Map(matches.map((match) => [match.integration_id, match]));
     const payload: AgentSessionPinnedConnectionNotMatchedPayload = {
         pinned: rejected.map((pin) => ({
             integration_id: pin.integrationId,
@@ -180,56 +193,16 @@ function pinnedNotMatchedError(rejected: AgentSessionPinnedConnection[], matches
     });
 }
 
-function unknownPinnedConnectionError(rejected: AgentSessionPinnedConnection[]): AgentSessionConnectionResolutionError {
-    const payload: AgentSessionUnknownPinnedConnectionsPayload = {
-        pinned: rejected.map((pin) => ({ integration_id: pin.integrationId, connection_id: pin.connectionId }))
-    };
-
-    return new AgentSessionConnectionResolutionError({
-        code: 'unknown_pinned_connection',
-        message: `${rejected.length} pinned ${rejected.length === 1 ? 'connection does' : 'connections do'} not exist on the integration given. Check the connection id and the integration id.`,
-        payload: { ...payload }
-    });
-}
-
-function toIntegrationMatch(group: ConnectionIntegrationMatchRow): AgentSessionIntegrationMatch {
-    return {
-        integrationId: group.integration_id,
-        provider: group.provider,
-        matchCount: group.match_count,
-        candidates: group.candidates.map((candidate) => toCandidate({ integrationId: group.integration_id, provider: group.provider, candidate }))
-    };
-}
-
-function toCandidate({
-    integrationId,
-    provider,
-    candidate
-}: {
-    integrationId: string;
-    provider: string;
-    candidate: ConnectionMatchCandidate;
-}): AgentSessionConnectionCandidate {
+function toResolvedConnection(integrationId: string, provider: string, candidate: ConnectionMatchCandidate): AgentSessionResolvedConnection {
     return {
         integrationId,
         provider,
         connectionId: candidate.connection_id,
         internalConnectionId: candidate.id,
-        configId: candidate.config_id,
-        tags: candidate.tags
+        configId: candidate.config_id
     };
 }
 
-function toResolvedConnection(candidate: AgentSessionConnectionCandidate): AgentSessionResolvedConnection {
-    return {
-        integrationId: candidate.integrationId,
-        provider: candidate.provider,
-        connectionId: candidate.connectionId,
-        internalConnectionId: candidate.internalConnectionId,
-        configId: candidate.configId
-    };
-}
-
-function toCandidateReport(candidate: AgentSessionConnectionCandidate): AgentSessionConnectionCandidateReport {
-    return { connection_id: candidate.connectionId, tags: candidate.tags };
+function toCandidateReport(candidate: ConnectionMatchCandidate): AgentSessionConnectionCandidateReport {
+    return { connection_id: candidate.connection_id, tags: candidate.tags };
 }

--- a/packages/server/lib/services/agentSessionConnections.service.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.ts
@@ -68,7 +68,7 @@ export class AgentSessionConnectionResolutionError extends Error {
     }
 }
 
-export async function resolveTenantConnectionsForEnvironment({
+export async function resolveTenantConnections({
     environmentId,
     connections
 }: {
@@ -76,39 +76,54 @@ export async function resolveTenantConnectionsForEnvironment({
     connections: AgentSessionTenantConnections;
 }): Promise<Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError>> {
     const tagSelectors = connections.any.map((selector) => selector.tags);
+    const pinnedConnections = connections.pinned.map((pin) => ({ integrationId: pin.integrationId, connectionId: pin.connectionId }));
 
     const matches = await connectionService.groupConnectionMatchesByIntegration({
         environmentId,
         tagSelectors,
+        pinnedConnections,
         candidateSampleSize: CANDIDATE_SAMPLE_SIZE
     });
 
     const verifiedPins: ConnectionMatch[] = [];
-    const unknownPins: AgentSessionPinnedConnection[] = [];
-    const notMatchedPins: AgentSessionPinnedConnection[] = [];
+    const missingPins: AgentSessionPinnedConnection[] = [];
 
     for (const pin of connections.pinned) {
-        const target = { environmentId, integrationId: pin.integrationId, connectionId: pin.connectionId };
+        const match = matches.find((candidate) => candidate.integration_id === pin.integrationId);
+        const candidate = match?.candidates.find((connection) => connection.connection_id === pin.connectionId);
 
-        // Queried per pin rather than searched in the samples above, which only hold part of the set.
-        const matched = await connectionService.findConnectionMatchingSelectors({ ...target, tagSelectors });
-        if (matched) {
-            verifiedPins.push(matched);
-            continue;
-        }
-
-        const exists = tagSelectors.length > 0 && (await connectionService.findConnectionMatchingSelectors({ ...target, tagSelectors: [] }));
-        if (exists) {
-            notMatchedPins.push(pin);
+        if (match && candidate) {
+            verifiedPins.push({ integration_id: match.integration_id, provider: match.provider, candidate });
         } else {
-            unknownPins.push(pin);
+            missingPins.push(pin);
         }
     }
 
-    return resolveTenantConnections({ matches, verifiedPins, unknownPins, notMatchedPins });
+    // A pin absent from the matches either does not exist or was excluded by the selectors.
+    const existing = await connectionService.findExistingConnections({
+        environmentId,
+        connections: missingPins.map((pin) => ({ integrationId: pin.integrationId, connectionId: pin.connectionId }))
+    });
+
+    const unknownPins: AgentSessionPinnedConnection[] = [];
+    const notMatchedPins: AgentSessionPinnedConnection[] = [];
+
+    for (const pin of missingPins) {
+        const found = existing.find((connection) => connection.integration_id === pin.integrationId && connection.candidate.connection_id === pin.connectionId);
+
+        if (!found) {
+            unknownPins.push(pin);
+        } else if (tagSelectors.length > 0) {
+            notMatchedPins.push(pin);
+        } else {
+            verifiedPins.push(found);
+        }
+    }
+
+    return pickConnectionPerIntegration({ matches, verifiedPins, unknownPins, notMatchedPins });
 }
 
-export function resolveTenantConnections({
+export function pickConnectionPerIntegration({
     matches,
     verifiedPins,
     unknownPins,

--- a/packages/server/lib/services/agentSessionConnections.service.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.ts
@@ -12,6 +12,7 @@ import type {
     AgentSessionConnectionResolutionErrorCode,
     AgentSessionConnectionSelector,
     AgentSessionPinnedConnection,
+    AgentSessionPinnedConnectionNotMatchedPayload,
     AgentSessionResolvedConnection,
     AgentSessionResolvedConnections,
     AgentSessionTenantConnections,
@@ -42,8 +43,9 @@ const selectorSchema = z
 
 /**
  * Public shape of `tenant.connections`. `any` is an OR between selectors, and the constraints within
- * one selector are matched together. `pinned` names connections outright, both for breaking ties
- * between selectors and for the customer who resolves connections themselves and sends ids.
+ * one selector are matched together. `pinned` then picks among what the selectors matched. Leaving
+ * `any` off applies no tag filter, which is how a customer who resolves connections themselves pins
+ * ids directly.
  */
 export const agentSessionTenantConnectionsSchema = z
     .strictObject({
@@ -131,8 +133,8 @@ export async function listTenantConnectionCandidates({
 }
 
 /**
- * Looks up each pinned connection in the environment. A pin stands on its own rather than narrowing
- * the selectors, so the connection only has to exist, be live, and belong to the integration named.
+ * Looks up each pinned connection in the environment, for the tenant that applies no tag filter.
+ * These lookups become the candidate set, so the pins are what the session resolves.
  */
 export async function listPinnedConnections({
     environmentId,
@@ -175,36 +177,61 @@ export async function listPinnedConnections({
 
 /**
  * Pure resolution: one connection per integration, or a report naming the candidates the caller has
- * to choose between. A pinned connection is authoritative for its integration, whether or not the
- * selectors matched it. Zero matches is not an error, the integration is simply absent from the
- * result and the session exposes it as not connected.
+ * to choose between. Selectors filter first and a pin picks from what they matched, so a pin can
+ * never reach a connection the selectors excluded. Zero matches is not an error, the integration is
+ * simply absent from the result and the session exposes it as not connected.
  */
 export function resolveTenantConnections({
     candidates,
     pinned
 }: {
     candidates: AgentSessionConnectionCandidate[];
-    pinned: AgentSessionConnectionCandidate[];
+    pinned: AgentSessionPinnedConnection[];
 }): Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError> {
-    const resolved: Record<string, AgentSessionResolvedConnection> = {};
-    for (const connection of pinned) {
-        resolved[connection.integrationId] = toResolvedConnection(connection);
-    }
-
     const candidatesByIntegration = new Map<string, AgentSessionConnectionCandidate[]>();
     for (const candidate of candidates) {
-        if (resolved[candidate.integrationId]) {
-            continue;
-        }
-
         const forIntegration = candidatesByIntegration.get(candidate.integrationId) ?? [];
         forIntegration.push(candidate);
         candidatesByIntegration.set(candidate.integrationId, forIntegration);
     }
 
+    const resolved: Record<string, AgentSessionResolvedConnection> = {};
+    const notMatched: AgentSessionPinnedConnectionNotMatchedPayload['pinned'] = [];
+
+    for (const pin of pinned) {
+        const forIntegration = candidatesByIntegration.get(pin.integrationId) ?? [];
+        const pinnedCandidate = forIntegration.find((candidate) => candidate.connectionId === pin.connectionId);
+
+        if (!pinnedCandidate) {
+            notMatched.push({
+                integration_id: pin.integrationId,
+                connection_id: pin.connectionId,
+                candidates: forIntegration.map(toCandidateReport)
+            });
+            continue;
+        }
+
+        resolved[pin.integrationId] = toResolvedConnection(pinnedCandidate);
+    }
+
+    if (notMatched.length > 0) {
+        const payload: AgentSessionPinnedConnectionNotMatchedPayload = { pinned: notMatched };
+        return Err(
+            new AgentSessionConnectionResolutionError({
+                code: 'pinned_connection_not_matched',
+                message: `${notMatched.length} pinned ${notMatched.length === 1 ? 'connection is' : 'connections are'} not among the connections the selectors matched. A pin chooses between matched connections, so widen the selectors or pin one of the candidates.`,
+                payload: { ...payload }
+            })
+        );
+    }
+
     const ambiguous: Record<string, { candidates: AgentSessionConnectionCandidateReport[] }> = {};
 
     for (const [integrationId, forIntegration] of candidatesByIntegration) {
+        if (resolved[integrationId]) {
+            continue;
+        }
+
         const [onlyCandidate, ...rest] = forIntegration;
         if (!onlyCandidate || rest.length > 0) {
             ambiguous[integrationId] = { candidates: forIntegration.map(toCandidateReport) };
@@ -236,17 +263,18 @@ export async function resolveTenantConnectionsForEnvironment({
     environmentId: number;
     connections: AgentSessionTenantConnections;
 }): Promise<Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError>> {
-    const pinned = await listPinnedConnections({ environmentId, pinned: connections.pinned });
-    if (pinned.isErr()) {
-        return Err(pinned.error);
-    }
+    // With no selectors there is no tag filter to resolve against, so the pinned connections are
+    // themselves the candidate set and the pin check below is satisfied by construction.
+    const candidates =
+        connections.any.length > 0
+            ? await listTenantConnectionCandidates({ environmentId, selectors: connections.any })
+            : await listPinnedConnections({ environmentId, pinned: connections.pinned });
 
-    const candidates = await listTenantConnectionCandidates({ environmentId, selectors: connections.any });
     if (candidates.isErr()) {
         return Err(candidates.error);
     }
 
-    return resolveTenantConnections({ candidates: candidates.value, pinned: pinned.value });
+    return resolveTenantConnections({ candidates: candidates.value, pinned: connections.pinned });
 }
 
 function toCandidate(row: Awaited<ReturnType<typeof connectionService.listConnections>>[number]): AgentSessionConnectionCandidate {

--- a/packages/server/lib/services/agentSessionConnections.service.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.ts
@@ -1,0 +1,269 @@
+import { z } from 'zod';
+
+import { connectionService, connectionTagsSchema } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import { connectionIdSchema, providerConfigKeySchema } from '../helpers/validation.js';
+
+import type {
+    AgentSessionAmbiguousConnectionsPayload,
+    AgentSessionConnectionCandidate,
+    AgentSessionConnectionCandidateReport,
+    AgentSessionConnectionDisambiguation,
+    AgentSessionConnectionResolutionErrorCode,
+    AgentSessionConnectionSelector,
+    AgentSessionDisambiguationIssueReason,
+    AgentSessionInvalidDisambiguationPayload,
+    AgentSessionResolvedConnection,
+    AgentSessionResolvedConnections,
+    AgentSessionTenantConnections
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+export const MAX_SELECTORS = 10;
+export const MAX_DISAMBIGUATION_PINS = 50;
+
+/**
+ * A tenant selector is expected to match a handful of connections, one per integration. Reading one
+ * row past the limit turns a pathologically broad selector into an error instead of a truncated
+ * candidate list, which could otherwise hide the second candidate of an integration and resolve a
+ * connection the caller never disambiguated.
+ */
+export const MAX_CANDIDATES_PER_SELECTOR = 200;
+
+const selectorSchema = z
+    .strictObject({
+        tags: connectionTagsSchema.optional(),
+        end_user_id: z.string().min(1).max(255).optional(),
+        end_user_organization_id: z.string().min(1).max(255).optional()
+    })
+    .refine((selector) => selector.tags !== undefined || selector.end_user_id !== undefined || selector.end_user_organization_id !== undefined, {
+        message: 'A connection selector must constrain at least one of tags, end_user_id or end_user_organization_id'
+    });
+
+/**
+ * Public shape of `tenant.connections`. `any` is an OR between selectors, and the constraints
+ * within one selector are matched together.
+ */
+export const agentSessionTenantConnectionsSchema = z
+    .strictObject({
+        any: z.array(selectorSchema).min(1).max(MAX_SELECTORS),
+        disambiguation: z
+            .array(
+                z.strictObject({
+                    integration_id: providerConfigKeySchema,
+                    connection_id: connectionIdSchema
+                })
+            )
+            .max(MAX_DISAMBIGUATION_PINS)
+            .optional()
+    })
+    .transform(
+        (connections): AgentSessionTenantConnections => ({
+            any: connections.any.map((selector) => ({
+                tags: selector.tags,
+                endUserId: selector.end_user_id,
+                endUserOrganizationId: selector.end_user_organization_id
+            })),
+            disambiguation: (connections.disambiguation ?? []).map((pin) => ({
+                integrationId: pin.integration_id,
+                connectionId: pin.connection_id
+            }))
+        })
+    );
+
+export class AgentSessionConnectionResolutionError extends Error {
+    public readonly code: AgentSessionConnectionResolutionErrorCode;
+    public readonly payload: Record<string, unknown>;
+
+    constructor({ code, message, payload }: { code: AgentSessionConnectionResolutionErrorCode; message: string; payload: Record<string, unknown> }) {
+        super(message);
+        this.name = 'AgentSessionConnectionResolutionError';
+        this.code = code;
+        this.payload = payload;
+    }
+}
+
+/**
+ * Runs one listConnections call per selector so each keeps the GIN-indexed `tags @> ?::jsonb`
+ * containment path, then unions the results. That union is the OR between selectors.
+ */
+export async function listTenantConnectionCandidates({
+    environmentId,
+    selectors
+}: {
+    environmentId: number;
+    selectors: AgentSessionConnectionSelector[];
+}): Promise<Result<AgentSessionConnectionCandidate[], AgentSessionConnectionResolutionError>> {
+    const byInternalId = new Map<number, AgentSessionConnectionCandidate>();
+
+    for (const selector of selectors) {
+        const rows = await connectionService.listConnections({
+            environmentId,
+            tags: selector.tags,
+            endUserId: selector.endUserId,
+            endUserOrganizationId: selector.endUserOrganizationId,
+            limit: MAX_CANDIDATES_PER_SELECTOR + 1
+        });
+
+        if (rows.length > MAX_CANDIDATES_PER_SELECTOR) {
+            return Err(
+                new AgentSessionConnectionResolutionError({
+                    code: 'selector_too_broad',
+                    message: `A connection selector matched more than ${MAX_CANDIDATES_PER_SELECTOR} connections. Narrow the selector so it identifies one tenant.`,
+                    payload: { limit: MAX_CANDIDATES_PER_SELECTOR }
+                })
+            );
+        }
+
+        for (const row of rows) {
+            byInternalId.set(row.connection.id, {
+                integrationId: row.integration_id,
+                provider: row.provider,
+                connectionId: row.connection.connection_id,
+                internalConnectionId: row.connection.id,
+                configId: row.connection.config_id,
+                tags: row.connection.tags
+            });
+        }
+    }
+
+    return Ok([...byInternalId.values()]);
+}
+
+/**
+ * Pure resolution: one connection per integration, or a report naming the candidates the caller
+ * has to choose between. Zero matches is not an error, the integration is simply absent from the
+ * result and the session exposes it as not connected.
+ */
+export function resolveTenantConnections({
+    candidates,
+    disambiguation
+}: {
+    candidates: AgentSessionConnectionCandidate[];
+    disambiguation: AgentSessionConnectionDisambiguation[];
+}): Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError> {
+    const candidatesByIntegration = new Map<string, AgentSessionConnectionCandidate[]>();
+    for (const candidate of candidates) {
+        const forIntegration = candidatesByIntegration.get(candidate.integrationId) ?? [];
+        forIntegration.push(candidate);
+        candidatesByIntegration.set(candidate.integrationId, forIntegration);
+    }
+
+    const pins = new Map<string, AgentSessionConnectionCandidate>();
+    const issues: AgentSessionInvalidDisambiguationPayload['disambiguation'] = [];
+
+    for (const pin of disambiguation) {
+        const forIntegration = candidatesByIntegration.get(pin.integrationId) ?? [];
+        const pinned = matchPin({ pin, candidates: forIntegration, alreadyPinned: pins.has(pin.integrationId) });
+
+        if ('reason' in pinned) {
+            issues.push({
+                integration_id: pin.integrationId,
+                connection_id: pin.connectionId,
+                reason: pinned.reason,
+                candidates: forIntegration.map(toCandidateReport)
+            });
+            continue;
+        }
+
+        pins.set(pin.integrationId, pinned.candidate);
+    }
+
+    if (issues.length > 0) {
+        const payload: AgentSessionInvalidDisambiguationPayload = { disambiguation: issues };
+        return Err(
+            new AgentSessionConnectionResolutionError({
+                code: 'invalid_disambiguation',
+                message: `${issues.length} pinned ${issues.length === 1 ? 'connection does' : 'connections do'} not narrow a matched integration. A pinned connection must be one the connection selectors already matched.`,
+                payload: { ...payload }
+            })
+        );
+    }
+
+    const resolved: Record<string, AgentSessionResolvedConnection> = {};
+    const ambiguous: Record<string, { candidates: AgentSessionConnectionCandidateReport[] }> = {};
+
+    for (const [integrationId, forIntegration] of candidatesByIntegration) {
+        const pinned = pins.get(integrationId);
+        if (pinned) {
+            resolved[integrationId] = toResolvedConnection(pinned);
+            continue;
+        }
+
+        const [onlyCandidate, ...rest] = forIntegration;
+        if (!onlyCandidate || rest.length > 0) {
+            ambiguous[integrationId] = { candidates: forIntegration.map(toCandidateReport) };
+            continue;
+        }
+
+        resolved[integrationId] = toResolvedConnection(onlyCandidate);
+    }
+
+    const ambiguousIntegrations = Object.keys(ambiguous);
+    if (ambiguousIntegrations.length > 0) {
+        const payload: AgentSessionAmbiguousConnectionsPayload = { integrations: ambiguous };
+        return Err(
+            new AgentSessionConnectionResolutionError({
+                code: 'ambiguous_connections',
+                message: `${ambiguousIntegrations.length} ${ambiguousIntegrations.length === 1 ? 'integration' : 'integrations'} matched more than one connection. Narrow the connection tags or pin a connection id.`,
+                payload: { ...payload }
+            })
+        );
+    }
+
+    return Ok(resolved);
+}
+
+export async function resolveTenantConnectionsForEnvironment({
+    environmentId,
+    connections
+}: {
+    environmentId: number;
+    connections: AgentSessionTenantConnections;
+}): Promise<Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError>> {
+    const candidates = await listTenantConnectionCandidates({ environmentId, selectors: connections.any });
+    if (candidates.isErr()) {
+        return Err(candidates.error);
+    }
+
+    return resolveTenantConnections({ candidates: candidates.value, disambiguation: connections.disambiguation });
+}
+
+function matchPin({
+    pin,
+    candidates,
+    alreadyPinned
+}: {
+    pin: AgentSessionConnectionDisambiguation;
+    candidates: AgentSessionConnectionCandidate[];
+    alreadyPinned: boolean;
+}): { candidate: AgentSessionConnectionCandidate } | { reason: AgentSessionDisambiguationIssueReason } {
+    if (alreadyPinned) {
+        return { reason: 'duplicate_pin' };
+    }
+    if (candidates.length === 0) {
+        return { reason: 'no_candidates' };
+    }
+
+    const candidate = candidates.find((candidate) => candidate.connectionId === pin.connectionId);
+    if (!candidate) {
+        return { reason: 'connection_not_a_candidate' };
+    }
+
+    return { candidate };
+}
+
+function toResolvedConnection(candidate: AgentSessionConnectionCandidate): AgentSessionResolvedConnection {
+    return {
+        integrationId: candidate.integrationId,
+        provider: candidate.provider,
+        connectionId: candidate.connectionId,
+        internalConnectionId: candidate.internalConnectionId,
+        configId: candidate.configId
+    };
+}
+
+function toCandidateReport(candidate: AgentSessionConnectionCandidate): AgentSessionConnectionCandidateReport {
+    return { connection_id: candidate.connectionId, tags: candidate.tags };
+}

--- a/packages/server/lib/services/agentSessionConnections.service.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.ts
@@ -5,7 +5,7 @@ import { Err, Ok } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../helpers/validation.js';
 
-import type { ConnectionMatchCandidate } from '@nangohq/shared';
+import type { ConnectionIntegrationMatchRow, ConnectionMatchCandidate } from '@nangohq/shared';
 import type {
     AgentSessionAmbiguousConnectionsPayload,
     AgentSessionConnectionCandidate,
@@ -17,13 +17,11 @@ import type {
     AgentSessionResolvedConnection,
     AgentSessionResolvedConnections,
     AgentSessionTenantConnections,
-    AgentSessionUnknownPinnedConnectionsPayload,
-    Tags
+    AgentSessionUnknownPinnedConnectionsPayload
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export const MAX_SELECTORS = 10;
-
 export const CANDIDATE_SAMPLE_SIZE = 10;
 
 const selectorSchema = z.strictObject({
@@ -72,56 +70,46 @@ export class AgentSessionConnectionResolutionError extends Error {
     }
 }
 
-export async function listIntegrationMatches({
+export async function resolveTenantConnectionsForEnvironment({
     environmentId,
-    selectors
+    connections
 }: {
     environmentId: number;
-    selectors: AgentSessionConnectionSelectorList;
-}): Promise<AgentSessionIntegrationMatch[]> {
+    connections: AgentSessionTenantConnections;
+}): Promise<Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError>> {
+    const tagSelectors = connections.any.map((selector) => selector.tags);
+
     const groups = await connectionService.groupConnectionMatchesByIntegration({
         environmentId,
-        tagSelectors: selectors,
+        tagSelectors,
         candidateSampleSize: CANDIDATE_SAMPLE_SIZE
     });
 
-    return groups.map((group) => ({
-        integrationId: group.integration_id,
-        provider: group.provider,
-        matchCount: group.match_count,
-        candidates: group.candidates.map((candidate) => toCandidate({ integrationId: group.integration_id, provider: group.provider, candidate }))
-    }));
-}
+    const verifiedPins: AgentSessionConnectionCandidate[] = [];
+    const rejectedPins: AgentSessionPinnedConnection[] = [];
 
-/** Queries per pin rather than searching the candidate sample, which only holds part of the set. */
-export async function checkPinnedConnections({
-    environmentId,
-    selectors,
-    pinned
-}: {
-    environmentId: number;
-    selectors: AgentSessionConnectionSelectorList;
-    pinned: AgentSessionPinnedConnection[];
-}): Promise<{ verified: AgentSessionConnectionCandidate[]; rejected: AgentSessionPinnedConnection[] }> {
-    const verified: AgentSessionConnectionCandidate[] = [];
-    const rejected: AgentSessionPinnedConnection[] = [];
-
-    for (const pin of pinned) {
+    for (const pin of connections.pinned) {
+        // Queried per pin rather than searched in the samples above, which only hold part of the set.
         const row = await connectionService.findConnectionMatchingSelectors({
             environmentId,
             integrationId: pin.integrationId,
             connectionId: pin.connectionId,
-            tagSelectors: selectors
+            tagSelectors
         });
 
         if (row) {
-            verified.push(toCandidate({ integrationId: row.integration_id, provider: row.provider, candidate: row.candidate }));
+            verifiedPins.push(toCandidate({ integrationId: row.integration_id, provider: row.provider, candidate: row.candidate }));
         } else {
-            rejected.push(pin);
+            rejectedPins.push(pin);
         }
     }
 
-    return { verified, rejected };
+    return resolveTenantConnections({
+        matches: groups.map(toIntegrationMatch),
+        verifiedPins,
+        rejectedPins,
+        hasSelectors: tagSelectors.length > 0
+    });
 }
 
 export function resolveTenantConnections({
@@ -175,27 +163,6 @@ export function resolveTenantConnections({
     return Ok(resolved);
 }
 
-export async function resolveTenantConnectionsForEnvironment({
-    environmentId,
-    connections
-}: {
-    environmentId: number;
-    connections: AgentSessionTenantConnections;
-}): Promise<Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError>> {
-    const selectors = connections.any.map((selector) => selector.tags);
-    const matches = await listIntegrationMatches({ environmentId, selectors });
-    const pins = await checkPinnedConnections({ environmentId, selectors, pinned: connections.pinned });
-
-    return resolveTenantConnections({
-        matches,
-        verifiedPins: pins.verified,
-        rejectedPins: pins.rejected,
-        hasSelectors: selectors.length > 0
-    });
-}
-
-type AgentSessionConnectionSelectorList = Tags[];
-
 function pinnedNotMatchedError(rejected: AgentSessionPinnedConnection[], matches: AgentSessionIntegrationMatch[]): AgentSessionConnectionResolutionError {
     const byIntegration = new Map(matches.map((match) => [match.integrationId, match]));
     const payload: AgentSessionPinnedConnectionNotMatchedPayload = {
@@ -223,6 +190,15 @@ function unknownPinnedConnectionError(rejected: AgentSessionPinnedConnection[]):
         message: `${rejected.length} pinned ${rejected.length === 1 ? 'connection does' : 'connections do'} not exist on the integration given. Check the connection id and the integration id.`,
         payload: { ...payload }
     });
+}
+
+function toIntegrationMatch(group: ConnectionIntegrationMatchRow): AgentSessionIntegrationMatch {
+    return {
+        integrationId: group.integration_id,
+        provider: group.provider,
+        matchCount: group.match_count,
+        candidates: group.candidates.map((candidate) => toCandidate({ integrationId: group.integration_id, provider: group.provider, candidate }))
+    };
 }
 
 function toCandidate({

--- a/packages/server/lib/services/agentSessionConnections.service.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.ts
@@ -5,46 +5,33 @@ import { Err, Ok } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../helpers/validation.js';
 
+import type { ConnectionMatchCandidate } from '@nangohq/shared';
 import type {
     AgentSessionAmbiguousConnectionsPayload,
     AgentSessionConnectionCandidate,
     AgentSessionConnectionCandidateReport,
     AgentSessionConnectionResolutionErrorCode,
-    AgentSessionConnectionSelector,
+    AgentSessionIntegrationMatch,
     AgentSessionPinnedConnection,
     AgentSessionPinnedConnectionNotMatchedPayload,
     AgentSessionResolvedConnection,
     AgentSessionResolvedConnections,
     AgentSessionTenantConnections,
-    AgentSessionUnknownPinnedConnectionsPayload
+    AgentSessionUnknownPinnedConnectionsPayload,
+    Tags
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export const MAX_SELECTORS = 10;
-export const MAX_PINNED_CONNECTIONS = 50;
 
-/**
- * A tenant selector is expected to match a handful of connections, one per integration. Reading one
- * row past the limit turns a pathologically broad selector into an error instead of a truncated
- * candidate list, which could otherwise hide the second candidate of an integration and resolve a
- * connection the caller never pinned.
- */
-export const MAX_CANDIDATES_PER_SELECTOR = 200;
+export const CANDIDATE_SAMPLE_SIZE = 10;
 
-// Tags are the only selector. End users are already projected onto connection tags on creation, so
-// an end user selector would be a second way to express the same match, on a slower query path.
 const selectorSchema = z.strictObject({
     tags: connectionTagsSchema.refine((tags) => Object.keys(tags).length > 0, {
         message: 'A connection selector must carry at least one tag'
     })
 });
 
-/**
- * Public shape of `tenant.connections`. `any` is an OR between selectors, and the constraints within
- * one selector are matched together. `pinned` then picks among what the selectors matched. Leaving
- * `any` off applies no tag filter, which is how a customer who resolves connections themselves pins
- * ids directly.
- */
 export const agentSessionTenantConnectionsSchema = z
     .strictObject({
         any: z.array(selectorSchema).max(MAX_SELECTORS).optional(),
@@ -55,7 +42,6 @@ export const agentSessionTenantConnectionsSchema = z
                     connection_id: connectionIdSchema
                 })
             )
-            .max(MAX_PINNED_CONNECTIONS)
             .refine((pinned) => new Set(pinned.map((pin) => pin.integration_id)).size === pinned.length, {
                 message: 'Only one connection can be pinned per integration'
             })
@@ -86,151 +72,92 @@ export class AgentSessionConnectionResolutionError extends Error {
     }
 }
 
-/**
- * Runs one listConnections call per selector so each keeps the GIN-indexed `tags @> ?::jsonb`
- * containment path, then unions the results. That union is the OR between selectors.
- */
-export async function listTenantConnectionCandidates({
+export async function listIntegrationMatches({
     environmentId,
     selectors
 }: {
     environmentId: number;
-    selectors: AgentSessionConnectionSelector[];
-}): Promise<Result<AgentSessionConnectionCandidate[], AgentSessionConnectionResolutionError>> {
-    const byInternalId = new Map<number, AgentSessionConnectionCandidate>();
+    selectors: AgentSessionConnectionSelectorList;
+}): Promise<AgentSessionIntegrationMatch[]> {
+    const groups = await connectionService.groupConnectionMatchesByIntegration({
+        environmentId,
+        tagSelectors: selectors,
+        candidateSampleSize: CANDIDATE_SAMPLE_SIZE
+    });
 
-    for (const selector of selectors) {
-        const rows = await connectionService.listConnections({
-            environmentId,
-            tags: selector.tags,
-            limit: MAX_CANDIDATES_PER_SELECTOR + 1
-        });
-
-        if (rows.length > MAX_CANDIDATES_PER_SELECTOR) {
-            return Err(
-                new AgentSessionConnectionResolutionError({
-                    code: 'selector_too_broad',
-                    message: `A connection selector matched more than ${MAX_CANDIDATES_PER_SELECTOR} connections. Narrow the selector so it identifies one tenant.`,
-                    payload: { limit: MAX_CANDIDATES_PER_SELECTOR }
-                })
-            );
-        }
-
-        for (const row of rows) {
-            byInternalId.set(row.connection.id, toCandidate(row));
-        }
-    }
-
-    return Ok([...byInternalId.values()]);
+    return groups.map((group) => ({
+        integrationId: group.integration_id,
+        provider: group.provider,
+        matchCount: group.match_count,
+        candidates: group.candidates.map((candidate) => toCandidate({ integrationId: group.integration_id, provider: group.provider, candidate }))
+    }));
 }
 
-/**
- * Looks up each pinned connection in the environment, for the tenant that applies no tag filter.
- * These lookups become the candidate set, so the pins are what the session resolves.
- */
-export async function listPinnedConnections({
+/** Queries per pin rather than searching the candidate sample, which only holds part of the set. */
+export async function checkPinnedConnections({
     environmentId,
+    selectors,
     pinned
 }: {
     environmentId: number;
+    selectors: AgentSessionConnectionSelectorList;
     pinned: AgentSessionPinnedConnection[];
-}): Promise<Result<AgentSessionConnectionCandidate[], AgentSessionConnectionResolutionError>> {
-    const found: AgentSessionConnectionCandidate[] = [];
-    const unknown: AgentSessionUnknownPinnedConnectionsPayload['pinned'] = [];
+}): Promise<{ verified: AgentSessionConnectionCandidate[]; rejected: AgentSessionPinnedConnection[] }> {
+    const verified: AgentSessionConnectionCandidate[] = [];
+    const rejected: AgentSessionPinnedConnection[] = [];
 
     for (const pin of pinned) {
-        const [row] = await connectionService.listConnections({
+        const row = await connectionService.findConnectionMatchingSelectors({
             environmentId,
+            integrationId: pin.integrationId,
             connectionId: pin.connectionId,
-            integrationIds: [pin.integrationId],
-            limit: 1
+            tagSelectors: selectors
         });
 
         if (row) {
-            found.push(toCandidate(row));
+            verified.push(toCandidate({ integrationId: row.integration_id, provider: row.provider, candidate: row.candidate }));
         } else {
-            unknown.push({ integration_id: pin.integrationId, connection_id: pin.connectionId });
+            rejected.push(pin);
         }
     }
 
-    if (unknown.length > 0) {
-        const payload: AgentSessionUnknownPinnedConnectionsPayload = { pinned: unknown };
-        return Err(
-            new AgentSessionConnectionResolutionError({
-                code: 'unknown_pinned_connection',
-                message: `${unknown.length} pinned ${unknown.length === 1 ? 'connection does' : 'connections do'} not exist on the integration given. Check the connection id and the integration id.`,
-                payload: { ...payload }
-            })
-        );
-    }
-
-    return Ok(found);
+    return { verified, rejected };
 }
 
-/**
- * Pure resolution: one connection per integration, or a report naming the candidates the caller has
- * to choose between. Selectors filter first and a pin picks from what they matched, so a pin can
- * never reach a connection the selectors excluded. Zero matches is not an error, the integration is
- * simply absent from the result and the session exposes it as not connected.
- */
 export function resolveTenantConnections({
-    candidates,
-    pinned
+    matches,
+    verifiedPins,
+    rejectedPins,
+    hasSelectors
 }: {
-    candidates: AgentSessionConnectionCandidate[];
-    pinned: AgentSessionPinnedConnection[];
+    matches: AgentSessionIntegrationMatch[];
+    verifiedPins: AgentSessionConnectionCandidate[];
+    rejectedPins: AgentSessionPinnedConnection[];
+    hasSelectors: boolean;
 }): Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError> {
-    const candidatesByIntegration = new Map<string, AgentSessionConnectionCandidate[]>();
-    for (const candidate of candidates) {
-        const forIntegration = candidatesByIntegration.get(candidate.integrationId) ?? [];
-        forIntegration.push(candidate);
-        candidatesByIntegration.set(candidate.integrationId, forIntegration);
+    if (rejectedPins.length > 0) {
+        return Err(hasSelectors ? pinnedNotMatchedError(rejectedPins, matches) : unknownPinnedConnectionError(rejectedPins));
     }
 
     const resolved: Record<string, AgentSessionResolvedConnection> = {};
-    const notMatched: AgentSessionPinnedConnectionNotMatchedPayload['pinned'] = [];
-
-    for (const pin of pinned) {
-        const forIntegration = candidatesByIntegration.get(pin.integrationId) ?? [];
-        const pinnedCandidate = forIntegration.find((candidate) => candidate.connectionId === pin.connectionId);
-
-        if (!pinnedCandidate) {
-            notMatched.push({
-                integration_id: pin.integrationId,
-                connection_id: pin.connectionId,
-                candidates: forIntegration.map(toCandidateReport)
-            });
-            continue;
-        }
-
-        resolved[pin.integrationId] = toResolvedConnection(pinnedCandidate);
+    for (const pin of verifiedPins) {
+        resolved[pin.integrationId] = toResolvedConnection(pin);
     }
 
-    if (notMatched.length > 0) {
-        const payload: AgentSessionPinnedConnectionNotMatchedPayload = { pinned: notMatched };
-        return Err(
-            new AgentSessionConnectionResolutionError({
-                code: 'pinned_connection_not_matched',
-                message: `${notMatched.length} pinned ${notMatched.length === 1 ? 'connection is' : 'connections are'} not among the connections the selectors matched. A pin chooses between matched connections, so widen the selectors or pin one of the candidates.`,
-                payload: { ...payload }
-            })
-        );
-    }
+    const ambiguous: AgentSessionAmbiguousConnectionsPayload['integrations'] = {};
 
-    const ambiguous: Record<string, { candidates: AgentSessionConnectionCandidateReport[] }> = {};
-
-    for (const [integrationId, forIntegration] of candidatesByIntegration) {
-        if (resolved[integrationId]) {
+    for (const match of matches) {
+        if (resolved[match.integrationId]) {
             continue;
         }
 
-        const [onlyCandidate, ...rest] = forIntegration;
-        if (!onlyCandidate || rest.length > 0) {
-            ambiguous[integrationId] = { candidates: forIntegration.map(toCandidateReport) };
+        const [onlyCandidate] = match.candidates;
+        if (match.matchCount > 1 || !onlyCandidate) {
+            ambiguous[match.integrationId] = { match_count: match.matchCount, candidates: match.candidates.map(toCandidateReport) };
             continue;
         }
 
-        resolved[integrationId] = toResolvedConnection(onlyCandidate);
+        resolved[match.integrationId] = toResolvedConnection(onlyCandidate);
     }
 
     const ambiguousIntegrations = Object.keys(ambiguous);
@@ -255,28 +182,65 @@ export async function resolveTenantConnectionsForEnvironment({
     environmentId: number;
     connections: AgentSessionTenantConnections;
 }): Promise<Result<AgentSessionResolvedConnections, AgentSessionConnectionResolutionError>> {
-    // With no selectors there is no tag filter to resolve against, so the pinned connections are
-    // themselves the candidate set and the pin check below is satisfied by construction.
-    const candidates =
-        connections.any.length > 0
-            ? await listTenantConnectionCandidates({ environmentId, selectors: connections.any })
-            : await listPinnedConnections({ environmentId, pinned: connections.pinned });
+    const selectors = connections.any.map((selector) => selector.tags);
+    const matches = await listIntegrationMatches({ environmentId, selectors });
+    const pins = await checkPinnedConnections({ environmentId, selectors, pinned: connections.pinned });
 
-    if (candidates.isErr()) {
-        return Err(candidates.error);
-    }
-
-    return resolveTenantConnections({ candidates: candidates.value, pinned: connections.pinned });
+    return resolveTenantConnections({
+        matches,
+        verifiedPins: pins.verified,
+        rejectedPins: pins.rejected,
+        hasSelectors: selectors.length > 0
+    });
 }
 
-function toCandidate(row: Awaited<ReturnType<typeof connectionService.listConnections>>[number]): AgentSessionConnectionCandidate {
+type AgentSessionConnectionSelectorList = Tags[];
+
+function pinnedNotMatchedError(rejected: AgentSessionPinnedConnection[], matches: AgentSessionIntegrationMatch[]): AgentSessionConnectionResolutionError {
+    const byIntegration = new Map(matches.map((match) => [match.integrationId, match]));
+    const payload: AgentSessionPinnedConnectionNotMatchedPayload = {
+        pinned: rejected.map((pin) => ({
+            integration_id: pin.integrationId,
+            connection_id: pin.connectionId,
+            candidates: (byIntegration.get(pin.integrationId)?.candidates ?? []).map(toCandidateReport)
+        }))
+    };
+
+    return new AgentSessionConnectionResolutionError({
+        code: 'pinned_connection_not_matched',
+        message: `${rejected.length} pinned ${rejected.length === 1 ? 'connection is' : 'connections are'} not among the connections the selectors matched. A pin chooses between matched connections, so widen the selectors or pin one of the candidates.`,
+        payload: { ...payload }
+    });
+}
+
+function unknownPinnedConnectionError(rejected: AgentSessionPinnedConnection[]): AgentSessionConnectionResolutionError {
+    const payload: AgentSessionUnknownPinnedConnectionsPayload = {
+        pinned: rejected.map((pin) => ({ integration_id: pin.integrationId, connection_id: pin.connectionId }))
+    };
+
+    return new AgentSessionConnectionResolutionError({
+        code: 'unknown_pinned_connection',
+        message: `${rejected.length} pinned ${rejected.length === 1 ? 'connection does' : 'connections do'} not exist on the integration given. Check the connection id and the integration id.`,
+        payload: { ...payload }
+    });
+}
+
+function toCandidate({
+    integrationId,
+    provider,
+    candidate
+}: {
+    integrationId: string;
+    provider: string;
+    candidate: ConnectionMatchCandidate;
+}): AgentSessionConnectionCandidate {
     return {
-        integrationId: row.integration_id,
-        provider: row.provider,
-        connectionId: row.connection.connection_id,
-        internalConnectionId: row.connection.id,
-        configId: row.connection.config_id,
-        tags: row.connection.tags
+        integrationId,
+        provider,
+        connectionId: candidate.connection_id,
+        internalConnectionId: candidate.id,
+        configId: candidate.config_id,
+        tags: candidate.tags
     };
 }
 

--- a/packages/server/lib/services/agentSessionConnections.service.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.ts
@@ -31,15 +31,13 @@ export const MAX_PINNED_CONNECTIONS = 50;
  */
 export const MAX_CANDIDATES_PER_SELECTOR = 200;
 
-const selectorSchema = z
-    .strictObject({
-        tags: connectionTagsSchema.optional(),
-        end_user_id: z.string().min(1).max(255).optional(),
-        end_user_organization_id: z.string().min(1).max(255).optional()
+// Tags are the only selector. End users are already projected onto connection tags on creation, so
+// an end user selector would be a second way to express the same match, on a slower query path.
+const selectorSchema = z.strictObject({
+    tags: connectionTagsSchema.refine((tags) => Object.keys(tags).length > 0, {
+        message: 'A connection selector must carry at least one tag'
     })
-    .refine((selector) => selector.tags !== undefined || selector.end_user_id !== undefined || selector.end_user_organization_id !== undefined, {
-        message: 'A connection selector must constrain at least one of tags, end_user_id or end_user_organization_id'
-    });
+});
 
 /**
  * Public shape of `tenant.connections`. `any` is an OR between selectors, and the constraints within
@@ -68,11 +66,7 @@ export const agentSessionTenantConnectionsSchema = z
     })
     .transform(
         (connections): AgentSessionTenantConnections => ({
-            any: (connections.any ?? []).map((selector) => ({
-                tags: selector.tags,
-                endUserId: selector.end_user_id,
-                endUserOrganizationId: selector.end_user_organization_id
-            })),
+            any: (connections.any ?? []).map((selector) => ({ tags: selector.tags })),
             pinned: (connections.pinned ?? []).map((pin) => ({
                 integrationId: pin.integration_id,
                 connectionId: pin.connection_id
@@ -109,8 +103,6 @@ export async function listTenantConnectionCandidates({
         const rows = await connectionService.listConnections({
             environmentId,
             tags: selector.tags,
-            endUserId: selector.endUserId,
-            endUserOrganizationId: selector.endUserOrganizationId,
             limit: MAX_CANDIDATES_PER_SELECTOR + 1
         });
 

--- a/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+
+import { agentSessionTenantConnectionsSchema, MAX_SELECTORS, resolveTenantConnections } from './agentSessionConnections.service.js';
+
+import type { AgentSessionConnectionResolutionError } from './agentSessionConnections.service.js';
+import type { AgentSessionConnectionCandidate } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+describe('resolveTenantConnections', () => {
+    it('resolves one connection per integration', () => {
+        const result = resolveTenantConnections({
+            candidates: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })
+            ],
+            disambiguation: []
+        });
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toStrictEqual({
+            notion: { integrationId: 'notion', provider: 'notion', connectionId: 'notion-1', internalConnectionId: 1, configId: 10 },
+            slack: { integrationId: 'slack', provider: 'slack', connectionId: 'slack-1', internalConnectionId: 2, configId: 11 }
+        });
+    });
+
+    it('treats zero matches as an empty resolution rather than an error', () => {
+        const result = resolveTenantConnections({ candidates: [], disambiguation: [] });
+
+        expect(result.isOk()).toBe(true);
+        expect(result.unwrap()).toStrictEqual({});
+    });
+
+    it('fails on an integration matching several connections, naming every candidate', () => {
+        const result = resolveTenantConnections({
+            candidates: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1', tags: { workspaceslug: 'marketing' } }),
+                candidate({ integrationId: 'notion', connectionId: 'notion-2', tags: { workspaceslug: 'eng' } }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-1' })
+            ],
+            disambiguation: []
+        });
+
+        expect(result.isErr()).toBe(true);
+        const error = expectError(result);
+        expect(error.code).toBe('ambiguous_connections');
+        expect(error.message).toBe('1 integration matched more than one connection. Narrow the connection tags or pin a connection id.');
+        expect(error.payload).toStrictEqual({
+            integrations: {
+                notion: {
+                    candidates: [
+                        { connection_id: 'notion-1', tags: { workspaceslug: 'marketing' } },
+                        { connection_id: 'notion-2', tags: { workspaceslug: 'eng' } }
+                    ]
+                }
+            }
+        });
+    });
+
+    it('reports every ambiguous integration so one retry can fix them all', () => {
+        const result = resolveTenantConnections({
+            candidates: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1' }),
+                candidate({ integrationId: 'notion', connectionId: 'notion-2' }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-1' }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-2' })
+            ],
+            disambiguation: []
+        });
+
+        const error = expectError(result);
+        expect(error.code).toBe('ambiguous_connections');
+        expect(Object.keys(error.payload['integrations'] as object)).toStrictEqual(['notion', 'slack']);
+        expect(error.message).toBe('2 integrations matched more than one connection. Narrow the connection tags or pin a connection id.');
+    });
+
+    it('breaks a tie with a pinned connection', () => {
+        const result = resolveTenantConnections({
+            candidates: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
+                candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })
+            ],
+            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-2' }]
+        });
+
+        expect(result.unwrap()).toStrictEqual({
+            notion: { integrationId: 'notion', provider: 'notion', connectionId: 'notion-2', internalConnectionId: 2, configId: 10 }
+        });
+    });
+
+    it('breaks ties per integration when two selectors both match the same integration', () => {
+        const result = resolveTenantConnections({
+            candidates: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-marketing', internalConnectionId: 1 }),
+                candidate({ integrationId: 'notion', connectionId: 'notion-eng', internalConnectionId: 2 }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-marketing', internalConnectionId: 3 }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-eng', internalConnectionId: 4 })
+            ],
+            disambiguation: [
+                { integrationId: 'notion', connectionId: 'notion-marketing' },
+                { integrationId: 'slack', connectionId: 'slack-eng' }
+            ]
+        });
+
+        expect(Object.values(result.unwrap()).map((connection) => connection.connectionId)).toStrictEqual(['notion-marketing', 'slack-eng']);
+    });
+
+    it('accepts a pin on an integration that was never ambiguous', () => {
+        const result = resolveTenantConnections({
+            candidates: [candidate({ integrationId: 'notion', connectionId: 'notion-1' })],
+            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-1' }]
+        });
+
+        expect(result.isOk()).toBe(true);
+    });
+
+    it('rejects a pin naming a connection the selectors did not match, so a pin can only narrow', () => {
+        const result = resolveTenantConnections({
+            candidates: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1', tags: { workspaceslug: 'marketing' } }),
+                candidate({ integrationId: 'notion', connectionId: 'notion-2', tags: { workspaceslug: 'eng' } })
+            ],
+            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
+        });
+
+        const error = expectError(result);
+        expect(error.code).toBe('invalid_disambiguation');
+        expect(error.payload).toStrictEqual({
+            disambiguation: [
+                {
+                    integration_id: 'notion',
+                    connection_id: 'notion-elsewhere',
+                    reason: 'connection_not_a_candidate',
+                    candidates: [
+                        { connection_id: 'notion-1', tags: { workspaceslug: 'marketing' } },
+                        { connection_id: 'notion-2', tags: { workspaceslug: 'eng' } }
+                    ]
+                }
+            ]
+        });
+    });
+
+    it('rejects a pin on an integration the selectors did not match at all', () => {
+        const result = resolveTenantConnections({
+            candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' })],
+            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-1' }]
+        });
+
+        const error = expectError(result);
+        expect(error.code).toBe('invalid_disambiguation');
+        expect(error.payload).toStrictEqual({
+            disambiguation: [{ integration_id: 'notion', connection_id: 'notion-1', reason: 'no_candidates', candidates: [] }]
+        });
+    });
+
+    it('rejects two pins on the same integration', () => {
+        const result = resolveTenantConnections({
+            candidates: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
+                candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })
+            ],
+            disambiguation: [
+                { integrationId: 'notion', connectionId: 'notion-1' },
+                { integrationId: 'notion', connectionId: 'notion-2' }
+            ]
+        });
+
+        const error = expectError(result);
+        expect(error.code).toBe('invalid_disambiguation');
+        expect((error.payload['disambiguation'] as { reason: string }[])[0]?.reason).toBe('duplicate_pin');
+    });
+
+    it('reports an invalid pin before it reports ambiguity, so the caller fixes the pin first', () => {
+        const result = resolveTenantConnections({
+            candidates: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1' }),
+                candidate({ integrationId: 'notion', connectionId: 'notion-2' }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-1' }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-2' })
+            ],
+            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
+        });
+
+        expect(expectError(result).code).toBe('invalid_disambiguation');
+    });
+});
+
+describe('agentSessionTenantConnectionsSchema', () => {
+    it('normalizes the public shape into the resolver contract', () => {
+        const parsed = agentSessionTenantConnectionsSchema.parse({
+            any: [{ tags: { WorkspaceSlug: 'marketing' } }, { end_user_id: 'user-74', end_user_organization_id: 'acme' }],
+            disambiguation: [{ integration_id: 'notion', connection_id: 'notion-1' }]
+        });
+
+        expect(parsed).toStrictEqual({
+            any: [
+                { tags: { workspaceslug: 'marketing' }, endUserId: undefined, endUserOrganizationId: undefined },
+                { tags: undefined, endUserId: 'user-74', endUserOrganizationId: 'acme' }
+            ],
+            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-1' }]
+        });
+    });
+
+    it('defaults disambiguation to an empty list', () => {
+        const parsed = agentSessionTenantConnectionsSchema.parse({ any: [{ end_user_id: 'user-74' }] });
+
+        expect(parsed.disambiguation).toStrictEqual([]);
+    });
+
+    it('rejects a selector that constrains nothing', () => {
+        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{}] }).success).toBe(false);
+    });
+
+    it('rejects an empty or oversized selector list', () => {
+        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [] }).success).toBe(false);
+        expect(
+            agentSessionTenantConnectionsSchema.safeParse({ any: Array.from({ length: MAX_SELECTORS + 1 }, () => ({ end_user_id: 'user-74' })) }).success
+        ).toBe(false);
+    });
+
+    it('rejects unknown keys so a typo never silently widens the selector', () => {
+        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{ tag: { a: 'b' } }] }).success).toBe(false);
+        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{ end_user_id: 'user-74' }], connections: [] }).success).toBe(false);
+    });
+});
+
+function expectError<T>(result: Result<T, AgentSessionConnectionResolutionError>): AgentSessionConnectionResolutionError {
+    if (!result.isErr()) {
+        throw new Error('Expected the resolution to fail');
+    }
+
+    return result.error;
+}
+
+function candidate({
+    integrationId,
+    connectionId,
+    internalConnectionId,
+    tags
+}: {
+    integrationId: string;
+    connectionId: string;
+    internalConnectionId?: number;
+    tags?: Record<string, string>;
+}): AgentSessionConnectionCandidate {
+    return {
+        integrationId,
+        provider: integrationId,
+        connectionId,
+        internalConnectionId: internalConnectionId ?? 1,
+        configId: integrationId === 'notion' ? 10 : 11,
+        tags: tags ?? {}
+    };
+}

--- a/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
@@ -79,7 +79,7 @@ describe('resolveTenantConnections', () => {
                 candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
                 candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })
             ],
-            pinned: [candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })]
+            pinned: [{ integrationId: 'notion', connectionId: 'notion-2' }]
         });
 
         expect(result.unwrap()).toStrictEqual({
@@ -96,48 +96,99 @@ describe('resolveTenantConnections', () => {
                 candidate({ integrationId: 'slack', connectionId: 'slack-eng', internalConnectionId: 4 })
             ],
             pinned: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-marketing', internalConnectionId: 1 }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-eng', internalConnectionId: 4 })
+                { integrationId: 'notion', connectionId: 'notion-marketing' },
+                { integrationId: 'slack', connectionId: 'slack-eng' }
             ]
         });
 
         expect(Object.values(result.unwrap()).map((connection) => connection.connectionId)).toStrictEqual(['notion-marketing', 'slack-eng']);
     });
 
-    it('resolves from pins alone, for the customer who resolves connections themselves', () => {
+    it('resolves from pins alone when the pins are the candidate set, the no tag filter case', () => {
+        const pinnedCandidates = [
+            candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
+            candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })
+        ];
+
         const result = resolveTenantConnections({
-            candidates: [],
+            candidates: pinnedCandidates,
             pinned: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })
+                { integrationId: 'notion', connectionId: 'notion-1' },
+                { integrationId: 'slack', connectionId: 'slack-1' }
             ]
         });
 
         expect(Object.keys(result.unwrap())).toStrictEqual(['notion', 'slack']);
     });
 
-    it('lets a pin name a connection no selector matched', () => {
+    it('rejects a pin on a connection the selectors did not match, so tags filter before a pin picks', () => {
         const result = resolveTenantConnections({
-            candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 1 })],
-            pinned: [candidate({ integrationId: 'notion', connectionId: 'notion-elsewhere', internalConnectionId: 9 })]
+            candidates: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1', tags: { workspaceslug: 'marketing' } }),
+                candidate({ integrationId: 'notion', connectionId: 'notion-2', tags: { workspaceslug: 'eng' } })
+            ],
+            pinned: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
         });
 
-        expect(result.unwrap()['notion']).toStrictEqual({
-            integrationId: 'notion',
-            provider: 'notion',
-            connectionId: 'notion-elsewhere',
-            internalConnectionId: 9,
-            configId: 10
+        const error = expectError(result);
+        expect(error.code).toBe('pinned_connection_not_matched');
+        expect(error.payload).toStrictEqual({
+            pinned: [
+                {
+                    integration_id: 'notion',
+                    connection_id: 'notion-elsewhere',
+                    candidates: [
+                        { connection_id: 'notion-1', tags: { workspaceslug: 'marketing' } },
+                        { connection_id: 'notion-2', tags: { workspaceslug: 'eng' } }
+                    ]
+                }
+            ]
         });
     });
 
-    it('lets a pin override the single connection the selectors matched for that integration', () => {
+    it('rejects a pin on an integration the selectors matched nothing for', () => {
         const result = resolveTenantConnections({
-            candidates: [candidate({ integrationId: 'notion', connectionId: 'notion-from-tags', internalConnectionId: 1 })],
-            pinned: [candidate({ integrationId: 'notion', connectionId: 'notion-pinned', internalConnectionId: 2 })]
+            candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' })],
+            pinned: [{ integrationId: 'notion', connectionId: 'notion-1' }]
         });
 
-        expect(result.unwrap()['notion']?.connectionId).toBe('notion-pinned');
+        const error = expectError(result);
+        expect(error.code).toBe('pinned_connection_not_matched');
+        expect(error.payload).toStrictEqual({
+            pinned: [{ integration_id: 'notion', connection_id: 'notion-1', candidates: [] }]
+        });
+    });
+
+    it('cannot use a pin to swap the connection the selectors matched for an integration', () => {
+        const result = resolveTenantConnections({
+            candidates: [candidate({ integrationId: 'notion', connectionId: 'notion-from-tags', internalConnectionId: 1 })],
+            pinned: [{ integrationId: 'notion', connectionId: 'notion-pinned' }]
+        });
+
+        expect(expectError(result).code).toBe('pinned_connection_not_matched');
+    });
+
+    it('accepts a pin on an integration that was never ambiguous', () => {
+        const result = resolveTenantConnections({
+            candidates: [candidate({ integrationId: 'notion', connectionId: 'notion-1' })],
+            pinned: [{ integrationId: 'notion', connectionId: 'notion-1' }]
+        });
+
+        expect(result.isOk()).toBe(true);
+    });
+
+    it('reports a bad pin before ambiguity, so the caller fixes the pin first', () => {
+        const result = resolveTenantConnections({
+            candidates: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
+                candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 3 }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-2', internalConnectionId: 4 })
+            ],
+            pinned: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
+        });
+
+        expect(expectError(result).code).toBe('pinned_connection_not_matched');
     });
 
     it('keeps a pinned integration out of the ambiguity report', () => {
@@ -148,7 +199,7 @@ describe('resolveTenantConnections', () => {
                 candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 3 }),
                 candidate({ integrationId: 'slack', connectionId: 'slack-2', internalConnectionId: 4 })
             ],
-            pinned: [candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 })]
+            pinned: [{ integrationId: 'notion', connectionId: 'notion-1' }]
         });
 
         const error = expectError(result);
@@ -178,7 +229,7 @@ describe('agentSessionTenantConnectionsSchema', () => {
         expect(parsed.pinned).toStrictEqual([]);
     });
 
-    it('accepts pins with no selectors', () => {
+    it('accepts pins with no selectors, the escape hatch that applies no tag filter', () => {
         const parsed = agentSessionTenantConnectionsSchema.parse({ pinned: [{ integration_id: 'notion', connection_id: 'notion-1' }] });
 
         expect(parsed.any).toStrictEqual([]);

--- a/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { agentSessionTenantConnectionsSchema, MAX_SELECTORS, resolveTenantConnections } from './agentSessionConnections.service.js';
+import { agentSessionTenantConnectionsSchema, MAX_SELECTORS, pickConnectionPerIntegration } from './agentSessionConnections.service.js';
 
 import type { AgentSessionConnectionResolutionError } from './agentSessionConnections.service.js';
 import type { ConnectionIntegrationMatchRow, ConnectionMatch, ConnectionMatchCandidate } from '@nangohq/shared';
 import type { Result } from '@nangohq/utils';
 
-describe('resolveTenantConnections', () => {
+describe('pickConnectionPerIntegration', () => {
     it('resolves one connection per integration', () => {
         const result = resolve({
             matches: [
@@ -341,7 +341,7 @@ function resolve({
     unknownPins?: { integrationId: string; connectionId: string }[];
     notMatchedPins?: { integrationId: string; connectionId: string }[];
 }) {
-    return resolveTenantConnections({ matches, verifiedPins, unknownPins, notMatchedPins });
+    return pickConnectionPerIntegration({ matches, verifiedPins, unknownPins, notMatchedPins });
 }
 
 function expectError<T>(result: Result<T, AgentSessionConnectionResolutionError>): AgentSessionConnectionResolutionError {

--- a/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
@@ -3,17 +3,16 @@ import { describe, expect, it } from 'vitest';
 import { agentSessionTenantConnectionsSchema, MAX_SELECTORS, resolveTenantConnections } from './agentSessionConnections.service.js';
 
 import type { AgentSessionConnectionResolutionError } from './agentSessionConnections.service.js';
-import type { AgentSessionConnectionCandidate } from '@nangohq/types';
+import type { AgentSessionConnectionCandidate, AgentSessionIntegrationMatch } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 describe('resolveTenantConnections', () => {
     it('resolves one connection per integration', () => {
-        const result = resolveTenantConnections({
-            candidates: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })
-            ],
-            pinned: []
+        const result = resolve({
+            matches: [
+                match({ integrationId: 'notion', candidates: [candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 })] }),
+                match({ integrationId: 'slack', candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })] })
+            ]
         });
 
         expect(result.isOk()).toBe(true);
@@ -24,29 +23,33 @@ describe('resolveTenantConnections', () => {
     });
 
     it('treats zero matches as an empty resolution rather than an error', () => {
-        const result = resolveTenantConnections({ candidates: [], pinned: [] });
+        const result = resolve({});
 
         expect(result.isOk()).toBe(true);
         expect(result.unwrap()).toStrictEqual({});
     });
 
     it('fails on an integration matching several connections, naming every candidate', () => {
-        const result = resolveTenantConnections({
-            candidates: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1', tags: { workspaceslug: 'marketing' } }),
-                candidate({ integrationId: 'notion', connectionId: 'notion-2', tags: { workspaceslug: 'eng' } }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-1' })
-            ],
-            pinned: []
+        const result = resolve({
+            matches: [
+                match({
+                    integrationId: 'notion',
+                    candidates: [
+                        candidate({ integrationId: 'notion', connectionId: 'notion-1', tags: { workspaceslug: 'marketing' } }),
+                        candidate({ integrationId: 'notion', connectionId: 'notion-2', tags: { workspaceslug: 'eng' } })
+                    ]
+                }),
+                match({ integrationId: 'slack', candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' })] })
+            ]
         });
 
-        expect(result.isErr()).toBe(true);
         const error = expectError(result);
         expect(error.code).toBe('ambiguous_connections');
         expect(error.message).toBe('1 integration matched more than one connection. Narrow the connection tags or pin a connection id.');
         expect(error.payload).toStrictEqual({
             integrations: {
                 notion: {
+                    match_count: 2,
                     candidates: [
                         { connection_id: 'notion-1', tags: { workspaceslug: 'marketing' } },
                         { connection_id: 'notion-2', tags: { workspaceslug: 'eng' } }
@@ -56,30 +59,67 @@ describe('resolveTenantConnections', () => {
         });
     });
 
+    it('reports the true match count even when more matched than the candidates listed', () => {
+        const result = resolve({
+            matches: [
+                match({
+                    integrationId: 'notion',
+                    matchCount: 37,
+                    candidates: [
+                        candidate({ integrationId: 'notion', connectionId: 'notion-1' }),
+                        candidate({ integrationId: 'notion', connectionId: 'notion-2' })
+                    ]
+                })
+            ]
+        });
+
+        const payload = expectError(result).payload['integrations'] as Record<string, { match_count: number; candidates: unknown[] }>;
+        expect(payload['notion']?.match_count).toBe(37);
+        expect(payload['notion']?.candidates).toHaveLength(2);
+    });
+
+    it('is ambiguous on a count above one even when only one candidate was sampled', () => {
+        const result = resolve({
+            matches: [match({ integrationId: 'notion', matchCount: 2, candidates: [candidate({ integrationId: 'notion', connectionId: 'notion-1' })] })]
+        });
+
+        expect(expectError(result).code).toBe('ambiguous_connections');
+    });
+
     it('reports every ambiguous integration so one retry can fix them all', () => {
-        const result = resolveTenantConnections({
-            candidates: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1' }),
-                candidate({ integrationId: 'notion', connectionId: 'notion-2' }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-1' }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-2' })
-            ],
-            pinned: []
+        const result = resolve({
+            matches: [
+                match({
+                    integrationId: 'notion',
+                    candidates: [
+                        candidate({ integrationId: 'notion', connectionId: 'notion-1' }),
+                        candidate({ integrationId: 'notion', connectionId: 'notion-2' })
+                    ]
+                }),
+                match({
+                    integrationId: 'slack',
+                    candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' }), candidate({ integrationId: 'slack', connectionId: 'slack-2' })]
+                })
+            ]
         });
 
         const error = expectError(result);
-        expect(error.code).toBe('ambiguous_connections');
         expect(Object.keys(error.payload['integrations'] as object)).toStrictEqual(['notion', 'slack']);
         expect(error.message).toBe('2 integrations matched more than one connection. Narrow the connection tags or pin a connection id.');
     });
 
     it('breaks a tie with a pinned connection', () => {
-        const result = resolveTenantConnections({
-            candidates: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
-                candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })
+        const result = resolve({
+            matches: [
+                match({
+                    integrationId: 'notion',
+                    candidates: [
+                        candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
+                        candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })
+                    ]
+                })
             ],
-            pinned: [{ integrationId: 'notion', connectionId: 'notion-2' }]
+            verifiedPins: [candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })]
         });
 
         expect(result.unwrap()).toStrictEqual({
@@ -87,47 +127,51 @@ describe('resolveTenantConnections', () => {
         });
     });
 
-    it('breaks ties per integration when two selectors both match the same integration', () => {
-        const result = resolveTenantConnections({
-            candidates: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-marketing', internalConnectionId: 1 }),
-                candidate({ integrationId: 'notion', connectionId: 'notion-eng', internalConnectionId: 2 }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-marketing', internalConnectionId: 3 }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-eng', internalConnectionId: 4 })
+    it('keeps a pinned integration out of the ambiguity report', () => {
+        const result = resolve({
+            matches: [
+                match({
+                    integrationId: 'notion',
+                    candidates: [
+                        candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
+                        candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })
+                    ]
+                }),
+                match({
+                    integrationId: 'slack',
+                    candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' }), candidate({ integrationId: 'slack', connectionId: 'slack-2' })]
+                })
             ],
-            pinned: [
-                { integrationId: 'notion', connectionId: 'notion-marketing' },
-                { integrationId: 'slack', connectionId: 'slack-eng' }
-            ]
+            verifiedPins: [candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 })]
         });
 
-        expect(Object.values(result.unwrap()).map((connection) => connection.connectionId)).toStrictEqual(['notion-marketing', 'slack-eng']);
+        expect(Object.keys(expectError(result).payload['integrations'] as object)).toStrictEqual(['slack']);
     });
 
-    it('resolves from pins alone when the pins are the candidate set, the no tag filter case', () => {
-        const pinnedCandidates = [
-            candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
-            candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })
-        ];
-
-        const result = resolveTenantConnections({
-            candidates: pinnedCandidates,
-            pinned: [
-                { integrationId: 'notion', connectionId: 'notion-1' },
-                { integrationId: 'slack', connectionId: 'slack-1' }
-            ]
+    it('resolves an integration only a pin reached, for the no tag filter tenant', () => {
+        const result = resolve({
+            verifiedPins: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })
+            ],
+            hasSelectors: false
         });
 
         expect(Object.keys(result.unwrap())).toStrictEqual(['notion', 'slack']);
     });
 
-    it('rejects a pin on a connection the selectors did not match, so tags filter before a pin picks', () => {
-        const result = resolveTenantConnections({
-            candidates: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1', tags: { workspaceslug: 'marketing' } }),
-                candidate({ integrationId: 'notion', connectionId: 'notion-2', tags: { workspaceslug: 'eng' } })
+    it('rejects a pin the selectors did not match, listing that integration candidates', () => {
+        const result = resolve({
+            matches: [
+                match({
+                    integrationId: 'notion',
+                    candidates: [
+                        candidate({ integrationId: 'notion', connectionId: 'notion-1', tags: { workspaceslug: 'marketing' } }),
+                        candidate({ integrationId: 'notion', connectionId: 'notion-2', tags: { workspaceslug: 'eng' } })
+                    ]
+                })
             ],
-            pinned: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
+            rejectedPins: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
         });
 
         const error = expectError(result);
@@ -147,63 +191,39 @@ describe('resolveTenantConnections', () => {
     });
 
     it('rejects a pin on an integration the selectors matched nothing for', () => {
-        const result = resolveTenantConnections({
-            candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' })],
-            pinned: [{ integrationId: 'notion', connectionId: 'notion-1' }]
+        const result = resolve({
+            matches: [match({ integrationId: 'slack', candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' })] })],
+            rejectedPins: [{ integrationId: 'notion', connectionId: 'notion-1' }]
         });
 
-        const error = expectError(result);
-        expect(error.code).toBe('pinned_connection_not_matched');
-        expect(error.payload).toStrictEqual({
+        expect(expectError(result).payload).toStrictEqual({
             pinned: [{ integration_id: 'notion', connection_id: 'notion-1', candidates: [] }]
         });
     });
 
-    it('cannot use a pin to swap the connection the selectors matched for an integration', () => {
-        const result = resolveTenantConnections({
-            candidates: [candidate({ integrationId: 'notion', connectionId: 'notion-from-tags', internalConnectionId: 1 })],
-            pinned: [{ integrationId: 'notion', connectionId: 'notion-pinned' }]
-        });
-
-        expect(expectError(result).code).toBe('pinned_connection_not_matched');
-    });
-
-    it('accepts a pin on an integration that was never ambiguous', () => {
-        const result = resolveTenantConnections({
-            candidates: [candidate({ integrationId: 'notion', connectionId: 'notion-1' })],
-            pinned: [{ integrationId: 'notion', connectionId: 'notion-1' }]
-        });
-
-        expect(result.isOk()).toBe(true);
-    });
-
-    it('reports a bad pin before ambiguity, so the caller fixes the pin first', () => {
-        const result = resolveTenantConnections({
-            candidates: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
-                candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 3 }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-2', internalConnectionId: 4 })
-            ],
-            pinned: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
-        });
-
-        expect(expectError(result).code).toBe('pinned_connection_not_matched');
-    });
-
-    it('keeps a pinned integration out of the ambiguity report', () => {
-        const result = resolveTenantConnections({
-            candidates: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
-                candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 3 }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-2', internalConnectionId: 4 })
-            ],
-            pinned: [{ integrationId: 'notion', connectionId: 'notion-1' }]
+    it('calls a rejected pin unknown when there is no tag filter to have excluded it', () => {
+        const result = resolve({
+            rejectedPins: [{ integrationId: 'notion', connectionId: 'notion-1' }],
+            hasSelectors: false
         });
 
         const error = expectError(result);
-        expect(Object.keys(error.payload['integrations'] as object)).toStrictEqual(['slack']);
+        expect(error.code).toBe('unknown_pinned_connection');
+        expect(error.payload).toStrictEqual({ pinned: [{ integration_id: 'notion', connection_id: 'notion-1' }] });
+    });
+
+    it('reports a rejected pin before ambiguity, so the caller fixes the pin first', () => {
+        const result = resolve({
+            matches: [
+                match({
+                    integrationId: 'slack',
+                    candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' }), candidate({ integrationId: 'slack', connectionId: 'slack-2' })]
+                })
+            ],
+            rejectedPins: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
+        });
+
+        expect(expectError(result).code).toBe('pinned_connection_not_matched');
     });
 });
 
@@ -230,6 +250,12 @@ describe('agentSessionTenantConnectionsSchema', () => {
         const parsed = agentSessionTenantConnectionsSchema.parse({ pinned: [{ integration_id: 'notion', connection_id: 'notion-1' }] });
 
         expect(parsed.any).toStrictEqual([]);
+    });
+
+    it('accepts one pin per integration without an arbitrary count limit', () => {
+        const pinned = Array.from({ length: 200 }, (_, index) => ({ integration_id: `integration-${index}`, connection_id: `connection-${index}` }));
+
+        expect(agentSessionTenantConnectionsSchema.safeParse({ pinned }).success).toBe(true);
     });
 
     it('rejects a tenant that constrains nothing at all', () => {
@@ -270,12 +296,43 @@ describe('agentSessionTenantConnectionsSchema', () => {
     });
 });
 
+function resolve({
+    matches = [],
+    verifiedPins = [],
+    rejectedPins = [],
+    hasSelectors = true
+}: {
+    matches?: AgentSessionIntegrationMatch[];
+    verifiedPins?: AgentSessionConnectionCandidate[];
+    rejectedPins?: { integrationId: string; connectionId: string }[];
+    hasSelectors?: boolean;
+}) {
+    return resolveTenantConnections({ matches, verifiedPins, rejectedPins, hasSelectors });
+}
+
 function expectError<T>(result: Result<T, AgentSessionConnectionResolutionError>): AgentSessionConnectionResolutionError {
     if (!result.isErr()) {
         throw new Error('Expected the resolution to fail');
     }
 
     return result.error;
+}
+
+function match({
+    integrationId,
+    candidates,
+    matchCount
+}: {
+    integrationId: string;
+    candidates: AgentSessionConnectionCandidate[];
+    matchCount?: number;
+}): AgentSessionIntegrationMatch {
+    return {
+        integrationId,
+        provider: integrationId,
+        matchCount: matchCount ?? candidates.length,
+        candidates
+    };
 }
 
 function candidate({

--- a/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
@@ -210,21 +210,18 @@ describe('resolveTenantConnections', () => {
 describe('agentSessionTenantConnectionsSchema', () => {
     it('normalizes the public shape into the resolver contract', () => {
         const parsed = agentSessionTenantConnectionsSchema.parse({
-            any: [{ tags: { WorkspaceSlug: 'marketing' } }, { end_user_id: 'user-74', end_user_organization_id: 'acme' }],
+            any: [{ tags: { WorkspaceSlug: 'marketing' } }, { tags: { end_user_id: 'user-74', organization_id: 'acme' } }],
             pinned: [{ integration_id: 'notion', connection_id: 'notion-1' }]
         });
 
         expect(parsed).toStrictEqual({
-            any: [
-                { tags: { workspaceslug: 'marketing' }, endUserId: undefined, endUserOrganizationId: undefined },
-                { tags: undefined, endUserId: 'user-74', endUserOrganizationId: 'acme' }
-            ],
+            any: [{ tags: { workspaceslug: 'marketing' } }, { tags: { end_user_id: 'user-74', organization_id: 'acme' } }],
             pinned: [{ integrationId: 'notion', connectionId: 'notion-1' }]
         });
     });
 
     it('accepts selectors with no pins', () => {
-        const parsed = agentSessionTenantConnectionsSchema.parse({ any: [{ end_user_id: 'user-74' }] });
+        const parsed = agentSessionTenantConnectionsSchema.parse({ any: [{ tags: { end_user_id: 'user-74' } }] });
 
         expect(parsed.pinned).toStrictEqual([]);
     });
@@ -242,6 +239,12 @@ describe('agentSessionTenantConnectionsSchema', () => {
 
     it('rejects a selector that constrains nothing', () => {
         expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{}] }).success).toBe(false);
+        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{ tags: {} }] }).success).toBe(false);
+    });
+
+    it('rejects end user fields, since end users are selected through their tags', () => {
+        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{ end_user_id: 'user-74' }] }).success).toBe(false);
+        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{ tags: { workspaceslug: 'marketing' }, end_user_id: 'user-74' }] }).success).toBe(false);
     });
 
     it('rejects two pins on the same integration', () => {
@@ -257,13 +260,13 @@ describe('agentSessionTenantConnectionsSchema', () => {
 
     it('rejects an oversized selector list', () => {
         expect(
-            agentSessionTenantConnectionsSchema.safeParse({ any: Array.from({ length: MAX_SELECTORS + 1 }, () => ({ end_user_id: 'user-74' })) }).success
+            agentSessionTenantConnectionsSchema.safeParse({ any: Array.from({ length: MAX_SELECTORS + 1 }, () => ({ tags: { endUser: 'user-74' } })) }).success
         ).toBe(false);
     });
 
     it('rejects unknown keys so a typo never silently widens the selector', () => {
         expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{ tag: { a: 'b' } }] }).success).toBe(false);
-        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{ end_user_id: 'user-74' }], connections: [] }).success).toBe(false);
+        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{ tags: { endUser: 'user-74' } }], connections: [] }).success).toBe(false);
     });
 });
 

--- a/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { agentSessionTenantConnectionsSchema, MAX_SELECTORS, resolveTenantConnections } from './agentSessionConnections.service.js';
 
 import type { AgentSessionConnectionResolutionError } from './agentSessionConnections.service.js';
-import type { AgentSessionConnectionCandidate, AgentSessionIntegrationMatch } from '@nangohq/types';
+import type { ConnectionIntegrationMatchRow, ConnectionMatch, ConnectionMatchCandidate } from '@nangohq/shared';
 import type { Result } from '@nangohq/utils';
 
 describe('resolveTenantConnections', () => {
@@ -119,7 +119,7 @@ describe('resolveTenantConnections', () => {
                     ]
                 })
             ],
-            verifiedPins: [candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })]
+            verifiedPins: [pin({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })]
         });
 
         expect(result.unwrap()).toStrictEqual({
@@ -142,7 +142,7 @@ describe('resolveTenantConnections', () => {
                     candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' }), candidate({ integrationId: 'slack', connectionId: 'slack-2' })]
                 })
             ],
-            verifiedPins: [candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 })]
+            verifiedPins: [pin({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 })]
         });
 
         expect(Object.keys(expectError(result).payload['integrations'] as object)).toStrictEqual(['slack']);
@@ -151,10 +151,9 @@ describe('resolveTenantConnections', () => {
     it('resolves an integration only a pin reached, for the no tag filter tenant', () => {
         const result = resolve({
             verifiedPins: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })
-            ],
-            hasSelectors: false
+                pin({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
+                pin({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })
+            ]
         });
 
         expect(Object.keys(result.unwrap())).toStrictEqual(['notion', 'slack']);
@@ -171,7 +170,7 @@ describe('resolveTenantConnections', () => {
                     ]
                 })
             ],
-            rejectedPins: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
+            notMatchedPins: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
         });
 
         const error = expectError(result);
@@ -193,7 +192,7 @@ describe('resolveTenantConnections', () => {
     it('rejects a pin on an integration the selectors matched nothing for', () => {
         const result = resolve({
             matches: [match({ integrationId: 'slack', candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' })] })],
-            rejectedPins: [{ integrationId: 'notion', connectionId: 'notion-1' }]
+            notMatchedPins: [{ integrationId: 'notion', connectionId: 'notion-1' }]
         });
 
         expect(expectError(result).payload).toStrictEqual({
@@ -201,15 +200,50 @@ describe('resolveTenantConnections', () => {
         });
     });
 
-    it('calls a rejected pin unknown when there is no tag filter to have excluded it', () => {
+    it('reports a pin whose connection does not exist as unknown', () => {
         const result = resolve({
-            rejectedPins: [{ integrationId: 'notion', connectionId: 'notion-1' }],
-            hasSelectors: false
+            unknownPins: [{ integrationId: 'notion', connectionId: 'notion-1' }]
         });
 
         const error = expectError(result);
         expect(error.code).toBe('unknown_pinned_connection');
         expect(error.payload).toStrictEqual({ pinned: [{ integration_id: 'notion', connection_id: 'notion-1' }] });
+    });
+
+    it('reports an unknown pin ahead of one the selectors merely excluded', () => {
+        const result = resolve({
+            unknownPins: [{ integrationId: 'notion', connectionId: 'gone' }],
+            notMatchedPins: [{ integrationId: 'slack', connectionId: 'slack-elsewhere' }]
+        });
+
+        expect(expectError(result).code).toBe('unknown_pinned_connection');
+    });
+
+    it('keeps an integration whose id would collide with Object prototype', () => {
+        const result = resolve({
+            matches: [match({ integrationId: '__proto__', candidates: [candidate({ integrationId: '__proto__', connectionId: 'proto-1' })] })]
+        });
+
+        expect(Object.keys(result.unwrap())).toStrictEqual(['__proto__']);
+        expect(result.unwrap()['__proto__']?.connectionId).toBe('proto-1');
+    });
+
+    it('reports an ambiguous integration whose id would collide with Object prototype', () => {
+        const result = resolve({
+            matches: [
+                match({
+                    integrationId: '__proto__',
+                    candidates: [
+                        candidate({ integrationId: '__proto__', connectionId: 'proto-1' }),
+                        candidate({ integrationId: '__proto__', connectionId: 'proto-2' })
+                    ]
+                })
+            ]
+        });
+
+        const error = expectError(result);
+        expect(error.code).toBe('ambiguous_connections');
+        expect(Object.keys(error.payload['integrations'] as object)).toStrictEqual(['__proto__']);
     });
 
     it('reports a rejected pin before ambiguity, so the caller fixes the pin first', () => {
@@ -220,7 +254,7 @@ describe('resolveTenantConnections', () => {
                     candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' }), candidate({ integrationId: 'slack', connectionId: 'slack-2' })]
                 })
             ],
-            rejectedPins: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
+            notMatchedPins: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
         });
 
         expect(expectError(result).code).toBe('pinned_connection_not_matched');
@@ -299,15 +333,15 @@ describe('agentSessionTenantConnectionsSchema', () => {
 function resolve({
     matches = [],
     verifiedPins = [],
-    rejectedPins = [],
-    hasSelectors = true
+    unknownPins = [],
+    notMatchedPins = []
 }: {
-    matches?: AgentSessionIntegrationMatch[];
-    verifiedPins?: AgentSessionConnectionCandidate[];
-    rejectedPins?: { integrationId: string; connectionId: string }[];
-    hasSelectors?: boolean;
+    matches?: ConnectionIntegrationMatchRow[];
+    verifiedPins?: ConnectionMatch[];
+    unknownPins?: { integrationId: string; connectionId: string }[];
+    notMatchedPins?: { integrationId: string; connectionId: string }[];
 }) {
-    return resolveTenantConnections({ matches, verifiedPins, rejectedPins, hasSelectors });
+    return resolveTenantConnections({ matches, verifiedPins, unknownPins, notMatchedPins });
 }
 
 function expectError<T>(result: Result<T, AgentSessionConnectionResolutionError>): AgentSessionConnectionResolutionError {
@@ -324,13 +358,13 @@ function match({
     matchCount
 }: {
     integrationId: string;
-    candidates: AgentSessionConnectionCandidate[];
+    candidates: ConnectionMatchCandidate[];
     matchCount?: number;
-}): AgentSessionIntegrationMatch {
+}): ConnectionIntegrationMatchRow {
     return {
-        integrationId,
+        integration_id: integrationId,
         provider: integrationId,
-        matchCount: matchCount ?? candidates.length,
+        match_count: matchCount ?? candidates.length,
         candidates
     };
 }
@@ -345,13 +379,19 @@ function candidate({
     connectionId: string;
     internalConnectionId?: number;
     tags?: Record<string, string>;
-}): AgentSessionConnectionCandidate {
+}): ConnectionMatchCandidate {
     return {
-        integrationId,
-        provider: integrationId,
-        connectionId,
-        internalConnectionId: internalConnectionId ?? 1,
-        configId: integrationId === 'notion' ? 10 : 11,
+        id: internalConnectionId ?? 1,
+        connection_id: connectionId,
+        config_id: integrationId === 'notion' ? 10 : 11,
         tags: tags ?? {}
+    };
+}
+
+function pin(args: { integrationId: string; connectionId: string; internalConnectionId?: number }): ConnectionMatch {
+    return {
+        integration_id: args.integrationId,
+        provider: args.integrationId,
+        candidate: candidate(args)
     };
 }

--- a/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionConnections.service.unit.test.ts
@@ -13,7 +13,7 @@ describe('resolveTenantConnections', () => {
                 candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
                 candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })
             ],
-            disambiguation: []
+            pinned: []
         });
 
         expect(result.isOk()).toBe(true);
@@ -24,7 +24,7 @@ describe('resolveTenantConnections', () => {
     });
 
     it('treats zero matches as an empty resolution rather than an error', () => {
-        const result = resolveTenantConnections({ candidates: [], disambiguation: [] });
+        const result = resolveTenantConnections({ candidates: [], pinned: [] });
 
         expect(result.isOk()).toBe(true);
         expect(result.unwrap()).toStrictEqual({});
@@ -37,7 +37,7 @@ describe('resolveTenantConnections', () => {
                 candidate({ integrationId: 'notion', connectionId: 'notion-2', tags: { workspaceslug: 'eng' } }),
                 candidate({ integrationId: 'slack', connectionId: 'slack-1' })
             ],
-            disambiguation: []
+            pinned: []
         });
 
         expect(result.isErr()).toBe(true);
@@ -64,7 +64,7 @@ describe('resolveTenantConnections', () => {
                 candidate({ integrationId: 'slack', connectionId: 'slack-1' }),
                 candidate({ integrationId: 'slack', connectionId: 'slack-2' })
             ],
-            disambiguation: []
+            pinned: []
         });
 
         const error = expectError(result);
@@ -79,7 +79,7 @@ describe('resolveTenantConnections', () => {
                 candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
                 candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })
             ],
-            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-2' }]
+            pinned: [candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })]
         });
 
         expect(result.unwrap()).toStrictEqual({
@@ -95,92 +95,64 @@ describe('resolveTenantConnections', () => {
                 candidate({ integrationId: 'slack', connectionId: 'slack-marketing', internalConnectionId: 3 }),
                 candidate({ integrationId: 'slack', connectionId: 'slack-eng', internalConnectionId: 4 })
             ],
-            disambiguation: [
-                { integrationId: 'notion', connectionId: 'notion-marketing' },
-                { integrationId: 'slack', connectionId: 'slack-eng' }
+            pinned: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-marketing', internalConnectionId: 1 }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-eng', internalConnectionId: 4 })
             ]
         });
 
         expect(Object.values(result.unwrap()).map((connection) => connection.connectionId)).toStrictEqual(['notion-marketing', 'slack-eng']);
     });
 
-    it('accepts a pin on an integration that was never ambiguous', () => {
+    it('resolves from pins alone, for the customer who resolves connections themselves', () => {
         const result = resolveTenantConnections({
-            candidates: [candidate({ integrationId: 'notion', connectionId: 'notion-1' })],
-            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-1' }]
-        });
-
-        expect(result.isOk()).toBe(true);
-    });
-
-    it('rejects a pin naming a connection the selectors did not match, so a pin can only narrow', () => {
-        const result = resolveTenantConnections({
-            candidates: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1', tags: { workspaceslug: 'marketing' } }),
-                candidate({ integrationId: 'notion', connectionId: 'notion-2', tags: { workspaceslug: 'eng' } })
-            ],
-            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
-        });
-
-        const error = expectError(result);
-        expect(error.code).toBe('invalid_disambiguation');
-        expect(error.payload).toStrictEqual({
-            disambiguation: [
-                {
-                    integration_id: 'notion',
-                    connection_id: 'notion-elsewhere',
-                    reason: 'connection_not_a_candidate',
-                    candidates: [
-                        { connection_id: 'notion-1', tags: { workspaceslug: 'marketing' } },
-                        { connection_id: 'notion-2', tags: { workspaceslug: 'eng' } }
-                    ]
-                }
+            candidates: [],
+            pinned: [
+                candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 2 })
             ]
         });
+
+        expect(Object.keys(result.unwrap())).toStrictEqual(['notion', 'slack']);
     });
 
-    it('rejects a pin on an integration the selectors did not match at all', () => {
+    it('lets a pin name a connection no selector matched', () => {
         const result = resolveTenantConnections({
-            candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1' })],
-            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-1' }]
+            candidates: [candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 1 })],
+            pinned: [candidate({ integrationId: 'notion', connectionId: 'notion-elsewhere', internalConnectionId: 9 })]
         });
 
-        const error = expectError(result);
-        expect(error.code).toBe('invalid_disambiguation');
-        expect(error.payload).toStrictEqual({
-            disambiguation: [{ integration_id: 'notion', connection_id: 'notion-1', reason: 'no_candidates', candidates: [] }]
+        expect(result.unwrap()['notion']).toStrictEqual({
+            integrationId: 'notion',
+            provider: 'notion',
+            connectionId: 'notion-elsewhere',
+            internalConnectionId: 9,
+            configId: 10
         });
     });
 
-    it('rejects two pins on the same integration', () => {
+    it('lets a pin override the single connection the selectors matched for that integration', () => {
+        const result = resolveTenantConnections({
+            candidates: [candidate({ integrationId: 'notion', connectionId: 'notion-from-tags', internalConnectionId: 1 })],
+            pinned: [candidate({ integrationId: 'notion', connectionId: 'notion-pinned', internalConnectionId: 2 })]
+        });
+
+        expect(result.unwrap()['notion']?.connectionId).toBe('notion-pinned');
+    });
+
+    it('keeps a pinned integration out of the ambiguity report', () => {
         const result = resolveTenantConnections({
             candidates: [
                 candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 }),
-                candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 })
+                candidate({ integrationId: 'notion', connectionId: 'notion-2', internalConnectionId: 2 }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-1', internalConnectionId: 3 }),
+                candidate({ integrationId: 'slack', connectionId: 'slack-2', internalConnectionId: 4 })
             ],
-            disambiguation: [
-                { integrationId: 'notion', connectionId: 'notion-1' },
-                { integrationId: 'notion', connectionId: 'notion-2' }
-            ]
+            pinned: [candidate({ integrationId: 'notion', connectionId: 'notion-1', internalConnectionId: 1 })]
         });
 
         const error = expectError(result);
-        expect(error.code).toBe('invalid_disambiguation');
-        expect((error.payload['disambiguation'] as { reason: string }[])[0]?.reason).toBe('duplicate_pin');
-    });
-
-    it('reports an invalid pin before it reports ambiguity, so the caller fixes the pin first', () => {
-        const result = resolveTenantConnections({
-            candidates: [
-                candidate({ integrationId: 'notion', connectionId: 'notion-1' }),
-                candidate({ integrationId: 'notion', connectionId: 'notion-2' }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-1' }),
-                candidate({ integrationId: 'slack', connectionId: 'slack-2' })
-            ],
-            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-elsewhere' }]
-        });
-
-        expect(expectError(result).code).toBe('invalid_disambiguation');
+        expect(Object.keys(error.payload['integrations'] as object)).toStrictEqual(['slack']);
     });
 });
 
@@ -188,7 +160,7 @@ describe('agentSessionTenantConnectionsSchema', () => {
     it('normalizes the public shape into the resolver contract', () => {
         const parsed = agentSessionTenantConnectionsSchema.parse({
             any: [{ tags: { WorkspaceSlug: 'marketing' } }, { end_user_id: 'user-74', end_user_organization_id: 'acme' }],
-            disambiguation: [{ integration_id: 'notion', connection_id: 'notion-1' }]
+            pinned: [{ integration_id: 'notion', connection_id: 'notion-1' }]
         });
 
         expect(parsed).toStrictEqual({
@@ -196,22 +168,43 @@ describe('agentSessionTenantConnectionsSchema', () => {
                 { tags: { workspaceslug: 'marketing' }, endUserId: undefined, endUserOrganizationId: undefined },
                 { tags: undefined, endUserId: 'user-74', endUserOrganizationId: 'acme' }
             ],
-            disambiguation: [{ integrationId: 'notion', connectionId: 'notion-1' }]
+            pinned: [{ integrationId: 'notion', connectionId: 'notion-1' }]
         });
     });
 
-    it('defaults disambiguation to an empty list', () => {
+    it('accepts selectors with no pins', () => {
         const parsed = agentSessionTenantConnectionsSchema.parse({ any: [{ end_user_id: 'user-74' }] });
 
-        expect(parsed.disambiguation).toStrictEqual([]);
+        expect(parsed.pinned).toStrictEqual([]);
+    });
+
+    it('accepts pins with no selectors', () => {
+        const parsed = agentSessionTenantConnectionsSchema.parse({ pinned: [{ integration_id: 'notion', connection_id: 'notion-1' }] });
+
+        expect(parsed.any).toStrictEqual([]);
+    });
+
+    it('rejects a tenant that constrains nothing at all', () => {
+        expect(agentSessionTenantConnectionsSchema.safeParse({}).success).toBe(false);
+        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [], pinned: [] }).success).toBe(false);
     });
 
     it('rejects a selector that constrains nothing', () => {
         expect(agentSessionTenantConnectionsSchema.safeParse({ any: [{}] }).success).toBe(false);
     });
 
-    it('rejects an empty or oversized selector list', () => {
-        expect(agentSessionTenantConnectionsSchema.safeParse({ any: [] }).success).toBe(false);
+    it('rejects two pins on the same integration', () => {
+        const result = agentSessionTenantConnectionsSchema.safeParse({
+            pinned: [
+                { integration_id: 'notion', connection_id: 'notion-1' },
+                { integration_id: 'notion', connection_id: 'notion-2' }
+            ]
+        });
+
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects an oversized selector list', () => {
         expect(
             agentSessionTenantConnectionsSchema.safeParse({ any: Array.from({ length: MAX_SELECTORS + 1 }, () => ({ end_user_id: 'user-74' })) }).success
         ).toBe(false);

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -45,6 +45,7 @@ export { CustomerKeyError, MAX_API_KEYS_PER_ACCOUNT } from './services/customerK
 export {
     GetConnectionError,
     type ConnectionIntegrationMatchRow,
+    type ConnectionMatch,
     type ConnectionMatchCandidate,
     type ConnectionWithDetails,
     type GetConnectionErrorCode,

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -42,7 +42,14 @@ export * from './services/tags/schema.js';
 export * as gettingStartedService from './services/getting-started.service.js';
 export { MFAError } from './services/mfa.service.js';
 export { CustomerKeyError, MAX_API_KEYS_PER_ACCOUNT } from './services/customerKey.service.js';
-export { GetConnectionError, type ConnectionWithDetails, type GetConnectionErrorCode, type RetrievedConnection } from './services/connection.service.js';
+export {
+    GetConnectionError,
+    type ConnectionIntegrationMatchRow,
+    type ConnectionMatchCandidate,
+    type ConnectionWithDetails,
+    type GetConnectionErrorCode,
+    type RetrievedConnection
+} from './services/connection.service.js';
 export * from './services/invitations.js';
 export * from './services/providers.js';
 export * from './services/proxy/utils.js';

--- a/packages/shared/lib/services/connection.matches.integration.test.ts
+++ b/packages/shared/lib/services/connection.matches.integration.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { multipleMigrations } from '@nangohq/database';
+import db, { multipleMigrations } from '@nangohq/database';
 
 import { createConfigSeed } from '../seeders/config.seeder.js';
 import { createConnectionSeed } from '../seeders/connection.seeder.js';
@@ -22,6 +22,28 @@ describe('connection matching by tag selectors', () => {
         await createConnectionSeed({ env, provider: 'notion', connectionId: 'notion-eng', tags: { tenant: 'acme', workspace: 'eng' } });
         await createConnectionSeed({ env, provider: 'slack', connectionId: 'slack-only', tags: { tenant: 'acme' } });
         await createConnectionSeed({ env, provider: 'slack', connectionId: 'slack-other-tenant', tags: { tenant: 'globex' } });
+
+        await createConfigSeed(env, 'notion-retired', 'notion');
+        await createConnectionSeed({ env, provider: 'notion-retired', connectionId: 'notion-retired-1', tags: { tenant: 'acme' } });
+        await db.knex('_nango_configs').where({ environment_id: env.id, unique_key: 'notion-retired' }).update({ deleted: true });
+    });
+
+    it('ignores connections on a deleted integration', async () => {
+        const groups = await connectionService.groupConnectionMatchesByIntegration({
+            environmentId: env.id,
+            tagSelectors: [{ tenant: 'acme' }],
+            pinnedConnections: [{ integrationId: 'notion-retired', connectionId: 'notion-retired-1' }],
+            candidateSampleSize: 10
+        });
+
+        expect(groups.map((group) => group.integration_id).sort()).toStrictEqual(['notion', 'slack']);
+
+        const existing = await connectionService.findExistingConnections({
+            environmentId: env.id,
+            connections: [{ integrationId: 'notion-retired', connectionId: 'notion-retired-1' }]
+        });
+
+        expect(existing).toStrictEqual([]);
     });
 
     describe('groupConnectionMatchesByIntegration', () => {

--- a/packages/shared/lib/services/connection.matches.integration.test.ts
+++ b/packages/shared/lib/services/connection.matches.integration.test.ts
@@ -50,21 +50,14 @@ describe('connection matching by tag selectors', () => {
         });
 
         it('keeps the true count while bounding the candidates listed', async () => {
-            const [group] = await connectionService.groupConnectionMatchesByIntegration({
+            const groups = await connectionService.groupConnectionMatchesByIntegration({
                 environmentId: env.id,
-                tagSelectors: [{ tenant: 'acme' }, { workspace: 'eng' }],
+                tagSelectors: [{ tenant: 'acme' }],
                 candidateSampleSize: 1
             });
 
-            const notion = (
-                await connectionService.groupConnectionMatchesByIntegration({
-                    environmentId: env.id,
-                    tagSelectors: [{ tenant: 'acme' }],
-                    candidateSampleSize: 1
-                })
-            ).find((match) => match.integration_id === 'notion');
+            const notion = groups.find((match) => match.integration_id === 'notion');
 
-            expect(group).toBeDefined();
             expect(notion?.match_count).toBe(2);
             expect(notion?.candidates).toHaveLength(1);
         });

--- a/packages/shared/lib/services/connection.matches.integration.test.ts
+++ b/packages/shared/lib/services/connection.matches.integration.test.ts
@@ -1,0 +1,182 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { multipleMigrations } from '@nangohq/database';
+
+import { createConfigSeed } from '../seeders/config.seeder.js';
+import { createConnectionSeed } from '../seeders/connection.seeder.js';
+import { createEnvironmentSeed } from '../seeders/environment.seeder.js';
+import connectionService from './connection.service.js';
+
+import type { DBEnvironment } from '@nangohq/types';
+
+describe('connection matching by tag selectors', () => {
+    let env: DBEnvironment;
+
+    beforeAll(async () => {
+        await multipleMigrations();
+        env = await createEnvironmentSeed();
+        await createConfigSeed(env, 'notion', 'notion');
+        await createConfigSeed(env, 'slack', 'slack');
+
+        await createConnectionSeed({ env, provider: 'notion', connectionId: 'notion-marketing', tags: { tenant: 'acme', workspace: 'marketing' } });
+        await createConnectionSeed({ env, provider: 'notion', connectionId: 'notion-eng', tags: { tenant: 'acme', workspace: 'eng' } });
+        await createConnectionSeed({ env, provider: 'slack', connectionId: 'slack-only', tags: { tenant: 'acme' } });
+        await createConnectionSeed({ env, provider: 'slack', connectionId: 'slack-other-tenant', tags: { tenant: 'globex' } });
+    });
+
+    describe('groupConnectionMatchesByIntegration', () => {
+        it('counts matches per integration and samples the candidates', async () => {
+            const groups = await connectionService.groupConnectionMatchesByIntegration({
+                environmentId: env.id,
+                tagSelectors: [{ tenant: 'acme' }],
+                candidateSampleSize: 10
+            });
+
+            const byIntegration = new Map(groups.map((group) => [group.integration_id, group]));
+
+            expect(byIntegration.get('notion')?.match_count).toBe(2);
+            expect(byIntegration.get('notion')?.provider).toBe('notion');
+            expect(
+                byIntegration
+                    .get('notion')
+                    ?.candidates.map((candidate) => candidate.connection_id)
+                    .sort()
+            ).toStrictEqual(['notion-eng', 'notion-marketing']);
+
+            expect(byIntegration.get('slack')?.match_count).toBe(1);
+            expect(byIntegration.get('slack')?.candidates).toHaveLength(1);
+            expect(byIntegration.get('slack')?.candidates[0]?.connection_id).toBe('slack-only');
+            expect(byIntegration.get('slack')?.candidates[0]?.tags).toStrictEqual({ tenant: 'acme' });
+        });
+
+        it('keeps the true count while bounding the candidates listed', async () => {
+            const [group] = await connectionService.groupConnectionMatchesByIntegration({
+                environmentId: env.id,
+                tagSelectors: [{ tenant: 'acme' }, { workspace: 'eng' }],
+                candidateSampleSize: 1
+            });
+
+            const notion = (
+                await connectionService.groupConnectionMatchesByIntegration({
+                    environmentId: env.id,
+                    tagSelectors: [{ tenant: 'acme' }],
+                    candidateSampleSize: 1
+                })
+            ).find((match) => match.integration_id === 'notion');
+
+            expect(group).toBeDefined();
+            expect(notion?.match_count).toBe(2);
+            expect(notion?.candidates).toHaveLength(1);
+        });
+
+        it('ORs the selectors together and matches all tags within one selector', async () => {
+            const unionGroups = await connectionService.groupConnectionMatchesByIntegration({
+                environmentId: env.id,
+                tagSelectors: [{ workspace: 'marketing' }, { tenant: 'globex' }],
+                candidateSampleSize: 10
+            });
+
+            expect(unionGroups.flatMap((group) => group.candidates.map((candidate) => candidate.connection_id)).sort()).toStrictEqual([
+                'notion-marketing',
+                'slack-other-tenant'
+            ]);
+
+            const conjunction = await connectionService.groupConnectionMatchesByIntegration({
+                environmentId: env.id,
+                tagSelectors: [{ tenant: 'acme', workspace: 'eng' }],
+                candidateSampleSize: 10
+            });
+
+            expect(conjunction.flatMap((group) => group.candidates.map((candidate) => candidate.connection_id))).toStrictEqual(['notion-eng']);
+        });
+
+        it('returns nothing for a selector that matches no connection', async () => {
+            const groups = await connectionService.groupConnectionMatchesByIntegration({
+                environmentId: env.id,
+                tagSelectors: [{ tenant: 'nobody' }],
+                candidateSampleSize: 10
+            });
+
+            expect(groups).toStrictEqual([]);
+        });
+
+        it('returns nothing when there are no selectors', async () => {
+            const groups = await connectionService.groupConnectionMatchesByIntegration({
+                environmentId: env.id,
+                tagSelectors: [],
+                candidateSampleSize: 10
+            });
+
+            expect(groups).toStrictEqual([]);
+        });
+    });
+
+    describe('findConnectionMatchingSelectors', () => {
+        it('finds a connection that matches the selectors', async () => {
+            const row = await connectionService.findConnectionMatchingSelectors({
+                environmentId: env.id,
+                integrationId: 'notion',
+                connectionId: 'notion-eng',
+                tagSelectors: [{ tenant: 'acme' }]
+            });
+
+            expect(row?.integration_id).toBe('notion');
+            expect(row?.provider).toBe('notion');
+            expect(row?.candidate.connection_id).toBe('notion-eng');
+            expect(row?.candidate.tags).toStrictEqual({ tenant: 'acme', workspace: 'eng' });
+        });
+
+        it('does not find a connection the selectors exclude', async () => {
+            const row = await connectionService.findConnectionMatchingSelectors({
+                environmentId: env.id,
+                integrationId: 'slack',
+                connectionId: 'slack-other-tenant',
+                tagSelectors: [{ tenant: 'acme' }]
+            });
+
+            expect(row).toBeNull();
+        });
+
+        it('does not find a connection under the wrong integration', async () => {
+            const row = await connectionService.findConnectionMatchingSelectors({
+                environmentId: env.id,
+                integrationId: 'slack',
+                connectionId: 'notion-eng',
+                tagSelectors: [{ tenant: 'acme' }]
+            });
+
+            expect(row).toBeNull();
+        });
+
+        it('checks existence only when there are no selectors', async () => {
+            const found = await connectionService.findConnectionMatchingSelectors({
+                environmentId: env.id,
+                integrationId: 'slack',
+                connectionId: 'slack-other-tenant',
+                tagSelectors: []
+            });
+            expect(found?.candidate.connection_id).toBe('slack-other-tenant');
+
+            const missing = await connectionService.findConnectionMatchingSelectors({
+                environmentId: env.id,
+                integrationId: 'slack',
+                connectionId: 'does-not-exist',
+                tagSelectors: []
+            });
+            expect(missing).toBeNull();
+        });
+
+        it('does not cross environments', async () => {
+            const otherEnv = await createEnvironmentSeed();
+
+            const row = await connectionService.findConnectionMatchingSelectors({
+                environmentId: otherEnv.id,
+                integrationId: 'notion',
+                connectionId: 'notion-eng',
+                tagSelectors: []
+            });
+
+            expect(row).toBeNull();
+        });
+    });
+});

--- a/packages/shared/lib/services/connection.matches.integration.test.ts
+++ b/packages/shared/lib/services/connection.matches.integration.test.ts
@@ -29,6 +29,7 @@ describe('connection matching by tag selectors', () => {
             const groups = await connectionService.groupConnectionMatchesByIntegration({
                 environmentId: env.id,
                 tagSelectors: [{ tenant: 'acme' }],
+                pinnedConnections: [],
                 candidateSampleSize: 10
             });
 
@@ -53,6 +54,7 @@ describe('connection matching by tag selectors', () => {
             const groups = await connectionService.groupConnectionMatchesByIntegration({
                 environmentId: env.id,
                 tagSelectors: [{ tenant: 'acme' }],
+                pinnedConnections: [],
                 candidateSampleSize: 1
             });
 
@@ -66,6 +68,7 @@ describe('connection matching by tag selectors', () => {
             const unionGroups = await connectionService.groupConnectionMatchesByIntegration({
                 environmentId: env.id,
                 tagSelectors: [{ workspace: 'marketing' }, { tenant: 'globex' }],
+                pinnedConnections: [],
                 candidateSampleSize: 10
             });
 
@@ -77,6 +80,7 @@ describe('connection matching by tag selectors', () => {
             const conjunction = await connectionService.groupConnectionMatchesByIntegration({
                 environmentId: env.id,
                 tagSelectors: [{ tenant: 'acme', workspace: 'eng' }],
+                pinnedConnections: [],
                 candidateSampleSize: 10
             });
 
@@ -87,6 +91,7 @@ describe('connection matching by tag selectors', () => {
             const groups = await connectionService.groupConnectionMatchesByIntegration({
                 environmentId: env.id,
                 tagSelectors: [{ tenant: 'nobody' }],
+                pinnedConnections: [],
                 candidateSampleSize: 10
             });
 
@@ -97,6 +102,7 @@ describe('connection matching by tag selectors', () => {
             const groups = await connectionService.groupConnectionMatchesByIntegration({
                 environmentId: env.id,
                 tagSelectors: [],
+                pinnedConnections: [],
                 candidateSampleSize: 10
             });
 
@@ -104,72 +110,74 @@ describe('connection matching by tag selectors', () => {
         });
     });
 
-    describe('findConnectionMatchingSelectors', () => {
-        it('finds a connection that matches the selectors', async () => {
-            const row = await connectionService.findConnectionMatchingSelectors({
+    describe('pinned connections', () => {
+        it('returns a pinned connection that the sample would otherwise have cut', async () => {
+            const groups = await connectionService.groupConnectionMatchesByIntegration({
                 environmentId: env.id,
-                integrationId: 'notion',
-                connectionId: 'notion-eng',
-                tagSelectors: [{ tenant: 'acme' }]
+                tagSelectors: [{ tenant: 'acme' }],
+                pinnedConnections: [{ integrationId: 'notion', connectionId: 'notion-marketing' }],
+                candidateSampleSize: 1
             });
 
-            expect(row?.integration_id).toBe('notion');
-            expect(row?.provider).toBe('notion');
-            expect(row?.candidate.connection_id).toBe('notion-eng');
-            expect(row?.candidate.tags).toStrictEqual({ tenant: 'acme', workspace: 'eng' });
+            const notion = groups.find((match) => match.integration_id === 'notion');
+
+            expect(notion?.match_count).toBe(2);
+            expect(notion?.candidates.map((candidate) => candidate.connection_id).sort()).toStrictEqual(['notion-eng', 'notion-marketing']);
         });
 
-        it('does not find a connection the selectors exclude', async () => {
-            const row = await connectionService.findConnectionMatchingSelectors({
+        it('does not return a pinned connection the selectors exclude', async () => {
+            const groups = await connectionService.groupConnectionMatchesByIntegration({
                 environmentId: env.id,
-                integrationId: 'slack',
-                connectionId: 'slack-other-tenant',
-                tagSelectors: [{ tenant: 'acme' }]
+                tagSelectors: [{ tenant: 'acme' }],
+                pinnedConnections: [{ integrationId: 'slack', connectionId: 'slack-other-tenant' }],
+                candidateSampleSize: 10
             });
 
-            expect(row).toBeNull();
+            const slack = groups.find((match) => match.integration_id === 'slack');
+
+            expect(slack?.candidates.map((candidate) => candidate.connection_id)).toStrictEqual(['slack-only']);
+        });
+    });
+
+    describe('findExistingConnections', () => {
+        it('finds several connections in one query, ignoring tags', async () => {
+            const found = await connectionService.findExistingConnections({
+                environmentId: env.id,
+                connections: [
+                    { integrationId: 'notion', connectionId: 'notion-eng' },
+                    { integrationId: 'slack', connectionId: 'slack-other-tenant' }
+                ]
+            });
+
+            expect(found.map((row) => row.candidate.connection_id).sort()).toStrictEqual(['notion-eng', 'slack-other-tenant']);
+            expect(found.find((row) => row.integration_id === 'notion')?.candidate.tags).toStrictEqual({ tenant: 'acme', workspace: 'eng' });
         });
 
-        it('does not find a connection under the wrong integration', async () => {
-            const row = await connectionService.findConnectionMatchingSelectors({
+        it('omits a connection that does not exist, and one under the wrong integration', async () => {
+            const found = await connectionService.findExistingConnections({
                 environmentId: env.id,
-                integrationId: 'slack',
-                connectionId: 'notion-eng',
-                tagSelectors: [{ tenant: 'acme' }]
+                connections: [
+                    { integrationId: 'notion', connectionId: 'does-not-exist' },
+                    { integrationId: 'slack', connectionId: 'notion-eng' }
+                ]
             });
 
-            expect(row).toBeNull();
+            expect(found).toStrictEqual([]);
         });
 
-        it('checks existence only when there are no selectors', async () => {
-            const found = await connectionService.findConnectionMatchingSelectors({
-                environmentId: env.id,
-                integrationId: 'slack',
-                connectionId: 'slack-other-tenant',
-                tagSelectors: []
-            });
-            expect(found?.candidate.connection_id).toBe('slack-other-tenant');
-
-            const missing = await connectionService.findConnectionMatchingSelectors({
-                environmentId: env.id,
-                integrationId: 'slack',
-                connectionId: 'does-not-exist',
-                tagSelectors: []
-            });
-            expect(missing).toBeNull();
+        it('returns nothing for an empty list, without querying', async () => {
+            expect(await connectionService.findExistingConnections({ environmentId: env.id, connections: [] })).toStrictEqual([]);
         });
 
         it('does not cross environments', async () => {
             const otherEnv = await createEnvironmentSeed();
 
-            const row = await connectionService.findConnectionMatchingSelectors({
+            const found = await connectionService.findExistingConnections({
                 environmentId: otherEnv.id,
-                integrationId: 'notion',
-                connectionId: 'notion-eng',
-                tagSelectors: []
+                connections: [{ integrationId: 'notion', connectionId: 'notion-eng' }]
             });
 
-            expect(row).toBeNull();
+            expect(found).toStrictEqual([]);
         });
     });
 });

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -115,6 +115,12 @@ export interface ConnectionIntegrationMatchRow {
     match_count: number;
     candidates: ConnectionMatchCandidate[];
 }
+
+export interface ConnectionMatch {
+    integration_id: string;
+    provider: string;
+    candidate: ConnectionMatchCandidate;
+}
 const ACTIVE_LOG_TABLE = dbNamespace + 'active_logs';
 const CONNECTION_COLUMNS_WITHOUT_CREDENTIALS = [
     '_nango_connections.id',
@@ -1366,7 +1372,7 @@ export class ConnectionService {
         integrationId: string;
         connectionId: string;
         tagSelectors: Tags[];
-    }): Promise<{ integration_id: string; provider: string; candidate: ConnectionMatchCandidate } | null> {
+    }): Promise<ConnectionMatch | null> {
         const query = db.readOnly
             .select(
                 '_nango_configs.unique_key as integration_id',
@@ -1390,7 +1396,7 @@ export class ConnectionService {
             );
         }
 
-        const row = await query.first<{ integration_id: string; provider: string; candidate: ConnectionMatchCandidate } | undefined>();
+        const row = await query.first<ConnectionMatch | undefined>();
 
         return row ?? null;
     }

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1185,7 +1185,15 @@ export class ConnectionService {
         tags?: Record<string, string> | undefined;
         limit?: number;
         page?: number | undefined;
-    }): Promise<{ connection: DBConnectionAsJSONRow; end_user: DBEndUser | null; active_logs: [{ type: string; log_id: string }]; provider: string }[]> {
+    }): Promise<
+        {
+            connection: DBConnectionAsJSONRow;
+            end_user: DBEndUser | null;
+            active_logs: [{ type: string; log_id: string }];
+            provider: string;
+            integration_id: string;
+        }[]
+    > {
         const query = db.readOnly
             // Filter and paginate connections
             .with('filtered_connections', (qb) => {
@@ -1272,7 +1280,8 @@ export class ConnectionService {
                 db.knex.raw('row_to_json(_nango_connections.*) as connection'),
                 db.knex.raw('row_to_json(end_users.*) as end_user'),
                 db.knex.raw(`COALESCE(active_logs_agg.active_logs, '[]'::json) as active_logs`),
-                '_nango_configs.provider'
+                '_nango_configs.provider',
+                '_nango_configs.unique_key as integration_id'
             )
             .from('_nango_connections')
             .innerJoin('filtered_connections', 'filtered_connections.id', '_nango_connections.id')

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1345,6 +1345,7 @@ export class ConnectionService {
                     .innerJoin('_nango_configs', '_nango_configs.id', '_nango_connections.config_id')
                     .where('_nango_connections.environment_id', environmentId)
                     .where('_nango_connections.deleted', false)
+                    .where('_nango_configs.deleted', false)
                     .whereRaw(`(${containment})`, containmentBindings);
             })
             .with('ranked', (qb) => {
@@ -1401,6 +1402,7 @@ export class ConnectionService {
             .innerJoin('_nango_configs', '_nango_configs.id', '_nango_connections.config_id')
             .where('_nango_connections.environment_id', environmentId)
             .where('_nango_connections.deleted', false)
+            .where('_nango_configs.deleted', false)
             .whereRaw(
                 `(_nango_configs.unique_key, _nango_connections.connection_id) IN (${connections.map(() => '(?, ?)').join(', ')})`,
                 connections.flatMap((connection) => [connection.integrationId, connection.connectionId])

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1316,43 +1316,45 @@ export class ConnectionService {
         }
 
         const containment = tagSelectors.map(() => '_nango_connections.tags @> ?::jsonb').join(' OR ');
-        const bindings = [environmentId, ...tagSelectors.map((tags) => JSON.stringify(tags)), candidateSampleSize];
+        const containmentBindings = tagSelectors.map((tags) => JSON.stringify(tags));
 
-        const result: { rows: ConnectionIntegrationMatchRow[] } = await db.readOnly.raw(
-            `WITH matched AS (
-                SELECT _nango_connections.id,
-                       _nango_connections.connection_id,
-                       _nango_connections.config_id,
-                       _nango_connections.tags,
-                       _nango_connections.created_at,
-                       _nango_configs.unique_key AS integration_id,
-                       _nango_configs.provider AS provider
-                FROM _nango_connections
-                INNER JOIN _nango_configs ON _nango_configs.id = _nango_connections.config_id
-                WHERE _nango_connections.environment_id = ?
-                  AND _nango_connections.deleted = false
-                  AND (${containment})
-            ),
-            ranked AS (
-                SELECT matched.*,
-                       ROW_NUMBER() OVER (PARTITION BY integration_id ORDER BY created_at DESC, id DESC) AS rn,
-                       COUNT(*) OVER (PARTITION BY integration_id) AS match_count
-                FROM matched
+        return await db.readOnly
+            // Connections matching any of the selectors, each selector keeping its own GIN indexed containment check
+            .with('matched', (qb) => {
+                qb.select(
+                    '_nango_connections.id',
+                    '_nango_connections.connection_id',
+                    '_nango_connections.config_id',
+                    '_nango_connections.tags',
+                    '_nango_connections.created_at',
+                    '_nango_configs.unique_key as integration_id',
+                    '_nango_configs.provider as provider'
+                )
+                    .from('_nango_connections')
+                    .innerJoin('_nango_configs', '_nango_configs.id', '_nango_connections.config_id')
+                    .where('_nango_connections.environment_id', environmentId)
+                    .where('_nango_connections.deleted', false)
+                    .whereRaw(`(${containment})`, containmentBindings);
+            })
+            // Count every match per integration, and number them so only a sample survives the filter below
+            .with('ranked', (qb) => {
+                qb.select(
+                    'matched.*',
+                    db.knex.raw('ROW_NUMBER() OVER (PARTITION BY integration_id ORDER BY created_at DESC, id DESC) as rn'),
+                    db.knex.raw('COUNT(*) OVER (PARTITION BY integration_id) as match_count')
+                ).from('matched');
+            })
+            .select<ConnectionIntegrationMatchRow[]>(
+                'integration_id',
+                'provider',
+                db.knex.raw('MAX(match_count)::int as match_count'),
+                db.knex.raw(
+                    `JSON_AGG(JSON_BUILD_OBJECT('id', id, 'connection_id', connection_id, 'config_id', config_id, 'tags', tags) ORDER BY rn) as candidates`
+                )
             )
-            SELECT integration_id,
-                   provider,
-                   MAX(match_count)::int AS match_count,
-                   JSON_AGG(
-                       JSON_BUILD_OBJECT('id', id, 'connection_id', connection_id, 'config_id', config_id, 'tags', tags)
-                       ORDER BY rn
-                   ) AS candidates
-            FROM ranked
-            WHERE rn <= ?
-            GROUP BY integration_id, provider`,
-            bindings
-        );
-
-        return result.rows;
+            .from('ranked')
+            .where('rn', '<=', candidateSampleSize)
+            .groupBy('integration_id', 'provider');
     }
 
     public async findConnectionMatchingSelectors({

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1307,13 +1307,20 @@ export class ConnectionService {
         return await query;
     }
 
+    /**
+     * `tagSelectors` is an OR between the tag objects, and an AND between the tags inside each one.
+     * Pinned connections survive the candidate sample so a caller can check them without listing
+     * every match.
+     */
     public async groupConnectionMatchesByIntegration({
         environmentId,
         tagSelectors,
+        pinnedConnections,
         candidateSampleSize
     }: {
         environmentId: number;
         tagSelectors: Tags[];
+        pinnedConnections: { integrationId: string; connectionId: string }[];
         candidateSampleSize: number;
     }): Promise<ConnectionIntegrationMatchRow[]> {
         if (tagSelectors.length === 0) {
@@ -1324,7 +1331,6 @@ export class ConnectionService {
         const containmentBindings = tagSelectors.map((tags) => JSON.stringify(tags));
 
         return await db.readOnly
-            // Connections matching any of the selectors, each selector keeping its own GIN indexed containment check
             .with('matched', (qb) => {
                 qb.select(
                     '_nango_connections.id',
@@ -1341,13 +1347,15 @@ export class ConnectionService {
                     .where('_nango_connections.deleted', false)
                     .whereRaw(`(${containment})`, containmentBindings);
             })
-            // Count every match per integration, and number them so only a sample survives the filter below
             .with('ranked', (qb) => {
-                qb.select(
-                    'matched.*',
-                    db.knex.raw('ROW_NUMBER() OVER (PARTITION BY integration_id ORDER BY created_at DESC, id DESC) as rn'),
-                    db.knex.raw('COUNT(*) OVER (PARTITION BY integration_id) as match_count')
-                ).from('matched');
+                qb.select('matched.*', db.knex.raw('COUNT(*) OVER (PARTITION BY integration_id) as match_count'))
+                    .rowNumber('rn', (rn) => {
+                        rn.partitionBy('integration_id').orderBy([
+                            { column: 'created_at', order: 'desc' },
+                            { column: 'id', order: 'desc' }
+                        ]);
+                    })
+                    .from('matched');
             })
             .select<ConnectionIntegrationMatchRow[]>(
                 'integration_id',
@@ -1358,23 +1366,31 @@ export class ConnectionService {
                 )
             )
             .from('ranked')
-            .where('rn', '<=', candidateSampleSize)
+            .where((qb) => {
+                qb.where('rn', '<=', candidateSampleSize);
+
+                for (const pin of pinnedConnections) {
+                    qb.orWhere((pinned) => {
+                        pinned.where('integration_id', pin.integrationId).where('connection_id', pin.connectionId);
+                    });
+                }
+            })
             .groupBy('integration_id', 'provider');
     }
 
-    public async findConnectionMatchingSelectors({
+    public async findExistingConnections({
         environmentId,
-        integrationId,
-        connectionId,
-        tagSelectors
+        connections
     }: {
         environmentId: number;
-        integrationId: string;
-        connectionId: string;
-        tagSelectors: Tags[];
-    }): Promise<ConnectionMatch | null> {
-        const query = db.readOnly
-            .select(
+        connections: { integrationId: string; connectionId: string }[];
+    }): Promise<ConnectionMatch[]> {
+        if (connections.length === 0) {
+            return [];
+        }
+
+        return await db.readOnly
+            .select<ConnectionMatch[]>(
                 '_nango_configs.unique_key as integration_id',
                 '_nango_configs.provider',
                 db.knex.raw(
@@ -1385,20 +1401,10 @@ export class ConnectionService {
             .innerJoin('_nango_configs', '_nango_configs.id', '_nango_connections.config_id')
             .where('_nango_connections.environment_id', environmentId)
             .where('_nango_connections.deleted', false)
-            .where('_nango_connections.connection_id', connectionId)
-            .where('_nango_configs.unique_key', integrationId);
-
-        if (tagSelectors.length > 0) {
-            const containment = tagSelectors.map(() => '_nango_connections.tags @> ?::jsonb').join(' OR ');
-            query.whereRaw(
-                `(${containment})`,
-                tagSelectors.map((tags) => JSON.stringify(tags))
+            .whereRaw(
+                `(_nango_configs.unique_key, _nango_connections.connection_id) IN (${connections.map(() => '(?, ?)').join(', ')})`,
+                connections.flatMap((connection) => [connection.integrationId, connection.connectionId])
             );
-        }
-
-        const row = await query.first<ConnectionMatch | undefined>();
-
-        return row ?? null;
     }
 
     public async deleteConnection({

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1301,7 +1301,6 @@ export class ConnectionService {
         return await query;
     }
 
-    /** `match_count` is the full count; `candidates` is capped at `candidateSampleSize`. */
     public async groupConnectionMatchesByIntegration({
         environmentId,
         tagSelectors,

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -101,6 +101,20 @@ import type { Result } from '@nangohq/utils';
 import type { Agent } from 'undici';
 
 const logger = getLogger('Connection');
+
+export interface ConnectionMatchCandidate {
+    id: number;
+    connection_id: string;
+    config_id: number;
+    tags: Tags;
+}
+
+export interface ConnectionIntegrationMatchRow {
+    integration_id: string;
+    provider: string;
+    match_count: number;
+    candidates: ConnectionMatchCandidate[];
+}
 const ACTIVE_LOG_TABLE = dbNamespace + 'active_logs';
 const CONNECTION_COLUMNS_WITHOUT_CREDENTIALS = [
     '_nango_connections.id',
@@ -1185,15 +1199,7 @@ export class ConnectionService {
         tags?: Record<string, string> | undefined;
         limit?: number;
         page?: number | undefined;
-    }): Promise<
-        {
-            connection: DBConnectionAsJSONRow;
-            end_user: DBEndUser | null;
-            active_logs: [{ type: string; log_id: string }];
-            provider: string;
-            integration_id: string;
-        }[]
-    > {
+    }): Promise<{ connection: DBConnectionAsJSONRow; end_user: DBEndUser | null; active_logs: [{ type: string; log_id: string }]; provider: string }[]> {
         const query = db.readOnly
             // Filter and paginate connections
             .with('filtered_connections', (qb) => {
@@ -1280,8 +1286,7 @@ export class ConnectionService {
                 db.knex.raw('row_to_json(_nango_connections.*) as connection'),
                 db.knex.raw('row_to_json(end_users.*) as end_user'),
                 db.knex.raw(`COALESCE(active_logs_agg.active_logs, '[]'::json) as active_logs`),
-                '_nango_configs.provider',
-                '_nango_configs.unique_key as integration_id'
+                '_nango_configs.provider'
             )
             .from('_nango_connections')
             .innerJoin('filtered_connections', 'filtered_connections.id', '_nango_connections.id')
@@ -1294,6 +1299,99 @@ export class ConnectionService {
             ]);
 
         return await query;
+    }
+
+    /** `match_count` is the full count; `candidates` is capped at `candidateSampleSize`. */
+    public async groupConnectionMatchesByIntegration({
+        environmentId,
+        tagSelectors,
+        candidateSampleSize
+    }: {
+        environmentId: number;
+        tagSelectors: Tags[];
+        candidateSampleSize: number;
+    }): Promise<ConnectionIntegrationMatchRow[]> {
+        if (tagSelectors.length === 0) {
+            return [];
+        }
+
+        const containment = tagSelectors.map(() => '_nango_connections.tags @> ?::jsonb').join(' OR ');
+        const bindings = [environmentId, ...tagSelectors.map((tags) => JSON.stringify(tags)), candidateSampleSize];
+
+        const result: { rows: ConnectionIntegrationMatchRow[] } = await db.readOnly.raw(
+            `WITH matched AS (
+                SELECT _nango_connections.id,
+                       _nango_connections.connection_id,
+                       _nango_connections.config_id,
+                       _nango_connections.tags,
+                       _nango_connections.created_at,
+                       _nango_configs.unique_key AS integration_id,
+                       _nango_configs.provider AS provider
+                FROM _nango_connections
+                INNER JOIN _nango_configs ON _nango_configs.id = _nango_connections.config_id
+                WHERE _nango_connections.environment_id = ?
+                  AND _nango_connections.deleted = false
+                  AND (${containment})
+            ),
+            ranked AS (
+                SELECT matched.*,
+                       ROW_NUMBER() OVER (PARTITION BY integration_id ORDER BY created_at DESC, id DESC) AS rn,
+                       COUNT(*) OVER (PARTITION BY integration_id) AS match_count
+                FROM matched
+            )
+            SELECT integration_id,
+                   provider,
+                   MAX(match_count)::int AS match_count,
+                   JSON_AGG(
+                       JSON_BUILD_OBJECT('id', id, 'connection_id', connection_id, 'config_id', config_id, 'tags', tags)
+                       ORDER BY rn
+                   ) AS candidates
+            FROM ranked
+            WHERE rn <= ?
+            GROUP BY integration_id, provider`,
+            bindings
+        );
+
+        return result.rows;
+    }
+
+    public async findConnectionMatchingSelectors({
+        environmentId,
+        integrationId,
+        connectionId,
+        tagSelectors
+    }: {
+        environmentId: number;
+        integrationId: string;
+        connectionId: string;
+        tagSelectors: Tags[];
+    }): Promise<{ integration_id: string; provider: string; candidate: ConnectionMatchCandidate } | null> {
+        const query = db.readOnly
+            .select(
+                '_nango_configs.unique_key as integration_id',
+                '_nango_configs.provider',
+                db.knex.raw(
+                    `JSON_BUILD_OBJECT('id', _nango_connections.id, 'connection_id', _nango_connections.connection_id, 'config_id', _nango_connections.config_id, 'tags', _nango_connections.tags) as candidate`
+                )
+            )
+            .from('_nango_connections')
+            .innerJoin('_nango_configs', '_nango_configs.id', '_nango_connections.config_id')
+            .where('_nango_connections.environment_id', environmentId)
+            .where('_nango_connections.deleted', false)
+            .where('_nango_connections.connection_id', connectionId)
+            .where('_nango_configs.unique_key', integrationId);
+
+        if (tagSelectors.length > 0) {
+            const containment = tagSelectors.map(() => '_nango_connections.tags @> ?::jsonb').join(' OR ');
+            query.whereRaw(
+                `(${containment})`,
+                tagSelectors.map((tags) => JSON.stringify(tags))
+            );
+        }
+
+        const row = await query.first<{ integration_id: string; provider: string; candidate: ConnectionMatchCandidate } | undefined>();
+
+        return row ?? null;
     }
 
     public async deleteConnection({

--- a/packages/types/lib/agent/connections.ts
+++ b/packages/types/lib/agent/connections.ts
@@ -11,17 +11,19 @@ export interface AgentSessionConnectionSelector {
 }
 
 /**
- * Breaks a tie when one integration matched several connections. A pin can only narrow the
- * selectors: the connection it names must already be a candidate.
+ * Names the connection an integration must use. Authoritative: it breaks a tie when selectors
+ * matched several connections, and it stands on its own for customers who resolve connections
+ * themselves and pass ids rather than tags.
  */
-export interface AgentSessionConnectionDisambiguation {
+export interface AgentSessionPinnedConnection {
     readonly integrationId: string;
     readonly connectionId: string;
 }
 
+/** At least one of `any` or `pinned` is always present. */
 export interface AgentSessionTenantConnections {
     readonly any: AgentSessionConnectionSelector[];
-    readonly disambiguation: AgentSessionConnectionDisambiguation[];
+    readonly pinned: AgentSessionPinnedConnection[];
 }
 
 /** A connection matching at least one selector, before cardinality is decided. */
@@ -49,7 +51,7 @@ export interface AgentSessionResolvedConnection {
 /** Keyed by integration id, holding exactly one connection each. */
 export type AgentSessionResolvedConnections = Record<string, AgentSessionResolvedConnection>;
 
-export type AgentSessionConnectionResolutionErrorCode = 'ambiguous_connections' | 'invalid_disambiguation' | 'selector_too_broad';
+export type AgentSessionConnectionResolutionErrorCode = 'ambiguous_connections' | 'selector_too_broad' | 'unknown_pinned_connection';
 
 /** Candidate as named back to the caller, so it can narrow the selectors or pin one of these. */
 export interface AgentSessionConnectionCandidateReport {
@@ -61,13 +63,9 @@ export interface AgentSessionAmbiguousConnectionsPayload {
     readonly integrations: Record<string, { readonly candidates: AgentSessionConnectionCandidateReport[] }>;
 }
 
-export type AgentSessionDisambiguationIssueReason = 'no_candidates' | 'connection_not_a_candidate' | 'duplicate_pin';
-
-export interface AgentSessionInvalidDisambiguationPayload {
-    readonly disambiguation: {
+export interface AgentSessionUnknownPinnedConnectionsPayload {
+    readonly pinned: {
         readonly integration_id: string;
         readonly connection_id: string;
-        readonly reason: AgentSessionDisambiguationIssueReason;
-        readonly candidates: AgentSessionConnectionCandidateReport[];
     }[];
 }

--- a/packages/types/lib/agent/connections.ts
+++ b/packages/types/lib/agent/connections.ts
@@ -31,7 +31,6 @@ export interface AgentSessionIntegrationMatch {
     readonly candidates: AgentSessionConnectionCandidate[];
 }
 
-/** Execute against `internalConnectionId`: a deleted external id can be reused by another row. */
 export interface AgentSessionResolvedConnection {
     readonly integrationId: string;
     readonly provider: string;

--- a/packages/types/lib/agent/connections.ts
+++ b/packages/types/lib/agent/connections.ts
@@ -23,7 +23,6 @@ export interface AgentSessionConnectionCandidate {
     readonly tags: Tags;
 }
 
-/** `candidates` is a bounded sample, so cardinality comes from `matchCount`, never its length. */
 export interface AgentSessionIntegrationMatch {
     readonly integrationId: string;
     readonly provider: string;

--- a/packages/types/lib/agent/connections.ts
+++ b/packages/types/lib/agent/connections.ts
@@ -11,16 +11,17 @@ export interface AgentSessionConnectionSelector {
 }
 
 /**
- * Names the connection an integration must use. Authoritative: it breaks a tie when selectors
- * matched several connections, and it stands on its own for customers who resolve connections
- * themselves and pass ids rather than tags.
+ * Chooses which of an integration's matched connections to use. Selectors filter first and a pin
+ * picks from what they matched, so a pin can never reach a connection the selectors excluded. A
+ * tenant with no selectors at all applies no tag filter, which is how a customer who resolves
+ * connections themselves pins ids directly.
  */
 export interface AgentSessionPinnedConnection {
     readonly integrationId: string;
     readonly connectionId: string;
 }
 
-/** At least one of `any` or `pinned` is always present. */
+/** At least one of `any` or `pinned` is always present. An empty `any` applies no tag filter. */
 export interface AgentSessionTenantConnections {
     readonly any: AgentSessionConnectionSelector[];
     readonly pinned: AgentSessionPinnedConnection[];
@@ -51,7 +52,11 @@ export interface AgentSessionResolvedConnection {
 /** Keyed by integration id, holding exactly one connection each. */
 export type AgentSessionResolvedConnections = Record<string, AgentSessionResolvedConnection>;
 
-export type AgentSessionConnectionResolutionErrorCode = 'ambiguous_connections' | 'selector_too_broad' | 'unknown_pinned_connection';
+export type AgentSessionConnectionResolutionErrorCode =
+    | 'ambiguous_connections'
+    | 'pinned_connection_not_matched'
+    | 'selector_too_broad'
+    | 'unknown_pinned_connection';
 
 /** Candidate as named back to the caller, so it can narrow the selectors or pin one of these. */
 export interface AgentSessionConnectionCandidateReport {
@@ -67,5 +72,13 @@ export interface AgentSessionUnknownPinnedConnectionsPayload {
     readonly pinned: {
         readonly integration_id: string;
         readonly connection_id: string;
+    }[];
+}
+
+export interface AgentSessionPinnedConnectionNotMatchedPayload {
+    readonly pinned: {
+        readonly integration_id: string;
+        readonly connection_id: string;
+        readonly candidates: AgentSessionConnectionCandidateReport[];
     }[];
 }

--- a/packages/types/lib/agent/connections.ts
+++ b/packages/types/lib/agent/connections.ts
@@ -14,22 +14,6 @@ export interface AgentSessionTenantConnections {
     readonly pinned: AgentSessionPinnedConnection[];
 }
 
-export interface AgentSessionConnectionCandidate {
-    readonly integrationId: string;
-    readonly provider: string;
-    readonly connectionId: string;
-    readonly internalConnectionId: number;
-    readonly configId: number;
-    readonly tags: Tags;
-}
-
-export interface AgentSessionIntegrationMatch {
-    readonly integrationId: string;
-    readonly provider: string;
-    readonly matchCount: number;
-    readonly candidates: AgentSessionConnectionCandidate[];
-}
-
 export interface AgentSessionResolvedConnection {
     readonly integrationId: string;
     readonly provider: string;

--- a/packages/types/lib/agent/connections.ts
+++ b/packages/types/lib/agent/connections.ts
@@ -1,34 +1,19 @@
 import type { Tags } from '../db.js';
 
-/**
- * One clause of `tenant.connections.any`. Every tag on a selector is matched together.
- *
- * Tags are the only selector. End users are projected onto connection tags on creation
- * (`end_user_id`, `end_user_email`, `organization_id` and friends), so selecting an end user means
- * a tag on those keys rather than a separate field.
- */
 export interface AgentSessionConnectionSelector {
     readonly tags: Tags;
 }
 
-/**
- * Chooses which of an integration's matched connections to use. Selectors filter first and a pin
- * picks from what they matched, so a pin can never reach a connection the selectors excluded. A
- * tenant with no selectors at all applies no tag filter, which is how a customer who resolves
- * connections themselves pins ids directly.
- */
 export interface AgentSessionPinnedConnection {
     readonly integrationId: string;
     readonly connectionId: string;
 }
 
-/** At least one of `any` or `pinned` is always present. An empty `any` applies no tag filter. */
 export interface AgentSessionTenantConnections {
     readonly any: AgentSessionConnectionSelector[];
     readonly pinned: AgentSessionPinnedConnection[];
 }
 
-/** A connection matching at least one selector, before cardinality is decided. */
 export interface AgentSessionConnectionCandidate {
     readonly integrationId: string;
     readonly provider: string;
@@ -38,10 +23,15 @@ export interface AgentSessionConnectionCandidate {
     readonly tags: Tags;
 }
 
-/**
- * The one connection an integration's tools run against. The internal id is what execution must
- * use: a deleted external connection id can be reused by a row that never matched the selectors.
- */
+/** `candidates` is a bounded sample, so cardinality comes from `matchCount`, never its length. */
+export interface AgentSessionIntegrationMatch {
+    readonly integrationId: string;
+    readonly provider: string;
+    readonly matchCount: number;
+    readonly candidates: AgentSessionConnectionCandidate[];
+}
+
+/** Execute against `internalConnectionId`: a deleted external id can be reused by another row. */
 export interface AgentSessionResolvedConnection {
     readonly integrationId: string;
     readonly provider: string;
@@ -50,23 +40,23 @@ export interface AgentSessionResolvedConnection {
     readonly configId: number;
 }
 
-/** Keyed by integration id, holding exactly one connection each. */
 export type AgentSessionResolvedConnections = Record<string, AgentSessionResolvedConnection>;
 
-export type AgentSessionConnectionResolutionErrorCode =
-    | 'ambiguous_connections'
-    | 'pinned_connection_not_matched'
-    | 'selector_too_broad'
-    | 'unknown_pinned_connection';
+export type AgentSessionConnectionResolutionErrorCode = 'ambiguous_connections' | 'pinned_connection_not_matched' | 'unknown_pinned_connection';
 
-/** Candidate as named back to the caller, so it can narrow the selectors or pin one of these. */
 export interface AgentSessionConnectionCandidateReport {
     readonly connection_id: string;
     readonly tags: Tags;
 }
 
 export interface AgentSessionAmbiguousConnectionsPayload {
-    readonly integrations: Record<string, { readonly candidates: AgentSessionConnectionCandidateReport[] }>;
+    readonly integrations: Record<
+        string,
+        {
+            readonly match_count: number;
+            readonly candidates: AgentSessionConnectionCandidateReport[];
+        }
+    >;
 }
 
 export interface AgentSessionUnknownPinnedConnectionsPayload {

--- a/packages/types/lib/agent/connections.ts
+++ b/packages/types/lib/agent/connections.ts
@@ -1,0 +1,73 @@
+import type { Tags } from '../db.js';
+
+/**
+ * One clause of `tenant.connections.any`. Every constraint on a selector is matched together,
+ * so a selector with tags and an end user matches connections satisfying all of them.
+ */
+export interface AgentSessionConnectionSelector {
+    readonly tags?: Tags | undefined;
+    readonly endUserId?: string | undefined;
+    readonly endUserOrganizationId?: string | undefined;
+}
+
+/**
+ * Breaks a tie when one integration matched several connections. A pin can only narrow the
+ * selectors: the connection it names must already be a candidate.
+ */
+export interface AgentSessionConnectionDisambiguation {
+    readonly integrationId: string;
+    readonly connectionId: string;
+}
+
+export interface AgentSessionTenantConnections {
+    readonly any: AgentSessionConnectionSelector[];
+    readonly disambiguation: AgentSessionConnectionDisambiguation[];
+}
+
+/** A connection matching at least one selector, before cardinality is decided. */
+export interface AgentSessionConnectionCandidate {
+    readonly integrationId: string;
+    readonly provider: string;
+    readonly connectionId: string;
+    readonly internalConnectionId: number;
+    readonly configId: number;
+    readonly tags: Tags;
+}
+
+/**
+ * The one connection an integration's tools run against. The internal id is what execution must
+ * use: a deleted external connection id can be reused by a row that never matched the selectors.
+ */
+export interface AgentSessionResolvedConnection {
+    readonly integrationId: string;
+    readonly provider: string;
+    readonly connectionId: string;
+    readonly internalConnectionId: number;
+    readonly configId: number;
+}
+
+/** Keyed by integration id, holding exactly one connection each. */
+export type AgentSessionResolvedConnections = Record<string, AgentSessionResolvedConnection>;
+
+export type AgentSessionConnectionResolutionErrorCode = 'ambiguous_connections' | 'invalid_disambiguation' | 'selector_too_broad';
+
+/** Candidate as named back to the caller, so it can narrow the selectors or pin one of these. */
+export interface AgentSessionConnectionCandidateReport {
+    readonly connection_id: string;
+    readonly tags: Tags;
+}
+
+export interface AgentSessionAmbiguousConnectionsPayload {
+    readonly integrations: Record<string, { readonly candidates: AgentSessionConnectionCandidateReport[] }>;
+}
+
+export type AgentSessionDisambiguationIssueReason = 'no_candidates' | 'connection_not_a_candidate' | 'duplicate_pin';
+
+export interface AgentSessionInvalidDisambiguationPayload {
+    readonly disambiguation: {
+        readonly integration_id: string;
+        readonly connection_id: string;
+        readonly reason: AgentSessionDisambiguationIssueReason;
+        readonly candidates: AgentSessionConnectionCandidateReport[];
+    }[];
+}

--- a/packages/types/lib/agent/connections.ts
+++ b/packages/types/lib/agent/connections.ts
@@ -1,13 +1,14 @@
 import type { Tags } from '../db.js';
 
 /**
- * One clause of `tenant.connections.any`. Every constraint on a selector is matched together,
- * so a selector with tags and an end user matches connections satisfying all of them.
+ * One clause of `tenant.connections.any`. Every tag on a selector is matched together.
+ *
+ * Tags are the only selector. End users are projected onto connection tags on creation
+ * (`end_user_id`, `end_user_email`, `organization_id` and friends), so selecting an end user means
+ * a tag on those keys rather than a separate field.
  */
 export interface AgentSessionConnectionSelector {
-    readonly tags?: Tags | undefined;
-    readonly endUserId?: string | undefined;
-    readonly endUserOrganizationId?: string | undefined;
+    readonly tags: Tags;
 }
 
 /**

--- a/packages/types/lib/agent/session.ts
+++ b/packages/types/lib/agent/session.ts
@@ -1,6 +1,6 @@
+import type { AgentSessionResolvedConnections } from './connections.js';
 import type { JsonObject } from 'type-fest';
 
-export type AgentSessionResolvedConnections = JsonObject;
 export type AgentSessionCompiledToolset = JsonObject;
 
 export interface AgentSessionMetaTools {

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -13,6 +13,7 @@ export type * from './logs/messages.js';
 export type * from './keystore/index.js';
 
 export type * from './action/api.js';
+export type * from './agent/connections.js';
 export type * from './agent/session.js';
 export type * from './admin/http.api.js';
 export type * from './account/api.js';


### PR DESCRIPTION
NAN-6594

A session acts for a tenant, so before it exists we have to turn the tenant's connection selectors into exactly one connection per integration. This adds that resolver, it is built on connection tag containment filtering.

```json
{
  "any": [{ "tags": { "workspaceslug": "marketing" } }, { "tags": { "end_user_id": "user-74" } }],
  "pinned": [{ "integration_id": "notion", "connection_id": "882386f9-..." }]
}
```

`any` is an OR between selectors and the constraints within one selector are matched together. One query counts the matches per integration, with each selector keeping its own GIN indexed `tags @> ?::jsonb` containment check. Both keys are optional, with at least one required.

## Test plan

- [x] `npm run ts-build` clean
- [x] `npx oxlint` clean on the new files


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



