### PR TITLE
feat(server): Connection deleted webhook

### DIFF
--- a/docs/guides/platform/webhooks-from-nango.mdx
+++ b/docs/guides/platform/webhooks-from-nango.mdx
@@ -334,7 +334,7 @@ Payload received following a connection deletion:
 ```
 
 <Note>
-  This webhook is only sent when a connection is deleted directly through the dashboard or the API (`DELETE` a single connection). It is not sent for bulk deletions caused by deleting an integration or environment, nor for the automatic cleanup of connections that were already soft-deleted.
+  This webhook is only sent when a connection is deleted directly through the dashboard or the API. It is not sent for bulk deletions caused by deleting an integration or environment.
 </Note>
 
 ### Sync webhooks

--- a/docs/guides/platform/webhooks-from-nango.mdx
+++ b/docs/guides/platform/webhooks-from-nango.mdx
@@ -259,6 +259,7 @@ All `operation` values are:
 - `creation`: a new connection has been created
 - `override`: a connection has been re-authorized
 - `refresh`: an OAuth connection's access token has failed to refresh, or has recovered after a previous failure
+- `deletion`: a connection has been deleted
 
 Payload received following a refresh token error:
 
@@ -310,6 +311,30 @@ Nango retries refreshing on its periodic cycle, so a single refresh failure does
 
 <Note>
   This recovery webhook is only sent when a refresh succeeds after a previous refresh failure — not on every routine successful refresh. It's gated by the same webhook setting as refresh failures.
+</Note>
+
+Payload received following a connection deletion:
+
+```json
+{
+    "type": "auth",
+    "operation": "deletion",
+    "connectionId": "<your-connection-id>",
+    "authMode": "OAUTH2 | BASIC | API_KEY | ...",
+    "providerConfigKey": "<your-integration-id>",
+    "provider": "<your-provider-key>",
+    "environment": "DEV | PROD | ...",
+    "success": true,
+    "tags": {
+        "end_user_id": "<your-end-user-id>",
+        "end_user_email": "<your-end-user-email>",
+        "organization_id": "<your-organization-id>"
+    }
+}
+```
+
+<Note>
+  This webhook is only sent when a connection is deleted directly through the dashboard or the API (`DELETE` a single connection). It is not sent for bulk deletions caused by deleting an integration or environment, nor for the automatic cleanup of connections that were already soft-deleted.
 </Note>
 
 ### Sync webhooks

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7563,6 +7563,7 @@ All `operation` values are:
 - `creation`: a new connection has been created
 - `override`: a connection has been re-authorized
 - `refresh`: an OAuth connection's access token has failed to refresh, or has recovered after a previous failure
+- `deletion`: a connection has been deleted
 
 Payload received following a refresh token error:
 
@@ -7614,6 +7615,30 @@ Nango retries refreshing on its periodic cycle, so a single refresh failure does
 
 <Note>
   This recovery webhook is only sent when a refresh succeeds after a previous refresh failure — not on every routine successful refresh. It's gated by the same webhook setting as refresh failures.
+</Note>
+
+Payload received following a connection deletion:
+
+```json
+{
+    "type": "auth",
+    "operation": "deletion",
+    "connectionId": "<your-connection-id>",
+    "authMode": "OAUTH2 | BASIC | API_KEY | ...",
+    "providerConfigKey": "<your-integration-id>",
+    "provider": "<your-provider-key>",
+    "environment": "DEV | PROD | ...",
+    "success": true,
+    "tags": {
+        "end_user_id": "<your-end-user-id>",
+        "end_user_email": "<your-end-user-email>",
+        "organization_id": "<your-organization-id>"
+    }
+}
+```
+
+<Note>
+  This webhook is only sent when a connection is deleted directly through the dashboard or the API (`DELETE` a single connection). It is not sent for bulk deletions caused by deleting an integration or environment, nor for the automatic cleanup of connections that were already soft-deleted.
 </Note>
 
 ### Sync webhooks

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7638,7 +7638,7 @@ Payload received following a connection deletion:
 ```
 
 <Note>
-  This webhook is only sent when a connection is deleted directly through the dashboard or the API (`DELETE` a single connection). It is not sent for bulk deletions caused by deleting an integration or environment, nor for the automatic cleanup of connections that were already soft-deleted.
+  This webhook is only sent when a connection is deleted directly through the dashboard or the API. It is not sent for bulk deletions caused by deleting an integration or environment.
 </Note>
 
 ### Sync webhooks

