### PR TITLE
feat(server): add POST /sessions to create an agent session (NAN-6597)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9258,6 +9258,16 @@ The **Default - Full access** key that comes with each environment already has a
 |-------|-------------|
 | `environment:connect_sessions:write` | Create and reconnect sessions for the Connect UI auth flow |
 
+#### Agent Sessions
+
+<Note>
+    Agent sessions are experimental. The endpoints and this scope are likely to change, including in breaking ways, until the feature is generally available.
+</Note>
+
+| Scope | Description |
+|-------|-------------|
+| `environment:agent_sessions:write` | Create agent sessions |
+
 #### Syncs
 
 | Scope | Description |

--- a/docs/reference/backend/http-api/api-keys.mdx
+++ b/docs/reference/backend/http-api/api-keys.mdx
@@ -171,6 +171,16 @@ The **Default - Full access** key that comes with each environment already has a
 |-------|-------------|
 | `environment:connect_sessions:write` | Create and reconnect sessions for the Connect UI auth flow |
 
+#### Agent Sessions
+
+<Note>
+    Agent sessions are experimental. The endpoints and this scope are likely to change, including in breaking ways, until the feature is generally available.
+</Note>
+
+| Scope | Description |
+|-------|-------------|
+| `environment:agent_sessions:write` | Create agent sessions |
+
 #### Syncs
 
 | Scope | Description |

