### PR TITLE
fix(server): move environment API key deletion IDs to path parameters

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9442,7 +9442,7 @@ Source: https://nango.dev/docs/reference/backend/http-api/environments/delete-ap
   Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys). Create one from [Account API keys](https://app.nango.dev/api-keys) in the dashboard.
 </Info>
 
-Deletes an Environment API key. `environment_id` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create). `key_id` is the numeric ID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).
+Deletes an Environment API key. `environmentId` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create). `keyId` is the numeric ID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).
 
 ## List all integrations
 

--- a/docs/reference/backend/http-api/environments/delete-api-key.mdx
+++ b/docs/reference/backend/http-api/environments/delete-api-key.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'Delete an environment API key'
-openapi: 'DELETE /environment/api-keys'
+openapi: 'DELETE /environments/{environmentId}/api-keys/{keyId}'
 ---
 
 <Info>
   Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys). Create one from [Account API keys](https://app.nango.dev/api-keys) in the dashboard.
 </Info>
 
-Deletes an Environment API key. `environment_id` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create). `key_id` is the numeric ID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).
+Deletes an Environment API key. `environmentId` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create). `keyId` is the numeric ID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2992,30 +2992,27 @@ paths:
                                 $ref: '#/components/schemas/StdError'
                 '500':
                     $ref: '#/components/responses/ServerError'
+    /environments/{environmentId}/api-keys/{keyId}:
         delete:
             summary: Delete an environment API key
             description: Delete an environment API key
-            requestBody:
-                required: true
-                content:
-                    application/json:
-                        schema:
-                            type: object
-                            additionalProperties: false
-                            required:
-                                - environment_id
-                                - key_id
-                            properties:
-                                environment_id:
-                                    type: integer
-                                    minimum: 1
-                                    description: Numeric environment ID that owns the key.
-                                    example: 123
-                                key_id:
-                                    type: integer
-                                    minimum: 1
-                                    description: Numeric key ID returned when the key was created.
-                                    example: 456
+            parameters:
+                - name: environmentId
+                  in: path
+                  required: true
+                  description: Numeric environment ID that owns the key.
+                  schema:
+                      type: integer
+                      minimum: 1
+                  example: 123
+                - name: keyId
+                  in: path
+                  required: true
+                  description: Numeric key ID returned when the key was created.
+                  schema:
+                      type: integer
+                      minimum: 1
+                  example: 456
             responses:
                 '200':
                     description: Successfully deleted the Environment API key

--- a/packages/server/lib/controllers/environment/deleteApiKey.ts
+++ b/packages/server/lib/controllers/environment/deleteApiKey.ts
@@ -8,10 +8,10 @@ import { handleDeleteApiKey } from '../shared/environments/deleteApiKey.js';
 
 import type { DeletePublicApiKey } from '@nangohq/types';
 
-const validationBody = z
+const validationParams = z
     .object({
-        environment_id: z.coerce.number().int().positive(),
-        key_id: z.coerce.number().int().positive()
+        environmentId: z.coerce.number().int().positive(),
+        keyId: z.coerce.number().int().positive()
     })
     .strict();
 
@@ -22,13 +22,13 @@ export const deletePublicApiKey = asyncWrapper<DeletePublicApiKey>(async (req, r
         return;
     }
 
-    const valBody = validationBody.safeParse(req.body);
-    if (!valBody.success) {
-        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
         return;
     }
 
-    const { environment_id: environmentId, key_id: keyId } = valBody.data;
+    const { environmentId, keyId } = valParams.data;
 
     const account = res.locals.account;
     if (!account) {

--- a/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
@@ -116,11 +116,11 @@ describe('Public environment API key management', () => {
         });
     });
 