--- a/packages/database/lib/migrations/20260824194800_connection_deletion_webhook.cjs
+++ b/packages/database/lib/migrations/20260824194800_connection_deletion_webhook.cjs
@@ -1,0 +1,11 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_external_webhooks" ADD COLUMN "on_connection_deletion" boolean DEFAULT false`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/logs/lib/models/helpers.ts
+++ b/packages/logs/lib/models/helpers.ts
@@ -126,6 +126,7 @@ export const operationTypeToMessage: Record<ConcatOperationList, string> = {
     'webhook:sync': 'Sync completion webhooks',
     'webhook:connection_create': 'Connection creation webhooks',
     'webhook:connection_refresh': 'Token refresh webhooks',
+    'webhook:connection_delete': 'Connection deletion webhooks',
     'events:post_connection_creation': 'Event-based executions',
     'events:pre_connection_deletion': 'Event-based executions',
     'events:validate_connection': 'Event-based executions',

--- a/packages/server/lib/controllers/connection/connectionId/deleteConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/deleteConnection.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
 import { configService, connectionService, pubsub } from '@nangohq/shared';
-import { zodErrorToHTTP } from '@nangohq/utils';
+import { report, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
 import { preConnectionDeletion } from '../../../hooks/connection/on/pre-connection-deletion.js';
@@ -49,6 +49,12 @@ export const deletePublicConnection = asyncWrapperWithEnvironment<DeletePublicCo
         return;
     }
 
+    const providerConfig = await configService.getProviderConfig(query.provider_config_key, environment.id);
+    if (!providerConfig) {
+        res.status(400).send({ error: { code: 'unknown_provider_config' } });
+        return;
+    }
+
     const preDeletionHook = () =>
         preConnectionDeletion({
             team,
@@ -66,15 +72,14 @@ export const deletePublicConnection = asyncWrapperWithEnvironment<DeletePublicCo
     });
 
     if (deleted > 0) {
-        const providerConfig = await configService.getProviderConfig(query.provider_config_key, environment.id);
-        if (providerConfig) {
-            void connectionDeleted({
-                connection,
-                environment,
-                account: team,
-                config: providerConfig
-            });
-        }
+        void connectionDeleted({
+            connection,
+            environment,
+            account: team,
+            config: providerConfig
+        }).catch((err) => {
+            report(new Error('connection_deletion_webhook_delivery_failed', { cause: err }), { id: connection.id });
+        });
     }
 
     void pubsub.publisher.publish({

--- a/packages/server/lib/controllers/connection/connectionId/deleteConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/deleteConnection.ts
@@ -1,11 +1,12 @@
 import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
-import { connectionService, pubsub } from '@nangohq/shared';
+import { configService, connectionService, pubsub } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
 import { preConnectionDeletion } from '../../../hooks/connection/on/pre-connection-deletion.js';
+import { connectionDeleted } from '../../../hooks/hooks.js';
 import { slackService } from '../../../services/slack.js';
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
@@ -63,6 +64,18 @@ export const deletePublicConnection = asyncWrapperWithEnvironment<DeletePublicCo
         slackService,
         preDeletionHook
     });
+
+    if (deleted > 0) {
+        const providerConfig = await configService.getProviderConfig(query.provider_config_key, environment.id);
+        if (providerConfig) {
+            void connectionDeleted({
+                connection,
+                environment,
+                account: team,
+                config: providerConfig
+            });
+        }
+    }
 
     void pubsub.publisher.publish({
         subject: 'usage',

--- a/packages/server/lib/controllers/connection/connectionId/deleteConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/deleteConnection.ts
@@ -1,8 +1,8 @@
 import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
-import { configService, connectionService, pubsub } from '@nangohq/shared';
-import { report, zodErrorToHTTP } from '@nangohq/utils';
+import { connectionService, pubsub } from '@nangohq/shared';
+import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
 import { preConnectionDeletion } from '../../../hooks/connection/on/pre-connection-deletion.js';
@@ -49,12 +49,6 @@ export const deletePublicConnection = asyncWrapperWithEnvironment<DeletePublicCo
         return;
     }
 
-    const providerConfig = await configService.getProviderConfig(query.provider_config_key, environment.id);
-    if (!providerConfig) {
-        res.status(400).send({ error: { code: 'unknown_provider_config' } });
-        return;
-    }
-
     const preDeletionHook = () =>
         preConnectionDeletion({
             team,
@@ -76,9 +70,7 @@ export const deletePublicConnection = asyncWrapperWithEnvironment<DeletePublicCo
             connection,
             environment,
             account: team,
-            config: providerConfig
-        }).catch((err) => {
-            report(new Error('connection_deletion_webhook_delivery_failed', { cause: err }), { id: connection.id });
+            providerConfigKey: query.provider_config_key
         });
     }
 

--- a/packages/server/lib/controllers/mcp/logs/schema.ts
+++ b/packages/server/lib/controllers/mcp/logs/schema.ts
@@ -138,9 +138,11 @@ const webhookOperationFilterSchema = z
     .object({
         type: z.literal('webhook'),
         actions: z
-            .array(z.enum(['incoming', 'forward', 'sync', 'connection_create', 'connection_refresh'] satisfies OperationWebhook['action'][]))
+            .array(
+                z.enum(['incoming', 'forward', 'sync', 'connection_create', 'connection_refresh', 'connection_delete'] satisfies OperationWebhook['action'][])
+            )
             .min(1)
-            .max(5)
+            .max(6)
             .optional()
     })
     .strict();

--- a/packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts
@@ -1,8 +1,8 @@
 import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
-import { configService, connectionService, pubsub } from '@nangohq/shared';
-import { report, zodErrorToHTTP } from '@nangohq/utils';
+import { connectionService, pubsub } from '@nangohq/shared';
+import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
 import { preConnectionDeletion } from '../../../../hooks/connection/on/pre-connection-deletion.js';
@@ -50,12 +50,6 @@ export const deleteConnection = asyncWrapperWithEnvironment<DeleteConnection>(as
         return;
     }
 
-    const providerConfig = await configService.getProviderConfig(query.provider_config_key, environment.id);
-    if (!providerConfig) {
-        res.status(400).send({ error: { code: 'unknown_provider_config' } });
-        return;
-    }
-
     const preDeletionHook = () =>
         preConnectionDeletion({
             team,
@@ -77,9 +71,7 @@ export const deleteConnection = asyncWrapperWithEnvironment<DeleteConnection>(as
             connection,
             environment,
             account: team,
-            config: providerConfig
-        }).catch((err) => {
-            report(new Error('connection_deletion_webhook_delivery_failed', { cause: err }), { id: connection.id });
+            providerConfigKey: query.provider_config_key
         });
     }
 

--- a/packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts
@@ -1,11 +1,12 @@
 import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
-import { connectionService, pubsub } from '@nangohq/shared';
+import { configService, connectionService, pubsub } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
 import { preConnectionDeletion } from '../../../../hooks/connection/on/pre-connection-deletion.js';
+import { connectionDeleted } from '../../../../hooks/hooks.js';
 import { slackService } from '../../../../services/slack.js';
 import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../../utils/utils.js';
@@ -65,6 +66,18 @@ export const deleteConnection = asyncWrapperWithEnvironment<DeleteConnection>(as
         orchestrator,
         preDeletionHook
     });
