### PR TITLE
feat(server): normalized principal and shadow evaluation (NAN-6657)

### DIFF
--- a/packages/authz/lib/authorize.ts
+++ b/packages/authz/lib/authorize.ts
@@ -47,10 +47,15 @@ export function authorizeAny(principal: Principal, scopes: readonly Scope[], tar
 }
 
 /**
- * A principal for a credential issued to a customer, such as an API key.
+ * A grant for a credential issued to a customer.
  * Selectors are resolved here rather than trusted, so a stored wildcard can never reach a private scope
- * or a tier. Anything unresolvable is dropped, leaving a principal that authorizes nothing.
+ * or a tier. Anything unresolvable is dropped, leaving a grant that authorizes nothing.
  */
+export function issuedGrant(scopes: readonly ScopeSelector[], where: readonly WhereSelector[]): Grant {
+    return { can: expandIssuable(scopes), where: where.filter(isIssuableWhere) };
+}
+
+/** A principal for a credential issued to a customer, such as an API key. */
 export function issuedPrincipal({
     subject,
     accountId,
@@ -62,9 +67,5 @@ export function issuedPrincipal({
     scopes: readonly ScopeSelector[];
     where: readonly WhereSelector[];
 }): Principal {
-    return {
-        subject,
-        accountId,
-        grants: [{ can: expandIssuable(scopes), where: where.filter(isIssuableWhere) }]
-    };
+    return { subject, accountId, grants: [issuedGrant(scopes, where)] };
 }

--- a/packages/server/lib/authz/legacyScopes.ts
+++ b/packages/server/lib/authz/legacyScopes.ts
@@ -44,6 +44,9 @@ export const LEGACY_SCOPES: Partial<Record<Scope, [Resource, Action, Plane]>> = 
     'environment:functions:list': ['flow', 'read', 'environment'],
     'environment:functions:read': ['flow', 'read', 'environment'],
     'environment:functions:delete': ['flow', 'delete', 'environment'],
+    // `canWriteProdFlows` guards deploy/upgrade and enable/disable/frequency alike.
+    'environment:deploy': ['flow', 'update', 'environment'],
+    'environment:syncs:update': ['flow', 'update', 'environment'],
     'environment:logs:read': ['log', 'read', 'environment'],
     'environment:syncs:execute': ['sync_command', 'update', 'environment'],
     'environment:settings:read': ['environment', 'read', 'environment'],

--- a/packages/server/lib/authz/legacyScopes.ts
+++ b/packages/server/lib/authz/legacyScopes.ts
@@ -1,0 +1,81 @@
+import type { Scope } from '@nangohq/authz';
+import type { Action, Permission, Scope as RbacTier, Resource } from '@nangohq/types';
+
+export type Plane = 'account' | 'environment';
+
+/**
+ * Scope -> the legacy permission it replaces, and the plane it is evaluated on. The deny map has no
+ * opinion on anything absent here.
+ *
+ * The plane is explicit because it cannot be derived: `account:environments:create` is account-plane
+ * while `account:environments:delete` is environment-plane, and both use the same legacy resource.
+ *
+ * Deleted together with ROLE_DENY_MAP once the private API authorizes through `authorize()`.
+ */
+export const LEGACY_SCOPES: Partial<Record<Scope, [Resource, Action, Plane]>> = {
+    // account plane
+    'account:team:update': ['team', 'update', 'account'],
+    'account:team:users:update': ['team_member', 'update', 'account'],
+    'account:team:users:delete': ['team_member', 'delete', 'account'],
+    'account:invites:create': ['invite', 'create', 'account'],
+    'account:invites:delete': ['invite', 'delete', 'account'],
+    'account:connect_ui:update': ['connect_ui_settings', 'update', 'account'],
+    'account:billing:payment_methods:list': ['billing', '*', 'account'],
+    'account:billing:payment_methods:create': ['billing', '*', 'account'],
+    'account:billing:payment_methods:delete': ['billing', '*', 'account'],
+    'account:plan:update': ['plan', 'update', 'account'],
+    'account:audit_trail:read': ['audit_trail', 'read', 'account'],
+    'account:api_keys:create': ['account_key', '*', 'account'],
+    'account:api_keys:list': ['account_key', '*', 'account'],
+    'account:api_keys:delete': ['account_key', '*', 'account'],
+    'account:environments:create': ['environment', 'create', 'account'],
+    'account:environments:set_production': ['environment_production_flag', 'update', 'account'],
+    // environment plane. `:list` and `:read` both map to the legacy `read` — the private grammar has
+    // no list action, so one permission guards the collection and the item alike.
+    'environment:integrations:list': ['integration', 'read', 'environment'],
+    'environment:integrations:read': ['integration', 'read', 'environment'],
+    'environment:integrations:update': ['integration', 'update', 'environment'],
+    'environment:integrations:delete': ['integration', 'delete', 'environment'],
+    'environment:connections:list': ['connection', 'read', 'environment'],
+    'environment:connections:read': ['connection', 'read', 'environment'],
+    'environment:connections:update': ['connection', 'update', 'environment'],
+    'environment:connections:delete': ['connection', 'delete', 'environment'],
+    'environment:connections:read_credentials': ['connection_credential', 'read', 'environment'],
+    'environment:functions:list': ['flow', 'read', 'environment'],
+    'environment:functions:read': ['flow', 'read', 'environment'],
+    'environment:functions:delete': ['flow', 'delete', 'environment'],
+    'environment:logs:read': ['log', 'read', 'environment'],
+    'environment:syncs:execute': ['sync_command', 'update', 'environment'],
+    'environment:settings:read': ['environment', 'read', 'environment'],
+    'environment:settings:update': ['environment', 'update', 'environment'],
+    'account:environments:delete': ['environment', 'delete', 'environment'],
+    'account:environments:api_keys:list': ['environment_key', 'read', 'environment'],
+    'account:environments:api_keys:update': ['environment_key', 'update', 'environment'],
+    'environment:settings:read_secret': ['secret_key', 'read', 'environment'],
+    'environment:variables:update': ['environment_variable', 'update', 'environment'],
+    'environment:webhooks:update': ['webhook', 'update', 'environment']
+};
+
+const planeForTier = (tier: RbacTier): Plane => (tier === 'global' ? 'account' : 'environment');
+
+/** Keyed with `|` so it cannot be misread as a scope: `webhook|update|environment` is not `environment:webhooks:update`. */
+const permissionKey = (resource: Resource, action: Action, plane: Plane): string => `${resource}|${action}|${plane}`;
+
+const byPermission = new Map<string, Scope[]>();
+for (const [scope, [resource, action, plane]] of Object.entries(LEGACY_SCOPES) as [Scope, [Resource, Action, Plane]][]) {
+    const key = permissionKey(resource, action, plane);
+    byPermission.set(key, [...(byPermission.get(key) ?? []), scope]);
+}
+
+/**
+ * The scopes that replace `permission`, or an empty list where the new model has no equivalent.
+ * More than one scope can map to a single permission: the legacy grammar has no `list` action, so
+ * `{integration, read}` guards both the collection and the item.
+ */
+export function scopesForPermission(permission: Permission): Scope[] {
+    return byPermission.get(permissionKey(permission.resource, permission.action, planeForTier(permission.scope))) ?? [];
+}
+
+export function planeForPermission(permission: Permission): Plane {
+    return planeForTier(permission.scope);
+}

--- a/packages/server/lib/authz/legacyScopes.unit.test.ts
+++ b/packages/server/lib/authz/legacyScopes.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { LEGACY_SCOPES, planeForPermission, scopesForPermission } from './legacyScopes.js';
+
+import type { Plane } from './legacyScopes.js';
+import type { Scope } from '@nangohq/authz';
+import type { Action, Permission, Scope as RbacTier, Resource } from '@nangohq/types';
+
+const entries = Object.entries(LEGACY_SCOPES) as [Scope, [Resource, Action, Plane]][];
+const tierFor = (plane: Plane): RbacTier => (plane === 'account' ? 'global' : 'production');
+
+describe('scopesForPermission', () => {
+    it.each(entries)('%s resolves back from the permission it replaces', (scope, [resource, action, plane]) => {
+        const permission: Permission = { resource, action, scope: tierFor(plane) };
+        expect(scopesForPermission(permission)).toContain(scope);
+        expect(planeForPermission(permission)).toBe(plane);
+    });
+
+    it('returns every scope sharing a permission, since the legacy grammar has no list action', () => {
+        expect(scopesForPermission({ resource: 'integration', action: 'read', scope: 'production' })).toEqual([
+            'environment:integrations:list',
+            'environment:integrations:read'
+        ]);
+    });
+
+    it('is empty where the new model has no equivalent', () => {
+        expect(scopesForPermission({ resource: '*', action: '*', scope: 'global' })).toEqual([]);
+    });
+
+    it('reads both environment tiers on the environment plane', () => {
+        expect(planeForPermission({ resource: 'log', action: 'read', scope: 'production' })).toBe('environment');
+        expect(planeForPermission({ resource: 'log', action: 'read', scope: 'non-production' })).toBe('environment');
+    });
+});

--- a/packages/server/lib/authz/legacyScopes.unit.test.ts
+++ b/packages/server/lib/authz/legacyScopes.unit.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { permissions } from '@nangohq/authz';
+
 import { LEGACY_SCOPES, planeForPermission, scopesForPermission } from './legacyScopes.js';
 
 import type { Plane } from './legacyScopes.js';
@@ -21,6 +23,29 @@ describe('scopesForPermission', () => {
             'environment:integrations:list',
             'environment:integrations:read'
         ]);
+    });
+
+    /**
+     * The round trip above derives its permission from the entry it asserts against, so it pins the
+     * key format but not the mapping's content. These do the latter.
+     */
+    it.each([
+        ['environment:webhooks:update', 'webhook', 'update', 'environment'],
+        ['environment:logs:read', 'log', 'read', 'environment'],
+        ['account:team:update', 'team', 'update', 'account'],
+        ['account:environments:create', 'environment', 'create', 'account'],
+        ['account:environments:delete', 'environment', 'delete', 'environment'],
+        ['environment:deploy', 'flow', 'update', 'environment']
+    ])('%s replaces %s/%s on the %s plane', (scope, resource, action, plane) => {
+        expect(LEGACY_SCOPES[scope as Scope]).toEqual([resource, action, plane]);
+    });
+
+    /** Anything missing here is a permission shadow evaluation can never compare, on every request. */
+    it('covers every permission the deny map has an opinion on', () => {
+        const unmapped = Object.entries(permissions)
+            .filter(([, permission]) => scopesForPermission(permission).length === 0)
+            .map(([name]) => name);
+        expect(unmapped).toEqual([]);
     });
 
     it('is empty where the new model has no equivalent', () => {

--- a/packages/server/lib/authz/middleware.ts
+++ b/packages/server/lib/authz/middleware.ts
@@ -1,6 +1,5 @@
-import { flagHasPlan, flags } from '@nangohq/utils';
-
-import { evaluator } from './evaluator.js';
+import { resolve } from './resolve.js';
+import { recordRoleDivergence } from './shadow.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { Permission, Scope } from '@nangohq/types';
@@ -12,28 +11,12 @@ type ScopedPermission = Omit<Permission, 'scope'> & { scopedBy: (locals: Partial
 
 export function can(permission: Permission | ScopedPermission): RequestHandler {
     return async (_req, res, next) => {
-        if (!flags.hasAuthRoles) {
-            next();
-            return;
-        }
-
-        const { plan, user } = res.locals as Partial<RequestLocals>;
-
-        if (flagHasPlan && (!plan || !plan.has_rbac)) {
-            next();
-            return;
-        }
-
-        if (!user) {
-            next();
-            return;
-        }
-
+        const locals = res.locals as Partial<RequestLocals>;
         const perm: Permission =
-            'scopedBy' in permission
-                ? { action: permission.action, resource: permission.resource, scope: permission.scopedBy(res.locals as Partial<RequestLocals>) }
-                : permission;
-        const allowed = await evaluator.evaluate(user.role, perm);
+            'scopedBy' in permission ? { action: permission.action, resource: permission.resource, scope: permission.scopedBy(locals) } : permission;
+
+        const allowed = await resolve(locals, perm);
+        recordRoleDivergence({ locals, permission: perm, legacy: allowed });
 
         if (!allowed) {
             res.status(403).json({ error: { code: 'forbidden', message: 'You do not have permission to perform this action' } });

--- a/packages/server/lib/authz/principal.ts
+++ b/packages/server/lib/authz/principal.ts
@@ -16,8 +16,7 @@ function rbacApplies(locals: Partial<RequestLocals>): boolean {
 }
 
 /**
- * Mirrors `targetForScope`: a key's `account:` scopes are evaluated against the account, and its
- * `environment:` scopes against the environments it is bound to.
+ * Generates grants from an API key based on its scopes and environment IDs.
  */
 function grantsForKey(key: ApiKeyPrincipal): Grant[] {
     const selectors = key.scopes as ScopeSelector[];

--- a/packages/server/lib/authz/principal.ts
+++ b/packages/server/lib/authz/principal.ts
@@ -1,0 +1,79 @@
+import { issuedGrant, ROLES } from '@nangohq/authz';
+import { flagHasPlan, flags } from '@nangohq/utils';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { Grant, Principal, PrincipalSubject, ScopeSelector, WhereSelector } from '@nangohq/authz';
+import type { ApiKeyPrincipal } from '@nangohq/types';
+
+/** What a caller reaches when RBAC does not apply: the flag is off, or the plan has no RBAC. */
+const UNRESTRICTED: Grant[] = [{ can: ['*'], where: ['*'] }];
+
+function rbacApplies(locals: Partial<RequestLocals>): boolean {
+    if (!flags.hasAuthRoles) {
+        return false;
+    }
+    return !flagHasPlan || Boolean(locals.plan?.has_rbac);
+}
+
+/**
+ * Mirrors `targetForScope`: a key's `account:` scopes are evaluated against the account, and its
+ * `environment:` scopes against the environments it is bound to.
+ */
+function grantsForKey(key: ApiKeyPrincipal): Grant[] {
+    const selectors = key.scopes as ScopeSelector[];
+    const environments = key.environmentIds.map((id): WhereSelector => `env:${id}`);
+
+    return [
+        issuedGrant(
+            selectors.filter((scope) => scope.startsWith('environment:')),
+            environments
+        ),
+        issuedGrant(
+            selectors.filter((scope) => scope.startsWith('account:')),
+            ['account']
+        )
+    ].filter((grant) => grant.can.length > 0);
+}
+
+function subjectForKey(key: ApiKeyPrincipal): PrincipalSubject {
+    return {
+        type: key.source === 'connect_session' ? 'connect_session' : 'api_key',
+        id: String(key.keyId ?? key.source),
+        ...(key.displayName ? { display: key.displayName } : {})
+    };
+}
+
+/**
+ * The grants behind the current request, or null when nothing authenticated well enough to have any.
+ * Nothing authorizes from this yet — it is compared against the legacy answer and counted.
+ */
+export function buildPrincipal(locals: Partial<RequestLocals>): Principal | null {
+    const account = locals.account;
+    if (!account) {
+        return null;
+    }
+
+    const user = locals.user;
+    if (user) {
+        return {
+            subject: { type: 'user', id: String(user.id), display: user.email },
+            accountId: account.id,
+            grants: rbacApplies(locals) ? ROLES[user.role] : UNRESTRICTED
+        };
+    }
+
+    const key = locals.apiKeyPrincipal;
+    if (key) {
+        return { subject: subjectForKey(key), accountId: account.id, grants: grantsForKey(key) };
+    }
+
+    return null;
+}
+
+/** `buildPrincipal`, computed once per request and kept on locals for later handlers. */
+export function principalFor(locals: Partial<RequestLocals>): Principal | null {
+    if (locals.principal === undefined) {
+        locals.principal = buildPrincipal(locals);
+    }
+    return locals.principal;
+}

--- a/packages/server/lib/authz/principal.unit.test.ts
+++ b/packages/server/lib/authz/principal.unit.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { accountTarget, authorize, environmentTarget, ROLES } from '@nangohq/authz';
+import { flags } from '@nangohq/utils';
+
+import { buildPrincipal, principalFor } from './principal.js';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { ApiKeyPrincipal, DBTeam, DBUser } from '@nangohq/types';
+import type * as NangoUtils from '@nangohq/utils';
+
+// `flagHasPlan` is a const export, so it can only be varied per test through the module mock.
+const planFlag = vi.hoisted(() => ({ enabled: true }));
+vi.mock('@nangohq/utils', async () => {
+    const actual: typeof NangoUtils = await vi.importActual('@nangohq/utils');
+    return {
+        ...actual,
+        get flagHasPlan() {
+            return planFlag.enabled;
+        }
+    };
+});
+
+const account = { id: 1 } as DBTeam;
+const prodEnv = { id: 5, account_id: 1, is_production: true };
+const devEnv = { id: 9, account_id: 1, is_production: false };
+
+function key(scopes: string[], environmentIds: number[], source: ApiKeyPrincipal['source'] = 'customer_key'): ApiKeyPrincipal {
+    return { type: 'api_key', source, accountId: 1, scopes, environmentIds };
+}
+
+function locals(over: Partial<RequestLocals>): Partial<RequestLocals> {
+    return { account, plan: { has_rbac: true } as RequestLocals['plan'], ...over };
+}
+
+describe('buildPrincipal', () => {
+    const originalFlag = flags.hasAuthRoles;
+    beforeAll(() => {
+        flags.hasAuthRoles = true;
+    });
+    afterAll(() => {
+        flags.hasAuthRoles = originalFlag;
+    });
+
+    it('returns null without an account', () => {
+        expect(buildPrincipal({})).toBeNull();
+    });
+
+    it('returns null when nothing authenticated', () => {
+        expect(buildPrincipal(locals({}))).toBeNull();
+    });
+
+    describe('session users', () => {
+        it('carries the grants of its role', () => {
+            const principal = buildPrincipal(locals({ user: { id: 7, role: 'production_support', email: 'a@b.c' } as DBUser }));
+            expect(principal?.grants).toEqual(ROLES.production_support);
+            expect(principal?.subject).toEqual({ type: 'user', id: '7', display: 'a@b.c' });
+        });
+
+        it('reaches everything when the flag is off', () => {
+            flags.hasAuthRoles = false;
+            const principal = buildPrincipal(locals({ user: { id: 7, role: 'production_support', email: 'a@b.c' } as DBUser }));
+            flags.hasAuthRoles = true;
+            expect(authorize(principal!, 'environment:settings:read_secret', environmentTarget(prodEnv))).toBe(true);
+        });
+
+        it('reaches everything when the plan has no rbac', () => {
+            const principal = buildPrincipal({
+                account,
+                plan: { has_rbac: false } as RequestLocals['plan'],
+                user: { id: 7, role: 'production_support', email: 'a@b.c' } as DBUser
+            });
+            expect(authorize(principal!, 'environment:settings:read_secret', environmentTarget(prodEnv))).toBe(true);
+        });
+
+        it('applies the role when plans are not in play at all', () => {
+            planFlag.enabled = false;
+            const principal = buildPrincipal({ account, plan: null, user: { id: 7, role: 'production_support', email: 'a@b.c' } as DBUser });
+            planFlag.enabled = true;
+            expect(authorize(principal!, 'environment:settings:read_secret', environmentTarget(prodEnv))).toBe(false);
+        });
+    });
+
+    describe('api keys', () => {
+        it('binds environment scopes to the environments the key is bound to', () => {
+            const principal = buildPrincipal(locals({ apiKeyPrincipal: key(['environment:connections:read'], [5]) }))!;
+            expect(authorize(principal, 'environment:connections:read', environmentTarget(prodEnv))).toBe(true);
+            expect(authorize(principal, 'environment:connections:read', environmentTarget(devEnv))).toBe(false);
+        });
+
+        it('binds account scopes to the account, mirroring targetForScope', () => {
+            const principal = buildPrincipal(locals({ apiKeyPrincipal: key(['account:environments:create'], [5]) }))!;
+            expect(authorize(principal, 'account:environments:create', accountTarget(1))).toBe(true);
+        });
+
+        it('keeps each plane to its own target', () => {
+            const principal = buildPrincipal(locals({ apiKeyPrincipal: key(['environment:connections:read', 'account:environments:create'], [5]) }))!;
+            expect(authorize(principal, 'account:environments:create', environmentTarget(prodEnv))).toBe(false);
+            expect(authorize(principal, 'environment:connections:read', accountTarget(1))).toBe(false);
+        });
+
+        it('carries both planes at once', () => {
+            const principal = buildPrincipal(locals({ apiKeyPrincipal: key(['environment:connections:read', 'account:environments:create'], [5]) }))!;
+            expect(principal.grants).toHaveLength(2);
+            expect(authorize(principal, 'environment:connections:read', environmentTarget(prodEnv))).toBe(true);
+            expect(authorize(principal, 'account:environments:create', accountTarget(1))).toBe(true);
+        });
+
+        it('resolves wildcards without reaching a private scope', () => {
+            const principal = buildPrincipal(locals({ apiKeyPrincipal: key(['environment:*'], [5]) }))!;
+            expect(authorize(principal, 'environment:connections:read', environmentTarget(prodEnv))).toBe(true);
+            expect(authorize(principal, 'environment:settings:read_secret', environmentTarget(prodEnv))).toBe(false);
+        });
+
+        it('reaches every environment it is bound to', () => {
+            const principal = buildPrincipal(locals({ apiKeyPrincipal: key(['environment:connections:read'], [5, 9]) }))!;
+            expect(authorize(principal, 'environment:connections:read', environmentTarget(prodEnv))).toBe(true);
+            expect(authorize(principal, 'environment:connections:read', environmentTarget(devEnv))).toBe(true);
+        });
+
+        it('never reaches another account', () => {
+            const principal = buildPrincipal(locals({ apiKeyPrincipal: key(['environment:*'], [5]) }))!;
+            expect(authorize(principal, 'environment:connections:read', environmentTarget({ ...prodEnv, account_id: 2 }))).toBe(false);
+        });
+
+        it('names a connect session as its own subject', () => {
+            const principal = buildPrincipal(locals({ apiKeyPrincipal: key(['environment:integrations:list'], [5], 'connect_session') }))!;
+            expect(principal.subject.type).toBe('connect_session');
+        });
+    });
+
+    it('principalFor computes once and keeps it on locals', () => {
+        const l = locals({ user: { id: 7, role: 'administrator', email: 'a@b.c' } as DBUser });
+        const first = principalFor(l);
+        expect(l.principal).toBe(first);
+        expect(principalFor(l)).toBe(first);
+    });
+});

--- a/packages/server/lib/authz/roles.equivalence.unit.test.ts
+++ b/packages/server/lib/authz/roles.equivalence.unit.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { accountTarget, authorize, environmentTarget, ISSUABLE_SCOPES, PRIVATE_SCOPES, ROLES } from '@nangohq/authz';
 
 import { evaluator } from './evaluator.js';
+import { LEGACY_SCOPES } from './legacyScopes.js';
 
+import type { Plane } from './legacyScopes.js';
 import type { Principal, Scope, Target } from '@nangohq/authz';
-import type { Action, Permission, Scope as RbacTier, Resource, Role } from '@nangohq/types';
+import type { Permission, Scope as RbacTier, Role } from '@nangohq/types';
 
 /**
  * Pins the new grant-based roles to what ROLE_DENY_MAP allows today. Converting a deny list to an
@@ -18,8 +20,6 @@ import type { Action, Permission, Scope as RbacTier, Resource, Role } from '@nan
 
 const ROLE_LIST: Role[] = ['administrator', 'production_support', 'development_full_access'];
 
-type Plane = 'account' | 'environment';
-
 /**
  * Scope -> the legacy permission it replaces, and the plane it is evaluated on. The deny map has
  * no opinion on anything absent here.
@@ -28,49 +28,6 @@ type Plane = 'account' | 'environment';
  * account-plane while `environment:delete` (deleting a specific one) is environment-plane, and both
  * use the same legacy resource.
  */
-const LEGACY: Partial<Record<Scope, [Resource, Action, Plane]>> = {
-    // account plane
-    'account:team:update': ['team', 'update', 'account'],
-    'account:team:users:update': ['team_member', 'update', 'account'],
-    'account:team:users:delete': ['team_member', 'delete', 'account'],
-    'account:invites:create': ['invite', 'create', 'account'],
-    'account:invites:delete': ['invite', 'delete', 'account'],
-    'account:connect_ui:update': ['connect_ui_settings', 'update', 'account'],
-    'account:billing:payment_methods:list': ['billing', '*', 'account'],
-    'account:billing:payment_methods:create': ['billing', '*', 'account'],
-    'account:billing:payment_methods:delete': ['billing', '*', 'account'],
-    'account:plan:update': ['plan', 'update', 'account'],
-    'account:audit_trail:read': ['audit_trail', 'read', 'account'],
-    'account:api_keys:create': ['account_key', '*', 'account'],
-    'account:api_keys:list': ['account_key', '*', 'account'],
-    'account:api_keys:delete': ['account_key', '*', 'account'],
-    'account:environments:create': ['environment', 'create', 'account'],
-    'account:environments:set_production': ['environment_production_flag', 'update', 'account'],
-    // environment plane. `:list` and `:read` both map to the legacy `read` — the private grammar has
-    // no list action, so one permission guards the collection and the item alike.
-    'environment:integrations:list': ['integration', 'read', 'environment'],
-    'environment:integrations:read': ['integration', 'read', 'environment'],
-    'environment:integrations:update': ['integration', 'update', 'environment'],
-    'environment:integrations:delete': ['integration', 'delete', 'environment'],
-    'environment:connections:list': ['connection', 'read', 'environment'],
-    'environment:connections:read': ['connection', 'read', 'environment'],
-    'environment:connections:update': ['connection', 'update', 'environment'],
-    'environment:connections:delete': ['connection', 'delete', 'environment'],
-    'environment:connections:read_credentials': ['connection_credential', 'read', 'environment'],
-    'environment:functions:list': ['flow', 'read', 'environment'],
-    'environment:functions:read': ['flow', 'read', 'environment'],
-    'environment:functions:delete': ['flow', 'delete', 'environment'],
-    'environment:logs:read': ['log', 'read', 'environment'],
-    'environment:syncs:execute': ['sync_command', 'update', 'environment'],
-    'environment:settings:read': ['environment', 'read', 'environment'],
-    'environment:settings:update': ['environment', 'update', 'environment'],
-    'account:environments:delete': ['environment', 'delete', 'environment'],
-    'account:environments:api_keys:list': ['environment_key', 'read', 'environment'],
-    'account:environments:api_keys:update': ['environment_key', 'update', 'environment'],
-    'environment:settings:read_secret': ['secret_key', 'read', 'environment'],
-    'environment:variables:update': ['environment_variable', 'update', 'environment'],
-    'environment:webhooks:update': ['webhook', 'update', 'environment']
-};
 
 /** Reviewed, deliberate departures from today. Everything else must match exactly. */
 const INTENTIONAL_CHANGES: { role: Role; scope: Scope; tier: RbacTier; wasAllowed: boolean; nowAllowed: boolean; reason: string }[] = [
@@ -95,13 +52,13 @@ function principalFor(role: Role): Principal {
 }
 
 // A scope is only ever evaluated on its own plane; the other combinations do not occur.
-const cases = (Object.keys(LEGACY) as Scope[]).flatMap((scope) =>
-    ROLE_LIST.flatMap((role) => TIERS.filter((t) => t.plane === LEGACY[scope]![2]).map(({ tier, target }) => ({ scope, role, tier, target })))
+const cases = (Object.keys(LEGACY_SCOPES) as Scope[]).flatMap((scope) =>
+    ROLE_LIST.flatMap((role) => TIERS.filter((t) => t.plane === LEGACY_SCOPES[scope]![2]).map(({ tier, target }) => ({ scope, role, tier, target })))
 );
 
 describe('role grants match the legacy deny map', () => {
     it.each(cases)('$role / $scope / $tier', async ({ scope, role, tier, target }) => {
-        const [resource, action] = LEGACY[scope]!;
+        const [resource, action] = LEGACY_SCOPES[scope]!;
         const permission: Permission = { resource, action, scope: tier };
 
         const expected = await evaluator.evaluate(role, permission);
@@ -124,7 +81,7 @@ describe('role grants match the legacy deny map', () => {
 
     it('covers every scope the deny map has an opinion on', () => {
         const all = [...ISSUABLE_SCOPES, ...PRIVATE_SCOPES] as Scope[];
-        const uncovered = all.filter((c) => !LEGACY[c]);
+        const uncovered = all.filter((c) => !LEGACY_SCOPES[c]);
         // Key-only scopes have no RBAC equivalent, so the deny map has no opinion to be an oracle for.
         expect(uncovered.every((c) => !c.startsWith('account:') || c.startsWith('account:environments:'))).toBe(true);
     });

--- a/packages/server/lib/authz/roles.equivalence.unit.test.ts
+++ b/packages/server/lib/authz/roles.equivalence.unit.test.ts
@@ -20,15 +20,6 @@ import type { Permission, Scope as RbacTier, Role } from '@nangohq/types';
 
 const ROLE_LIST: Role[] = ['administrator', 'production_support', 'development_full_access'];
 
-/**
- * Scope -> the legacy permission it replaces, and the plane it is evaluated on. The deny map has
- * no opinion on anything absent here.
- *
- * The plane is explicit because it cannot be derived: `environment:create` (creating one) is
- * account-plane while `environment:delete` (deleting a specific one) is environment-plane, and both
- * use the same legacy resource.
- */
-
 /** Reviewed, deliberate departures from today. Everything else must match exactly. */
 const INTENTIONAL_CHANGES: { role: Role; scope: Scope; tier: RbacTier; wasAllowed: boolean; nowAllowed: boolean; reason: string }[] = [
     {

--- a/packages/server/lib/authz/shadow.role.unit.test.ts
+++ b/packages/server/lib/authz/shadow.role.unit.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { metrics } from '@nangohq/utils';
+
+import { recordRoleDivergence } from './shadow.js';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { DBEnvironment, DBTeam, DBUser, Permission } from '@nangohq/types';
+import type { MockInstance } from 'vitest';
+
+const account = { id: 1 } as DBTeam;
+const environment = { id: 5, account_id: 1, is_production: true } as DBEnvironment;
+const user = { id: 7, role: 'administrator', email: 'a@b.c' } as DBUser;
+
+describe('recordRoleDivergence', () => {
+    let increment: MockInstance<typeof metrics.increment>;
+    beforeEach(() => {
+        increment = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+        increment.mockRestore();
+    });
+
+    const reasons = () =>
+        increment.mock.calls.filter(([type]) => type === metrics.Types.AUTHZ_ROLE_UNMAPPED).map(([, , tags]) => (tags as { reason: string }).reason);
+
+    const record = (permission: Permission, locals: Partial<RequestLocals>) => recordRoleDivergence({ locals, permission, legacy: true });
+
+    it('reports a permission the map cannot resolve, the case that blinds a route forever', () => {
+        record({ resource: '*', action: '*', scope: 'global' }, { account, environment, user });
+        expect(reasons()).toEqual(['no_scope_mapping']);
+    });
+
+    it('reports a missing principal separately', () => {
+        record({ resource: 'log', action: 'read', scope: 'production' }, { account, environment });
+        expect(reasons()).toEqual(['no_principal']);
+    });
+
+    it('reports a missing target separately', () => {
+        record({ resource: 'log', action: 'read', scope: 'production' }, { account, user });
+        expect(reasons()).toEqual(['no_target']);
+    });
+
+    it('records nothing when it can compare', () => {
+        record({ resource: 'log', action: 'read', scope: 'production' }, { account, environment, user });
+        expect(reasons()).toEqual([]);
+    });
+});

--- a/packages/server/lib/authz/shadow.ts
+++ b/packages/server/lib/authz/shadow.ts
@@ -1,4 +1,4 @@
-import { accountTarget, authorizeAny, environmentTarget } from '@nangohq/authz';
+import { accountTarget, authorize, authorizeAny, environmentTarget } from '@nangohq/authz';
 import { metrics } from '@nangohq/utils';
 
 import { planeForPermission, scopesForPermission } from './legacyScopes.js';
@@ -24,6 +24,9 @@ function targetFor(locals: Partial<RequestLocals>, plane: Plane): Target | null 
 /**
  * Compares the grant model against the answer the request actually used, and counts the difference.
  * Nothing here changes what the caller is allowed to do — the count is the gate on the flip.
+ *
+ * This is the signal that matters: roles are a deny map today, so the allow-list has to enumerate a
+ * complement, and over-denial is how that goes wrong.
  */
 export function recordRoleDivergence({ locals, permission, legacy }: { locals: Partial<RequestLocals>; permission: Permission; legacy: boolean }): void {
     const tags = { resource: permission.resource, action: permission.action, tier: permission.scope };
@@ -41,6 +44,11 @@ export function recordRoleDivergence({ locals, permission, legacy }: { locals: P
     }
 }
 
+/**
+ * Both sides read the same stored scopes with the same wildcard semantics, so this should sit at zero
+ * from the first deploy. Movement means `buildPrincipal` derived the grants wrong, not that the grant
+ * model disagrees — a different bug with a different fix.
+ */
 export function recordScopeDivergence({
     locals,
     requiredScopes,
@@ -53,14 +61,14 @@ export function recordScopeDivergence({
     const tags = { scope: requiredScopes.join('|') };
 
     const principal = principalFor(locals);
-    // Every scope in a withAnyScope set shares a plane, so the first decides the target.
-    const target = targetFor(locals, requiredScopes[0]?.startsWith('account:') ? 'account' : 'environment');
-    if (!principal || !target || requiredScopes.length === 0) {
-        metrics.increment(metrics.Types.AUTHZ_ROLE_UNMAPPED, 1, tags);
+    // Each scope carries its own plane, so a mixed any-of set gets a target per scope.
+    const targeted = requiredScopes.map((scope) => ({ scope, target: targetFor(locals, scope.startsWith('account:') ? 'account' : 'environment') }));
+    if (!principal || requiredScopes.length === 0 || targeted.some(({ target }) => !target)) {
+        metrics.increment(metrics.Types.AUTHZ_KEY_DERIVATION_UNMAPPED, 1, tags);
         return;
     }
 
-    if (authorizeAny(principal, requiredScopes as readonly Scope[], target) !== legacy) {
-        metrics.increment(metrics.Types.AUTHZ_ROLE_DIVERGENCE, 1, { ...tags, expected: String(legacy) });
+    if (targeted.some(({ scope, target }) => authorize(principal, scope as Scope, target!)) !== legacy) {
+        metrics.increment(metrics.Types.AUTHZ_KEY_DERIVATION_DIVERGENCE, 1, { ...tags, expected: String(legacy) });
     }
 }

--- a/packages/server/lib/authz/shadow.ts
+++ b/packages/server/lib/authz/shadow.ts
@@ -1,0 +1,66 @@
+import { accountTarget, authorizeAny, environmentTarget } from '@nangohq/authz';
+import { metrics } from '@nangohq/utils';
+
+import { planeForPermission, scopesForPermission } from './legacyScopes.js';
+import { principalFor } from './principal.js';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { Plane } from './legacyScopes.js';
+import type { Scope, Target } from '@nangohq/authz';
+import type { CustomerKeyScope, Permission } from '@nangohq/types';
+
+function targetFor(locals: Partial<RequestLocals>, plane: Plane): Target | null {
+    const account = locals.account;
+    if (!account) {
+        return null;
+    }
+    if (plane === 'account') {
+        return accountTarget(account.id);
+    }
+    const environment = locals.environment;
+    return environment ? environmentTarget(environment) : null;
+}
+
+/**
+ * Compares the grant model against the answer the request actually used, and counts the difference.
+ * Nothing here changes what the caller is allowed to do — the count is the gate on the flip.
+ */
+export function recordRoleDivergence({ locals, permission, legacy }: { locals: Partial<RequestLocals>; permission: Permission; legacy: boolean }): void {
+    const tags = { resource: permission.resource, action: permission.action, tier: permission.scope };
+
+    const principal = principalFor(locals);
+    const scopes = scopesForPermission(permission);
+    const target = targetFor(locals, planeForPermission(permission));
+    if (!principal || !target || scopes.length === 0) {
+        metrics.increment(metrics.Types.AUTHZ_ROLE_UNMAPPED, 1, tags);
+        return;
+    }
+
+    if (authorizeAny(principal, scopes, target) !== legacy) {
+        metrics.increment(metrics.Types.AUTHZ_ROLE_DIVERGENCE, 1, { ...tags, expected: String(legacy) });
+    }
+}
+
+export function recordScopeDivergence({
+    locals,
+    requiredScopes,
+    legacy
+}: {
+    locals: Partial<RequestLocals>;
+    requiredScopes: readonly CustomerKeyScope[];
+    legacy: boolean;
+}): void {
+    const tags = { scope: requiredScopes.join('|') };
+
+    const principal = principalFor(locals);
+    // Every scope in a withAnyScope set shares a plane, so the first decides the target.
+    const target = targetFor(locals, requiredScopes[0]?.startsWith('account:') ? 'account' : 'environment');
+    if (!principal || !target || requiredScopes.length === 0) {
+        metrics.increment(metrics.Types.AUTHZ_ROLE_UNMAPPED, 1, tags);
+        return;
+    }
+
+    if (authorizeAny(principal, requiredScopes as readonly Scope[], target) !== legacy) {
+        metrics.increment(metrics.Types.AUTHZ_ROLE_DIVERGENCE, 1, { ...tags, expected: String(legacy) });
+    }
+}

--- a/packages/server/lib/authz/shadow.ts
+++ b/packages/server/lib/authz/shadow.ts
@@ -34,8 +34,21 @@ export function recordRoleDivergence({ locals, permission, legacy }: { locals: P
     const principal = principalFor(locals);
     const scopes = scopesForPermission(permission);
     const target = targetFor(locals, planeForPermission(permission));
-    if (!principal || !target || scopes.length === 0) {
-        metrics.increment(metrics.Types.AUTHZ_ROLE_UNMAPPED, 1, tags);
+
+    const unmapped = (reason: string) => metrics.increment(metrics.Types.AUTHZ_ROLE_UNMAPPED, 1, { ...tags, reason });
+
+    // Checked first: a missing mapping is a property of the permission, so it holds on every request
+    // rather than being a transient miss, and it leaves the route permanently uncompared.
+    if (scopes.length === 0) {
+        unmapped('no_scope_mapping');
+        return;
+    }
+    if (!principal) {
+        unmapped('no_principal');
+        return;
+    }
+    if (!target) {
+        unmapped('no_target');
         return;
     }
 
@@ -63,8 +76,20 @@ export function recordScopeDivergence({
     const principal = principalFor(locals);
     // Each scope carries its own plane, so a mixed any-of set gets a target per scope.
     const targeted = requiredScopes.map((scope) => ({ scope, target: targetFor(locals, scope.startsWith('account:') ? 'account' : 'environment') }));
-    if (!principal || requiredScopes.length === 0 || targeted.some(({ target }) => !target)) {
-        metrics.increment(metrics.Types.AUTHZ_KEY_DERIVATION_UNMAPPED, 1, tags);
+
+    const unmapped = (reason: string) => metrics.increment(metrics.Types.AUTHZ_KEY_DERIVATION_UNMAPPED, 1, { ...tags, reason });
+
+    // No mapping step on this path: the required scope is already a scope.
+    if (requiredScopes.length === 0) {
+        unmapped('no_scope_required');
+        return;
+    }
+    if (!principal) {
+        unmapped('no_principal');
+        return;
+    }
+    if (targeted.some(({ target }) => !target)) {
+        unmapped('no_target');
         return;
     }
 

--- a/packages/server/lib/authz/shadow.unit.test.ts
+++ b/packages/server/lib/authz/shadow.unit.test.ts
@@ -49,8 +49,17 @@ describe('recordScopeDivergence', () => {
         expect(divergences()).toHaveLength(0);
     });
 
-    it('cannot compare without a principal', () => {
+    const unmappedReasons = () =>
+        increment.mock.calls.filter(([type]) => type === metrics.Types.AUTHZ_KEY_DERIVATION_UNMAPPED).map(([, , tags]) => (tags as { reason: string }).reason);
+
+    it('says why it could not compare', () => {
         recordScopeDivergence({ locals: { account }, requiredScopes: ['environment:connections:read'], legacy: true });
-        expect(increment.mock.calls.filter(([type]) => type === metrics.Types.AUTHZ_KEY_DERIVATION_UNMAPPED)).toHaveLength(1);
+        expect(unmappedReasons()).toEqual(['no_principal']);
+    });
+
+    it('distinguishes a missing target from a missing principal', () => {
+        const { environment: _dropped, ...withoutEnvironment } = localsFor(['environment:*']);
+        recordScopeDivergence({ locals: withoutEnvironment, requiredScopes: ['environment:connections:read'], legacy: true });
+        expect(unmappedReasons()).toEqual(['no_target']);
     });
 });

--- a/packages/server/lib/authz/shadow.unit.test.ts
+++ b/packages/server/lib/authz/shadow.unit.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { metrics } from '@nangohq/utils';
+
+import { recordScopeDivergence } from './shadow.js';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { ApiKeyPrincipal, CustomerKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
+import type { MockInstance } from 'vitest';
+
+const account = { id: 1 } as DBTeam;
+const environment = { id: 5, account_id: 1, is_production: true } as DBEnvironment;
+
+function localsFor(scopes: string[]): Partial<RequestLocals> {
+    const apiKeyPrincipal: ApiKeyPrincipal = { type: 'api_key', source: 'customer_key', accountId: 1, scopes, environmentIds: [5] };
+    return { account, environment, apiKeyPrincipal };
+}
+
+describe('recordScopeDivergence', () => {
+    let increment: MockInstance<typeof metrics.increment>;
+    beforeEach(() => {
+        increment = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+        increment.mockRestore();
+    });
+
+    const divergences = () => increment.mock.calls.filter(([type]) => type === metrics.Types.AUTHZ_KEY_DERIVATION_DIVERGENCE);
+
+    it('records nothing when the grants agree', () => {
+        recordScopeDivergence({ locals: localsFor(['environment:*']), requiredScopes: ['environment:connections:read'], legacy: true });
+        expect(divergences()).toHaveLength(0);
+    });
+
+    it('records when they disagree', () => {
+        recordScopeDivergence({ locals: localsFor([]), requiredScopes: ['environment:connections:read'], legacy: true });
+        expect(divergences()).toHaveLength(1);
+    });
+
+    it('gives each scope in a mixed-plane any-of set its own target', () => {
+        const mixed: CustomerKeyScope[] = ['environment:connections:read', 'account:environments:create'];
+
+        // Only the account scope is held, and it needs an account target the environment scope would not get.
+        recordScopeDivergence({ locals: localsFor(['account:environments:create']), requiredScopes: mixed, legacy: true });
+        expect(divergences()).toHaveLength(0);
+
+        // Reversed order, same answer — the first scope must not decide the target for the rest.
+        recordScopeDivergence({ locals: localsFor(['account:environments:create']), requiredScopes: [...mixed].reverse(), legacy: true });
+        expect(divergences()).toHaveLength(0);
+    });
+
+    it('cannot compare without a principal', () => {
+        recordScopeDivergence({ locals: { account }, requiredScopes: ['environment:connections:read'], legacy: true });
+        expect(increment.mock.calls.filter(([type]) => type === metrics.Types.AUTHZ_KEY_DERIVATION_UNMAPPED)).toHaveLength(1);
+    });
+});

--- a/packages/server/lib/middleware/scope.middleware.ts
+++ b/packages/server/lib/middleware/scope.middleware.ts
@@ -1,5 +1,7 @@
 import { authorizeApiKey, canAccessApiKeyTarget } from '@nangohq/utils';
 
+import { recordScopeDivergence } from '../authz/shadow.js';
+
 import type { RequestLocals } from '../utils/express.js';
 import type { ApiKeyAuthorizationTarget, CustomerKeyScope } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
@@ -53,7 +55,10 @@ export function withEnvironmentTarget(_req: Request, res: Response<unknown, Part
 
 export function withScope(requiredScope: CustomerKeyScope) {
     return function (_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
-        if (hasAuthorizedScope({ locals: res.locals, requiredScope })) {
+        const allowed = hasAuthorizedScope({ locals: res.locals, requiredScope });
+        recordScopeDivergence({ locals: res.locals, requiredScopes: [requiredScope], legacy: allowed });
+
+        if (allowed) {
             next();
             return;
         }
@@ -64,11 +69,12 @@ export function withScope(requiredScope: CustomerKeyScope) {
 
 export function withAnyScope(...requiredScopes: CustomerKeyScope[]) {
     return function (_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
-        for (const scope of requiredScopes) {
-            if (hasAuthorizedScope({ locals: res.locals, requiredScope: scope })) {
-                next();
-                return;
-            }
+        const allowed = requiredScopes.some((requiredScope) => hasAuthorizedScope({ locals: res.locals, requiredScope }));
+        recordScopeDivergence({ locals: res.locals, requiredScopes, legacy: allowed });
+
+        if (allowed) {
+            next();
+            return;
         }
 
         res.status(403).json({ error: { code: 'forbidden', message: `Insufficient scope. Required one of: ${requiredScopes.join(' or ')}` } });

--- a/packages/server/lib/utils/express.ts
+++ b/packages/server/lib/utils/express.ts
@@ -1,3 +1,4 @@
+import type { Principal } from '@nangohq/authz';
 import type { AgentSession, ApiKeyPrincipal, ConnectSession, DBAPISecret, DBEnvironment, DBPlan, DBTeam, DBUser, InternalEndUser } from '@nangohq/types';
 
 // Types are historically loose so we need to fix them at some point
@@ -40,6 +41,7 @@ export interface RequestLocals {
     lang?: string;
     secret?: DBAPISecret;
     apiKeyPrincipal?: ApiKeyPrincipal;
+    principal?: Principal | null;
     apiKeyId?: number;
     apiKeyDisplayName?: string;
     apiKeyAuthSource?: 'customer_key' | 'sandbox_token' | 'api_secret' | 'env_var';

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -6,6 +6,8 @@ export enum Types {
     ACTION_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.action.incoming.payloadSizeBytes',
 
     AUTH_SECRET_KEY_HASH_CACHE = 'nango.auth.secretKeyHashCache',
+    AUTHZ_KEY_DERIVATION_DIVERGENCE = 'nango.authz.keyDerivationDivergence',
+    AUTHZ_KEY_DERIVATION_UNMAPPED = 'nango.authz.keyDerivationUnmapped',
     AUTHZ_ROLE_DIVERGENCE = 'nango.authz.roleDivergence',
     AUTHZ_ROLE_UNMAPPED = 'nango.authz.roleUnmapped',
     AUTH_SHADOW_CACHE = 'nango.auth.shadowCache',

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -6,6 +6,8 @@ export enum Types {
     ACTION_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.action.incoming.payloadSizeBytes',
 
     AUTH_SECRET_KEY_HASH_CACHE = 'nango.auth.secretKeyHashCache',
+    AUTHZ_ROLE_DIVERGENCE = 'nango.authz.roleDivergence',
+    AUTHZ_ROLE_UNMAPPED = 'nango.authz.roleUnmapped',
     AUTH_SHADOW_CACHE = 'nango.auth.shadowCache',
     AUTH_CONTEXT_CACHE = 'nango.auth.contextCache',
     AUTH_GET_ENV_BY_AGENT_SESSION = 'nango.auth.getEnvByAgentSession',


### PR DESCRIPTION
The previous PR added the grant language, but nothing used it. This one starts using it, but in a shadow form. The existing evaluator is still used to authorize requests, but we also run it through the new grants, and we register a metric in case they disagree. 

The goal is to deploy this and observe if there's any disagreement between the old and the new resolvers, mainly to detect divergences in role permissions, since it's going from a deny-list to an allow-list, but also to sanity check the code that currently derives the grants (`{ can: [...], where: [...] }`) from our stored scopes (in `customer_keys` and `customer_keys_relations`).

For such, we now resolve a `res.locals.principal` in every authorized request. We have `res.local.apiKeyPrincipal`, which will eventually be fully replaced by this new principal with grants, which also covers session tokens.

The produced metrics are:
- `nango.authz.roleDivergence` -> Something diverged in an RBAC permission check.
- `nango.authz.roleUnmapped` -> Couldn't compare — no principal, no target, or a permission with no scope equivalent.
- `nango.authz.keyDerivationDivergence` -> Some divergence between stored scopes and the mapped grants (mostly here for sanity, I don't expect to see this one triggering).
- `nango.authz.keyDerivationUnmapped` -> Couldn't compare — no principal or no resolvable target.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