-    describe('DELETE /environment/api-keys', () => {
+    describe('DELETE /environments/:environmentId/api-keys/:keyId', () => {
         it('should be protected', async () => {
-            const res = await api.fetch('/environment/api-keys', {
+            const res = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
-                body: { environment_id: 1, key_id: 1 }
+                params: { environmentId: 1, keyId: 1 }
             });
 
             shouldBeProtected(res);
@@ -139,10 +139,10 @@ describe('Public environment API key management', () => {
             expect(created.res.status).toBe(200);
             isSuccess(created.json);
 
-            const deniedDelete = await api.fetch('/environment/api-keys', {
+            const deniedDelete = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
                 token: createKey.secret,
-                body: { environment_id: env.id, key_id: created.json.data.id }
+                params: { environmentId: env.id, keyId: created.json.data.id }
             });
             expect(deniedDelete.res.status).toBe(403);
 
@@ -153,10 +153,10 @@ describe('Public environment API key management', () => {
             });
             expect(deniedCreate.res.status).toBe(403);
 
-            const deleted = await api.fetch('/environment/api-keys', {
+            const deleted = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
                 token: deleteKey.secret,
-                body: { environment_id: env.id, key_id: created.json.data.id }
+                params: { environmentId: env.id, keyId: created.json.data.id }
             });
             expect(deleted.res.status).toBe(200);
             isSuccess(deleted.json);
@@ -175,10 +175,10 @@ describe('Public environment API key management', () => {
             ).unwrap();
             const deleteKey = await createAccountKey(first.account.id, ['account:environments:api_keys:delete']);
 
-            const res = await api.fetch('/environment/api-keys', {
+            const res = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
                 token: deleteKey.secret,
-                body: { environment_id: second.env.id, key_id: created.id }
+                params: { environmentId: second.env.id, keyId: created.id }
             });
 
             expect(res.res.status).toBe(404);
@@ -201,10 +201,10 @@ describe('Public environment API key management', () => {
             expect(created.res.status).toBe(200);
             isSuccess(created.json);
 
-            const deleted = await api.fetch('/environment/api-keys', {
+            const deleted = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
                 token: accountKey.secret,
-                body: { environment_id: env.id, key_id: created.json.data.id }
+                params: { environmentId: env.id, keyId: created.json.data.id }
             });
             expect(deleted.res.status).toBe(200);
             isSuccess(deleted.json);

--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -428,10 +428,10 @@ describe('audit middleware — live-stack contract', () => {
             expect(JSON.stringify(auditEvent('api_key', 'created'))).not.toContain(secret);
 
             auditSpy.mockClear();
-            const deletion = await api.fetch('/environment/api-keys', {
+            const deletion = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
                 token: accountKey.secret,
-                body: { environment_id: env.id, key_id: create.json.data.id }
+                params: { environmentId: env.id, keyId: create.json.data.id }
             });
 
             expect(deletion.res.status).toBe(200);

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -705,8 +705,8 @@ export const auditApiKeyDeleted = auditable<DeleteApiKey>({
 });
 export const auditPublicApiKeyDeleted = auditable<DeletePublicApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'deleted', scope: 'account' }),
-    target: (req, locals) => publicEnvApiKeyTarget(req.body.key_id, req.body.environment_id, locals),
-    metadata: (req) => omitUndefined({ environmentId: req.body.environment_id })
+    target: (req, locals) => publicEnvApiKeyTarget(req.params.keyId, req.params.environmentId, locals),
+    metadata: (req) => omitUndefined({ environmentId: Number(req.params.environmentId) })
 });
 export const auditAccountApiKeyDeleted = auditable<DeleteAccountApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'deleted', scope: 'account' }),

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -322,9 +322,9 @@ publicAPI.use('/environment-variables', jsonContentTypeMiddleware);
 publicAPI.route('/environment-variables').get(apiAuth, withScope('environment:variables:read'), getPublicEnvironmentVariables);
 
 publicAPI.use('/environment', jsonContentTypeMiddleware);
+publicAPI.route('/environment/api-keys').post(apiAuth, auditPublicApiKeyCreated, withScope('account:environments:api_keys:create'), postPublicApiKey);
 publicAPI
-    .route('/environment/api-keys')
-    .post(apiAuth, auditPublicApiKeyCreated, withScope('account:environments:api_keys:create'), postPublicApiKey)
+    .route('/environments/:environmentId/api-keys/:keyId')
     .delete(apiAuth, auditPublicApiKeyDeleted, withScope('account:environments:api_keys:delete'), deletePublicApiKey);
 publicAPI
     .route('/environment/webhook-signing-key/rotate')

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -193,11 +193,8 @@ export type PostPublicApiKey = ApiEndpoint<{
 export type DeletePublicApiKey = ApiEndpoint<{
     Audit: AuditPolicy<'api_key', 'deleted', 'account'>;
     Method: 'DELETE';
-    Path: '/environment/api-keys';
-    Body: {
-        environment_id: number;
-        key_id: number;
-    };
+    Path: '/environments/:environmentId/api-keys/:keyId';
+    Params: { environmentId: number; keyId: number };
     Success: { success: true };
 }>;
 


### PR DESCRIPTION
Deleting an Environment API key required `environment_id` and `key_id` in the DELETE request body, unlike the standard resource-oriented route contract.

This PR fixes that by moving deletion to `DELETE
/environments/:environmentId/api-keys/:keyId`, updating validations, audit target resolution and the accompanying documentation.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