+
+    if (deleted > 0) {
+        const providerConfig = await configService.getProviderConfig(query.provider_config_key, environment.id);
+        if (providerConfig) {
+            void connectionDeleted({
+                connection,
+                environment,
+                account: team,
+                config: providerConfig
+            });
+        }
+    }
 
     void pubsub.publisher.publish({
         subject: 'usage',

--- a/packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
 import { configService, connectionService, pubsub } from '@nangohq/shared';
-import { zodErrorToHTTP } from '@nangohq/utils';
+import { report, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
 import { preConnectionDeletion } from '../../../../hooks/connection/on/pre-connection-deletion.js';
@@ -45,9 +45,14 @@ export const deleteConnection = asyncWrapperWithEnvironment<DeleteConnection>(as
     const query: DeleteConnection['Querystring'] = valQuery.data;
 
     const { success, response: connection } = await connectionService.getConnection(params.connectionId, query.provider_config_key, environment.id);
-
     if (!success || !connection) {
         res.status(400).send({ error: { code: 'unknown_connection' } });
+        return;
+    }
+
+    const providerConfig = await configService.getProviderConfig(query.provider_config_key, environment.id);
+    if (!providerConfig) {
+        res.status(400).send({ error: { code: 'unknown_provider_config' } });
         return;
     }
 
@@ -68,15 +73,14 @@ export const deleteConnection = asyncWrapperWithEnvironment<DeleteConnection>(as
     });
 
     if (deleted > 0) {
-        const providerConfig = await configService.getProviderConfig(query.provider_config_key, environment.id);
-        if (providerConfig) {
-            void connectionDeleted({
-                connection,
-                environment,
-                account: team,
-                config: providerConfig
-            });
-        }
+        void connectionDeleted({
+            connection,
+            environment,
+            account: team,
+            config: providerConfig
+        }).catch((err) => {
+            report(new Error('connection_deletion_webhook_delivery_failed', { cause: err }), { id: connection.id });
+        });
     }
 
     void pubsub.publisher.publish({

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -90,6 +90,7 @@ export const getEnvironment = asyncWrapperWithEnvironment<GetEnvironment>(async 
                     on_sync_completion_always: false,
                     on_async_action_completion: false,
                     on_sync_error: false,
+                    on_connection_deletion: false,
                     primary_url: null,
                     secondary_url: null
                 }

--- a/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
+++ b/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
@@ -17,7 +17,8 @@ const validation = z
         on_auth_creation: z.boolean().optional(),
         on_auth_refresh_error: z.boolean().optional(),
         on_sync_error: z.boolean().optional(),
-        on_async_action_completion: z.boolean().optional()
+        on_async_action_completion: z.boolean().optional(),
+        on_connection_deletion: z.boolean().optional()
     })
     .strict();
 
@@ -59,6 +60,9 @@ export const patchWebhook = asyncWrapperWithEnvironment<PatchWebhook>(async (req
     }
     if (typeof body.on_async_action_completion !== 'undefined') {
         data.on_async_action_completion = body.on_async_action_completion;
+    }
+    if (typeof body.on_connection_deletion !== 'undefined') {
+        data.on_connection_deletion = body.on_connection_deletion;
     }
 
     if (Object.keys(data).length <= 0) {

--- a/packages/server/lib/controllers/v1/logs/searchOperations.ts
+++ b/packages/server/lib/controllers/v1/logs/searchOperations.ts
@@ -43,7 +43,8 @@ const validation = z
                     'webhook:forward',
                     'webhook:sync',
                     'webhook:connection_create',
-                    'webhook:connection_refresh'
+                    'webhook:connection_refresh',
+                    'webhook:connection_delete'
                 ])
             )
             .max(20)

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -243,7 +243,7 @@ export const connectionDeleted = async ({
 
         const webhookSettings = await externalWebhookService.get(environment.id);
         if (!webhookSettings) {
-            throw new Error('webhook_settings_not_found');
+            return;
         }
 
         const webhookSigningKey = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -235,20 +235,13 @@ export const connectionDeleted = async ({
     providerConfigKey: string;
 }): Promise<void> => {
     try {
-        const providerConfig = await configService.getProviderConfig(providerConfigKey, environment.id);
-        if (!providerConfig) {
-            return;
-        }
-
-        const provider = getProvider(providerConfig.provider);
-        if (!provider) {
-            return;
+        const providerConfig = (await configService.getProviderConfig(providerConfigKey, environment.id)) ?? undefined;
+        let provider: Provider | undefined;
+        if (providerConfig?.provider) {
+            provider = getProvider(providerConfig.provider) ?? undefined;
         }
 
         const webhookSettings = await externalWebhookService.get(environment.id);
-        if (!webhookSettings) {
-            return;
-        }
 
         const webhookSigningKey = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);
         if (webhookSigningKey.isErr()) {
@@ -260,7 +253,7 @@ export const connectionDeleted = async ({
             environment,
             secret: webhookSigningKey.value,
             webhookSettings,
-            auth_mode: provider.auth_mode,
+            auth_mode: provider?.auth_mode ?? 'unknown',
             operation: 'deletion',
             success: true,
             providerConfig,

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -2,6 +2,7 @@ import tracer from 'dd-trace';
 
 import db from '@nangohq/database';
 import {
+    configService,
     connectionService,
     customerKeyService,
     errorNotificationService,
@@ -226,15 +227,20 @@ export const connectionDeleted = async ({
     connection,
     environment,
     account,
-    config
+    providerConfigKey
 }: {
     connection: Pick<DBConnectionDecrypted, 'id' | 'connection_id' | 'provider_config_key' | 'environment_id'>;
     environment: DBEnvironment;
     account: DBTeam;
-    config: IntegrationConfig;
+    providerConfigKey: string;
 }): Promise<void> => {
     try {
-        const provider = getProvider(config.provider);
+        const providerConfig = await configService.getProviderConfig(providerConfigKey, environment.id);
+        if (!providerConfig) {
+            return;
+        }
+
+        const provider = getProvider(providerConfig.provider);
         if (!provider) {
             return;
         }
@@ -257,7 +263,7 @@ export const connectionDeleted = async ({
             auth_mode: provider.auth_mode,
             operation: 'deletion',
             success: true,
-            providerConfig: config,
+            providerConfig,
             account
         });
     } catch (err) {

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -242,6 +242,9 @@ export const connectionDeleted = async ({
         }
 
         const webhookSettings = await externalWebhookService.get(environment.id);
+        if (!webhookSettings) {
+            throw new Error('webhook_settings_not_found');
+        }
 
         const webhookSigningKey = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);
         if (webhookSigningKey.isErr()) {

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -6,6 +6,7 @@ import {
     customerKeyService,
     errorNotificationService,
     externalWebhookService,
+    getProvider,
     getProxyConfiguration,
     getServerOutboundUrlPolicy,
     makeDataTransferEvent,
@@ -218,6 +219,49 @@ export const connectionCreationFailed = async (
                 account
             });
         }
+    }
+};
+
+export const connectionDeleted = async ({
+    connection,
+    environment,
+    account,
+    config
+}: {
+    connection: Pick<DBConnectionDecrypted, 'id' | 'connection_id' | 'provider_config_key' | 'environment_id'>;
+    environment: DBEnvironment;
+    account: DBTeam;
+    config: IntegrationConfig;
+}): Promise<void> => {
+    try {
+        const provider = getProvider(config.provider);
+        if (!provider) {
+            return;
+        }
+
+        const webhookSettings = await externalWebhookService.get(environment.id);
+        if (!webhookSettings) {
+            return;
+        }
+
+        const webhookSigningKey = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);
+        if (webhookSigningKey.isErr()) {
+            throw webhookSigningKey.error;
+        }
+
+        void sendAuthWebhook({
+            connection,
+            environment,
+            secret: webhookSigningKey.value,
+            webhookSettings,
+            auth_mode: provider.auth_mode,
+            operation: 'deletion',
+            success: true,
+            providerConfig: config,
+            account
+        });
+    } catch (err) {
+        report(new Error('connection_deletion_webhook_failed', { cause: err }), { id: connection.id });
     }
 };
 

--- a/packages/shared/lib/services/environment.service.integration.test.ts
+++ b/packages/shared/lib/services/environment.service.integration.test.ts
@@ -72,7 +72,8 @@ describe('Environment service', () => {
             on_auth_creation: true,
             on_auth_refresh_error: true,
             on_sync_completion_always: true,
-            on_sync_error: true
+            on_sync_error: true,
+            on_connection_deletion: true
         });
     });
 

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -242,7 +242,8 @@ class EnvironmentService {
                         on_auth_creation: true,
                         on_auth_refresh_error: true,
                         on_sync_completion_always: true,
-                        on_sync_error: true
+                        on_sync_error: true,
+                        on_connection_deletion: true
                     }
                 });
 

--- a/packages/shared/lib/services/external-webhook.service.ts
+++ b/packages/shared/lib/services/external-webhook.service.ts
@@ -27,6 +27,7 @@ export async function update(
                 | 'on_sync_completion_always'
                 | 'on_sync_error'
                 | 'on_async_action_completion'
+                | 'on_connection_deletion'
             >
         >;
     }

--- a/packages/types/lib/auth/api.ts
+++ b/packages/types/lib/auth/api.ts
@@ -23,7 +23,7 @@ export interface AuthModes {
 
 export type AuthModeType = AuthModes[keyof AuthModes];
 
-export type AuthOperationType = 'creation' | 'override' | 'refresh' | 'unknown';
+export type AuthOperationType = 'creation' | 'override' | 'refresh' | 'deletion' | 'unknown';
 
 export interface OAuthAuthorizationMethod {
     BODY: 'body';

--- a/packages/types/lib/environment/api/webhook.ts
+++ b/packages/types/lib/environment/api/webhook.ts
@@ -16,6 +16,7 @@ export type PatchWebhook = ApiEndpoint<{
         on_auth_refresh_error?: boolean | undefined;
         on_sync_error?: boolean | undefined;
         on_async_action_completion?: boolean | undefined;
+        on_connection_deletion?: boolean | undefined;
     };
     Success: {
         success: boolean;

--- a/packages/types/lib/environment/db.ts
+++ b/packages/types/lib/environment/db.ts
@@ -66,6 +66,7 @@ export interface DBExternalWebhook extends Timestamps {
     on_auth_refresh_error: boolean;
     on_sync_error: boolean;
     on_async_action_completion: boolean;
+    on_connection_deletion: boolean;
 }
 
 export interface DBAPISecret extends Timestamps {

--- a/packages/types/lib/logs/messages.ts
+++ b/packages/types/lib/logs/messages.ts
@@ -58,7 +58,7 @@ export interface OperationAdmin {
 }
 export interface OperationWebhook {
     type: 'webhook';
-    action: 'incoming' | 'forward' | 'sync' | 'connection_create' | 'connection_refresh';
+    action: 'incoming' | 'forward' | 'sync' | 'connection_create' | 'connection_refresh' | 'connection_delete';
 }
 
 export interface OperationDeploy {

--- a/packages/types/lib/webhooks/api.ts
+++ b/packages/types/lib/webhooks/api.ts
@@ -51,7 +51,8 @@ export type NangoSyncWebhookBody = NangoSyncWebhookBodySuccess | NangoSyncWebhoo
 export interface NangoAuthWebhookBodyBase extends NangoWebhookBase {
     type: 'auth';
     connectionId: string;
-    authMode: AuthModeType;
+    /** 'unknown' when the connection's integration could no longer be resolved (e.g. it was deleted). */
+    authMode: AuthModeType | 'unknown';
     providerConfigKey: string;
     provider: string;
     environment: string;

--- a/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
@@ -43,6 +43,11 @@ const checkboxesConfig: CheckboxConfig[] = [
         label: 'Async Actions: completion',
         tooltip: 'If checked, a webhook will be sent when an async action completes.',
         stateKey: 'on_async_action_completion'
+    },
+    {
+        label: 'Auth: connection deletion webhooks',
+        tooltip: 'If checked, a webhook will be sent when a connection is deleted.',
+        stateKey: 'on_connection_deletion'
     }
 ];
 
@@ -77,6 +82,7 @@ export const WebhookCheckboxes: React.FC<CheckboxFormProps> = ({ env, checkboxSt
                 on_sync_completion_always: checkboxState['on_sync_completion_always'],
                 on_sync_error: checkboxState['on_sync_error'],
                 on_async_action_completion: checkboxState['on_async_action_completion'],
+                on_connection_deletion: checkboxState['on_connection_deletion'],
                 [name]: checked
             });
         } catch {

--- a/packages/webapp/src/pages/Logs/components/OperationTag.tsx
+++ b/packages/webapp/src/pages/Logs/components/OperationTag.tsx
@@ -41,6 +41,7 @@ export const OperationTag: React.FC<{ message: string; operation: SearchOperatio
                             {operation.action === 'connection_create' && <Link className="w-3.5 h-3.5" />}
                             {operation.action === 'sync' && <RefreshCw className="w-3.5 h-3.5" />}
                             {operation.action === 'connection_refresh' && <Lock className="w-3.5 h-3.5" />}
+                            {operation.action === 'connection_delete' && <Trash2 className="w-3.5 h-3.5" />}
                         </Tag>
                     )}
                 </div>

--- a/packages/webapp/src/pages/Logs/constants.tsx
+++ b/packages/webapp/src/pages/Logs/constants.tsx
@@ -145,7 +145,8 @@ export const typesOptions: FilterOption<SearchOperationsType>[] = [
             { label: 'External webhook forwarded', value: 'webhook:forward' },
             { label: 'Connection creation webhook', value: 'webhook:connection_create' },
             { label: 'Sync completion webhook', value: 'webhook:sync' },
-            { label: 'Token refresh webhook', value: 'webhook:connection_refresh' }
+            { label: 'Token refresh webhook', value: 'webhook:connection_refresh' },
+            { label: 'Connection deletion webhook', value: 'webhook:connection_delete' }
         ]
     },
     { value: 'action', label: 'Action' },
@@ -182,6 +183,7 @@ export const typesList = Object.keys({
     'sync:unpause': null,
     'webhook:connection_create': null,
     'webhook:connection_refresh': null,
+    'webhook:connection_delete': null,
     'webhook:forward': null,
     'webhook:incoming': null,
     'webhook:sync': null,

--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -28,6 +28,7 @@ const webhookSettings: DBExternalWebhook = {
     on_auth_refresh_error: true,
     on_sync_error: true,
     on_async_action_completion: true,
+    on_connection_deletion: true,
     created_at: new Date(),
     updated_at: new Date()
 };

--- a/packages/webhooks/lib/auth.ts
+++ b/packages/webhooks/lib/auth.ts
@@ -50,7 +50,7 @@ export async function sendAuth({
     environment: DBEnvironment;
     secret: DBAPISecret['secret'];
     webhookSettings: DBExternalWebhook | null;
-    auth_mode: AuthModeType;
+    auth_mode: AuthModeType | 'unknown';
     success: boolean;
     endUser?: InternalEndUser | null | undefined;
     error?: ErrorPayload;

--- a/packages/webhooks/lib/auth.ts
+++ b/packages/webhooks/lib/auth.ts
@@ -22,7 +22,15 @@ import type {
 const AUTH_OPERATION_TO_TYPE = {
     creation: 'auth_creation',
     override: 'auth_override',
-    refresh: 'auth_refresh'
+    refresh: 'auth_refresh',
+    deletion: 'auth_deletion'
+} as const;
+
+const AUTH_OPERATION_TO_LOG_ACTION = {
+    creation: 'connection_create',
+    override: 'connection_refresh',
+    refresh: 'connection_refresh',
+    deletion: 'connection_delete'
 } as const;
 
 export async function sendAuth({
@@ -108,7 +116,7 @@ export async function sendAuth({
         webhooks.push({ url: settings.secondary_url, type: 'secondary webhook url' });
     }
 
-    const action = operation === 'creation' ? 'connection_create' : 'connection_refresh';
+    const action = AUTH_OPERATION_TO_LOG_ACTION[operation];
     const logCtx = await logContextGetter.create(
         { operation: { type: 'webhook', action } },
         {

--- a/packages/webhooks/lib/auth.unit.test.ts
+++ b/packages/webhooks/lib/auth.unit.test.ts
@@ -42,6 +42,7 @@ const webhookSettings: DBExternalWebhook = {
     on_auth_refresh_error: true,
     on_sync_error: true,
     on_async_action_completion: true,
+    on_connection_deletion: true,
     created_at: new Date(),
     updated_at: new Date()
 };
@@ -317,6 +318,55 @@ describe('Webhooks: auth notification tests', () => {
             success: true,
             operation: 'refresh'
         });
+    });
+
+    it('Should send an auth webhook with operation deletion when on_connection_deletion is checked', async () => {
+        await sendAuth({
+            connection,
+            success: true,
+            environment: {
+                name: 'dev',
+                id: 1
+            } as DBEnvironment,
+            secret,
+            webhookSettings: {
+                ...webhookSettings,
+                secondary_url: '',
+                on_connection_deletion: true
+            },
+            providerConfig,
+            account,
+            auth_mode: 'OAUTH2',
+            operation: 'deletion'
+        });
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([{ url: primaryUrl, type: 'webhook url' }]);
+        expect(deliverMock.mock.calls[0]![0].body).toMatchObject({
+            type: 'auth',
+            operation: 'deletion',
+            success: true
+        });
+    });
+
+    it('Should not send an auth webhook with operation deletion when on_connection_deletion is not checked', async () => {
+        await sendAuth({
+            connection,
+            success: true,
+            environment: {
+                name: 'dev',
+                id: 1
+            } as DBEnvironment,
+            secret,
+            webhookSettings: {
+                ...webhookSettings,
+                on_connection_deletion: false
+            },
+            providerConfig,
+            account,
+            auth_mode: 'OAUTH2',
+            operation: 'deletion'
+        });
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
     it('sends only to the per-connection webhook URL override (env secondary is dropped)', async () => {

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -37,6 +37,7 @@ const webhookSettings: DBExternalWebhook = {
     on_auth_refresh_error: true,
     on_sync_error: true,
     on_async_action_completion: true,
+    on_connection_deletion: true,
     created_at: new Date(),
     updated_at: new Date()
 };

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -94,6 +94,7 @@ const webhookSettings: DBExternalWebhook = {
     on_auth_refresh_error: true,
     on_sync_error: true,
     on_async_action_completion: true,
+    on_connection_deletion: true,
     created_at: new Date(),
     updated_at: new Date()
 };

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -160,7 +160,7 @@ export const shouldSend = ({
 }: {
     webhookSettings: DBExternalWebhook;
     success: boolean;
-    type: 'auth_creation' | 'auth_refresh' | 'auth_override' | 'sync' | 'forward' | 'async_action';
+    type: 'auth_creation' | 'auth_refresh' | 'auth_override' | 'auth_deletion' | 'sync' | 'forward' | 'async_action';
 }): boolean => {
     const hasAnyWebhook = Boolean(webhookSettings.primary_url || webhookSettings.secondary_url);
 
@@ -177,6 +177,10 @@ export const shouldSend = ({
     }
 
     if (type === 'auth_refresh' && !webhookSettings.on_auth_refresh_error) {
+        return false;
+    }
+
+    if (type === 'auth_deletion' && !webhookSettings.on_connection_deletion) {
         return false;
     }
 

--- a/packages/webhooks/lib/utils.unit.test.ts
+++ b/packages/webhooks/lib/utils.unit.test.ts
@@ -4,7 +4,7 @@ import { axiosInstance, stringifyStable } from '@nangohq/utils';
 
 import { allowAllWebhookOutbound } from './helpers/setup.unit.js';
 import { TestWebhookServer } from './helpers/test.js';
-import { deliver, getHmacSignatureHeader, getSignatureHeaderUnsafe, resolveWebhookSettings } from './utils.js';
+import { deliver, getHmacSignatureHeader, getSignatureHeaderUnsafe, resolveWebhookSettings, shouldSend } from './utils.js';
 
 import type { DBAPISecret, DBExternalWebhook } from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
@@ -121,6 +121,7 @@ describe('resolveWebhookSettings', () => {
         on_auth_refresh_error: true,
         on_sync_error: true,
         on_async_action_completion: true,
+        on_connection_deletion: true,
         created_at: new Date(),
         updated_at: new Date()
     };
@@ -149,6 +150,41 @@ describe('resolveWebhookSettings', () => {
         resolveWebhookSettings(envSettings, 'https://dev-tunnel.example.com/hook');
         expect(envSettings.primary_url).toBe('https://env-primary.example.com/hook');
         expect(envSettings.secondary_url).toBe('https://env-secondary.example.com/hook');
+    });
+});
+
+describe('shouldSend', () => {
+    const baseSettings: DBExternalWebhook = {
+        id: 1,
+        environment_id: 1,
+        primary_url: 'https://example.com/hook',
+        secondary_url: null,
+        on_sync_completion_always: false,
+        on_auth_creation: false,
+        on_auth_refresh_error: false,
+        on_sync_error: false,
+        on_async_action_completion: false,
+        on_connection_deletion: false,
+        created_at: new Date(),
+        updated_at: new Date()
+    };
+
+    it('sends auth_deletion webhooks when on_connection_deletion is enabled', () => {
+        expect(shouldSend({ webhookSettings: { ...baseSettings, on_connection_deletion: true }, success: true, type: 'auth_deletion' })).toBe(true);
+    });
+
+    it('does not send auth_deletion webhooks when on_connection_deletion is disabled', () => {
+        expect(shouldSend({ webhookSettings: { ...baseSettings, on_connection_deletion: false }, success: true, type: 'auth_deletion' })).toBe(false);
+    });
+
+    it('does not send auth_deletion webhooks when no webhook URL is configured', () => {
+        expect(
+            shouldSend({
+                webhookSettings: { ...baseSettings, primary_url: null, secondary_url: null, on_connection_deletion: true },
+                success: true,
+                type: 'auth_deletion'
+            })
+        ).toBe(false);
     });
 });
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Adds connection webhook deletion so customers can take appropriate cleanup actions on a connection deletion event

<!-- Issue ticket number and link (if applicable) -->
[NAN-5591: feat(server): Connection deleted webhook](https://linear.app/nango/issue/NAN-5591/featserver-connection-deleted-webhook)

<!-- Testing instructions (skip if just adding/editing providers) -->
1. Configure your webhooks locally to point somewhere like [webhook.site](https://webhook.site/) or a local server for testing
2. Create a new connection if required
3. Delete connection 
4. Receive webhook:
{
  "operation": "deletion",
  "success": true,
  "type": "auth",
  ...
}
5. Check log for associated entry


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

