### PR TITLE
fix(onboarding): rank team suggestions by users on the matching domain

### DIFF
--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -64,6 +64,22 @@ describe('Account service', () => {
         return result.unwrap();
     }
 
+    async function addUser({ email, accountId, role = 'development_full_access' }: { email: string; accountId: number; role?: Role }): Promise<DBUser> {
+        const user = await userService.createUser({
+            email,
+            name: email,
+            account_id: accountId,
+            email_verified: true,
+            role
+        });
+
+        if (!user) {
+            throw new Error('Failed to create test user');
+        }
+
+        return user;
+    }
+
     describe('findAccountWithSameDomain', () => {
         it('does not suggest accounts for a free email domain', async () => {
             const current = await createAccountWithUser({ email: `${uuid()}@gmail.com` });
@@ -127,6 +143,36 @@ describe('Account service', () => {
             const noAdministrator = await createAccountWithUser({ email: `member@${domain}`, role: 'development_full_access' });
             await createPlan(suspendedCandidate.account.id, 'growth-v2');
             await createPlan(noAdministrator.account.id, 'growth-v2');
+
+            await expect(accountService.findAccountWithSameDomain({ email: current.user.email, currentAccountId: current.account.id })).resolves.toBeNull();
+        });
+
+        it('prefers the account with more users on the domain over a bigger paid account with a single one', async () => {
+            const domain = `${uuid()}.example.com`;
+            const current = await createAccountWithUser({ email: `new@${domain}` });
+            const strayCandidate = await createAccountWithUser({ email: `contractor@${domain}` });
+            const realCandidate = await createAccountWithUser({ email: `admin@${domain}` });
+            await createPlan(strayCandidate.account.id, 'growth-v2');
+            await createPlan(realCandidate.account.id, 'free');
+
+            await addUser({ email: `second@${domain}`, accountId: realCandidate.account.id });
+
+            // The stray candidate is paid and has more active members, but only one user on the domain.
+            await addUser({ email: `${uuid()}@another.example.com`, accountId: strayCandidate.account.id });
+            await addUser({ email: `${uuid()}@another.example.com`, accountId: strayCandidate.account.id });
+
+            await expect(accountService.findAccountWithSameDomain({ email: current.user.email, currentAccountId: current.account.id })).resolves.toEqual({
+                id: realCandidate.account.id,
+                name: realCandidate.account.name
+            });
+        });
+
+        it('excludes accounts without an active administrator on the matching domain', async () => {
+            const domain = `${uuid()}.example.com`;
+            const current = await createAccountWithUser({ email: `new@${domain}` });
+            const candidate = await createAccountWithUser({ email: `admin@${uuid()}.another.example.com` });
+            await createPlan(candidate.account.id, 'growth-v2');
+            await addUser({ email: `contractor@${domain}`, accountId: candidate.account.id });
 
             await expect(accountService.findAccountWithSameDomain({ email: current.user.email, currentAccountId: current.account.id })).resolves.toBeNull();
         });

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -162,14 +162,17 @@ class AccountService {
             return null;
         }
 
-        // Find eligible accounts with an active user from the same domain and an active administrator,
-        // excluding the user's current team. Prefer paid accounts, then accounts with more active members,
+        // Find eligible accounts with an active user from the same domain and an active administrator
+        // whose own email is on that domain, excluding the user's current team. Rank by how many active
+        // users share the domain first, since a single user from the domain is a weak signal on its own
+        // (contractors, ex-employees). Then prefer paid accounts, then accounts with more active members,
         // and finally the lowest account ID for a stable tie-breaker.
         const account = await db.knex
             .with('candidate_account', (qb) => {
                 qb.from<DBTeam>('_nango_accounts as account')
                     .innerJoin<DBUser>('_nango_users as same_domain_user', 'same_domain_user.account_id', 'account.id')
-                    .distinct('account.id', 'account.name')
+                    .select('account.id', 'account.name')
+                    .count('* as domain_members')
                     .where('account.id', '!=', currentAccountId)
                     .where('same_domain_user.suspended', false)
                     .whereRaw("LOWER(SPLIT_PART(same_domain_user.email, '@', 2)) = ?", [emailDomain])
@@ -178,12 +181,15 @@ class AccountService {
                             .from<DBUser>('_nango_users as administrator')
                             .whereRaw('administrator.account_id = account.id')
                             .where('administrator.suspended', false)
-                            .where('administrator.role', 'administrator');
-                    });
+                            .where('administrator.role', 'administrator')
+                            .whereRaw("LOWER(SPLIT_PART(administrator.email, '@', 2)) = ?", [emailDomain]);
+                    })
+                    .groupBy('account.id', 'account.name');
             })
             .from('candidate_account')
             .leftJoin<DBPlan>('plans', 'plans.account_id', 'candidate_account.id')
             .select<Pick<DBTeam, 'id' | 'name'>>('candidate_account.id', 'candidate_account.name')
+            .orderBy('candidate_account.domain_members', 'desc')
             .orderByRaw("CASE WHEN plans.name IS NOT NULL AND plans.name NOT IN ('free', 'free-uncapped') THEN 1 ELSE 0 END DESC")
             .orderByRaw(`(SELECT COUNT(*) FROM _nango_users AS member WHERE member.account_id = candidate_account.id AND member.suspended = false) DESC`)
             .orderBy('candidate_account.id', 'asc')


### PR DESCRIPTION
findAccountWithSameDomain only asserted that a candidate account had at least one active user on the email domain, then ranked candidates by paid plan and total active member count. Both ranking signals are domain-blind, so a large paid account holding a single contractor on the domain outranked the real team with twenty users on it.

The administrator check had the same problem: it required any active administrator, with no constraint on that administrator's own domain, so a suggestion could point at an org whose admins had no relation to the domain at all.

Count the active users on the domain in the CTE and order by that first, ahead of the paid-plan and member-count tie-breakers. Require at least one active administrator whose own email is on the matching domain.

The count replaces the previous DISTINCT with a GROUP BY on the same join, so this adds no extra scan.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