--- a/packages/authz/lib/scopes.ts
+++ b/packages/authz/lib/scopes.ts
@@ -23,6 +23,8 @@ export const PUBLIC_ENVIRONMENT_SCOPES = [
     'environment:connections:delete',
     // Connect Sessions
     'environment:connect_sessions:write',
+    // Agent Sessions
+    'environment:agent_sessions:write',
     // Syncs
     'environment:syncs:read',
     'environment:syncs:execute',

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -105,6 +105,7 @@ export function parseCursor(str: string): unknown[] {
 export const operationTypeToMessage: Record<ConcatOperationList, string> = {
     'action:run': 'Action',
     'admin:impersonation': 'Admin logged into another account',
+    'agent_session:create': 'Agent session created',
     'auth:create_connection': 'Connection created',
     'auth:post_connection': 'post connection execution',
     'auth:refresh_token': 'Token refreshed',

--- a/packages/server/lib/controllers/agent/postSessions.integration.test.ts
+++ b/packages/server/lib/controllers/agent/postSessions.integration.test.ts
@@ -63,10 +63,6 @@ async function seedEnvironment(): Promise<{ account: DBTeam; env: DBEnvironment;
     return { account: seed.account, env: seed.env, token: key.secret };
 }
 
-/**
- * notion has two connections on the same tenant, so it is ambiguous unless narrowed or pinned.
- * slack has one. reddit has actions but no connection at all.
- */
 async function seedTenant() {
     const { account, env, token } = await seedEnvironment();
 

--- a/packages/server/lib/controllers/agent/postSessions.integration.test.ts
+++ b/packages/server/lib/controllers/agent/postSessions.integration.test.ts
@@ -1,0 +1,330 @@
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import * as keystore from '@nangohq/keystore';
+import { customerKeyService, seeders } from '@nangohq/shared';
+import { baseUrl } from '@nangohq/utils';
+
+import { getAgentSessionByToken } from '../../services/agentSession.service.js';
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
+
+import type { DBEnvironment, DBSyncConfig, DBTeam, IntegrationConfig } from '@nangohq/types';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/sessions';
+const FIFTEEN_DAYS_IN_MS = 15 * 24 * 60 * 60 * 1000;
+
+async function insertAction({
+    environmentId,
+    integration,
+    name,
+    type = 'action'
+}: {
+    environmentId: number;
+    integration: IntegrationConfig;
+    name: string;
+    type?: 'sync' | 'action';
+}): Promise<void> {
+    await db.knex.from<DBSyncConfig>('_nango_sync_configs').insert({
+        environment_id: environmentId,
+        nango_config_id: integration.id!,
+        sync_name: name,
+        type,
+        file_location: 'file_location',
+        version: '0.0.1',
+        source: 'repo',
+        runs: type === 'sync' ? 'every day' : null,
+        track_deletes: false,
+        auto_start: false,
+        webhook_subscriptions: [],
+        models: [],
+        metadata: {},
+        active: true,
+        enabled: true,
+        deleted: false,
+        deleted_at: null
+    });
+}
+
+async function seedEnvironment(): Promise<{ account: DBTeam; env: DBEnvironment; token: string }> {
+    const seed = await seeders.seedAccountEnvAndUser();
+    const key = (
+        await customerKeyService.createApiKey(db.knex, {
+            accountId: seed.account.id,
+            environmentId: seed.env.id,
+            displayName: `test-${randomUUID()}`,
+            scopes: ['environment:agent_sessions:write']
+        })
+    ).unwrap();
+
+    return { account: seed.account, env: seed.env, token: key.secret };
+}
+
+/**
+ * notion has two connections on the same tenant, so it is ambiguous unless narrowed or pinned.
+ * slack has one. reddit has actions but no connection at all.
+ */
+async function seedTenant() {
+    const { account, env, token } = await seedEnvironment();
+
+    const notion = await seeders.createConfigSeed(env, 'notion', 'notion');
+    const slack = await seeders.createConfigSeed(env, 'slack', 'slack');
+    const reddit = await seeders.createConfigSeed(env, 'reddit', 'reddit');
+
+    await insertAction({ environmentId: env.id, integration: notion, name: 'read_doc' });
+    await insertAction({ environmentId: env.id, integration: notion, name: 'upsert_doc' });
+    await insertAction({ environmentId: env.id, integration: notion, name: 'sync_docs', type: 'sync' });
+    await insertAction({ environmentId: env.id, integration: slack, name: 'send_message' });
+    await insertAction({ environmentId: env.id, integration: reddit, name: 'search_posts' });
+
+    const notionMarketing = await seeders.createConnectionSeed({
+        env,
+        provider: 'notion',
+        connectionId: 'notion-marketing',
+        tags: { tenant: 'acme', workspace: 'marketing' }
+    });
+    await seeders.createConnectionSeed({ env, provider: 'notion', connectionId: 'notion-eng', tags: { tenant: 'acme', workspace: 'eng' } });
+    await seeders.createConnectionSeed({ env, provider: 'slack', connectionId: 'slack-acme', tags: { tenant: 'acme', workspace: 'marketing' } });
+
+    return { account, env, token, notionMarketing };
+}
+
+describe(`POST ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+        await keystore.migrate(db.knex);
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, { method: 'POST', body: { tenant: { connections: { any: [{ tags: { tenant: 'acme' } }] } } } });
+
+        shouldBeProtected(res);
+    });
+
+    it('should reject a key without the agent_sessions:write scope', async () => {
+        const seed = await seeders.seedAccountEnvAndUser();
+        const key = (
+            await customerKeyService.createApiKey(db.knex, {
+                accountId: seed.account.id,
+                environmentId: seed.env.id,
+                displayName: `test-${randomUUID()}`,
+                scopes: ['environment:connect_sessions:write']
+            })
+        ).unwrap();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: key.secret,
+            body: { tenant: { connections: { any: [{ tags: { tenant: 'acme' } }] } } }
+        });
+
+        expect(res.res.status).toBe(403);
+    });
+
+    it('creates a session over the tenant connections, with every action searchable by default', async () => {
+        const { token } = await seedTenant();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token,
+            body: { tenant: { connections: { any: [{ tags: { tenant: 'acme', workspace: 'marketing' } }] } } }
+        });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(201);
+        expect(res.json.data.mcp_url).toBe(`${baseUrl}/session/${res.json.data.session_id}/mcp`);
+        expect(res.json.data.meta_tools).toStrictEqual({ nango_tool_search: true, nango_execute: true });
+
+        // The sync on notion is not a tool, and reddit has no connection so the default toolset leaves it out.
+        expect(res.json.data.toolset).toStrictEqual({
+            notion: { connected: true, tools_pinned: 0, tools_searchable: 2 },
+            slack: { connected: true, tools_pinned: 0, tools_searchable: 1 }
+        });
+
+        const expiresIn = new Date(res.json.data.expires_at).getTime() - Date.now();
+        expect(expiresIn).toBeGreaterThan(FIFTEEN_DAYS_IN_MS - 60_000);
+        expect(expiresIn).toBeLessThanOrEqual(FIFTEEN_DAYS_IN_MS);
+
+        const session = (await getAgentSessionByToken(db.knex, res.json.data.session_token)).unwrap();
+        expect(session.id).toBe(res.json.data.session_id);
+        expect(session.resolvedConnections['notion']?.connectionId).toBe('notion-marketing');
+        expect(session.resolvedConnections['slack']?.connectionId).toBe('slack-acme');
+    });
+
+    it('exposes an integration with no connection when the toolset asks for the whole environment', async () => {
+        const { token } = await seedTenant();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token,
+            body: { tenant: { connections: { any: [{ tags: { tenant: 'acme', workspace: 'marketing' } }] } }, toolset: '*' }
+        });
+
+        isSuccess(res.json);
+        expect(res.json.data.toolset['reddit']).toStrictEqual({ connected: false, tools_pinned: 0, tools_searchable: 1 });
+    });
+
+    it('applies the toolset policy and the pinned tools it was given', async () => {
+        const { token } = await seedTenant();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token,
+            body: {
+                tenant: { connections: { any: [{ tags: { tenant: 'acme', workspace: 'marketing' } }] } },
+                toolset: { notion: { allow: { tools: ['read_doc', 'upsert_doc'] } }, slack: '*' },
+                pinned_tools: { notion: ['read_doc'] },
+                meta_tools: { nango_execute: false }
+            }
+        });
+
+        isSuccess(res.json);
+        expect(res.json.data.toolset).toStrictEqual({
+            notion: { connected: true, tools_pinned: 1, tools_searchable: 1 },
+            slack: { connected: true, tools_pinned: 0, tools_searchable: 1 }
+        });
+        expect(res.json.data.meta_tools.nango_execute).toBe(false);
+    });
+
+    it('honours expires_in', async () => {
+        const { token } = await seedTenant();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token,
+            body: { tenant: { connections: { any: [{ tags: { tenant: 'acme', workspace: 'marketing' } }] } }, toolset: { slack: '*' }, expires_in: '2h' }
+        });
+
+        isSuccess(res.json);
+        const expiresIn = new Date(res.json.data.expires_at).getTime() - Date.now();
+        expect(expiresIn).toBeGreaterThan(2 * 60 * 60 * 1000 - 60_000);
+        expect(expiresIn).toBeLessThanOrEqual(2 * 60 * 60 * 1000);
+    });
+
+    it.each(['16d', '30s'])('rejects an expires_in outside the bounds (%s)', async (expiresIn) => {
+        const { token } = await seedTenant();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token,
+            body: { tenant: { connections: { any: [{ tags: { tenant: 'acme' } }] } }, expires_in: expiresIn }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+
+    it('fails without creating a session when an integration matches several connections', async () => {
+        const { token, env } = await seedTenant();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token,
+            body: { tenant: { connections: { any: [{ tags: { tenant: 'acme' } }] } } }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('ambiguous_connections');
+        expect(res.json.error.payload).toStrictEqual({
+            integrations: {
+                notion: {
+                    match_count: 2,
+                    candidates: expect.arrayContaining([
+                        { connection_id: 'notion-marketing', tags: { tenant: 'acme', workspace: 'marketing' } },
+                        { connection_id: 'notion-eng', tags: { tenant: 'acme', workspace: 'eng' } }
+                    ])
+                }
+            }
+        });
+
+        const sessions = await db.knex('agent_sessions').where({ environment_id: env.id });
+        expect(sessions).toHaveLength(0);
+    });
+
+    it('lets a pinned connection break the ambiguity', async () => {
+        const { token, notionMarketing } = await seedTenant();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token,
+            body: {
+                tenant: {
+                    connections: {
+                        any: [{ tags: { tenant: 'acme' } }],
+                        pinned: [{ integration_id: 'notion', connection_id: notionMarketing.connection_id }]
+                    }
+                }
+            }
+        });
+
+        isSuccess(res.json);
+        const session = (await getAgentSessionByToken(db.knex, res.json.data.session_token)).unwrap();
+        expect(session.resolvedConnections['notion']?.connectionId).toBe('notion-marketing');
+    });
+
+    it('rejects a toolset naming an integration the environment does not have', async () => {
+        const { token } = await seedTenant();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token,
+            body: { tenant: { connections: { any: [{ tags: { tenant: 'acme', workspace: 'marketing' } }] } }, toolset: { hubspot: '*' } }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('unknown_integration');
+        expect(res.json.error.payload).toStrictEqual({ integrations: ['hubspot'] });
+    });
+
+    it('rejects a toolset naming a function that is not an action', async () => {
+        const { token } = await seedTenant();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token,
+            body: {
+                tenant: { connections: { any: [{ tags: { tenant: 'acme', workspace: 'marketing' } }] } },
+                toolset: { notion: { allow: { tools: ['sync_docs'] } } }
+            }
+        });
+
+        isError(res.json);
+        expect(res.json.error.code).toBe('unsupported_function_type');
+        expect(res.json.error.payload).toStrictEqual({ tools: [{ integration_id: 'notion', tool: 'sync_docs', type: 'sync' }] });
+    });
+
+    it('rejects a meta tool Nango does not ship', async () => {
+        const { token } = await seedTenant();
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token,
+            body: { tenant: { connections: { any: [{ tags: { tenant: 'acme' } }] } }, meta_tools: { nango_teleport: true } }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('unknown_meta_tool');
+        expect(res.json.error.payload).toStrictEqual({ meta_tools: ['nango_teleport'] });
+    });
+
+    it('rejects a body with no connection selector at all', async () => {
+        const { token } = await seedTenant();
+
+        const res = await api.fetch(endpoint, { method: 'POST', token, body: { tenant: { connections: {} } } });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+});

--- a/packages/server/lib/controllers/agent/postSessions.integration.test.ts
+++ b/packages/server/lib/controllers/agent/postSessions.integration.test.ts
@@ -234,10 +234,7 @@ describe(`POST ${endpoint}`, () => {
             integrations: {
                 notion: {
                     match_count: 2,
-                    candidates: expect.arrayContaining([
-                        { connection_id: 'notion-marketing', tags: { tenant: 'acme', workspace: 'marketing' } },
-                        { connection_id: 'notion-eng', tags: { tenant: 'acme', workspace: 'eng' } }
-                    ])
+                    candidates: expect.arrayContaining([{ connection_id: 'notion-marketing' }, { connection_id: 'notion-eng' }])
                 }
             }
         });

--- a/packages/server/lib/controllers/agent/postSessions.ts
+++ b/packages/server/lib/controllers/agent/postSessions.ts
@@ -1,0 +1,225 @@
+import { z } from 'zod';
+
+import db from '@nangohq/database';
+import { logContextGetter } from '@nangohq/logs';
+import { baseUrl, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import * as agentSessionService from '../../services/agentSession.service.js';
+import * as agentSessionConnectionsService from '../../services/agentSessionConnections.service.js';
+import * as agentSessionToolsetService from '../../services/agentSessionToolset.service.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
+
+import type { LogContextOrigin } from '@nangohq/logs';
+import type {
+    AgentSessionCompiledToolset,
+    AgentSessionCreationErrorCode,
+    AgentSessionCreationErrorPayload,
+    AgentSessionMetaTools,
+    AgentSessionResolvedConnections,
+    AgentSessionToolsetSummary,
+    PostAgentSessions
+} from '@nangohq/types';
+import type { Response } from 'express';
+
+const MIN_EXPIRES_IN_MS = 60 * 1000;
+const MAX_EXPIRES_IN_MS = 15 * 24 * 60 * 60 * 1000;
+const DEFAULT_EXPIRES_IN_MS = MAX_EXPIRES_IN_MS;
+
+const EXPIRES_IN_UNITS_IN_MS: Record<string, number> = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000
+};
+
+const META_TOOLS = ['nango_tool_search', 'nango_execute'] as const;
+
+const DEFAULT_META_TOOLS: AgentSessionMetaTools = { nangoToolSearch: true, nangoExecute: true };
+
+const expiresInSchema = z
+    .string()
+    .regex(/^[1-9]\d*[smhd]$/, { message: 'expires_in must be a positive integer followed by s, m, h or d, for example 1h' })
+    .refine((value) => expiresInToMs(value) >= MIN_EXPIRES_IN_MS, { message: 'expires_in cannot be shorter than 60s' })
+    .refine((value) => expiresInToMs(value) <= MAX_EXPIRES_IN_MS, { message: 'expires_in cannot exceed 15d' });
+
+const bodySchema = z.strictObject({
+    tenant: z.strictObject({
+        connections: agentSessionConnectionsService.agentSessionTenantConnectionsSchema
+    }),
+    toolset: agentSessionToolsetService.agentSessionToolsetSchema.optional(),
+    pinned_tools: agentSessionToolsetService.agentSessionPinnedToolsSchema.optional(),
+    meta_tools: z.record(z.string(), z.boolean()).optional(),
+    expires_in: expiresInSchema.optional()
+});
+
+export const postAgentSessions = asyncWrapperWithEnvironment<PostAgentSessions>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const body = bodySchema.safeParse(req.body);
+    if (!body.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(body.error) } });
+        return;
+    }
+
+    const { account, environment } = res.locals;
+    const logCtx = await logContextGetter.create(
+        { operation: { type: 'agent_session', action: 'create' } },
+        { account, environment, meta: { requested: req.body } }
+    );
+
+    try {
+        const metaTools = parseMetaTools(body.data.meta_tools);
+        if (metaTools.unknown.length > 0) {
+            await rejectCreation(res, logCtx, {
+                code: 'unknown_meta_tool',
+                message: `${metaTools.unknown.length} ${metaTools.unknown.length === 1 ? 'key is' : 'keys are'} not a meta tool Nango ships. Supported meta tools are ${META_TOOLS.join(', ')}.`,
+                payload: { meta_tools: metaTools.unknown }
+            });
+            return;
+        }
+
+        const resolvedConnections = await agentSessionConnectionsService.resolveTenantConnections({
+            environmentId: environment.id,
+            connections: body.data.tenant.connections
+        });
+        if (resolvedConnections.isErr()) {
+            await rejectCreation(res, logCtx, resolvedConnections.error);
+            return;
+        }
+
+        const compiledToolset = await agentSessionToolsetService.compileToolset({
+            environmentId: environment.id,
+            toolset: body.data.toolset,
+            pinnedTools: body.data.pinned_tools,
+            connectedIntegrations: Object.keys(resolvedConnections.value)
+        });
+        if (compiledToolset.isErr()) {
+            await rejectCreation(res, logCtx, compiledToolset.error);
+            return;
+        }
+
+        const expiresAt = new Date(Date.now() + (body.data.expires_in ? expiresInToMs(body.data.expires_in) : DEFAULT_EXPIRES_IN_MS));
+
+        const session = await agentSessionService.createAgentSession(db.knex, {
+            accountId: account.id,
+            environmentId: environment.id,
+            resolvedConnections: resolvedConnections.value,
+            compiledToolset: compiledToolset.value,
+            metaTools: metaTools.applied,
+            expiresAt
+        });
+        if (session.isErr()) {
+            report(session.error);
+            void logCtx.error('Failed to create the agent session', { error: session.error });
+            await logCtx.failed();
+            res.status(500).send({ error: { code: 'server_error', message: 'Failed to create agent session' } });
+            return;
+        }
+
+        const token = await agentSessionService.createAgentSessionToken(db.knex, session.value);
+        if (token.isErr()) {
+            // A session no token can reach is unusable, so it is ended rather than left to expire.
+            const ended = await agentSessionService.terminateAgentSession(db.knex, {
+                id: session.value.id,
+                accountId: account.id,
+                environmentId: environment.id,
+                reason: 'terminated'
+            });
+            if (ended.isErr()) {
+                void logCtx.error('Failed to end the agent session left behind by the token failure', {
+                    error: ended.error,
+                    sessionId: session.value.id
+                });
+            }
+
+            report(token.error);
+            void logCtx.error('Failed to mint the agent session token', { error: token.error });
+            await logCtx.failed();
+            res.status(500).send({ error: { code: 'server_error', message: 'Failed to create agent session token' } });
+            return;
+        }
+
+        await logCtx.enrichOperation({
+            actor: { kind: 'session', id: session.value.id },
+            meta: {
+                requested: req.body,
+                resolvedConnections: resolvedConnections.value,
+                toolset: compiledToolset.value,
+                metaTools: metaTools.applied,
+                expiresAt: expiresAt.toISOString()
+            }
+        });
+        void logCtx.info('Agent session created');
+        await logCtx.success();
+
+        res.status(201).send({
+            data: {
+                session_id: session.value.id,
+                session_token: token.value.token,
+                mcp_url: mcpUrl(session.value.id),
+                expires_at: session.value.expiresAt.toISOString(),
+                toolset: toolsetSummary(session.value.compiledToolset, session.value.resolvedConnections),
+                meta_tools: {
+                    nango_tool_search: session.value.metaTools.nangoToolSearch,
+                    nango_execute: session.value.metaTools.nangoExecute
+                }
+            }
+        });
+    } catch (err) {
+        void logCtx.error('Failed to create the agent session', { error: err });
+        await logCtx.failed();
+        throw err;
+    }
+});
+
+export function toolsetSummary(
+    toolset: AgentSessionCompiledToolset,
+    resolvedConnections: AgentSessionResolvedConnections
+): Record<string, AgentSessionToolsetSummary> {
+    return Object.fromEntries(
+        Object.entries(toolset).map(([integrationId, integration]) => [
+            integrationId,
+            {
+                connected: Object.hasOwn(resolvedConnections, integrationId),
+                tools_pinned: integration.pinned.length,
+                tools_searchable: integration.searchable.length
+            }
+        ])
+    );
+}
+
+export function expiresInToMs(expiresIn: string): number {
+    const unit = expiresIn.slice(-1);
+    return parseInt(expiresIn.slice(0, -1), 10) * EXPIRES_IN_UNITS_IN_MS[unit]!;
+}
+
+function mcpUrl(sessionId: string): string {
+    return `${baseUrl}/session/${sessionId}/mcp`;
+}
+
+function parseMetaTools(requested: Record<string, boolean> | undefined): { applied: AgentSessionMetaTools; unknown: string[] } {
+    const unknown = Object.keys(requested ?? {}).filter((key) => !META_TOOLS.includes(key as (typeof META_TOOLS)[number]));
+
+    return {
+        applied: {
+            nangoToolSearch: requested?.['nango_tool_search'] ?? DEFAULT_META_TOOLS.nangoToolSearch,
+            nangoExecute: requested?.['nango_execute'] ?? DEFAULT_META_TOOLS.nangoExecute
+        },
+        unknown
+    };
+}
+
+async function rejectCreation(
+    res: Response<PostAgentSessions['Reply']>,
+    logCtx: LogContextOrigin,
+    error: { code: AgentSessionCreationErrorCode; message: string; payload: Record<string, unknown> }
+): Promise<void> {
+    void logCtx.error(error.message, { code: error.code, payload: error.payload });
+    await logCtx.failed();
+
+    res.status(400).send({ error: { code: error.code, message: error.message, payload: error.payload as unknown as AgentSessionCreationErrorPayload } });
+}

--- a/packages/server/lib/controllers/agent/postSessions.ts
+++ b/packages/server/lib/controllers/agent/postSessions.ts
@@ -25,6 +25,8 @@ const MIN_EXPIRES_IN_MS = 60 * 1000;
 const MAX_EXPIRES_IN_MS = 15 * 24 * 60 * 60 * 1000;
 const DEFAULT_EXPIRES_IN_MS = MAX_EXPIRES_IN_MS;
 
+const EXPIRES_IN_PATTERN = /^([1-9]\d*)([smhd])$/;
+
 const EXPIRES_IN_UNITS_IN_MS: Record<string, number> = {
     s: 1000,
     m: 60 * 1000,
@@ -38,9 +40,17 @@ const DEFAULT_META_TOOLS: AgentSessionMetaTools = { nangoToolSearch: true, nango
 
 const expiresInSchema = z
     .string()
-    .regex(/^[1-9]\d*[smhd]$/, { message: 'expires_in must be a positive integer followed by s, m, h or d, for example 1h' })
-    .refine((value) => expiresInToMs(value) >= MIN_EXPIRES_IN_MS, { message: 'expires_in cannot be shorter than 60s' })
-    .refine((value) => expiresInToMs(value) <= MAX_EXPIRES_IN_MS, { message: 'expires_in cannot exceed 15d' });
+    .transform((value, ctx) => {
+        const ms = expiresInToMs(value);
+        if (ms === null) {
+            ctx.addIssue({ code: 'custom', message: 'expires_in must be a positive integer followed by s, m, h or d, for example 1h' });
+            return z.NEVER;
+        }
+
+        return ms;
+    })
+    .refine((ms) => ms >= MIN_EXPIRES_IN_MS, { message: 'expires_in cannot be shorter than 60s' })
+    .refine((ms) => ms <= MAX_EXPIRES_IN_MS, { message: 'expires_in cannot exceed 15d' });
 
 const bodySchema = z.strictObject({
     tenant: z.strictObject({
@@ -102,7 +112,7 @@ export const postAgentSessions = asyncWrapperWithEnvironment<PostAgentSessions>(
             return;
         }
 
-        const expiresAt = new Date(Date.now() + (body.data.expires_in ? expiresInToMs(body.data.expires_in) : DEFAULT_EXPIRES_IN_MS));
+        const expiresAt = new Date(Date.now() + (body.data.expires_in ?? DEFAULT_EXPIRES_IN_MS));
 
         const session = await agentSessionService.createAgentSession(db.knex, {
             accountId: account.id,
@@ -192,9 +202,16 @@ export function toolsetSummary(
     );
 }
 
-export function expiresInToMs(expiresIn: string): number {
-    const unit = expiresIn.slice(-1);
-    return parseInt(expiresIn.slice(0, -1), 10) * EXPIRES_IN_UNITS_IN_MS[unit]!;
+export function expiresInToMs(expiresIn: string): number | null {
+    const match = EXPIRES_IN_PATTERN.exec(expiresIn);
+    if (!match) {
+        return null;
+    }
+
+    const [, amount, unit] = match;
+    const unitInMs = unit ? EXPIRES_IN_UNITS_IN_MS[unit] : undefined;
+
+    return unitInMs ? Number(amount) * unitInMs : null;
 }
 
 function mcpUrl(sessionId: string): string {

--- a/packages/server/lib/controllers/agent/postSessions.ts
+++ b/packages/server/lib/controllers/agent/postSessions.ts
@@ -1,56 +1,13 @@
 import { z } from 'zod';
 
-import db from '@nangohq/database';
-import { logContextGetter } from '@nangohq/logs';
-import { baseUrl, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import * as agentSessionService from '../../services/agentSession.service.js';
 import * as agentSessionConnectionsService from '../../services/agentSessionConnections.service.js';
+import * as agentSessionCreationService from '../../services/agentSessionCreation.service.js';
 import * as agentSessionToolsetService from '../../services/agentSessionToolset.service.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 
-import type { LogContextOrigin } from '@nangohq/logs';
-import type {
-    AgentSessionCompiledToolset,
-    AgentSessionCreationErrorCode,
-    AgentSessionCreationErrorPayload,
-    AgentSessionMetaTools,
-    AgentSessionResolvedConnections,
-    AgentSessionToolsetSummary,
-    PostAgentSessions
-} from '@nangohq/types';
-import type { Response } from 'express';
-
-const MIN_EXPIRES_IN_MS = 60 * 1000;
-const MAX_EXPIRES_IN_MS = 15 * 24 * 60 * 60 * 1000;
-const DEFAULT_EXPIRES_IN_MS = MAX_EXPIRES_IN_MS;
-
-const EXPIRES_IN_PATTERN = /^([1-9]\d*)([smhd])$/;
-
-const EXPIRES_IN_UNITS_IN_MS: Record<string, number> = {
-    s: 1000,
-    m: 60 * 1000,
-    h: 60 * 60 * 1000,
-    d: 24 * 60 * 60 * 1000
-};
-
-const META_TOOLS = ['nango_tool_search', 'nango_execute'] as const;
-
-const DEFAULT_META_TOOLS: AgentSessionMetaTools = { nangoToolSearch: true, nangoExecute: true };
-
-const expiresInSchema = z
-    .string()
-    .transform((value, ctx) => {
-        const ms = expiresInToMs(value);
-        if (ms === null) {
-            ctx.addIssue({ code: 'custom', message: 'expires_in must be a positive integer followed by s, m, h or d, for example 1h' });
-            return z.NEVER;
-        }
-
-        return ms;
-    })
-    .refine((ms) => ms >= MIN_EXPIRES_IN_MS, { message: 'expires_in cannot be shorter than 60s' })
-    .refine((ms) => ms <= MAX_EXPIRES_IN_MS, { message: 'expires_in cannot exceed 15d' });
+import type { AgentSessionCreationErrorPayload, PostAgentSessions } from '@nangohq/types';
 
 const bodySchema = z.strictObject({
     tenant: z.strictObject({
@@ -59,7 +16,7 @@ const bodySchema = z.strictObject({
     toolset: agentSessionToolsetService.agentSessionToolsetSchema.optional(),
     pinned_tools: agentSessionToolsetService.agentSessionPinnedToolsSchema.optional(),
     meta_tools: z.record(z.string(), z.boolean()).optional(),
-    expires_in: expiresInSchema.optional()
+    expires_in: agentSessionCreationService.agentSessionExpiresInSchema.optional()
 });
 
 export const postAgentSessions = asyncWrapperWithEnvironment<PostAgentSessions>(async (req, res) => {
@@ -76,167 +33,40 @@ export const postAgentSessions = asyncWrapperWithEnvironment<PostAgentSessions>(
     }
 
     const { account, environment } = res.locals;
-    const logCtx = await logContextGetter.create(
-        { operation: { type: 'agent_session', action: 'create' } },
-        { account, environment, meta: { requested: req.body } }
-    );
+    const created = await agentSessionCreationService.createAgentSession({
+        account,
+        environment,
+        connections: body.data.tenant.connections,
+        toolset: body.data.toolset,
+        pinnedTools: body.data.pinned_tools,
+        metaTools: body.data.meta_tools,
+        expiresInMs: body.data.expires_in
+    });
 
-    try {
-        const metaTools = parseMetaTools(body.data.meta_tools);
-        if (metaTools.unknown.length > 0) {
-            await rejectCreation(res, logCtx, {
-                code: 'unknown_meta_tool',
-                message: `${metaTools.unknown.length} ${metaTools.unknown.length === 1 ? 'key is' : 'keys are'} not a meta tool Nango ships. Supported meta tools are ${META_TOOLS.join(', ')}.`,
-                payload: { meta_tools: metaTools.unknown }
-            });
+    if (created.isErr()) {
+        if (created.error.code === 'server_error') {
+            res.status(500).send({ error: { code: 'server_error', message: created.error.message } });
             return;
         }
 
-        const resolvedConnections = await agentSessionConnectionsService.resolveTenantConnections({
-            environmentId: environment.id,
-            connections: body.data.tenant.connections
-        });
-        if (resolvedConnections.isErr()) {
-            await rejectCreation(res, logCtx, resolvedConnections.error);
-            return;
-        }
-
-        const compiledToolset = await agentSessionToolsetService.compileToolset({
-            environmentId: environment.id,
-            toolset: body.data.toolset,
-            pinnedTools: body.data.pinned_tools,
-            connectedIntegrations: Object.keys(resolvedConnections.value)
-        });
-        if (compiledToolset.isErr()) {
-            await rejectCreation(res, logCtx, compiledToolset.error);
-            return;
-        }
-
-        const expiresAt = new Date(Date.now() + (body.data.expires_in ?? DEFAULT_EXPIRES_IN_MS));
-
-        const session = await agentSessionService.createAgentSession(db.knex, {
-            accountId: account.id,
-            environmentId: environment.id,
-            resolvedConnections: resolvedConnections.value,
-            compiledToolset: compiledToolset.value,
-            metaTools: metaTools.applied,
-            expiresAt
-        });
-        if (session.isErr()) {
-            report(session.error);
-            void logCtx.error('Failed to create the agent session', { error: session.error });
-            await logCtx.failed();
-            res.status(500).send({ error: { code: 'server_error', message: 'Failed to create agent session' } });
-            return;
-        }
-
-        const token = await agentSessionService.createAgentSessionToken(db.knex, session.value);
-        if (token.isErr()) {
-            // A session no token can reach is unusable, so it is ended rather than left to expire.
-            const ended = await agentSessionService.terminateAgentSession(db.knex, {
-                id: session.value.id,
-                accountId: account.id,
-                environmentId: environment.id,
-                reason: 'terminated'
-            });
-            if (ended.isErr()) {
-                void logCtx.error('Failed to end the agent session left behind by the token failure', {
-                    error: ended.error,
-                    sessionId: session.value.id
-                });
-            }
-
-            report(token.error);
-            void logCtx.error('Failed to mint the agent session token', { error: token.error });
-            await logCtx.failed();
-            res.status(500).send({ error: { code: 'server_error', message: 'Failed to create agent session token' } });
-            return;
-        }
-
-        await logCtx.enrichOperation({
-            actor: { kind: 'session', id: session.value.id },
-            meta: {
-                requested: req.body,
-                resolvedConnections: resolvedConnections.value,
-                toolset: compiledToolset.value,
-                metaTools: metaTools.applied,
-                expiresAt: expiresAt.toISOString()
+        res.status(400).send({
+            error: {
+                code: created.error.code,
+                message: created.error.message,
+                payload: created.error.payload as unknown as AgentSessionCreationErrorPayload
             }
         });
-        void logCtx.info('Agent session created');
-        await logCtx.success();
-
-        res.status(201).send({
-            data: {
-                session_id: session.value.id,
-                session_token: token.value.token,
-                mcp_url: mcpUrl(session.value.id),
-                expires_at: session.value.expiresAt.toISOString(),
-                toolset: toolsetSummary(session.value.compiledToolset, session.value.resolvedConnections),
-                meta_tools: {
-                    nango_tool_search: session.value.metaTools.nangoToolSearch,
-                    nango_execute: session.value.metaTools.nangoExecute
-                }
-            }
-        });
-    } catch (err) {
-        void logCtx.error('Failed to create the agent session', { error: err });
-        await logCtx.failed();
-        throw err;
+        return;
     }
+
+    res.status(201).send({
+        data: {
+            session_id: created.value.session.id,
+            session_token: created.value.token,
+            mcp_url: created.value.mcpUrl,
+            expires_at: created.value.session.expiresAt.toISOString(),
+            toolset: created.value.toolset,
+            meta_tools: created.value.metaTools
+        }
+    });
 });
-
-export function toolsetSummary(
-    toolset: AgentSessionCompiledToolset,
-    resolvedConnections: AgentSessionResolvedConnections
-): Record<string, AgentSessionToolsetSummary> {
-    return Object.fromEntries(
-        Object.entries(toolset).map(([integrationId, integration]) => [
-            integrationId,
-            {
-                connected: Object.hasOwn(resolvedConnections, integrationId),
-                tools_pinned: integration.pinned.length,
-                tools_searchable: integration.searchable.length
-            }
-        ])
-    );
-}
-
-export function expiresInToMs(expiresIn: string): number | null {
-    const match = EXPIRES_IN_PATTERN.exec(expiresIn);
-    if (!match) {
-        return null;
-    }
-
-    const [, amount, unit] = match;
-    const unitInMs = unit ? EXPIRES_IN_UNITS_IN_MS[unit] : undefined;
-
-    return unitInMs ? Number(amount) * unitInMs : null;
-}
-
-function mcpUrl(sessionId: string): string {
-    return `${baseUrl}/session/${sessionId}/mcp`;
-}
-
-function parseMetaTools(requested: Record<string, boolean> | undefined): { applied: AgentSessionMetaTools; unknown: string[] } {
-    const unknown = Object.keys(requested ?? {}).filter((key) => !META_TOOLS.includes(key as (typeof META_TOOLS)[number]));
-
-    return {
-        applied: {
-            nangoToolSearch: requested?.['nango_tool_search'] ?? DEFAULT_META_TOOLS.nangoToolSearch,
-            nangoExecute: requested?.['nango_execute'] ?? DEFAULT_META_TOOLS.nangoExecute
-        },
-        unknown
-    };
-}
-
-async function rejectCreation(
-    res: Response<PostAgentSessions['Reply']>,
-    logCtx: LogContextOrigin,
-    error: { code: AgentSessionCreationErrorCode; message: string; payload: Record<string, unknown> }
-): Promise<void> {
-    void logCtx.error(error.message, { code: error.code, payload: error.payload });
-    await logCtx.failed();
-
-    res.status(400).send({ error: { code: error.code, message: error.message, payload: error.payload as unknown as AgentSessionCreationErrorPayload } });
-}

--- a/packages/server/lib/controllers/agent/postSessions.unit.test.ts
+++ b/packages/server/lib/controllers/agent/postSessions.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { expiresInToMs, toolsetSummary } from './postSessions.js';
+
+describe('expiresInToMs', () => {
+    it.each([
+        ['60s', 60_000],
+        ['5m', 300_000],
+        ['2h', 7_200_000],
+        ['15d', 1_296_000_000]
+    ])('parses %s', (expiresIn, expected) => {
+        expect(expiresInToMs(expiresIn)).toBe(expected);
+    });
+});
+
+describe('toolsetSummary', () => {
+    it('counts the tools per integration and marks the ones with no connection', () => {
+        const summary = toolsetSummary(
+            {
+                notion: {
+                    provider: 'notion',
+                    pinned: [{ name: 'read_doc', description: 'Read a doc' }],
+                    searchable: [{ name: 'upsert_doc', description: 'Upsert a doc' }]
+                },
+                reddit: { provider: 'reddit', pinned: [], searchable: [{ name: 'search_posts', description: 'Search posts' }] }
+            },
+            {
+                notion: { integrationId: 'notion', provider: 'notion', connectionId: 'notion-1', internalConnectionId: 1, configId: 10 }
+            }
+        );
+
+        expect(summary).toStrictEqual({
+            notion: { connected: true, tools_pinned: 1, tools_searchable: 1 },
+            reddit: { connected: false, tools_pinned: 0, tools_searchable: 1 }
+        });
+    });
+});

--- a/packages/server/lib/controllers/agent/postSessions.unit.test.ts
+++ b/packages/server/lib/controllers/agent/postSessions.unit.test.ts
@@ -11,6 +11,10 @@ describe('expiresInToMs', () => {
     ])('parses %s', (expiresIn, expected) => {
         expect(expiresInToMs(expiresIn)).toBe(expected);
     });
+
+    it.each(['', '5', 's', '5x', '0s', '1.5h', '-1d', '5 m', '5S'])('returns null for %s', (expiresIn) => {
+        expect(expiresInToMs(expiresIn)).toBeNull();
+    });
 });
 
 describe('toolsetSummary', () => {

--- a/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
@@ -184,6 +184,22 @@ describe('Scope enforcement on public API routes', () => {
         });
     });
 
+    // ── Agent Sessions ──────────────────────────────────────────────
+
+    describe('POST /sessions', () => {
+        it('should allow with agent_sessions:write scope', async () => {
+            const token = await createKeyWithScopes(['environment:agent_sessions:write']);
+            const res = await api.fetch('/sessions', { method: 'POST', token, body: {} } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without agent_sessions:write scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/sessions', { method: 'POST', token, body: {} } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
     // ── Deploy ───────────────────────────────────────────────────────
 
     describe('POST /sync/deploy', () => {

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -8,6 +8,7 @@ import { connectUrl, flagEnforceCLIVersion } from '@nangohq/utils';
 
 import { getAsyncActionResult } from './controllers/action/getAsyncActionResult.js';
 import { postPublicTriggerAction } from './controllers/action/postTriggerAction.js';
+import { postAgentSessions } from './controllers/agent/postSessions.js';
 import appAuthController from './controllers/appAuth.controller.js';
 import { postPublicApiKeyAuthorization } from './controllers/auth/postApiKey.js';
 import { postPublicAwsSigV4Authorization } from './controllers/auth/postAwsSigV4.js';
@@ -399,6 +400,10 @@ publicAPI.route('/connect/sessions/reconnect').post(apiAuth, withScope('environm
 publicAPI.route('/connect/session').get(connectSessionAuth, getConnectSession);
 publicAPI.route('/connect/session').delete(connectSessionAuth, deleteConnectSession);
 publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTelemetry);
+
+// Agent sessions
+publicAPI.use('/sessions', jsonContentTypeMiddleware);
+publicAPI.route('/sessions').post(apiAuth, withScope('environment:agent_sessions:write'), postAgentSessions);
 
 // V1 passthrough (deprecated) — scope checks are inline in allPublicV1 after action/model resolution
 publicAPI.use('/v1', jsonContentTypeMiddleware);

--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -55,7 +55,7 @@ describe('agentSession service', () => {
                 environmentId: environment.id,
                 resolvedConnections,
                 compiledToolset,
-                metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+                metaTools: { nangoToolSearch: true, nangoExecute: true },
                 expiresAt
             })
         ).unwrap();
@@ -65,7 +65,7 @@ describe('agentSession service', () => {
             environmentId: environment.id,
             resolvedConnections,
             compiledToolset,
-            metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+            metaTools: { nangoToolSearch: true, nangoExecute: true },
             expiresAt,
             endedAt: null,
             endedReason: null
@@ -117,7 +117,7 @@ describe('agentSession service', () => {
             environmentId: other.env.id,
             resolvedConnections: {},
             compiledToolset: {},
-            metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+            metaTools: { nangoToolSearch: true, nangoExecute: true },
             expiresAt: new Date(Date.now() + 60_000)
         });
 
@@ -135,7 +135,7 @@ describe('agentSession service', () => {
             environmentId: environment.id,
             resolvedConnections: {},
             compiledToolset: {},
-            metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+            metaTools: { nangoToolSearch: true, nangoExecute: true },
             expiresAt: new Date(Date.now() + 60_000)
         });
 
@@ -274,7 +274,7 @@ async function createSession({
             environmentId: environment.id,
             resolvedConnections: {},
             compiledToolset: {},
-            metaTools: { nangoProxy: false, nangoSearch: true, nangoExecute: true },
+            metaTools: { nangoToolSearch: true, nangoExecute: true },
             expiresAt
         })
     ).unwrap();

--- a/packages/server/lib/services/agentSessionCreation.service.ts
+++ b/packages/server/lib/services/agentSessionCreation.service.ts
@@ -114,7 +114,7 @@ export async function createAgentSession(params: CreateAgentSessionParams): Prom
         if (created.isErr()) {
             void logCtx.error(created.error.message, { code: created.error.code, payload: created.error.payload });
             await logCtx.failed();
-            return created;
+            return Err(withoutCandidateTags(created.error));
         }
 
         await logCtx.enrichOperation({
@@ -254,6 +254,44 @@ function parseMetaTools(requested: Record<string, boolean> | undefined): { appli
 
 function rejected(error: { code: AgentSessionCreationErrorCode; message: string; payload: Record<string, unknown> }): AgentSessionCreationError {
     return new AgentSessionCreationError({ code: error.code, message: error.message, payload: error.payload });
+}
+
+/**
+ * Tags are customer data and creating a session does not require the connections read scope, so a
+ * candidate keeps the connection id the caller needs to pin it and loses everything else. The
+ * operation above already recorded the full payload, which is where an ambiguity gets debugged.
+ */
+function withoutCandidateTags(error: AgentSessionCreationError): AgentSessionCreationError {
+    return new AgentSessionCreationError({
+        code: error.code,
+        message: error.message,
+        payload: redactCandidates(error.payload) as Record<string, unknown>,
+        cause: error.cause
+    });
+}
+
+function redactCandidates(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(redactCandidates);
+    }
+
+    if (value === null || typeof value !== 'object') {
+        return value;
+    }
+
+    return Object.fromEntries(
+        Object.entries(value).map(([key, nested]) =>
+            key === 'candidates' && Array.isArray(nested) ? [key, nested.map(onlyConnectionId)] : [key, redactCandidates(nested)]
+        )
+    );
+}
+
+function onlyConnectionId(candidate: unknown): unknown {
+    if (candidate === null || typeof candidate !== 'object') {
+        return candidate;
+    }
+
+    return Object.fromEntries(Object.entries(candidate).filter(([field]) => field === 'connection_id'));
 }
 
 function requestedConfig(params: CreateAgentSessionParams): Record<string, unknown> {

--- a/packages/server/lib/services/agentSessionCreation.service.ts
+++ b/packages/server/lib/services/agentSessionCreation.service.ts
@@ -1,0 +1,267 @@
+import { z } from 'zod';
+
+import db from '@nangohq/database';
+import { logContextGetter } from '@nangohq/logs';
+import { baseUrl, Err, Ok, report } from '@nangohq/utils';
+
+import * as agentSessionService from './agentSession.service.js';
+import * as agentSessionConnectionsService from './agentSessionConnections.service.js';
+import * as agentSessionToolsetService from './agentSessionToolset.service.js';
+
+import type { LogContextOrigin } from '@nangohq/logs';
+import type {
+    AgentSession,
+    AgentSessionCompiledToolset,
+    AgentSessionCreationErrorCode,
+    AgentSessionMetaTools,
+    AgentSessionMetaToolsSummary,
+    AgentSessionPinnedTools,
+    AgentSessionResolvedConnections,
+    AgentSessionTenantConnections,
+    AgentSessionToolsetPolicy,
+    AgentSessionToolsetSummary,
+    DBEnvironment,
+    DBTeam
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+const MIN_EXPIRES_IN_MS = 60 * 1000;
+const MAX_EXPIRES_IN_MS = 15 * 24 * 60 * 60 * 1000;
+const DEFAULT_EXPIRES_IN_MS = MAX_EXPIRES_IN_MS;
+
+const EXPIRES_IN_PATTERN = /^([1-9]\d*)([smhd])$/;
+
+const EXPIRES_IN_UNITS_IN_MS: Record<string, number> = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000
+};
+
+const META_TOOLS = ['nango_tool_search', 'nango_execute'] as const;
+
+const DEFAULT_META_TOOLS: AgentSessionMetaTools = { nangoToolSearch: true, nangoExecute: true };
+
+export const agentSessionExpiresInSchema = z
+    .string()
+    .transform((value, ctx) => {
+        const ms = expiresInToMs(value);
+        if (ms === null) {
+            ctx.addIssue({ code: 'custom', message: 'expires_in must be a positive integer followed by s, m, h or d, for example 1h' });
+            return z.NEVER;
+        }
+
+        return ms;
+    })
+    .refine((ms) => ms >= MIN_EXPIRES_IN_MS, { message: 'expires_in cannot be shorter than 60s' })
+    .refine((ms) => ms <= MAX_EXPIRES_IN_MS, { message: 'expires_in cannot exceed 15d' });
+
+export type AgentSessionCreationFailureCode = AgentSessionCreationErrorCode | 'server_error';
+
+export class AgentSessionCreationError extends Error {
+    public readonly code: AgentSessionCreationFailureCode;
+    public readonly payload: Record<string, unknown>;
+
+    constructor({
+        code,
+        message,
+        payload,
+        cause
+    }: {
+        code: AgentSessionCreationFailureCode;
+        message: string;
+        payload?: Record<string, unknown>;
+        cause?: unknown;
+    }) {
+        super(message, { cause });
+        this.name = 'AgentSessionCreationError';
+        this.code = code;
+        this.payload = payload ?? {};
+    }
+}
+
+export interface CreateAgentSessionParams {
+    account: DBTeam;
+    environment: DBEnvironment;
+    connections: AgentSessionTenantConnections;
+    toolset: AgentSessionToolsetPolicy | undefined;
+    pinnedTools: AgentSessionPinnedTools | undefined;
+    metaTools: Record<string, boolean> | undefined;
+    expiresInMs: number | undefined;
+}
+
+export interface CreatedAgentSession {
+    session: AgentSession;
+    token: string;
+    mcpUrl: string;
+    toolset: Record<string, AgentSessionToolsetSummary>;
+    metaTools: AgentSessionMetaToolsSummary;
+}
+
+/**
+ * Every entry point that creates a session goes through here, so the session created operation and
+ * the creation error codes stay in one place.
+ */
+export async function createAgentSession(params: CreateAgentSessionParams): Promise<Result<CreatedAgentSession, AgentSessionCreationError>> {
+    const { account, environment } = params;
+    const logCtx = await logContextGetter.create(
+        { operation: { type: 'agent_session', action: 'create' } },
+        { account, environment, meta: { requested: requestedConfig(params) } }
+    );
+
+    try {
+        const created = await runCreation(params, logCtx);
+        if (created.isErr()) {
+            void logCtx.error(created.error.message, { code: created.error.code, payload: created.error.payload });
+            await logCtx.failed();
+            return created;
+        }
+
+        await logCtx.enrichOperation({
+            actor: { kind: 'session', id: created.value.session.id },
+            meta: {
+                requested: requestedConfig(params),
+                resolvedConnections: created.value.session.resolvedConnections,
+                toolset: created.value.session.compiledToolset,
+                metaTools: created.value.session.metaTools,
+                expiresAt: created.value.session.expiresAt.toISOString()
+            }
+        });
+        void logCtx.info('Agent session created');
+        await logCtx.success();
+
+        return created;
+    } catch (err) {
+        void logCtx.error('Failed to create the agent session', { error: err });
+        await logCtx.failed();
+        throw err;
+    }
+}
+
+export function expiresInToMs(expiresIn: string): number | null {
+    const match = EXPIRES_IN_PATTERN.exec(expiresIn);
+    if (!match) {
+        return null;
+    }
+
+    const [, amount, unit] = match;
+    const unitInMs = unit ? EXPIRES_IN_UNITS_IN_MS[unit] : undefined;
+
+    return unitInMs ? Number(amount) * unitInMs : null;
+}
+
+export function toolsetSummary(
+    toolset: AgentSessionCompiledToolset,
+    resolvedConnections: AgentSessionResolvedConnections
+): Record<string, AgentSessionToolsetSummary> {
+    return Object.fromEntries(
+        Object.entries(toolset).map(([integrationId, integration]) => [
+            integrationId,
+            {
+                connected: Object.hasOwn(resolvedConnections, integrationId),
+                tools_pinned: integration.pinned.length,
+                tools_searchable: integration.searchable.length
+            }
+        ])
+    );
+}
+
+async function runCreation(params: CreateAgentSessionParams, logCtx: LogContextOrigin): Promise<Result<CreatedAgentSession, AgentSessionCreationError>> {
+    const { account, environment } = params;
+
+    const metaTools = parseMetaTools(params.metaTools);
+    if (metaTools.unknown.length > 0) {
+        return Err(
+            new AgentSessionCreationError({
+                code: 'unknown_meta_tool',
+                message: `${metaTools.unknown.length} ${metaTools.unknown.length === 1 ? 'key is' : 'keys are'} not a meta tool Nango ships. Supported meta tools are ${META_TOOLS.join(', ')}.`,
+                payload: { meta_tools: metaTools.unknown }
+            })
+        );
+    }
+
+    const resolvedConnections = await agentSessionConnectionsService.resolveTenantConnections({
+        environmentId: environment.id,
+        connections: params.connections
+    });
+    if (resolvedConnections.isErr()) {
+        return Err(rejected(resolvedConnections.error));
+    }
+
+    const compiledToolset = await agentSessionToolsetService.compileToolset({
+        environmentId: environment.id,
+        toolset: params.toolset,
+        pinnedTools: params.pinnedTools,
+        connectedIntegrations: Object.keys(resolvedConnections.value)
+    });
+    if (compiledToolset.isErr()) {
+        return Err(rejected(compiledToolset.error));
+    }
+
+    const session = await agentSessionService.createAgentSession(db.knex, {
+        accountId: account.id,
+        environmentId: environment.id,
+        resolvedConnections: resolvedConnections.value,
+        compiledToolset: compiledToolset.value,
+        metaTools: metaTools.applied,
+        expiresAt: new Date(Date.now() + (params.expiresInMs ?? DEFAULT_EXPIRES_IN_MS))
+    });
+    if (session.isErr()) {
+        report(session.error);
+        return Err(new AgentSessionCreationError({ code: 'server_error', message: 'Failed to create agent session', cause: session.error }));
+    }
+
+    const token = await agentSessionService.createAgentSessionToken(db.knex, session.value);
+    if (token.isErr()) {
+        // A session no token can reach is unusable, so it is ended rather than left to expire.
+        const ended = await agentSessionService.terminateAgentSession(db.knex, {
+            id: session.value.id,
+            accountId: account.id,
+            environmentId: environment.id,
+            reason: 'terminated'
+        });
+        if (ended.isErr()) {
+            void logCtx.error('Failed to end the agent session left behind by the token failure', { error: ended.error, sessionId: session.value.id });
+        }
+
+        report(token.error);
+        return Err(new AgentSessionCreationError({ code: 'server_error', message: 'Failed to create agent session token', cause: token.error }));
+    }
+
+    return Ok({
+        session: session.value,
+        token: token.value.token,
+        mcpUrl: `${baseUrl}/session/${session.value.id}/mcp`,
+        toolset: toolsetSummary(session.value.compiledToolset, session.value.resolvedConnections),
+        metaTools: {
+            nango_tool_search: session.value.metaTools.nangoToolSearch,
+            nango_execute: session.value.metaTools.nangoExecute
+        }
+    });
+}
+
+function parseMetaTools(requested: Record<string, boolean> | undefined): { applied: AgentSessionMetaTools; unknown: string[] } {
+    const unknown = Object.keys(requested ?? {}).filter((key) => !META_TOOLS.includes(key as (typeof META_TOOLS)[number]));
+
+    return {
+        applied: {
+            nangoToolSearch: requested?.['nango_tool_search'] ?? DEFAULT_META_TOOLS.nangoToolSearch,
+            nangoExecute: requested?.['nango_execute'] ?? DEFAULT_META_TOOLS.nangoExecute
+        },
+        unknown
+    };
+}
+
+function rejected(error: { code: AgentSessionCreationErrorCode; message: string; payload: Record<string, unknown> }): AgentSessionCreationError {
+    return new AgentSessionCreationError({ code: error.code, message: error.message, payload: error.payload });
+}
+
+function requestedConfig(params: CreateAgentSessionParams): Record<string, unknown> {
+    return {
+        connections: params.connections,
+        toolset: params.toolset,
+        pinnedTools: params.pinnedTools,
+        metaTools: params.metaTools,
+        expiresInMs: params.expiresInMs
+    };
+}

--- a/packages/server/lib/services/agentSessionCreation.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionCreation.service.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { expiresInToMs, toolsetSummary } from './postSessions.js';
+import { expiresInToMs, toolsetSummary } from './agentSessionCreation.service.js';
 
 describe('expiresInToMs', () => {
     it.each([

--- a/packages/types/lib/agent/api.ts
+++ b/packages/types/lib/agent/api.ts
@@ -1,0 +1,97 @@
+import type { ApiEndpoint, ApiError } from '../api.js';
+import type { Tags } from '../db.js';
+import type {
+    AgentSessionAmbiguousConnectionsPayload,
+    AgentSessionPinnedConnectionNotMatchedPayload,
+    AgentSessionUnknownPinnedConnectionsPayload
+} from './connections.js';
+import type {
+    AgentSessionToolsNotInToolsetPayload,
+    AgentSessionUnknownIntegrationsPayload,
+    AgentSessionUnknownToolsPayload,
+    AgentSessionUnsupportedFunctionTypesPayload
+} from './toolset.js';
+
+export interface AgentSessionToolListInput {
+    tools: string[];
+}
+
+export type AgentSessionIntegrationPolicyInput =
+    | '*'
+    | {
+          allow?: AgentSessionToolListInput | '*' | undefined;
+          deny?: AgentSessionToolListInput | undefined;
+      };
+
+export interface PostAgentSessionsBody {
+    tenant: {
+        connections: {
+            any?: { tags: Tags }[] | undefined;
+            pinned?: { integration_id: string; connection_id: string }[] | undefined;
+        };
+    };
+    toolset?: '*' | Record<string, AgentSessionIntegrationPolicyInput> | undefined;
+    pinned_tools?: Record<string, string[]> | undefined;
+    meta_tools?: Record<string, boolean> | undefined;
+    expires_in?: string | undefined;
+}
+
+export interface AgentSessionToolsetSummary {
+    connected: boolean;
+    tools_pinned: number;
+    tools_searchable: number;
+}
+
+export interface AgentSessionMetaToolsSummary {
+    nango_tool_search: boolean;
+    nango_execute: boolean;
+}
+
+export interface AgentSessionUnknownMetaToolsPayload {
+    meta_tools: string[];
+}
+
+export type AgentSessionCreationErrorCode =
+    | 'ambiguous_connections'
+    | 'unknown_pinned_connection'
+    | 'pinned_connection_not_matched'
+    | 'unknown_integration'
+    | 'unknown_tool'
+    | 'unsupported_function_type'
+    | 'tool_not_in_toolset'
+    | 'unknown_meta_tool';
+
+/**
+ * The payload is not correlated to the code by the compiler on purpose: the resolver and the
+ * toolset compiler both erase theirs to a plain record on the error they raise, so a
+ * discriminated union here would only be a cast at the controller.
+ */
+export type AgentSessionCreationErrorPayload =
+    | AgentSessionAmbiguousConnectionsPayload
+    | AgentSessionUnknownPinnedConnectionsPayload
+    | AgentSessionPinnedConnectionNotMatchedPayload
+    | AgentSessionUnknownIntegrationsPayload
+    | AgentSessionUnknownToolsPayload
+    | AgentSessionUnsupportedFunctionTypesPayload
+    | AgentSessionToolsNotInToolsetPayload
+    | AgentSessionUnknownMetaToolsPayload;
+
+export type PostAgentSessionsCreationError = ApiError<AgentSessionCreationErrorCode, undefined, AgentSessionCreationErrorPayload>;
+
+export type PostAgentSessions = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Method: 'POST';
+    Path: '/sessions';
+    Body: PostAgentSessionsBody;
+    Error: PostAgentSessionsCreationError;
+    Success: {
+        data: {
+            session_id: string;
+            session_token: string;
+            mcp_url: string;
+            expires_at: string;
+            toolset: Record<string, AgentSessionToolsetSummary>;
+            meta_tools: AgentSessionMetaToolsSummary;
+        };
+    };
+}>;

--- a/packages/types/lib/agent/api.ts
+++ b/packages/types/lib/agent/api.ts
@@ -1,10 +1,6 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 import type { Tags } from '../db.js';
-import type {
-    AgentSessionAmbiguousConnectionsPayload,
-    AgentSessionPinnedConnectionNotMatchedPayload,
-    AgentSessionUnknownPinnedConnectionsPayload
-} from './connections.js';
+import type { AgentSessionUnknownPinnedConnectionsPayload } from './connections.js';
 import type {
     AgentSessionToolsNotInToolsetPayload,
     AgentSessionUnknownIntegrationsPayload,
@@ -51,6 +47,33 @@ export interface AgentSessionUnknownMetaToolsPayload {
     meta_tools: string[];
 }
 
+/**
+ * Creating a session does not require the connections read scope, so a returned candidate names the
+ * connection and nothing else. The tags that made it a candidate are on the session created
+ * operation, which is where an ambiguity gets debugged.
+ */
+export interface AgentSessionReturnedCandidate {
+    connection_id: string;
+}
+
+export interface AgentSessionAmbiguousConnectionsReply {
+    integrations: Record<
+        string,
+        {
+            match_count: number;
+            candidates: AgentSessionReturnedCandidate[];
+        }
+    >;
+}
+
+export interface AgentSessionPinnedConnectionNotMatchedReply {
+    pinned: {
+        integration_id: string;
+        connection_id: string;
+        candidates: AgentSessionReturnedCandidate[];
+    }[];
+}
+
 export type AgentSessionCreationErrorCode =
     | 'ambiguous_connections'
     | 'unknown_pinned_connection'
@@ -66,9 +89,9 @@ export type AgentSessionCreationErrorCode =
  * carries it as a plain record, so a discriminated union here would only be a cast at the caller.
  */
 export type AgentSessionCreationErrorPayload =
-    | AgentSessionAmbiguousConnectionsPayload
+    | AgentSessionAmbiguousConnectionsReply
     | AgentSessionUnknownPinnedConnectionsPayload
-    | AgentSessionPinnedConnectionNotMatchedPayload
+    | AgentSessionPinnedConnectionNotMatchedReply
     | AgentSessionUnknownIntegrationsPayload
     | AgentSessionUnknownToolsPayload
     | AgentSessionUnsupportedFunctionTypesPayload

--- a/packages/types/lib/agent/api.ts
+++ b/packages/types/lib/agent/api.ts
@@ -62,9 +62,8 @@ export type AgentSessionCreationErrorCode =
     | 'unknown_meta_tool';
 
 /**
- * The payload is not correlated to the code by the compiler on purpose: the resolver and the
- * toolset compiler both erase theirs to a plain record on the error they raise, so a
- * discriminated union here would only be a cast at the controller.
+ * The payload is not correlated to the code by the compiler on purpose. AgentSessionCreationError
+ * carries it as a plain record, so a discriminated union here would only be a cast at the caller.
  */
 export type AgentSessionCreationErrorPayload =
     | AgentSessionAmbiguousConnectionsPayload

--- a/packages/types/lib/agent/session.ts
+++ b/packages/types/lib/agent/session.ts
@@ -2,8 +2,7 @@ import type { AgentSessionResolvedConnections } from './connections.js';
 import type { AgentSessionCompiledToolset } from './toolset.js';
 
 export interface AgentSessionMetaTools {
-    readonly nangoProxy: boolean;
-    readonly nangoSearch: boolean;
+    readonly nangoToolSearch: boolean;
     readonly nangoExecute: boolean;
 }
 

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -21,6 +21,8 @@ export const API_KEY_SCOPES = [
     'environment:connections:delete',
     // Connect Sessions
     'environment:connect_sessions:write',
+    // Agent Sessions
+    'environment:agent_sessions:write',
     // Syncs
     'environment:syncs:read',
     'environment:syncs:execute',

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -19,6 +19,7 @@ import type {
 } from './account/api.js';
 import type { GetAsyncActionResult, GetPublicV1, PostInternalTriggerFunction, PostPublicTriggerAction } from './action/api.js';
 import type { PostImpersonate } from './admin/http.api.js';
+import type { PostAgentSessions } from './agent/api.js';
 import type { EndpointMethod } from './api.js';
 import type { GetAuditTrail, GetAuditTrailExport } from './audit-trail/api.js';
 import type {
@@ -166,6 +167,7 @@ export type PublicApiEndpoints =
     | GetPublicIntegration
     | DeletePublicIntegration
     | PostConnectSessions
+    | PostAgentSessions
     | PostPublicConnectSessionsReconnect
     | GetPublicConnections
     | GetPublicConnection

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -13,6 +13,7 @@ export type * from './logs/messages.js';
 export type * from './keystore/index.js';
 
 export type * from './action/api.js';
+export type * from './agent/api.js';
 export type * from './agent/connections.js';
 export type * from './agent/session.js';
 export type * from './agent/toolset.js';

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -66,6 +66,11 @@ export interface OperationDeploy {
     action: 'prebuilt' | 'custom';
 }
 
+export interface OperationAgentSession {
+    type: 'agent_session';
+    action: 'create';
+}
+
 export type OperationList =
     | OperationFunction
     | OperationSync
@@ -75,7 +80,8 @@ export type OperationList =
     | OperationOnEvents
     | OperationDeploy
     | OperationAuth
-    | OperationAdmin;
+    | OperationAdmin
+    | OperationAgentSession;
 /**
  * Who triggered an operation
  */

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
@@ -34,6 +34,7 @@ export const SCOPE_GROUPS: ScopeGroup[] = [
         ]
     },
     { group: 'Connect Sessions', items: [{ value: 'environment:connect_sessions:write', label: 'write' }] },
+    { group: 'Agent Sessions', items: [{ value: 'environment:agent_sessions:write', label: 'write' }] },
     {
         group: 'Syncs',
         items: [

--- a/packages/webapp/src/pages/Logs/constants.tsx
+++ b/packages/webapp/src/pages/Logs/constants.tsx
@@ -156,11 +156,13 @@ export const typesOptions: FilterOption<SearchOperationsType>[] = [
         value: 'function',
         label: 'Function',
         children: [{ label: 'Function invoked', value: 'function:invoke' }]
-    }
+    },
+    { value: 'agent_session', label: 'Agent session' }
 ];
 export const typesList = Object.keys({
     'action:run': null,
     'admin:impersonation': null,
+    'agent_session:create': null,
     'auth:connection_test': null,
     'auth:create_connection': null,
     'auth:post_connection': null,
@@ -188,6 +190,7 @@ export const typesList = Object.keys({
     'function:invoke': null,
     action: null,
     admin: null,
+    agent_session: null,
     all: null,
     auth: null,
     deploy: null,


### PR DESCRIPTION
NAN-6597

Adds an env-key endpoint to create an agent session, under a new `environment:agent_sessions:write` scope. It resolves the tenant into one connection per integration, compiles the toolset against what the environment has deployed, and returns the session with its token and MCP url.

```
POST /sessions
{
  "tenant": { "connections": { "any": [{ "tags": { "tenant": "acme", "workspace": "marketing" } }] } },
  "toolset": { "notion": { "allow": { "tools": ["read_doc", "upsert_doc"] } }, "slack": "*" },
  "pinned_tools": { "notion": ["read_doc"] },
  "meta_tools": { "nango_execute": false },
  "expires_in": "2h"
}

201
{
  "data": {
    "session_id": "...",
    "session_token": "nango_agent_session_...",
    "mcp_url": "https://api.nango.dev/session/{id}/mcp",
    "expires_at": "...",
    "toolset": {
      "notion": { "connected": true, "tools_pinned": 1, "tools_searchable": 1 },
      "slack":  { "connected": true, "tools_pinned": 0, "tools_searchable": 1 }
    },
    "meta_tools": { "nango_tool_search": true, "nango_execute": false }
  }
}
```

Creation failures are 400s carrying a machine readable payload: `ambiguous_connections`, `unknown_pinned_connection`, `pinned_connection_not_matched`, `unknown_integration`, `unknown_tool`, `unsupported_function_type`, `tool_not_in_toolset`, `unknown_meta_tool`. No session is created on any of them.

Also adds an `agent_session` operation type, so a created session shows up in the logs alongside what the agent goes on to do.

