### PR TITLE
chore: execute simple function

### DIFF
--- a/packages/jobs/lib/execution/function.ts
+++ b/packages/jobs/lib/execution/function.ts
@@ -1,0 +1,598 @@
+import tracer from 'dd-trace';
+
+import db from '@nangohq/database';
+import { getFormattedOperation, logContextGetter, OtlpSpan } from '@nangohq/logs';
+import {
+    accountService,
+    configService,
+    environmentService,
+    errorManager,
+    ErrorSourceEnum,
+    functionConfigService,
+    getApiUrl,
+    getEndUserByConnectionId,
+    LogActionEnum,
+    NangoError,
+    secretService
+} from '@nangohq/shared';
+import { Err, Ok, tagTraceUser } from '@nangohq/utils';
+
+import { bigQueryClient, slackService } from '../clients.js';
+import { capping } from '../utils/capping.js';
+import { getRunnerFlags } from '../utils/flags.js';
+import { pubsub } from '../utils/pubsub.js';
+import { startScript } from './operations/start.js';
+import { setTaskFailed, setTaskSuccess } from './operations/state.js';
+
+import type { LogContext } from '@nangohq/logs';
+import type { OrchestratorTask, TaskFunction } from '@nangohq/nango-orchestrator';
+import type { Config } from '@nangohq/shared';
+import type {
+    CheckpointRange,
+    ConnectionJobs,
+    DBEnvironment,
+    DBFunctionConfig,
+    DBFunctionConfigVersion,
+    DBSyncConfig,
+    DBTeam,
+    FunctionRuntime,
+    NangoProps,
+    RoutingContext,
+    SdkLogger,
+    TelemetryBag
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+import type { JsonValue } from 'type-fest';
+
+export async function startFunction(task: TaskFunction): Promise<Result<void>> {
+    let account: DBTeam | undefined;
+    let environment: DBEnvironment | undefined;
+    let providerConfig: Config | null | undefined;
+    let syncConfig: DBSyncConfig | null = null;
+    let endUser: NangoProps['endUser'] | null = null;
+
+    try {
+        const accountContext = await tracer.trace('function.prepare.accountContext', async () =>
+            accountService.getAccountContext({ environmentId: task.connection.environment_id })
+        );
+        if (!accountContext) {
+            throw new Error('Account and environment not found');
+        }
+        account = accountContext.account;
+        environment = accountContext.environment;
+        const plan = accountContext.plan;
+        tagTraceUser({ ...accountContext });
+
+        providerConfig = await tracer.trace('function.prepare.providerConfig', async () =>
+            configService.getProviderConfig(task.connection.provider_config_key, task.connection.environment_id)
+        );
+        if (providerConfig === null) {
+            throw new Error(`Provider config not found for connection: ${task.connection.connection_id}`);
+        }
+
+        const functions = await tracer.trace('function.prepare.functionConfig', async () =>
+            functionConfigService.search(db.knex, {
+                environmentId: task.connection.environment_id,
+                filter: { integrationKey: task.connection.provider_config_key, name: task.functionName }
+            })
+        );
+        if (functions.isErr()) {
+            throw functions.error;
+        }
+        const func = functions.value[0];
+        if (functions.value.length !== 1 || !func) {
+            throw new Error(`Function not found: ${task.functionName}`);
+        }
+        const functionConfig = func.config;
+        const functionVersion = func.currentVersion;
+        if (!functionConfig.enabled) {
+            throw new Error(`Function is disabled: ${task.functionName}`);
+        }
+        syncConfig = toLegacyConfig(functionConfig, functionVersion);
+
+        const getEndUser = await tracer.trace('function.prepare.endUser', async () => getEndUserByConnectionId(db.knex, { connectionId: task.connection.id }));
+        if (getEndUser.isOk()) {
+            endUser = { id: getEndUser.value.id, endUserId: getEndUser.value.endUserId, orgId: getEndUser.value.organization?.organizationId || null };
+        }
+
+        const now = new Date();
+        const logCtx = getLogCtx({
+            team: account,
+            activityLogId: task.activityLogId,
+            environmentId: task.connection.environment_id,
+            environmentName: environment.name,
+            syncConfig,
+            providerConfigKey: task.connection.provider_config_key,
+            provider: providerConfig.provider,
+            nangoConnectionId: task.connection.id,
+            connectionId: task.connection.connection_id,
+            startedAt: now
+        });
+
+        // capping
+        const cappingStatus = await tracer.trace('function.prepare.cappingExecutions', async () =>
+            capping.getStatus(plan, 'function_executions', 'function_compute_gbms')
+        );
+        if (cappingStatus.isCapped) {
+            const message = cappingStatus.message || 'Your plan limits have been reached. Please upgrade your plan.';
+            void logCtx.error(message, { cappingStatus });
+            throw new Error(message);
+        }
+
+        // Function logs capping is just informational - it does not block functions from running
+        // nango.log() will still work, but logs won't be persisted
+        const cappingFunctionLogsStatus = await tracer.trace('function.prepare.cappingLogs', async () => capping.getStatus(plan, 'function_logs'));
+        if (cappingFunctionLogsStatus.isCapped) {
+            const message = cappingFunctionLogsStatus.message || 'Function logs limit has been reached. Function logs will not be saved.';
+            void logCtx.warn(message, { cappingFunctionLogsStatus });
+        }
+
+        void logCtx.info(`Starting function '${task.functionName}'${formatAttempts(task)}`, {
+            input: task.input,
+            function: task.functionName,
+            connection: task.connection.connection_id,
+            integration: task.connection.provider_config_key
+        });
+
+        let sdkLogger: SdkLogger;
+        if (cappingFunctionLogsStatus.isCapped) {
+            sdkLogger = { level: 'off' };
+        } else {
+            sdkLogger = await tracer.trace('function.prepare.sdkLogger', async () => environmentService.getSdkLogger(accountContext.environment.id));
+        }
+
+        const defaultSecret = await tracer.trace('function.prepare.defaultSecret', async () =>
+            secretService.getDefaultSecretForEnv(db.readOnly, accountContext.environment)
+        );
+        if (defaultSecret.isErr()) {
+            return Err(defaultSecret.error);
+        }
+
+        const nangoProps: NangoProps = {
+            scriptType: 'function',
+            host: getApiUrl(),
+            team: {
+                id: account.id,
+                name: account.name
+            },
+            connectionId: task.connection.connection_id,
+            environmentId: task.connection.environment_id,
+            environmentName: environment.name,
+            providerConfigKey: task.connection.provider_config_key,
+            provider: providerConfig.provider,
+            activityLogId: task.activityLogId,
+            secretKey: defaultSecret.value.secret,
+            nangoConnectionId: task.connection.id,
+            attributes: syncConfig.attributes,
+            syncConfig,
+            debug: false,
+            logger: sdkLogger,
+            runnerFlags: getRunnerFlags(plan),
+            startedAt: now,
+            endUser,
+            heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
+            integrationConfig: {
+                oauth_client_id: providerConfig.oauth_client_id,
+                oauth_client_secret: providerConfig.oauth_client_secret,
+                custom: providerConfig.custom
+            }
+        };
+
+        const routingContext: RoutingContext = {
+            plan: plan,
+            features: syncConfig.features
+        };
+
+        const res = await startScript({
+            taskId: task.id,
+            nangoProps,
+            routingContext,
+            logCtx: logCtx,
+            input: {
+                kind: 'invoke',
+                input: task.input,
+                connection: {
+                    connection_id: task.connection.connection_id,
+                    integrationId: task.connection.provider_config_key
+                }
+            }
+        });
+
+        if (res.isErr()) {
+            throw res.error;
+        }
+
+        return Ok(undefined);
+    } catch (err) {
+        const error = new NangoError('function_failure', { error: err instanceof Error ? err.message : err });
+        onFailure({
+            connection: {
+                id: task.connection.id,
+                connection_id: task.connection.connection_id,
+                environment_id: task.connection.environment_id,
+                provider_config_key: task.connection.provider_config_key
+            },
+            functionName: task.functionName,
+            provider: providerConfig?.provider || 'unknown',
+            providerConfigKey: task.connection.provider_config_key,
+            activityLogId: task.activityLogId,
+            runTime: 0,
+            error,
+            syncConfig,
+            team: account,
+            environment: environment,
+            endUser
+        });
+        return Err(error);
+    }
+}
+
+export async function handleFunctionSuccess({
+    taskId,
+    nangoProps,
+    output,
+    telemetryBag,
+    functionRuntime,
+    checkpoints
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    output: JsonValue;
+    telemetryBag: TelemetryBag;
+    functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
+}): Promise<void> {
+    const logCtx = getLogCtx(nangoProps);
+    const { environment, account } = (await accountService.getAccountContext({ environmentId: nangoProps.environmentId })) || {
+        environment: undefined,
+        account: undefined
+    };
+
+    const task = await setTaskSuccess({ taskId, output });
+    if (task.isErr()) {
+        onFailure({
+            connection: {
+                id: nangoProps.nangoConnectionId,
+                connection_id: nangoProps.connectionId,
+                environment_id: nangoProps.environmentId,
+                provider_config_key: nangoProps.providerConfigKey
+            },
+            functionName: nangoProps.syncConfig.sync_name,
+            provider: nangoProps.provider,
+            providerConfigKey: nangoProps.providerConfigKey,
+            activityLogId: nangoProps.activityLogId,
+            runTime: (new Date().getTime() - nangoProps.startedAt.getTime()) / 1000,
+            error: new NangoError('function_execution_failure', { error: task.error }),
+            team: account,
+            environment,
+            syncConfig: nangoProps.syncConfig,
+            endUser: nangoProps.endUser,
+            telemetryBag,
+            functionRuntime
+        });
+        return;
+    }
+
+    void logCtx.info(`The function was successfully run${formatAttempts(task)}`, {
+        function: nangoProps.syncConfig.sync_name,
+        connection: nangoProps.connectionId,
+        integration: nangoProps.providerConfigKey,
+        meta: { checkpoints }
+    });
+    void logCtx.enrichOperation({ meta: { checkpoints } });
+    void logCtx.success();
+
+    const connection: ConnectionJobs = {
+        id: nangoProps.nangoConnectionId,
+        connection_id: nangoProps.connectionId,
+        environment_id: nangoProps.environmentId,
+        provider_config_key: nangoProps.providerConfigKey
+    };
+    void slackService.removeFailingConnection({
+        connection,
+        name: nangoProps.syncConfig.sync_name,
+        type: 'function',
+        originalActivityLogId: nangoProps.activityLogId,
+        provider: nangoProps.provider
+    });
+
+    void bigQueryClient.insert({
+        executionType: 'function',
+        connectionId: nangoProps.connectionId,
+        internalConnectionId: nangoProps.nangoConnectionId,
+        accountId: nangoProps.team.id,
+        accountName: nangoProps.team.name,
+        scriptName: nangoProps.syncConfig.sync_name,
+        scriptType: 'function',
+        environmentId: nangoProps.environmentId,
+        environmentName: nangoProps.environmentName,
+        provider: nangoProps.provider,
+        providerConfigKey: nangoProps.providerConfigKey,
+        status: 'success',
+        syncId: null as unknown as string,
+        syncVariant: null as unknown as string,
+        scriptVersion: nangoProps.syncConfig.version,
+        content: `The function "${nangoProps.syncConfig.sync_name}" completed successfully.`,
+        runTimeInSeconds: (new Date().getTime() - nangoProps.startedAt.getTime()) / 1000,
+        createdAt: Date.now(),
+        internalIntegrationId: nangoProps.syncConfig.nango_config_id,
+        endUser: nangoProps.endUser,
+        source: nangoProps.syncConfig.source
+    });
+
+    void pubsub.publisher.publish({
+        subject: 'usage',
+        type: 'usage.function_executions',
+        payload: {
+            value: 1,
+            properties: {
+                accountId: nangoProps.team.id,
+                environmentId: nangoProps.environmentId,
+                environmentName: nangoProps.environmentName,
+                integrationId: nangoProps.providerConfigKey,
+                connectionId: connection.connection_id,
+                type: 'function',
+                functionName: nangoProps.syncConfig.sync_name,
+                success: true,
+                telemetryBag,
+                runtime: functionRuntime
+            }
+        }
+    });
+}
+
+export async function handleFunctionError({
+    taskId,
+    nangoProps,
+    error,
+    telemetryBag,
+    functionRuntime,
+    checkpoints
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    error: NangoError;
+    telemetryBag: TelemetryBag;
+    functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
+}): Promise<void> {
+    const accountAndEnv = await accountService.getAccountContext({ environmentId: nangoProps.environmentId });
+    if (!accountAndEnv) {
+        throw new Error('Account and environment not found');
+    }
+    const { account, environment } = accountAndEnv;
+
+    const task = await setTaskFailed({ taskId, error });
+    if (task.isErr()) {
+        onFailure({
+            connection: {
+                id: nangoProps.nangoConnectionId,
+                connection_id: nangoProps.connectionId,
+                environment_id: nangoProps.environmentId,
+                provider_config_key: nangoProps.providerConfigKey
+            },
+            functionName: nangoProps.syncConfig.sync_name,
+            provider: nangoProps.provider,
+            providerConfigKey: nangoProps.providerConfigKey,
+            activityLogId: nangoProps.activityLogId,
+            runTime: (new Date().getTime() - nangoProps.startedAt.getTime()) / 1000,
+            error: new NangoError('function_execution_failure', { error: task.error }),
+            team: account,
+            environment,
+            syncConfig: nangoProps.syncConfig,
+            endUser: nangoProps.endUser,
+            telemetryBag,
+            functionRuntime
+        });
+        return;
+    }
+
+    const logCtx = getLogCtx(nangoProps);
+    void logCtx.error(`Function '${nangoProps.syncConfig.sync_name}' failed${formatAttempts(task)}`, {
+        error,
+        function: nangoProps.syncConfig.sync_name,
+        connection: nangoProps.connectionId,
+        integration: nangoProps.providerConfigKey,
+        meta: { checkpoints }
+    });
+    void logCtx.enrichOperation({ meta: { checkpoints } });
+    if (task.value.attempt === task.value.attemptMax) {
+        void logCtx.failed();
+    }
+    onFailure({
+        connection: {
+            id: nangoProps.nangoConnectionId,
+            connection_id: nangoProps.connectionId,
+            environment_id: nangoProps.environmentId,
+            provider_config_key: nangoProps.providerConfigKey
+        },
+        functionName: nangoProps.syncConfig.sync_name,
+        provider: nangoProps.provider,
+        providerConfigKey: nangoProps.providerConfigKey,
+        activityLogId: nangoProps.activityLogId,
+        runTime: (new Date().getTime() - nangoProps.startedAt.getTime()) / 1000,
+        error,
+        team: account,
+        environment,
+        syncConfig: nangoProps.syncConfig,
+        endUser: nangoProps.endUser,
+        telemetryBag,
+        functionRuntime
+    });
+}
+
+function onFailure({
+    team,
+    environment,
+    connection,
+    functionName,
+    provider,
+    providerConfigKey,
+    activityLogId,
+    syncConfig,
+    runTime,
+    error,
+    endUser,
+    telemetryBag,
+    functionRuntime
+}: {
+    team?: DBTeam | undefined;
+    environment?: DBEnvironment | undefined;
+    connection: ConnectionJobs;
+    functionName: string;
+    provider: string;
+    providerConfigKey: string;
+    activityLogId: string;
+    syncConfig: DBSyncConfig | null;
+    runTime: number;
+    error: NangoError;
+    endUser: NangoProps['endUser'];
+    telemetryBag?: TelemetryBag | undefined;
+    functionRuntime?: FunctionRuntime | undefined;
+}): void {
+    if (team && environment) {
+        try {
+            void slackService.reportFailure({
+                account: team,
+                environment,
+                connection,
+                name: functionName,
+                type: 'function',
+                originalActivityLogId: activityLogId,
+                provider
+            });
+        } catch {
+            errorManager.report('slack notification service reported a failure', {
+                environmentId: connection.environment_id,
+                source: ErrorSourceEnum.PLATFORM,
+                operation: LogActionEnum.FUNCTION,
+                metadata: {
+                    functionName: functionName,
+                    connectionDetails: connection,
+                    debug: false
+                }
+            });
+        }
+
+        void bigQueryClient.insert({
+            executionType: 'function',
+            connectionId: connection.connection_id,
+            internalConnectionId: connection.id,
+            accountId: team.id,
+            accountName: team.name,
+            scriptName: functionName,
+            scriptType: 'function',
+            environmentId: environment.id,
+            environmentName: environment.name,
+            provider,
+            providerConfigKey,
+            status: 'failed',
+            syncId: null as unknown as string,
+            syncVariant: null as unknown as string,
+            scriptVersion: syncConfig?.version,
+            content: error.message,
+            runTimeInSeconds: runTime,
+            createdAt: Date.now(),
+            internalIntegrationId: syncConfig?.nango_config_id || null,
+            endUser,
+            source: syncConfig?.source
+        });
+
+        void pubsub.publisher.publish({
+            subject: 'usage',
+            type: 'usage.function_executions',
+            payload: {
+                value: 1,
+                properties: {
+                    accountId: team.id,
+                    environmentId: environment.id,
+                    environmentName: environment.name,
+                    integrationId: providerConfigKey,
+                    connectionId: connection.connection_id,
+                    functionName,
+                    type: 'function',
+                    success: false,
+                    telemetryBag,
+                    runtime: functionRuntime
+                }
+            }
+        });
+    }
+}
+
+function formatAttempts(task: OrchestratorTask | Result<OrchestratorTask>): string {
+    const t = 'id' in task ? task : task.isOk() ? task.value : null;
+    if (!t) {
+        return '';
+    }
+    return t.attemptMax > 1 ? ` (attempt ${t.attempt}/${t.attemptMax})` : '';
+}
+
+function getLogCtx(
+    opts: Pick<
+        NangoProps,
+        | 'team'
+        | 'activityLogId'
+        | 'environmentId'
+        | 'environmentName'
+        | 'syncConfig'
+        | 'providerConfigKey'
+        | 'provider'
+        | 'nangoConnectionId'
+        | 'connectionId'
+        | 'startedAt'
+    >
+): LogContext {
+    const logCtx = logContextGetter.get({ id: opts.activityLogId, accountId: opts.team.id });
+    // Origin log context is created in server.
+    // Attaching a span here so it is correctly ended when the logCtx operation ends and shows up in exported traces.
+    logCtx.attachSpan(
+        new OtlpSpan(
+            getFormattedOperation(
+                { operation: { type: 'function', action: 'invoke' } },
+                {
+                    account: opts.team,
+                    environment: { id: opts.environmentId, name: opts.environmentName },
+                    integration: { id: opts.syncConfig.nango_config_id, name: opts.providerConfigKey, provider: opts.provider },
+                    connection: { id: opts.nangoConnectionId, name: opts.connectionId },
+                    syncConfig: { id: opts.syncConfig.id, name: opts.syncConfig.sync_name }
+                }
+            ),
+            opts.startedAt
+        )
+    );
+    return logCtx;
+}
+
+// TODO: refactor NangoProps to support native function config
+function toLegacyConfig(config: DBFunctionConfig, version: DBFunctionConfigVersion): DBSyncConfig {
+    const features: DBSyncConfig['features'] = version.capabilities.usesCheckpoints ? ['checkpoints'] : [];
+    return {
+        id: version.id,
+        sync_name: config.name,
+        nango_config_id: config.nango_config_id,
+        file_location: version.file_location,
+        version: version.version,
+        models: [],
+        active: true,
+        runs: null,
+        model_schema: null,
+        environment_id: config.environment_id,
+        track_deletes: false,
+        type: 'action', // TODO: change to 'function' when runner-sdk supports it
+        auto_start: false,
+        attributes: {},
+        source: version.source,
+        metadata: {},
+        input: version.input_schema_ref,
+        sync_type: null,
+        webhook_subscriptions: [],
+        enabled: config.enabled,
+        models_json_schema: version.json_schema,
+        sdk_version: null,
+        features,
+        created_at: version.created_at,
+        updated_at: version.updated_at,
+        deleted_at: version.deleted_at
+    };
+}

--- a/packages/jobs/lib/execution/operations/handler.ts
+++ b/packages/jobs/lib/execution/operations/handler.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../logger.js';
 import { handleActionError, handleActionSuccess } from '../action.js';
+import { handleFunctionError, handleFunctionSuccess } from '../function.js';
 import { handleOnEventError, handleOnEventSuccess } from '../onEvent.js';
 import { handleSyncError, handleSyncSuccess } from '../sync.js';
 import { handleWebhookError, handleWebhookSuccess } from '../webhook.js';
@@ -30,6 +31,9 @@ async function handleSuccess({ taskId, nangoProps, output, telemetryBag, functio
     switch (nangoProps.scriptType) {
         case 'action':
             await handleActionSuccess({ taskId, nangoProps, output, telemetryBag, functionRuntime, checkpoints });
+            break;
+        case 'function':
+            await handleFunctionSuccess({ taskId, nangoProps, output, telemetryBag, functionRuntime, checkpoints });
             break;
         case 'sync':
             await handleSyncSuccess({ taskId, nangoProps, telemetryBag, functionRuntime, checkpoints });
@@ -64,13 +68,16 @@ async function handleError({ taskId, nangoProps, error, telemetryBag, functionRu
 
     const formattedError = toNangoError({
         err: error,
-        defaultErrorType: `${nangoProps.scriptType}_script_failure`,
+        defaultErrorType: nangoProps.scriptType === 'function' ? 'function_execution_failure' : `${nangoProps.scriptType}_script_failure`,
         scriptName: nangoProps.syncConfig.sync_name
     });
 
     switch (nangoProps.scriptType) {
         case 'action':
             await handleActionError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime, checkpoints });
+            break;
+        case 'function':
+            await handleFunctionError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime, checkpoints });
             break;
         case 'sync':
             await handleSyncError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime, checkpoints });

--- a/packages/jobs/lib/execution/operations/start.ts
+++ b/packages/jobs/lib/execution/operations/start.ts
@@ -43,7 +43,8 @@ export async function startScript({
                         ? await tracer.trace('runScript.getFile', async () => remoteFileService.getFile(integrationData.fileLocation))
                         : localFileService.getIntegrationFile({
                               syncConfig: nangoProps.syncConfig,
-                              providerConfigKey: nangoProps.providerConfigKey
+                              providerConfigKey: nangoProps.providerConfigKey,
+                              scriptType: nangoProps.scriptType
                           });
 
                 if (!script) {

--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -5,6 +5,7 @@ import { getFlags } from '@nangohq/feature-flags';
 import { Err, Ok } from '@nangohq/utils';
 
 import { startAction } from '../execution/action.js';
+import { startFunction } from '../execution/function.js';
 import { startOnEvent } from '../execution/onEvent.js';
 import { abortTask } from '../execution/operations/abort.js';
 import { abortSync, startSync } from '../execution/sync.js';
@@ -47,6 +48,20 @@ export async function handler(task: OrchestratorTask): Promise<Result<void>> {
                 }
                 return startAction(task);
             }
+        );
+    }
+    if (task.isFunction()) {
+        return tracer.trace(
+            'jobs.handler.function',
+            {
+                tags: {
+                    'task.id': task.id,
+                    'function.name': task.functionName,
+                    'connection.id': task.connection.connection_id,
+                    'environment.id': task.connection.environment_id
+                }
+            },
+            () => startFunction(task)
         );
     }
     if (task.isWebhook()) {

--- a/packages/jobs/lib/processor/processor.unit.test.ts
+++ b/packages/jobs/lib/processor/processor.unit.test.ts
@@ -31,6 +31,7 @@ vi.mock('../env.js', () => ({
         JOBS_PROCESSOR_CONFIG: [
             { groupKeyPattern: 'sync*', maxConcurrency: 100 },
             { groupKeyPattern: 'action*', maxConcurrency: 100 },
+            { groupKeyPattern: 'function*', maxConcurrency: 100 },
             { groupKeyPattern: 'webhook*', maxConcurrency: 0 },
             { groupKeyPattern: 'on-event*', maxConcurrency: 50 }
         ]
@@ -45,12 +46,13 @@ describe('Processor', () => {
     it('should create processors from config and skip zero concurrency ones', () => {
         new Processor('http://localhost:3008');
 
-        // Should create 3 processors (webhook* skipped due to maxConcurrency = 0)
-        expect(OrchestratorProcessor).toHaveBeenCalledTimes(3);
+        // Should create 4 processors (webhook* skipped due to maxConcurrency = 0)
+        expect(OrchestratorProcessor).toHaveBeenCalledTimes(4);
 
         // Verify correct processors were created
         expect(OrchestratorProcessor).toHaveBeenCalledWith(expect.objectContaining({ groupKeyPattern: 'sync*', maxConcurrency: 100 }));
         expect(OrchestratorProcessor).toHaveBeenCalledWith(expect.objectContaining({ groupKeyPattern: 'action*', maxConcurrency: 100 }));
+        expect(OrchestratorProcessor).toHaveBeenCalledWith(expect.objectContaining({ groupKeyPattern: 'function*', maxConcurrency: 100 }));
         expect(OrchestratorProcessor).toHaveBeenCalledWith(expect.objectContaining({ groupKeyPattern: 'on-event*', maxConcurrency: 50 }));
 
         // Verify webhook* was not created

--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -52,7 +52,7 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<PutTask>) =>
         telemetryBag,
         functionRuntime,
         checkpoints: checkpoints || null,
-        ...(error ? { error } : { output: output || null })
+        ...(error ? { error } : { output: output ?? null })
     });
     res.status(204).send();
     return;

--- a/packages/jobs/lib/runtime/runtimes.rules.ts
+++ b/packages/jobs/lib/runtime/runtimes.rules.ts
@@ -2,13 +2,14 @@ import { Ok } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 
-import type { DBPlan, NangoProps, Result, RoutingContext } from '@nangohq/types';
+import type { DBPlan, FunctionRuntime, NangoProps, Result, RoutingContext, ScriptType } from '@nangohq/types';
 
-const runtimeSelectors = {
+const runtimeSelectors: Record<ScriptType, (plan: DBPlan) => FunctionRuntime> = {
     sync: (plan: DBPlan) => plan.sync_function_runtime,
     action: (plan: DBPlan) => plan.action_function_runtime,
     webhook: (plan: DBPlan) => plan.webhook_function_runtime,
-    'on-event': (plan: DBPlan) => plan.on_event_function_runtime
+    'on-event': (plan: DBPlan) => plan.on_event_function_runtime,
+    function: () => 'lambda' // TODO: add function runtime to plan
 };
 
 export async function getFleetId({

--- a/packages/jobs/lib/schemas/nango-props.ts
+++ b/packages/jobs/lib/schemas/nango-props.ts
@@ -5,7 +5,7 @@ import { operationIdRegex } from '@nangohq/logs';
 import type { Feature } from '@nangohq/types';
 
 export const nangoPropsSchema = z.looseObject({
-    scriptType: z.enum(['action', 'webhook', 'sync', 'on-event']),
+    scriptType: z.enum(['function', 'action', 'webhook', 'sync', 'on-event']),
     connectionId: z.string().min(1),
     nangoConnectionId: z.number(),
     environmentId: z.number(),

--- a/packages/lambda-runner/lib/schemas.ts
+++ b/packages/lambda-runner/lib/schemas.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import type { LambdaRequestType } from '@nangohq/types';
 
 export const nangoPropsSchema = z.object({
-    scriptType: z.enum(['sync', 'action', 'webhook', 'on-event']),
+    scriptType: z.enum(['function', 'sync', 'action', 'webhook', 'on-event']),
     host: z.string().optional(),
     secretKey: z.string().min(1),
     team: z.object({

--- a/packages/orchestrator/lib/clients/validate.unit.test.ts
+++ b/packages/orchestrator/lib/clients/validate.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateTask } from './validate.js';
+
+import type { Task } from '@nangohq/scheduler';
+
+describe('validateTask', () => {
+    it('deserializes a dequeued function task', () => {
+        const result = validateTask({
+            id: '4a14038c-3a57-4a4d-bb9e-c8a5e85474ae',
+            name: 'function-task',
+            groupKey: 'function:environment:2:connection:1:function:my-function',
+            groupMaxConcurrency: 1,
+            state: 'STARTED',
+            retryKey: 'retry-key',
+            retryCount: 0,
+            retryMax: 2,
+            ownerKey: 'environment:2',
+            heartbeatTimeoutSecs: 60,
+            startsAfter: new Date(),
+            createdToStartedTimeoutSecs: 30,
+            startedToCompletedTimeoutSecs: 120,
+            createdAt: new Date(),
+            lastStateTransitionAt: new Date(),
+            lastHeartbeatAt: new Date(),
+            output: null,
+            terminated: false,
+            scheduleId: null,
+            payload: {
+                type: 'function',
+                functionName: 'my-function',
+                activityLogId: 'activity-log-id',
+                input: { value: 42 },
+                async: false,
+                connection: {
+                    id: 1,
+                    connection_id: 'connection-id',
+                    provider_config_key: 'integration-id',
+                    environment_id: 2
+                }
+            }
+        } as Task);
+
+        const task = result.unwrap();
+        expect(task.isFunction()).toBe(true);
+        if (task.isFunction()) {
+            expect(task).toMatchObject({
+                functionName: 'my-function',
+                input: { value: 42 },
+                async: false,
+                attempt: 1,
+                attemptMax: 3
+            });
+        }
+    });
+});

--- a/packages/orchestrator/lib/events.ts
+++ b/packages/orchestrator/lib/events.ts
@@ -8,6 +8,7 @@ import { envs } from './env.js';
 import { GROUP_PREFIX_SEPARATOR } from './scheduler-config.js';
 import { logger } from './utils.js';
 
+import type { OrchestratorTask } from './clients/types.js';
 import type { Task } from '@nangohq/scheduler';
 import type knex from 'knex';
 
@@ -183,12 +184,12 @@ export const taskEvents = {
             return `task:completed:${prop}`;
         }
 
-        // Only action and onEvent tasks are being listened to for completion
         const res = validateTask(prop);
         if (res.isErr()) {
             return undefined;
         }
-        if (res.value.isOnEvent() || res.value.isAction()) {
+
+        if (shouldListenForCompletion(res.value)) {
             return `task:completed:${prop.id}`;
         }
         return undefined;
@@ -275,4 +276,16 @@ export class TaskEventsHandler extends PgEventEmitter {
             }
         };
     }
+}
+
+function shouldListenForCompletion(t: OrchestratorTask): boolean {
+    // synchronous action and function tasks are being listened to for completion
+    if (t.isFunction() || t.isAction()) {
+        return !t.async;
+    }
+    // onEvent tasks are also being listened to for completion
+    if (t.isOnEvent()) {
+        return true;
+    }
+    return false;
 }

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -1,14 +1,26 @@
 import type { NangoActionBase } from './action.js';
+import type { CreateFunctionResponse, FunctionRequires, FunctionTriggerDefinition } from './function.js';
 import type { NangoSyncBase } from './sync.js';
 import type { ZodCheckpoint, ZodMetadata, ZodModel } from './types.js';
 import type { NangoSyncEndpointV2 } from '@nangohq/types';
 import type { MaybePromise } from 'rollup';
 import type * as z from 'zod';
 
+type CreateAnyFunctionResponse = CreateFunctionResponse<
+    Record<string, ZodModel>,
+    z.ZodTypeAny,
+    z.ZodTypeAny,
+    ZodMetadata,
+    ZodCheckpoint,
+    FunctionTriggerDefinition | undefined,
+    FunctionRequires
+>;
+
 export type CreateAnyResponse =
     | CreateSyncResponse<any, ZodMetadata, ZodCheckpoint>
     | CreateActionResponse<any, any, ZodMetadata, ZodCheckpoint>
-    | CreateOnEventResponse<ZodMetadata, ZodCheckpoint>;
+    | CreateOnEventResponse<ZodMetadata, ZodCheckpoint>
+    | CreateAnyFunctionResponse;
 
 export type { ActionError } from './errors.js';
 export type { NangoActionBase as NangoAction, ProxyConfiguration } from './action.js';

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -39,6 +39,20 @@ function formatStackTrace(stack: string | undefined, filename: string): string[]
         .slice(0, 10);
 }
 
+function assertOutputSizeAllowed(output: unknown, additionalMessage?: string): void {
+    if (!output || isEnterprise) {
+        return;
+    }
+
+    const outputSizeInBytes = Buffer.byteLength(JSON.stringify(output), 'utf8');
+    const maxSizeInBytes = 2 * 1024 * 1024; // 2MB
+    if (outputSizeInBytes > maxSizeInBytes) {
+        throw new Error(
+            `Output size is too large: ${outputSizeInBytes} bytes. Maximum allowed size is ${maxSizeInBytes} bytes (2MB).${additionalMessage ? ` ${additionalMessage}` : ''}`
+        );
+    }
+}
+
 export async function exec({
     nangoProps,
     code,
@@ -65,6 +79,7 @@ export async function exec({
                 return new NangoSyncRunner(nangoProps, { persistClient, telemetryRecorder, locks });
             case 'action':
             case 'on-event':
+            case 'function':
                 return new NangoActionRunner(nangoProps, { persistClient, telemetryRecorder, locks });
         }
     })();
@@ -141,7 +156,11 @@ export async function exec({
             if (!isZeroYaml && !isNangoYaml) {
                 throw new Error(`Invalid script exports`);
             }
-            if (isZeroYaml && (!nangoProps.syncConfig.sdk_version || !nangoProps.syncConfig.sdk_version.includes('-zero'))) {
+            if (
+                isZeroYaml &&
+                nangoProps.scriptType !== 'function' &&
+                (!nangoProps.syncConfig.sdk_version || !nangoProps.syncConfig.sdk_version.includes('-zero'))
+            ) {
                 throw new Error(`Invalid script configuration`);
             }
 
@@ -177,6 +196,24 @@ export async function exec({
                 }
             }
 
+            // Function
+            if (nangoProps.scriptType === 'function') {
+                if (!isZeroYaml || def.type !== 'function') {
+                    throw new Error('Failed to load function');
+                }
+                if (!def.exec) {
+                    throw new Error('Missing exec function');
+                }
+
+                const output = await def.exec(functionNango as any, codeParams as any);
+                assertOutputSizeAllowed(output);
+                return Ok({
+                    output: output ?? null,
+                    telemetryBag: nango.telemetryBag,
+                    checkpoints: nango.getCheckpointRange()
+                });
+            }
+
             // Action
             if (nangoProps.scriptType === 'action') {
                 let inputParams = codeParams;
@@ -198,19 +235,7 @@ export async function exec({
                     output = await def(functionNango, inputParams);
                 }
 
-                if (output) {
-                    const stringifiedOutput = JSON.stringify(output);
-                    const outputSizeInBytes = Buffer.byteLength(stringifiedOutput, 'utf8');
-                    const maxSizeInBytes = 2 * 1024 * 1024; // 2MB
-
-                    if (!isEnterprise) {
-                        if (outputSizeInBytes > maxSizeInBytes) {
-                            throw new Error(
-                                `Output size is too large: ${outputSizeInBytes} bytes. Maximum allowed size is ${maxSizeInBytes} bytes (2MB). See the deprecation announcement: https://nango.dev/docs/updates/dev#august-22-2025`
-                            );
-                        }
-                    }
-                }
+                assertOutputSizeAllowed(output, 'See the deprecation announcement: https://nango.dev/docs/updates/dev#august-22-2025');
 
                 return Ok({
                     output,

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -40,6 +40,31 @@ function getNangoProps(): NangoProps {
 }
 
 describe('Exec', () => {
+    it('executes a function', async () => {
+        const nangoProps = {
+            ...getNangoProps(),
+            scriptType: 'function' as const,
+            syncId: undefined,
+            syncJobId: undefined,
+            syncConfig: { sync_name: 'my-function' } as DBSyncConfig
+        };
+        const code = `
+        exports.default = {
+            type: 'function',
+            exec: async (_nango, trigger) => ({ kind: trigger.kind, value: trigger.input.value })
+        }
+        `;
+        const trigger = {
+            kind: 'invoke',
+            input: { value: 42 },
+            connection: { connection_id: 'connection-id', integrationId: 'provider-config-key' }
+        };
+
+        const res = await exec({ nangoProps, code, codeParams: trigger });
+
+        expect(res.unwrap().output).toEqual({ kind: 'invoke', value: 42 });
+    });
+
     it('execute code', async () => {
         const nangoProps = getNangoProps();
         const code = `

--- a/packages/server/lib/controllers/functions/postInvocation.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.ts
@@ -73,14 +73,18 @@ export const postFunctionInvocation = asyncWrapperWithEnvironment<PostFunctionIn
             return;
         case 'function_failed': {
             const cause = invoke.error.cause;
-            const isInfrastructureFailure = !(cause instanceof NangoError) || cause.type === 'function_execution_failure' || cause.type === 'function_failure';
+            const isUserFunctionFailure = cause instanceof NangoError && cause.type === 'function_execution_failure';
+            const isInternalFailure = !(cause instanceof NangoError) || cause.type === 'function_failure';
 
-            if (!isInfrastructureFailure) {
+            if (cause instanceof NangoError && !isUserFunctionFailure && !isInternalFailure) {
                 errorManager.errResFromNangoErr(res, cause);
                 return;
             }
 
-            report(invoke.error);
+            if (isInternalFailure) {
+                report(invoke.error);
+            }
+
             res.status(500).send({ error: { code: invoke.error.code, message: invoke.error.message } });
             return;
         }

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -168,7 +168,7 @@ export class Orchestrator {
 
                 throw (
                     deserializeNangoError(res.error.payload) ||
-                    new NangoError('function_execution_failure', {
+                    new NangoError('function_failure', {
                         error: res.error.message,
                         ...(res.error.payload ? { payload: res.error.payload } : {})
                     })

--- a/packages/shared/lib/models/Telemetry.ts
+++ b/packages/shared/lib/models/Telemetry.ts
@@ -1,6 +1,7 @@
 export enum LogActionEnum {
     ACCOUNT = 'account',
     ACTION = 'action',
+    FUNCTION = 'function',
     ANALYTICS = 'analytics',
     AUTH = 'auth',
     DATABASE = 'database',

--- a/packages/shared/lib/services/file/local.service.ts
+++ b/packages/shared/lib/services/file/local.service.ts
@@ -13,17 +13,25 @@ import { resolveLocalFileName, resolveLocalFilePath } from '../../utils/utils.js
 import type { DBSyncConfig, NangoProps } from '@nangohq/types';
 import type { Response } from 'express';
 
-const scriptTypeToPath: Record<NangoProps['scriptType'], string> = {
+const scriptTypeToPath: Record<DBSyncConfig['type'], string> = {
     'on-event': 'on-events',
     action: 'actions',
-    sync: 'syncs',
-    webhook: 'syncs'
+    sync: 'syncs'
 };
 
 class LocalFileService {
-    public getIntegrationFile({ syncConfig, providerConfigKey }: { syncConfig: DBSyncConfig; providerConfigKey: string }) {
+    public getIntegrationFile({
+        syncConfig,
+        providerConfigKey,
+        scriptType
+    }: {
+        syncConfig: DBSyncConfig;
+        providerConfigKey: string;
+        scriptType: NangoProps['scriptType'];
+    }) {
         try {
-            const filePath = resolveLocalFilePath({ fileName: resolveLocalFileName({ syncName: syncConfig.sync_name, providerConfigKey }) });
+            const fileName = resolveLocalFileName({ syncName: syncConfig.sync_name, providerConfigKey, scriptType });
+            const filePath = resolveLocalFilePath({ fileName, providerConfigKey, scriptType });
             const integrationFileContents = fs.readFileSync(filePath, 'utf8');
             return integrationFileContents;
         } catch (err) {

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -8,7 +8,7 @@ import get from 'lodash-es/get.js';
 
 import { isEnterprise, localhostUrl } from '@nangohq/utils';
 
-import type { DBConnection, Provider } from '@nangohq/types';
+import type { DBConnection, NangoProps, Provider } from '@nangohq/types';
 
 export enum NodeEnv {
     Dev = 'development',
@@ -702,10 +702,35 @@ function getNowDate(replacers: Record<string, any>): Date {
 const __dirname = dirname();
 const basePath = process.env['NANGO_INTEGRATIONS_FULL_PATH'] || path.resolve(__dirname, `../nango-integrations`);
 
-export function resolveLocalFileName({ syncName, providerConfigKey }: { syncName: string; providerConfigKey: string }): string {
+export function resolveLocalFileName({
+    syncName,
+    providerConfigKey,
+    scriptType
+}: {
+    syncName: string;
+    providerConfigKey: string;
+    scriptType?: NangoProps['scriptType'] | undefined;
+}): string {
+    if (scriptType === 'function') {
+        return `${syncName}.js`;
+    }
     return `${syncName}-${providerConfigKey}.js`;
 }
 
-export function resolveLocalFilePath({ fileName }: { fileName: string }): string {
+export function resolveLocalFilePath({
+    fileName,
+    providerConfigKey,
+    scriptType
+}: {
+    fileName: string;
+    providerConfigKey?: string | undefined;
+    scriptType?: NangoProps['scriptType'] | undefined;
+}): string {
+    if (scriptType === 'function') {
+        if (!providerConfigKey) {
+            throw new Error('providerConfigKey is required to resolve a local function path');
+        }
+        return path.resolve(basePath, providerConfigKey, 'functions', fileName);
+    }
     return path.resolve(basePath, fileName);
 }

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -1,10 +1,28 @@
 import crypto from 'node:crypto';
+import path from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as utils from './utils.js';
 
 import type { Provider } from '@nangohq/types';
+
+describe('local integration file paths', () => {
+    it('resolves legacy scripts to their flat local filename', () => {
+        const fileName = utils.resolveLocalFileName({ syncName: 'fetch-issues', providerConfigKey: 'github', scriptType: 'action' });
+
+        expect(fileName).toBe('fetch-issues-github.js');
+        expect(utils.resolveLocalFilePath({ fileName, providerConfigKey: 'github', scriptType: 'action' })).toBe(utils.resolveLocalFilePath({ fileName }));
+    });
+
+    it('resolves functions under their integration functions directory', () => {
+        const fileName = utils.resolveLocalFileName({ syncName: 'fetch-issues', providerConfigKey: 'github', scriptType: 'function' });
+        const filePath = utils.resolveLocalFilePath({ fileName, providerConfigKey: 'github', scriptType: 'function' });
+
+        expect(fileName).toBe('fetch-issues.js');
+        expect(filePath.endsWith(path.join('github', 'functions', 'fetch-issues.js'))).toBe(true);
+    });
+});
 
 describe('Proxy service Construct Header Tests', () => {
     it('Should correctly return true if the url is valid', () => {

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -257,7 +257,7 @@ export type PostFunctionInvocation = ApiEndpoint<{
         options?: Record<string, unknown> | undefined;
     };
     Error: ApiError<FunctionInvocationErrorCode>;
-    // `wait` invocations return the function output (any json value); `no_wait` invocations return `{ id, statusUrl }`.
+    // Returns the function output (any json value) or `{ id, statusUrl }`.
     // ApiEndpoint definition is not flexible enough to support any json value.
     // TODO: fix ApiEndpoint definition to support any json value
     Success: any;

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -118,7 +118,7 @@ export type UsageFunctionExecutionsEvent = UsageEventBase<
     {
         value: number;
         properties: {
-            type: 'sync' | 'action' | 'webhook' | 'on-event';
+            type: 'function' | 'sync' | 'action' | 'webhook' | 'on-event';
             success: boolean;
             functionName: string;
             runtime: FunctionRuntime | undefined;

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -11,7 +11,7 @@ export interface SdkLogger {
 
 export type ConflictResolutionMode = 'IN_MEMORY' | 'DISTRIBUTED';
 
-export type ScriptType = 'sync' | 'action' | 'webhook' | 'on-event';
+export type ScriptType = 'function' | 'sync' | 'action' | 'webhook' | 'on-event';
 
 export interface NangoProps {
     scriptType: ScriptType;

--- a/packages/utils/lib/checkpoint/checkpoint.ts
+++ b/packages/utils/lib/checkpoint/checkpoint.ts
@@ -1,3 +1,3 @@
-export function getCheckpointKey(opts: { type: 'sync' | 'webhook' | 'action' | 'on-event'; name: string; variant?: string | undefined }) {
+export function getCheckpointKey(opts: { type: 'function' | 'sync' | 'webhook' | 'action' | 'on-event'; name: string; variant?: string | undefined }) {
     return `${opts.type}:${opts.name}${opts.variant ? `:${opts.variant}` : ''}`;
 }

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -381,6 +381,10 @@ const ENVS_SHAPE = z.object({
                 maxConcurrency: 200
             },
             {
+                groupKeyPattern: 'function*',
+                maxConcurrency: 200
+            },
+            {
                 groupKeyPattern: 'webhook*',
                 maxConcurrency: 200
             },

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -180,12 +180,13 @@ describe('parse', () => {
     it('should parse JOBS_PROCESSOR_CONFIG', () => {
         const res = parseEnvs(ENVS, {
             JOBS_PROCESSOR_CONFIG:
-                '[{"groupKeyPattern":"sync","maxConcurrency":200},{"groupKeyPattern":"action","maxConcurrency":200},{"groupKeyPattern":"webhook","maxConcurrency":200},{"groupKeyPattern":"on-event","maxConcurrency":50}]'
+                '[{"groupKeyPattern":"sync","maxConcurrency":200},{"groupKeyPattern":"action","maxConcurrency":200},{"groupKeyPattern":"function","maxConcurrency":200},{"groupKeyPattern":"webhook","maxConcurrency":200},{"groupKeyPattern":"on-event","maxConcurrency":50}]'
         });
         expect(res).toMatchObject({
             JOBS_PROCESSOR_CONFIG: [
                 { groupKeyPattern: 'sync', maxConcurrency: 200 },
                 { groupKeyPattern: 'action', maxConcurrency: 200 },
+                { groupKeyPattern: 'function', maxConcurrency: 200 },
                 { groupKeyPattern: 'webhook', maxConcurrency: 200 },
                 { groupKeyPattern: 'on-event', maxConcurrency: 50 }
             ]


### PR DESCRIPTION
Adding support for function execution in jobs/runner.

This is the minimal changes to execute a function. I am trying to not refactor the entire runner and jobs all at once so implementation for now piggybacks on current logic, transforming function config into existing NangoProps and executing it as an action in order to minimize the amount of code change. The goal is to avoid big bang PRs that are introducing many changes and are hard to test or review. Over time the current function execution logic will be extended and some part of the runner would need to be refactored but I prefer to do it little by little rather than all at once

Note: it is not yet possible to deploy a function that can be invoked. 



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

