### PR TITLE
fix(audit): identify an accepted or declined invite by the user, not the email

### DIFF
--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -924,7 +924,7 @@ export const auditAccountApiKeyCreated = auditable<CreateAccountApiKey>({
 
 export const auditMemberInvited = auditable<PostInvite>({
     policy: Audit.auditable({ resource: 'member', action: 'invited', scope: 'account' }),
-    // Invitees have no user id yet — the email is their identity. One target per invited email.
+    // An invitee may not have an account at all, so the email is the only identity available.
     target: (req) =>
         Array.isArray(req.body.emails)
             ? req.body.emails.map((email) => makeTarget('member', email, email)).filter((t): t is AuditTarget => Boolean(t))
@@ -952,12 +952,12 @@ async function invitingAccount(req: Request<{ id: string }>): Promise<{ id: numb
 export const auditMemberInviteAccepted = auditable<AcceptInvite>({
     policy: Audit.auditable({ resource: 'member', action: 'invite_accepted', scope: 'account' }),
     account: invitingAccount,
-    target: (_req, locals) => makeTarget('member', locals.user?.email, locals.user?.email)
+    target: (_req, locals) => makeTarget('member', locals.user?.id, locals.user?.email)
 });
 export const auditMemberInviteDeclined = auditable<DeclineInvite>({
     policy: Audit.auditable({ resource: 'member', action: 'invite_declined', scope: 'account' }),
     account: invitingAccount,
-    target: (_req, locals) => makeTarget('member', locals.user?.email, locals.user?.email)
+    target: (_req, locals) => makeTarget('member', locals.user?.id, locals.user?.email)
 });
 
 export const auditFunctionDeployed = auditable<PostFunctionDeployment>({

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -324,7 +324,7 @@ describe('auditable() lifecycle specs (unit)', () => {
             accountId: 100,
             environment: null,
             actor: { type: 'user', id: '7', display: 'dev@example.com' },
-            targets: [{ type: 'member', id: 'dev@example.com', display: 'dev@example.com' }]
+            targets: [{ type: 'member', id: '7', display: 'dev@example.com' }]
         });
     });
 
@@ -347,7 +347,7 @@ describe('auditable() lifecycle specs (unit)', () => {
             accountId: 100,
             environment: null,
             actor: { type: 'user', id: '7', display: 'dev@example.com' },
-            targets: [{ type: 'member', id: 'dev@example.com', display: 'dev@example.com' }]
+            targets: [{ type: 'member', id: '7', display: 'dev@example.com' }]
         });
     });
 
@@ -368,7 +368,7 @@ describe('auditable() lifecycle specs (unit)', () => {
             outcome: 'failure',
             accountId: 100,
             environment: null,
-            targets: [{ type: 'member', id: 'dev@example.com', display: 'dev@example.com' }]
+            targets: [{ type: 'member', id: '7', display: 'dev@example.com' }]
         });
     });
 


### PR DESCRIPTION
- A `member` target was a user id on `removed` and `role_changed`, and an email on the four invite events. Inviting someone and later changing their role produced rows that did not group, and the invite rows put an email in the id rather than only in the display.
- Accepting or declining an invite happens with the invitee signed in, so those two events now use the user id, with the email as the display like every other member event.
- `invited` and `invite_revoked` keep the email. `PostInvite` takes a list of addresses and `DeleteInvite` takes one, and an invitee may not have a Nango account at all, so there is no id to resolve.

## Test plan

- [x] Accept and decline record the user id as the target and the email as the display
- [x] Confirmed all three existing assertions go red against the previous behaviour
- [x] 95 middleware tests pass; `npm run ts-build`, `npm run lint` and Prettier clean
- [ ] Neither accept nor decline has integration coverage, only unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

