### PR TITLE
feat(server): compile a toolset policy into a resolved tool list (NAN-6595)

### DIFF
--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -41,8 +41,12 @@ describe('agentSession service', () => {
             github: { integrationId: 'github', provider: 'github', connectionId: 'github-connection', internalConnectionId: 1, configId: 10 }
         } satisfies AgentSessionResolvedConnections;
         const compiledToolset = {
-            github: { pinned: ['create_issue'], searchable: ['get_issue'] },
-            slack: { pinned: [], searchable: ['send_message'] }
+            github: {
+                provider: 'github',
+                pinned: [{ name: 'create_issue', description: 'Create an issue' }],
+                searchable: [{ name: 'get_issue', description: 'Get an issue' }]
+            },
+            slack: { provider: 'slack', pinned: [], searchable: [{ name: 'send_message', description: 'Send a message' }] }
         } satisfies AgentSessionCompiledToolset;
 
         const created = (

--- a/packages/server/lib/services/agentSessionToolset.service.ts
+++ b/packages/server/lib/services/agentSessionToolset.service.ts
@@ -21,21 +21,18 @@ import type {
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
-export const MAX_INTEGRATIONS = 50;
-export const MAX_TOOLS_PER_SELECTOR = 200;
-
 const ALLOW_ALL = '*';
 
-const toolListSchema = z.array(scriptNameSchema).max(MAX_TOOLS_PER_SELECTOR);
+const toolListSchema = z.array(scriptNameSchema);
 
-const toolSelectorSchema = z.union([z.literal(ALLOW_ALL), z.strictObject({ tools: toolListSchema })]);
+const toolListSelectorSchema = z.strictObject({ tools: toolListSchema });
 
 const integrationPolicySchema = z
     .union([
         z.literal(ALLOW_ALL),
         z.strictObject({
-            allow: toolSelectorSchema.optional(),
-            deny: toolSelectorSchema.optional()
+            allow: z.union([z.literal(ALLOW_ALL), toolListSelectorSchema]).optional(),
+            deny: toolListSelectorSchema.optional()
         })
     ])
     .transform((policy): AgentSessionIntegrationPolicy => {
@@ -43,12 +40,9 @@ const integrationPolicySchema = z
             return { allow: ALLOW_ALL, deny: [] };
         }
 
-        // `deny: '*'` leaves the integration in the toolset with nothing reachable on it,
-        // which is how a customer switches one off without rewriting the rest of the policy.
-        const deny = policy.deny === ALLOW_ALL ? undefined : policy.deny?.tools;
-        const allow = policy.deny === ALLOW_ALL ? [] : policy.allow === undefined || policy.allow === ALLOW_ALL ? ALLOW_ALL : policy.allow.tools;
+        const allow = policy.allow === undefined || policy.allow === ALLOW_ALL ? ALLOW_ALL : policy.allow.tools;
 
-        return { allow, deny: deny ?? [] };
+        return { allow, deny: policy.deny?.tools ?? [] };
     });
 
 export const agentSessionToolsetSchema = z.union([
@@ -56,14 +50,9 @@ export const agentSessionToolsetSchema = z.union([
     z
         .record(providerConfigKeySchema, integrationPolicySchema)
         .refine((toolset) => Object.keys(toolset).length > 0, { message: 'A toolset must name at least one integration' })
-        .refine((toolset) => Object.keys(toolset).length <= MAX_INTEGRATIONS, { message: `A toolset cannot name more than ${MAX_INTEGRATIONS} integrations` })
 ]);
 
-export const agentSessionPinnedToolsSchema = z
-    .record(providerConfigKeySchema, toolListSchema)
-    .refine((pinned) => Object.keys(pinned).length <= MAX_INTEGRATIONS, {
-        message: `Tools cannot be pinned on more than ${MAX_INTEGRATIONS} integrations`
-    });
+export const agentSessionPinnedToolsSchema = z.record(providerConfigKeySchema, toolListSchema);
 
 export class AgentSessionToolsetCompilationError extends Error {
     public readonly code: AgentSessionToolsetCompilationErrorCode;

--- a/packages/server/lib/services/agentSessionToolset.service.ts
+++ b/packages/server/lib/services/agentSessionToolset.service.ts
@@ -91,6 +91,12 @@ export async function compileToolset({
     return compileToolsetFromCatalog({ toolset, pinnedTools, connectedIntegrations, catalog });
 }
 
+/**
+ * Works out which integrations the policy covers, rejects every name in it the catalog cannot
+ * back, filters each integration's actions through its allow and deny lists, and splits what
+ * survives into pinned and searchable. Any rejection fails the whole compilation, so a session
+ * is either fully valid or not created at all.
+ */
 export function compileToolsetFromCatalog({
     toolset,
     pinnedTools,
@@ -104,13 +110,13 @@ export function compileToolsetFromCatalog({
 }): Result<AgentSessionCompiledToolset, AgentSessionToolsetCompilationError> {
     const integrations = groupCatalogByIntegration(catalog);
 
+    // Step 1. Resolve which integrations the policy covers.
     const policies = resolvePolicies({ toolset, connectedIntegrations, integrations });
     if (policies.isErr()) {
         return Err(policies.error);
     }
 
-    // A Map for the same reason the result is one: `pinned['__proto__']` on a plain object
-    // resolves to Object.prototype instead of being absent.
+    // Step 2. Fold in the integrations named only by pinned_tools.
     const pinned = new Map(Object.entries(pinnedTools ?? {}).map(([integrationId, tools]) => [integrationId, [...tools]]));
     const unknownIntegrations = [...pinned.keys()].filter((integrationId) => !integrations.has(integrationId));
     if (unknownIntegrations.length > 0) {
@@ -125,14 +131,14 @@ export function compileToolsetFromCatalog({
         }
     }
 
+    // Step 3. Reject any name the catalog cannot back.
     const referenced = referencedTools({ policies: policies.value, pinned });
     const rejected = rejectUnusableReferences({ referenced, integrations });
     if (rejected) {
         return Err(rejected);
     }
 
-    // Maps rather than plain objects: an integration id of `__proto__` would not become an own
-    // property, and the integration would silently drop out of the result.
+    // Step 4. Filter each integration's actions through its policy and split them into pinned and searchable.
     const compiled = new Map<string, AgentSessionCompiledIntegration>();
     const notInToolset: { integration_id: string; tool: string }[] = [];
 
@@ -244,6 +250,14 @@ function referencedTools({ policies, pinned }: { policies: Map<string, AgentSess
     return referenced;
 }
 
+/**
+ * Classifies every named reference against the catalog and returns the error to fail on, or null
+ * when all of them are usable.
+ *
+ * A name that is deployed but is not an action is reported ahead of one that does not exist at
+ * all, since the wrong function type is the more specific thing to hand back. A disabled action
+ * counts as unknown, because a session cannot serve it either way.
+ */
 function rejectUnusableReferences({
     referenced,
     integrations
@@ -303,8 +317,6 @@ function groupCatalogByIntegration(catalog: IntegrationFunctionCatalogRow[]): Ma
 
         integration.functionTypesByName.set(row.name, row.type);
 
-        // A disabled action is deployed but switched off, so it is not a tool a session can serve
-        // and naming it reads as unknown.
         if (row.type === 'action' && row.enabled) {
             integration.actions.push({ name: row.name, description: row.description ?? row.name });
         }

--- a/packages/server/lib/services/agentSessionToolset.service.ts
+++ b/packages/server/lib/services/agentSessionToolset.service.ts
@@ -1,0 +1,373 @@
+import { z } from 'zod';
+
+import { legacyFunctionService } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import { providerConfigKeySchema, scriptNameSchema } from '../helpers/validation.js';
+
+import type { IntegrationFunctionCatalogRow } from '@nangohq/shared';
+import type {
+    AgentSessionCompiledIntegration,
+    AgentSessionCompiledTool,
+    AgentSessionCompiledToolset,
+    AgentSessionIntegrationPolicy,
+    AgentSessionPinnedTools,
+    AgentSessionToolsetCompilationErrorCode,
+    AgentSessionToolsetPolicy,
+    AgentSessionToolsNotInToolsetPayload,
+    AgentSessionUnknownIntegrationsPayload,
+    AgentSessionUnknownToolsPayload,
+    AgentSessionUnsupportedFunctionTypesPayload
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+export const MAX_INTEGRATIONS = 50;
+export const MAX_TOOLS_PER_SELECTOR = 200;
+
+const ALLOW_ALL = '*';
+
+const toolListSchema = z.array(scriptNameSchema).max(MAX_TOOLS_PER_SELECTOR);
+
+const toolSelectorSchema = z.union([z.literal(ALLOW_ALL), z.strictObject({ tools: toolListSchema })]);
+
+const integrationPolicySchema = z
+    .union([
+        z.literal(ALLOW_ALL),
+        z.strictObject({
+            allow: toolSelectorSchema.optional(),
+            deny: toolSelectorSchema.optional()
+        })
+    ])
+    .transform((policy): AgentSessionIntegrationPolicy => {
+        if (policy === ALLOW_ALL) {
+            return { allow: ALLOW_ALL, deny: [] };
+        }
+
+        // `deny: '*'` leaves the integration in the toolset with nothing reachable on it,
+        // which is how a customer switches one off without rewriting the rest of the policy.
+        const deny = policy.deny === ALLOW_ALL ? undefined : policy.deny?.tools;
+        const allow = policy.deny === ALLOW_ALL ? [] : policy.allow === undefined || policy.allow === ALLOW_ALL ? ALLOW_ALL : policy.allow.tools;
+
+        return { allow, deny: deny ?? [] };
+    });
+
+export const agentSessionToolsetSchema = z.union([
+    z.literal(ALLOW_ALL),
+    z
+        .record(providerConfigKeySchema, integrationPolicySchema)
+        .refine((toolset) => Object.keys(toolset).length > 0, { message: 'A toolset must name at least one integration' })
+        .refine((toolset) => Object.keys(toolset).length <= MAX_INTEGRATIONS, { message: `A toolset cannot name more than ${MAX_INTEGRATIONS} integrations` })
+]);
+
+export const agentSessionPinnedToolsSchema = z
+    .record(providerConfigKeySchema, toolListSchema)
+    .refine((pinned) => Object.keys(pinned).length <= MAX_INTEGRATIONS, {
+        message: `Tools cannot be pinned on more than ${MAX_INTEGRATIONS} integrations`
+    });
+
+export class AgentSessionToolsetCompilationError extends Error {
+    public readonly code: AgentSessionToolsetCompilationErrorCode;
+    public readonly payload: Record<string, unknown>;
+
+    constructor({ code, message, payload }: { code: AgentSessionToolsetCompilationErrorCode; message: string; payload: Record<string, unknown> }) {
+        super(message);
+        this.name = 'AgentSessionToolsetCompilationError';
+        this.code = code;
+        this.payload = payload;
+    }
+}
+
+/**
+ * Evaluates a toolset policy against what the environment actually has deployed and produces
+ * the pinned and searchable tool lists the session serves for the rest of its life.
+ *
+ * An omitted toolset means every integration the tenant resolved a connection for. An explicit
+ * `'*'` means every integration in the environment, connected or not, which is the difference
+ * between "whatever this tenant has" and "everything we offer".
+ */
+export async function compileToolset({
+    environmentId,
+    toolset,
+    pinnedTools,
+    connectedIntegrations
+}: {
+    environmentId: number;
+    toolset: AgentSessionToolsetPolicy | undefined;
+    pinnedTools: AgentSessionPinnedTools | undefined;
+    connectedIntegrations: string[];
+}): Promise<Result<AgentSessionCompiledToolset, AgentSessionToolsetCompilationError>> {
+    const named = namedIntegrations({ toolset, pinnedTools, connectedIntegrations });
+    const catalog = await legacyFunctionService.findIntegrationFunctionCatalog({ environmentId, providerConfigKeys: named });
+
+    return compileToolsetFromCatalog({ toolset, pinnedTools, connectedIntegrations, catalog });
+}
+
+export function compileToolsetFromCatalog({
+    toolset,
+    pinnedTools,
+    connectedIntegrations,
+    catalog
+}: {
+    toolset: AgentSessionToolsetPolicy | undefined;
+    pinnedTools: AgentSessionPinnedTools | undefined;
+    connectedIntegrations: string[];
+    catalog: IntegrationFunctionCatalogRow[];
+}): Result<AgentSessionCompiledToolset, AgentSessionToolsetCompilationError> {
+    const integrations = groupCatalogByIntegration(catalog);
+
+    const policies = resolvePolicies({ toolset, connectedIntegrations, integrations });
+    if (policies.isErr()) {
+        return Err(policies.error);
+    }
+
+    // A Map for the same reason the result is one: `pinned['__proto__']` on a plain object
+    // resolves to Object.prototype instead of being absent.
+    const pinned = new Map(Object.entries(pinnedTools ?? {}).map(([integrationId, tools]) => [integrationId, [...tools]]));
+    const unknownIntegrations = [...pinned.keys()].filter((integrationId) => !integrations.has(integrationId));
+    if (unknownIntegrations.length > 0) {
+        return Err(unknownIntegrationError(unknownIntegrations));
+    }
+
+    // Pinning on an integration the toolset never allowed reaches nothing, so it is evaluated
+    // against a deny-all policy and comes back out as tool_not_in_toolset.
+    for (const integrationId of pinned.keys()) {
+        if (!policies.value.has(integrationId)) {
+            policies.value.set(integrationId, { allow: [], deny: [] });
+        }
+    }
+
+    const referenced = referencedTools({ policies: policies.value, pinned });
+    const rejected = rejectUnusableReferences({ referenced, integrations });
+    if (rejected) {
+        return Err(rejected);
+    }
+
+    // Maps rather than plain objects: an integration id of `__proto__` would not become an own
+    // property, and the integration would silently drop out of the result.
+    const compiled = new Map<string, AgentSessionCompiledIntegration>();
+    const notInToolset: { integration_id: string; tool: string }[] = [];
+
+    for (const [integrationId, policy] of policies.value) {
+        const integration = integrations.get(integrationId);
+        if (!integration) {
+            continue;
+        }
+
+        const allowed = integration.actions.filter((action) => isAllowed(action.name, policy));
+        const pinnedNames = new Set(pinned.get(integrationId) ?? []);
+
+        for (const name of pinnedNames) {
+            if (!allowed.some((action) => action.name === name)) {
+                notInToolset.push({ integration_id: integrationId, tool: name });
+            }
+        }
+
+        compiled.set(integrationId, {
+            provider: integration.provider,
+            pinned: allowed.filter((action) => pinnedNames.has(action.name)).map(toCompiledTool),
+            searchable: allowed.filter((action) => !pinnedNames.has(action.name)).map(toCompiledTool)
+        });
+    }
+
+    if (notInToolset.length > 0) {
+        return Err(toolNotInToolsetError(notInToolset));
+    }
+
+    return Ok(Object.fromEntries(compiled));
+}
+
+interface CatalogIntegration {
+    provider: string;
+    actions: { name: string; description: string }[];
+    functionTypesByName: Map<string, string>;
+}
+
+interface ToolReference {
+    integrationId: string;
+    name: string;
+}
+
+/**
+ * The integrations a policy could possibly touch, or undefined when it could touch any of them
+ * and the whole environment has to be loaded.
+ */
+function namedIntegrations({
+    toolset,
+    pinnedTools,
+    connectedIntegrations
+}: {
+    toolset: AgentSessionToolsetPolicy | undefined;
+    pinnedTools: AgentSessionPinnedTools | undefined;
+    connectedIntegrations: string[];
+}): string[] | undefined {
+    if (toolset === ALLOW_ALL) {
+        return undefined;
+    }
+
+    const named = toolset === undefined ? connectedIntegrations : Object.keys(toolset);
+
+    // Pinned integrations are loaded too, so that pinning outside the toolset is reported as
+    // unknown rather than passing because the integration was never looked up.
+    return [...new Set([...named, ...Object.keys(pinnedTools ?? {})])];
+}
+
+function resolvePolicies({
+    toolset,
+    connectedIntegrations,
+    integrations
+}: {
+    toolset: AgentSessionToolsetPolicy | undefined;
+    connectedIntegrations: string[];
+    integrations: Map<string, CatalogIntegration>;
+}): Result<Map<string, AgentSessionIntegrationPolicy>, AgentSessionToolsetCompilationError> {
+    const allTools: AgentSessionIntegrationPolicy = { allow: ALLOW_ALL, deny: [] };
+
+    if (toolset === ALLOW_ALL) {
+        return Ok(new Map([...integrations.keys()].map((integrationId) => [integrationId, allTools])));
+    }
+
+    if (toolset === undefined) {
+        return Ok(new Map(connectedIntegrations.map((integrationId) => [integrationId, allTools])));
+    }
+
+    const unknown = Object.keys(toolset).filter((integrationId) => !integrations.has(integrationId));
+    if (unknown.length > 0) {
+        return Err(unknownIntegrationError(unknown));
+    }
+
+    return Ok(new Map(Object.entries(toolset)));
+}
+
+/**
+ * Every tool named explicitly anywhere in the policy. Denied names are checked as strictly as
+ * allowed ones: a typo in a deny list silently exposes the tool it was meant to keep out.
+ */
+function referencedTools({ policies, pinned }: { policies: Map<string, AgentSessionIntegrationPolicy>; pinned: Map<string, string[]> }): ToolReference[] {
+    const referenced: ToolReference[] = [];
+
+    for (const [integrationId, policy] of policies) {
+        const names = [...(policy.allow === ALLOW_ALL ? [] : policy.allow), ...policy.deny, ...(pinned.get(integrationId) ?? [])];
+        for (const name of new Set(names)) {
+            referenced.push({ integrationId, name });
+        }
+    }
+
+    return referenced;
+}
+
+function rejectUnusableReferences({
+    referenced,
+    integrations
+}: {
+    referenced: ToolReference[];
+    integrations: Map<string, CatalogIntegration>;
+}): AgentSessionToolsetCompilationError | null {
+    const unknown: ToolReference[] = [];
+    const unsupported: { integrationId: string; name: string; type: string }[] = [];
+
+    for (const reference of referenced) {
+        const integration = integrations.get(reference.integrationId);
+        if (integration?.actions.some((action) => action.name === reference.name)) {
+            continue;
+        }
+
+        const type = integration?.functionTypesByName.get(reference.name);
+        if (type && type !== 'action') {
+            unsupported.push({ ...reference, type });
+        } else {
+            unknown.push(reference);
+        }
+    }
+
+    if (unsupported.length > 0) {
+        return unsupportedFunctionTypeError(unsupported);
+    }
+
+    if (unknown.length > 0) {
+        return unknownToolError(unknown);
+    }
+
+    return null;
+}
+
+function isAllowed(name: string, policy: AgentSessionIntegrationPolicy): boolean {
+    if (policy.deny.includes(name)) {
+        return false;
+    }
+
+    return policy.allow === ALLOW_ALL || policy.allow.includes(name);
+}
+
+function groupCatalogByIntegration(catalog: IntegrationFunctionCatalogRow[]): Map<string, CatalogIntegration> {
+    const integrations = new Map<string, CatalogIntegration>();
+
+    for (const row of catalog) {
+        let integration = integrations.get(row.integration_id);
+        if (!integration) {
+            integration = { provider: row.provider, actions: [], functionTypesByName: new Map() };
+            integrations.set(row.integration_id, integration);
+        }
+
+        if (row.name === null || row.type === null) {
+            continue;
+        }
+
+        integration.functionTypesByName.set(row.name, row.type);
+
+        // A disabled action is deployed but switched off, so it is not a tool a session can serve
+        // and naming it reads as unknown.
+        if (row.type === 'action' && row.enabled) {
+            integration.actions.push({ name: row.name, description: row.description ?? row.name });
+        }
+    }
+
+    return integrations;
+}
+
+function toCompiledTool(action: { name: string; description: string }): AgentSessionCompiledTool {
+    return { name: action.name, description: action.description };
+}
+
+function unknownIntegrationError(rejected: string[]): AgentSessionToolsetCompilationError {
+    const payload: AgentSessionUnknownIntegrationsPayload = { integrations: rejected };
+
+    return new AgentSessionToolsetCompilationError({
+        code: 'unknown_integration',
+        message: `${rejected.length} ${rejected.length === 1 ? 'integration does' : 'integrations do'} not exist in this environment. Check the integration ids in the toolset.`,
+        payload: { ...payload }
+    });
+}
+
+function unknownToolError(rejected: ToolReference[]): AgentSessionToolsetCompilationError {
+    const payload: AgentSessionUnknownToolsPayload = {
+        tools: rejected.map((reference) => ({ integration_id: reference.integrationId, tool: reference.name }))
+    };
+
+    return new AgentSessionToolsetCompilationError({
+        code: 'unknown_tool',
+        message: `${rejected.length} ${rejected.length === 1 ? 'tool is' : 'tools are'} not a deployed and enabled action on the integration given. Check the tool names, and that the action is enabled.`,
+        payload: { ...payload }
+    });
+}
+
+function unsupportedFunctionTypeError(rejected: { integrationId: string; name: string; type: string }[]): AgentSessionToolsetCompilationError {
+    const payload: AgentSessionUnsupportedFunctionTypesPayload = {
+        tools: rejected.map((reference) => ({ integration_id: reference.integrationId, tool: reference.name, type: reference.type }))
+    };
+
+    return new AgentSessionToolsetCompilationError({
+        code: 'unsupported_function_type',
+        message: `${rejected.length} ${rejected.length === 1 ? 'name refers' : 'names refer'} to a function that is not an action. Only actions can be exposed as tools.`,
+        payload: { ...payload }
+    });
+}
+
+function toolNotInToolsetError(rejected: { integration_id: string; tool: string }[]): AgentSessionToolsetCompilationError {
+    const payload: AgentSessionToolsNotInToolsetPayload = { pinned: rejected };
+
+    return new AgentSessionToolsetCompilationError({
+        code: 'tool_not_in_toolset',
+        message: `${rejected.length} pinned ${rejected.length === 1 ? 'tool is' : 'tools are'} not allowed by the toolset. Pinning controls what the agent sees first, not what it may reach, so allow the tool in the toolset as well.`,
+        payload: { ...payload }
+    });
+}

--- a/packages/server/lib/services/agentSessionToolset.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionToolset.service.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { agentSessionPinnedToolsSchema, agentSessionToolsetSchema, compileToolsetFromCatalog, MAX_INTEGRATIONS } from './agentSessionToolset.service.js';
+import { agentSessionPinnedToolsSchema, agentSessionToolsetSchema, compileToolsetFromCatalog } from './agentSessionToolset.service.js';
 
 import type { AgentSessionToolsetCompilationError } from './agentSessionToolset.service.js';
 import type { IntegrationFunctionCatalogRow } from '@nangohq/shared';
@@ -84,14 +84,12 @@ describe('agentSessionToolsetSchema', () => {
                 notion: { allow: { tools: ['read_doc'] } },
                 slack: { deny: { tools: ['send_message'] } },
                 github: '*',
-                'google-calendar': { deny: '*' },
                 linear: {}
             })
         ).toEqual({
             notion: { allow: ['read_doc'], deny: [] },
             slack: { allow: '*', deny: ['send_message'] },
             github: { allow: '*', deny: [] },
-            'google-calendar': { allow: [], deny: [] },
             linear: { allow: '*', deny: [] }
         });
     });
@@ -110,9 +108,13 @@ describe('agentSessionToolsetSchema', () => {
         expect(agentSessionToolsetSchema.safeParse({}).success).toBe(false);
     });
 
-    it('rejects more integrations than the cap', () => {
-        const oversized = Object.fromEntries(Array.from({ length: MAX_INTEGRATIONS + 1 }, (_, index) => [`integration-${index}`, '*']));
-        expect(agentSessionToolsetSchema.safeParse(oversized).success).toBe(false);
+    it('rejects denying every tool, since leaving the integration out says the same thing', () => {
+        expect(agentSessionToolsetSchema.safeParse({ notion: { deny: '*' } }).success).toBe(false);
+        expect(agentSessionToolsetSchema.safeParse({ notion: { allow: { tools: ['read_doc'] }, deny: '*' } }).success).toBe(false);
+    });
+
+    it('keeps the star shorthand on allow', () => {
+        expect(parseToolset({ notion: { allow: '*' } })).toEqual({ notion: { allow: '*', deny: [] } });
     });
 
     it('rejects unknown keys on an integration policy', () => {
@@ -181,13 +183,6 @@ describe('compileToolset', () => {
         const compiled = compile({ toolset: parseToolset({ notion: { allow: { tools: ['read_doc', 'delete_doc'] }, deny: { tools: ['delete_doc'] } } }) });
 
         expect(names(integration(compiled.unwrap(), 'notion').searchable)).toEqual(['read_doc']);
-    });
-
-    it('keeps an integration denied outright but empty', () => {
-        const compiled = compile({ toolset: parseToolset({ notion: { deny: '*' }, slack: '*' }) });
-
-        expect(integration(compiled.unwrap(), 'notion')).toEqual({ provider: 'notion', pinned: [], searchable: [] });
-        expect(names(integration(compiled.unwrap(), 'slack').searchable)).toEqual(['send_message', 'list_channels']);
     });
 
     it('splits pinned tools out of the searchable set', () => {

--- a/packages/server/lib/services/agentSessionToolset.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionToolset.service.unit.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest';
+
+import { agentSessionPinnedToolsSchema, agentSessionToolsetSchema, compileToolsetFromCatalog, MAX_INTEGRATIONS } from './agentSessionToolset.service.js';
+
+import type { AgentSessionToolsetCompilationError } from './agentSessionToolset.service.js';
+import type { IntegrationFunctionCatalogRow } from '@nangohq/shared';
+import type {
+    AgentSessionCompiledIntegration,
+    AgentSessionCompiledTool,
+    AgentSessionCompiledToolset,
+    AgentSessionPinnedTools,
+    AgentSessionToolsetPolicy
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+function action(integrationId: string, name: string, overrides: Partial<IntegrationFunctionCatalogRow> = {}): IntegrationFunctionCatalogRow {
+    return {
+        integration_id: integrationId,
+        provider: integrationId,
+        name,
+        type: 'action',
+        description: `${name} description`,
+        enabled: true,
+        ...overrides
+    };
+}
+
+function emptyIntegration(integrationId: string): IntegrationFunctionCatalogRow {
+    return { integration_id: integrationId, provider: integrationId, name: null, type: null, description: null, enabled: null };
+}
+
+const catalog: IntegrationFunctionCatalogRow[] = [
+    action('notion', 'read_doc'),
+    action('notion', 'upsert_doc'),
+    action('notion', 'delete_doc'),
+    action('notion', 'sync_pages', { type: 'sync' }),
+    action('notion', 'archive_doc', { enabled: false }),
+    action('slack', 'send_message'),
+    action('slack', 'list_channels'),
+    emptyIntegration('gmail')
+];
+
+function compile({
+    toolset,
+    pinnedTools,
+    connectedIntegrations = ['notion', 'slack']
+}: {
+    toolset?: AgentSessionToolsetPolicy | undefined;
+    pinnedTools?: AgentSessionPinnedTools | undefined;
+    connectedIntegrations?: string[];
+}) {
+    return compileToolsetFromCatalog({ toolset, pinnedTools, connectedIntegrations, catalog });
+}
+
+function parseToolset(input: unknown): AgentSessionToolsetPolicy {
+    return agentSessionToolsetSchema.parse(input) as AgentSessionToolsetPolicy;
+}
+
+function integration(compiled: AgentSessionCompiledToolset, integrationId: string): AgentSessionCompiledIntegration {
+    const entry = compiled[integrationId];
+    if (!entry) {
+        throw new Error(`Expected ${integrationId} in the compiled toolset`);
+    }
+
+    return entry;
+}
+
+function names(tools: AgentSessionCompiledTool[]): string[] {
+    return tools.map((tool) => tool.name);
+}
+
+function expectError(result: Result<AgentSessionCompiledToolset, AgentSessionToolsetCompilationError>): AgentSessionToolsetCompilationError {
+    if (!result.isErr()) {
+        throw new Error('Expected the compilation to fail');
+    }
+
+    return result.error;
+}
+
+describe('agentSessionToolsetSchema', () => {
+    it('normalises every shorthand to an allow and deny pair', () => {
+        expect(
+            parseToolset({
+                notion: { allow: { tools: ['read_doc'] } },
+                slack: { deny: { tools: ['send_message'] } },
+                github: '*',
+                'google-calendar': { deny: '*' },
+                linear: {}
+            })
+        ).toEqual({
+            notion: { allow: ['read_doc'], deny: [] },
+            slack: { allow: '*', deny: ['send_message'] },
+            github: { allow: '*', deny: [] },
+            'google-calendar': { allow: [], deny: [] },
+            linear: { allow: '*', deny: [] }
+        });
+    });
+
+    it('keeps deny alongside an explicit allow', () => {
+        expect(parseToolset({ notion: { allow: { tools: ['read_doc', 'upsert_doc'] }, deny: { tools: ['upsert_doc'] } } })).toEqual({
+            notion: { allow: ['read_doc', 'upsert_doc'], deny: ['upsert_doc'] }
+        });
+    });
+
+    it('accepts the environment wide shorthand', () => {
+        expect(parseToolset('*')).toBe('*');
+    });
+
+    it('rejects an empty toolset', () => {
+        expect(agentSessionToolsetSchema.safeParse({}).success).toBe(false);
+    });
+
+    it('rejects more integrations than the cap', () => {
+        const oversized = Object.fromEntries(Array.from({ length: MAX_INTEGRATIONS + 1 }, (_, index) => [`integration-${index}`, '*']));
+        expect(agentSessionToolsetSchema.safeParse(oversized).success).toBe(false);
+    });
+
+    it('rejects unknown keys on an integration policy', () => {
+        expect(agentSessionToolsetSchema.safeParse({ notion: { allow: { tags: { destructive: true } } } }).success).toBe(false);
+    });
+
+    it('rejects a pinned tools map keyed by nothing', () => {
+        expect(agentSessionPinnedToolsSchema.safeParse({ notion: ['read_doc'] }).success).toBe(true);
+        expect(agentSessionPinnedToolsSchema.safeParse({ notion: 'read_doc' }).success).toBe(false);
+    });
+});
+
+describe('compileToolset', () => {
+    it('defaults to every connected integration, all searchable', () => {
+        const compiled = compile({ toolset: undefined });
+
+        expect(compiled.isOk()).toBe(true);
+        expect(compiled.unwrap()).toEqual({
+            notion: {
+                provider: 'notion',
+                pinned: [],
+                searchable: [
+                    { name: 'read_doc', description: 'read_doc description' },
+                    { name: 'upsert_doc', description: 'upsert_doc description' },
+                    { name: 'delete_doc', description: 'delete_doc description' }
+                ]
+            },
+            slack: {
+                provider: 'slack',
+                pinned: [],
+                searchable: [
+                    { name: 'send_message', description: 'send_message description' },
+                    { name: 'list_channels', description: 'list_channels description' }
+                ]
+            }
+        });
+    });
+
+    it('excludes syncs and disabled actions from the default', () => {
+        const compiled = compile({ toolset: undefined, connectedIntegrations: ['notion'] });
+
+        expect(names(integration(compiled.unwrap(), 'notion').searchable)).toEqual(['read_doc', 'upsert_doc', 'delete_doc']);
+    });
+
+    it('takes the whole environment on the explicit star, connected or not', () => {
+        const compiled = compile({ toolset: '*' });
+
+        expect(Object.keys(compiled.unwrap())).toEqual(['notion', 'slack', 'gmail']);
+        expect(integration(compiled.unwrap(), 'gmail')).toEqual({ provider: 'gmail', pinned: [], searchable: [] });
+    });
+
+    it('treats an explicit allow as an allowlist', () => {
+        const compiled = compile({ toolset: parseToolset({ notion: { allow: { tools: ['read_doc'] } } }) });
+
+        expect(Object.keys(compiled.unwrap())).toEqual(['notion']);
+        expect(names(integration(compiled.unwrap(), 'notion').searchable)).toEqual(['read_doc']);
+    });
+
+    it('subtracts a deny list from everything else', () => {
+        const compiled = compile({ toolset: parseToolset({ notion: { deny: { tools: ['delete_doc'] } } }) });
+
+        expect(names(integration(compiled.unwrap(), 'notion').searchable)).toEqual(['read_doc', 'upsert_doc']);
+    });
+
+    it('lets deny win over an explicit allow', () => {
+        const compiled = compile({ toolset: parseToolset({ notion: { allow: { tools: ['read_doc', 'delete_doc'] }, deny: { tools: ['delete_doc'] } } }) });
+
+        expect(names(integration(compiled.unwrap(), 'notion').searchable)).toEqual(['read_doc']);
+    });
+
+    it('keeps an integration denied outright but empty', () => {
+        const compiled = compile({ toolset: parseToolset({ notion: { deny: '*' }, slack: '*' }) });
+
+        expect(integration(compiled.unwrap(), 'notion')).toEqual({ provider: 'notion', pinned: [], searchable: [] });
+        expect(names(integration(compiled.unwrap(), 'slack').searchable)).toEqual(['send_message', 'list_channels']);
+    });
+
+    it('splits pinned tools out of the searchable set', () => {
+        const compiled = compile({ toolset: parseToolset({ notion: '*' }), pinnedTools: { notion: ['upsert_doc'] } });
+
+        expect(names(integration(compiled.unwrap(), 'notion').pinned)).toEqual(['upsert_doc']);
+        expect(names(integration(compiled.unwrap(), 'notion').searchable)).toEqual(['read_doc', 'delete_doc']);
+    });
+
+    it('pins against the default toolset', () => {
+        const compiled = compile({ toolset: undefined, pinnedTools: { slack: ['send_message'] } });
+
+        expect(names(integration(compiled.unwrap(), 'slack').pinned)).toEqual(['send_message']);
+    });
+
+    it('rejects an integration that does not exist in the environment', () => {
+        const compiled = expectError(compile({ toolset: parseToolset({ notion: '*', hubspot: '*' }) }));
+
+        expect(compiled.code).toBe('unknown_integration');
+        expect(compiled.payload).toEqual({ integrations: ['hubspot'] });
+    });
+
+    it('rejects pinning on an integration that does not exist', () => {
+        const compiled = expectError(compile({ toolset: parseToolset({ notion: '*' }), pinnedTools: { hubspot: ['anything'] } }));
+
+        expect(compiled.code).toBe('unknown_integration');
+        expect(compiled.payload).toEqual({ integrations: ['hubspot'] });
+    });
+
+    it('rejects an allowed tool that does not exist', () => {
+        const compiled = expectError(compile({ toolset: parseToolset({ notion: { allow: { tools: ['read_doc', 'read_dco'] } } }) }));
+
+        expect(compiled.code).toBe('unknown_tool');
+        expect(compiled.payload).toEqual({ tools: [{ integration_id: 'notion', tool: 'read_dco' }] });
+    });
+
+    it('rejects a denied tool that does not exist, so a typo cannot silently expose it', () => {
+        const compiled = expectError(compile({ toolset: parseToolset({ notion: { deny: { tools: ['delete_dco'] } } }) }));
+
+        expect(compiled.code).toBe('unknown_tool');
+        expect(compiled.payload).toEqual({ tools: [{ integration_id: 'notion', tool: 'delete_dco' }] });
+    });
+
+    it('rejects a disabled action as unknown', () => {
+        const compiled = expectError(compile({ toolset: parseToolset({ notion: { allow: { tools: ['archive_doc'] } } }) }));
+
+        expect(compiled.code).toBe('unknown_tool');
+        expect(compiled.payload).toEqual({ tools: [{ integration_id: 'notion', tool: 'archive_doc' }] });
+    });
+
+    it('rejects a function that is not an action', () => {
+        const compiled = expectError(compile({ toolset: parseToolset({ notion: { allow: { tools: ['sync_pages'] } } }) }));
+
+        expect(compiled.code).toBe('unsupported_function_type');
+        expect(compiled.payload).toEqual({ tools: [{ integration_id: 'notion', tool: 'sync_pages', type: 'sync' }] });
+    });
+
+    it('reports the wrong function type ahead of unknown names', () => {
+        const compiled = expectError(compile({ toolset: parseToolset({ notion: { allow: { tools: ['sync_pages', 'read_dco'] } } }) }));
+
+        expect(compiled.code).toBe('unsupported_function_type');
+    });
+
+    it('rejects a pinned tool the toolset denies', () => {
+        const compiled = expectError(
+            compile({ toolset: parseToolset({ notion: { allow: { tools: ['read_doc'] } } }), pinnedTools: { notion: ['delete_doc'] } })
+        );
+
+        expect(compiled.code).toBe('tool_not_in_toolset');
+        expect(compiled.payload).toEqual({ pinned: [{ integration_id: 'notion', tool: 'delete_doc' }] });
+    });
+
+    it('rejects a pinned tool on an integration outside the toolset', () => {
+        const compiled = expectError(compile({ toolset: parseToolset({ notion: '*' }), pinnedTools: { slack: ['send_message'] } }));
+
+        expect(compiled.code).toBe('tool_not_in_toolset');
+        expect(compiled.payload).toEqual({ pinned: [{ integration_id: 'slack', tool: 'send_message' }] });
+    });
+
+    it('does not let a prototype integration id fall out of the result', () => {
+        const proto = '__proto__';
+        const compiled = compileToolsetFromCatalog({
+            toolset: undefined,
+            pinnedTools: undefined,
+            connectedIntegrations: [proto],
+            catalog: [action(proto, 'read_doc')]
+        });
+
+        expect(Object.keys(compiled.unwrap())).toEqual([proto]);
+    });
+});

--- a/packages/shared/lib/services/functions/index.ts
+++ b/packages/shared/lib/services/functions/index.ts
@@ -2,6 +2,7 @@ export { deployBundle, prepareDeploymentBundle } from './deploy.js';
 export type { DeploymentBundleError, DeploymentBundlePreparationError } from './deploy.js';
 export * as legacyFunctionService from './legacy/index.js';
 export type { ListFunctionsError, ListFunctionsErrorCode } from './legacy/service.js';
+export type { IntegrationFunctionCatalogRow } from './legacy/models/functions.js';
 export * as functionConfigService from './models/functions.js';
 export { reconcile } from './reconcile.js';
 export type { DeploymentBundleReconciliation } from './reconcile.js';

--- a/packages/shared/lib/services/functions/legacy/index.ts
+++ b/packages/shared/lib/services/functions/legacy/index.ts
@@ -1,4 +1,5 @@
 // Legacy unification over `_nango_sync_configs` and `on_event_scripts`.
 export { getFunction, ListFunctionsError, listFunctions } from './service.js';
 export type { ListFunctionsErrorCode } from './service.js';
-export { findActiveDeployedMeta } from './models/functions.js';
+export { findActiveDeployedMeta, findIntegrationFunctionCatalog } from './models/functions.js';
+export type { IntegrationFunctionCatalogRow } from './models/functions.js';

--- a/packages/shared/lib/services/functions/legacy/models/functions.integration.test.ts
+++ b/packages/shared/lib/services/functions/legacy/models/functions.integration.test.ts
@@ -1,0 +1,124 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import db, { multipleMigrations } from '@nangohq/database';
+
+import { createAccount } from '../../../../seeders/account.seeder.js';
+import { createConfigSeed } from '../../../../seeders/config.seeder.js';
+import { createEnvironmentSeed } from '../../../../seeders/environment.seeder.js';
+import { findIntegrationFunctionCatalog } from './functions.js';
+
+import type { DBSyncConfig, IntegrationConfig, NangoConfigMetadata } from '@nangohq/types';
+
+async function insertSyncConfig({
+    environmentId,
+    integration,
+    name,
+    type,
+    metadata,
+    enabled = true,
+    active = true,
+    deleted = false
+}: {
+    environmentId: number;
+    integration: IntegrationConfig;
+    name: string;
+    type: 'sync' | 'action';
+    metadata?: NangoConfigMetadata;
+    enabled?: boolean;
+    active?: boolean;
+    deleted?: boolean;
+}): Promise<void> {
+    if (integration.id === undefined) {
+        throw new Error('Seeded integration has no id');
+    }
+
+    await db.knex.from<DBSyncConfig>('_nango_sync_configs').insert({
+        environment_id: environmentId,
+        nango_config_id: integration.id,
+        sync_name: name,
+        type,
+        file_location: 'file_location',
+        version: '0.0.1',
+        source: 'repo',
+        runs: type === 'sync' ? 'every day' : null,
+        track_deletes: false,
+        auto_start: false,
+        webhook_subscriptions: [],
+        models: [],
+        metadata: metadata ?? {},
+        active,
+        enabled,
+        deleted,
+        deleted_at: deleted ? new Date() : null
+    });
+}
+
+describe(findIntegrationFunctionCatalog, () => {
+    beforeAll(async () => {
+        await multipleMigrations();
+    });
+
+    it('returns every integration with its active syncs and actions', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const notion = await createConfigSeed(environment, 'notion', 'notion');
+        const github = await createConfigSeed(environment, 'github', 'github');
+        await createConfigSeed(environment, 'gmail', 'google');
+
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'upsert_doc', type: 'action', metadata: { description: 'Upsert' } });
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'sync_pages', type: 'sync' });
+        await insertSyncConfig({ environmentId: environment.id, integration: github, name: 'create_issue', type: 'action', enabled: false });
+
+        const catalog = await findIntegrationFunctionCatalog({ environmentId: environment.id });
+
+        expect(catalog).toStrictEqual([
+            { integration_id: 'github', provider: 'github', name: 'create_issue', type: 'action', description: null, enabled: false },
+            { integration_id: 'gmail', provider: 'google', name: null, type: null, description: null, enabled: null },
+            { integration_id: 'notion', provider: 'notion', name: 'sync_pages', type: 'sync', description: null, enabled: true },
+            { integration_id: 'notion', provider: 'notion', name: 'upsert_doc', type: 'action', description: 'Upsert', enabled: true }
+        ]);
+    });
+
+    it('leaves out deleted and superseded function versions', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const notion = await createConfigSeed(environment, 'notion', 'notion');
+
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'old_version', type: 'action', active: false });
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'removed', type: 'action', deleted: true });
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'kept', type: 'action' });
+
+        const catalog = await findIntegrationFunctionCatalog({ environmentId: environment.id });
+
+        expect(catalog.map((row) => row.name)).toStrictEqual(['kept']);
+    });
+
+    it('narrows to the integrations asked for', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const notion = await createConfigSeed(environment, 'notion', 'notion');
+        const github = await createConfigSeed(environment, 'github', 'github');
+
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'upsert_doc', type: 'action' });
+        await insertSyncConfig({ environmentId: environment.id, integration: github, name: 'create_issue', type: 'action' });
+
+        const catalog = await findIntegrationFunctionCatalog({ environmentId: environment.id, providerConfigKeys: ['notion'] });
+
+        expect(catalog.map((row) => row.integration_id)).toStrictEqual(['notion']);
+    });
+
+    it('does not leak another environment', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const other = await createEnvironmentSeed(account.id);
+        const notion = await createConfigSeed(environment, 'notion', 'notion');
+        const otherNotion = await createConfigSeed(other, 'notion', 'notion');
+
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'mine', type: 'action' });
+        await insertSyncConfig({ environmentId: other.id, integration: otherNotion, name: 'theirs', type: 'action' });
+
+        const catalog = await findIntegrationFunctionCatalog({ environmentId: environment.id });
+
+        expect(catalog.map((row) => row.name)).toStrictEqual(['mine']);
+    });
+});

--- a/packages/shared/lib/services/functions/legacy/models/functions.integration.test.ts
+++ b/packages/shared/lib/services/functions/legacy/models/functions.integration.test.ts
@@ -121,4 +121,17 @@ describe(findIntegrationFunctionCatalog, () => {
 
         expect(catalog.map((row) => row.name)).toStrictEqual(['mine']);
     });
+
+    it('does not return a function whose environment disagrees with its integration', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const other = await createEnvironmentSeed(account.id);
+        const notion = await createConfigSeed(environment, 'notion', 'notion');
+
+        await insertSyncConfig({ environmentId: other.id, integration: notion, name: 'stray', type: 'action' });
+
+        const catalog = await findIntegrationFunctionCatalog({ environmentId: environment.id });
+
+        expect(catalog).toStrictEqual([{ integration_id: 'notion', provider: 'notion', name: null, type: null, description: null, enabled: null }]);
+    });
 });

--- a/packages/shared/lib/services/functions/legacy/models/functions.ts
+++ b/packages/shared/lib/services/functions/legacy/models/functions.ts
@@ -119,7 +119,11 @@ export async function findIntegrationFunctionCatalog({
     const query = db.knex
         .from({ nc: '_nango_configs' })
         .leftJoin({ sc: '_nango_sync_configs' }, function () {
-            this.on('sc.nango_config_id', 'nc.id').andOnVal('sc.deleted', false).andOnVal('sc.active', true).andOnIn('sc.type', ['sync', 'action']);
+            this.on('sc.nango_config_id', 'nc.id')
+                .andOnVal('sc.environment_id', environmentId)
+                .andOnVal('sc.deleted', false)
+                .andOnVal('sc.active', true)
+                .andOnIn('sc.type', ['sync', 'action']);
         })
         .where('nc.environment_id', environmentId)
         .andWhere('nc.deleted', false)

--- a/packages/shared/lib/services/functions/legacy/models/functions.ts
+++ b/packages/shared/lib/services/functions/legacy/models/functions.ts
@@ -91,6 +91,58 @@ export async function findActiveDeployedMeta({
     );
 }
 
+export interface IntegrationFunctionCatalogRow {
+    integration_id: string;
+    provider: string;
+    name: string | null;
+    type: 'sync' | 'action' | null;
+    description: string | null;
+    enabled: boolean | null;
+}
+
+/**
+ * Returns every integration in the environment alongside its active sync and action
+ * functions, one row per function and a single row with null function columns for an
+ * integration that has none.
+ *
+ * Built for compiling an agent session toolset, which has to tell "this integration does
+ * not exist" apart from "it exists and has no tools", and has to see syncs so that naming
+ * one is rejected as the wrong function type rather than as an unknown tool.
+ */
+export async function findIntegrationFunctionCatalog({
+    environmentId,
+    providerConfigKeys
+}: {
+    environmentId: number;
+    providerConfigKeys?: string[] | undefined;
+}): Promise<IntegrationFunctionCatalogRow[]> {
+    const query = db.knex
+        .from({ nc: '_nango_configs' })
+        .leftJoin({ sc: '_nango_sync_configs' }, function () {
+            this.on('sc.nango_config_id', 'nc.id').andOnVal('sc.deleted', false).andOnVal('sc.active', true).andOnIn('sc.type', ['sync', 'action']);
+        })
+        .where('nc.environment_id', environmentId)
+        .andWhere('nc.deleted', false)
+        .select<IntegrationFunctionCatalogRow[]>(
+            'nc.unique_key AS integration_id',
+            'nc.provider',
+            'sc.sync_name AS name',
+            'sc.type',
+            db.knex.raw("sc.metadata->>'description' AS description"),
+            'sc.enabled'
+        )
+        .orderBy([
+            { column: 'nc.unique_key', order: 'asc' },
+            { column: 'sc.sync_name', order: 'asc' }
+        ]);
+
+    if (providerConfigKeys) {
+        query.whereIn('nc.unique_key', providerConfigKeys);
+    }
+
+    return query;
+}
+
 function activeSyncConfigBase({ environmentId, providerConfigKey }: { environmentId: number; providerConfigKey: string }): Knex.QueryBuilder {
     return db.knex
         .from({ sc: '_nango_sync_configs' })

--- a/packages/types/lib/agent/session.ts
+++ b/packages/types/lib/agent/session.ts
@@ -1,7 +1,5 @@
 import type { AgentSessionResolvedConnections } from './connections.js';
-import type { JsonObject } from 'type-fest';
-
-export type AgentSessionCompiledToolset = JsonObject;
+import type { AgentSessionCompiledToolset } from './toolset.js';
 
 export interface AgentSessionMetaTools {
     readonly nangoProxy: boolean;

--- a/packages/types/lib/agent/toolset.ts
+++ b/packages/types/lib/agent/toolset.ts
@@ -1,0 +1,59 @@
+/**
+ * The toolset policy as it arrives on the wire, before normalisation. Every form
+ * collapses to `AgentSessionIntegrationPolicy` once parsed.
+ */
+export type AgentSessionToolSelector = '*' | { readonly tools: readonly string[] };
+
+/**
+ * `allow` absent means every tool on the integration. `allow` present makes the
+ * integration an allowlist. `deny` always subtracts from whatever `allow` gave.
+ */
+export interface AgentSessionIntegrationPolicy {
+    readonly allow: '*' | readonly string[];
+    readonly deny: readonly string[];
+}
+
+export type AgentSessionToolsetPolicy = '*' | Readonly<Record<string, AgentSessionIntegrationPolicy>>;
+
+export type AgentSessionPinnedTools = Readonly<Record<string, readonly string[]>>;
+
+export interface AgentSessionCompiledTool {
+    readonly name: string;
+    readonly description: string;
+}
+
+export interface AgentSessionCompiledIntegration {
+    readonly provider: string;
+    readonly pinned: AgentSessionCompiledTool[];
+    readonly searchable: AgentSessionCompiledTool[];
+}
+
+export type AgentSessionCompiledToolset = Record<string, AgentSessionCompiledIntegration>;
+
+export type AgentSessionToolsetCompilationErrorCode = 'unknown_integration' | 'unknown_tool' | 'unsupported_function_type' | 'tool_not_in_toolset';
+
+export interface AgentSessionUnknownIntegrationsPayload {
+    readonly integrations: string[];
+}
+
+export interface AgentSessionUnknownToolsPayload {
+    readonly tools: {
+        readonly integration_id: string;
+        readonly tool: string;
+    }[];
+}
+
+export interface AgentSessionUnsupportedFunctionTypesPayload {
+    readonly tools: {
+        readonly integration_id: string;
+        readonly tool: string;
+        readonly type: string;
+    }[];
+}
+
+export interface AgentSessionToolsNotInToolsetPayload {
+    readonly pinned: {
+        readonly integration_id: string;
+        readonly tool: string;
+    }[];
+}

--- a/packages/types/lib/agent/toolset.ts
+++ b/packages/types/lib/agent/toolset.ts
@@ -1,10 +1,4 @@
 /**
- * The toolset policy as it arrives on the wire, before normalisation. Every form
- * collapses to `AgentSessionIntegrationPolicy` once parsed.
- */
-export type AgentSessionToolSelector = '*' | { readonly tools: readonly string[] };
-
-/**
  * `allow` absent means every tool on the integration. `allow` present makes the
  * integration an allowlist. `deny` always subtracts from whatever `allow` gave.
  */

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -15,6 +15,7 @@ export type * from './keystore/index.js';
 export type * from './action/api.js';
 export type * from './agent/connections.js';
 export type * from './agent/session.js';
+export type * from './agent/toolset.js';
 export type * from './admin/http.api.js';
 export type * from './account/api.js';
 export type * from './account/context.js';


### PR DESCRIPTION
NAN-6595

Compiles the toolset policy on an agent session into the pinned and searchable tool lists that session serves. Integrations and tools that do not exist are rejected, as are functions that are not actions.

No route yet. NAN-6597 calls this when creating a session.