### PR TITLE
feat(server): serve a session-scoped MCP endpoint at /session/{id}/mcp (NAN-6600)

### DIFF
--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
@@ -156,7 +156,7 @@ async function listTools({ token, mcpPath, cursor }: { token: string; mcpPath: s
     });
 }
 
-describe('POST /session/:sessionId/mcp', () => {
+describe('/session/:sessionId/mcp', () => {
     beforeAll(async () => {
         api = await runServer();
         await keystore.migrate(db.knex);
@@ -252,19 +252,22 @@ describe('POST /session/:sessionId/mcp', () => {
 
         expect(res.json.result.isError).toBe(true);
     });
-});
 
-describe('GET /session/:sessionId/mcp', () => {
-    beforeAll(async () => {
-        api = await runServer();
-        await keystore.migrate(db.knex);
+    it('rejects a call to a meta tool the session turned off', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey, { meta_tools: { nango_tool_search: false } });
+
+        const res = await mcpFetch({
+            token,
+            path: mcpPath,
+            method: 'POST',
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'nango_tool_search', arguments: { query: 'anything' } } }
+        });
+
+        expect(res.json.result?.isError ?? Boolean(res.json.error)).toBe(true);
     });
 
-    afterAll(() => {
-        api.server.close();
-    });
-
-    it('does not support SSE', async () => {
+    it('does not support SSE on GET', async () => {
         const { apiKey } = await seedTenant();
         const { token, mcpPath } = await createSession(apiKey);
 

--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
@@ -1,0 +1,276 @@
+import { randomUUID } from 'node:crypto';
+import { request } from 'node:http';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import * as keystore from '@nangohq/keystore';
+import { customerKeyService, seeders } from '@nangohq/shared';
+
+import { runServer } from '../../../utils/tests.js';
+
+import type { DBEnvironment, DBSyncConfig, DBTeam, IntegrationConfig, PostAgentSessionsBody } from '@nangohq/types';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function mcpFetch({
+    token,
+    path,
+    method,
+    body
+}: {
+    token: string;
+    path: string;
+    method: 'GET' | 'POST';
+    body?: Record<string, unknown>;
+}): Promise<{ status: number; json: any }> {
+    const url = new URL(path, api.url);
+    const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+
+    if (body) {
+        headers['Accept'] = 'application/json, text/event-stream';
+        headers['content-type'] = 'application/json';
+    }
+
+    return await new Promise((resolve, reject) => {
+        const req = request({ hostname: url.hostname, port: url.port, path: url.pathname, method, headers }, (res) => {
+            let data = '';
+            res.setEncoding('utf8');
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+            res.on('end', () => {
+                try {
+                    resolve({ status: res.statusCode ?? 0, json: parseMcpResponse(data) });
+                } catch (err) {
+                    reject(err);
+                }
+            });
+        });
+        req.on('error', reject);
+        if (body) {
+            req.write(JSON.stringify(body));
+        }
+        req.end();
+    });
+}
+
+function parseMcpResponse(data: string): any {
+    const trimmed = data.trim();
+    if (!trimmed) {
+        return {};
+    }
+    if (!trimmed.startsWith('event:') && !trimmed.startsWith('data:')) {
+        return JSON.parse(trimmed);
+    }
+
+    for (const event of trimmed.split(/\r?\n\r?\n/)) {
+        const payload = event
+            .split(/\r?\n/)
+            .filter((line) => line.startsWith('data:'))
+            .map((line) => line.slice('data:'.length).trimStart())
+            .join('\n');
+
+        if (payload) {
+            return JSON.parse(payload);
+        }
+    }
+
+    throw new Error('MCP SSE response did not contain a data payload');
+}
+
+async function insertAction({ environmentId, integration, name }: { environmentId: number; integration: IntegrationConfig; name: string }): Promise<void> {
+    await db.knex.from<DBSyncConfig>('_nango_sync_configs').insert({
+        environment_id: environmentId,
+        nango_config_id: integration.id!,
+        sync_name: name,
+        type: 'action',
+        file_location: 'file_location',
+        version: '0.0.1',
+        source: 'repo',
+        runs: null,
+        track_deletes: false,
+        auto_start: false,
+        webhook_subscriptions: [],
+        models: [],
+        metadata: { description: `${name} description` },
+        active: true,
+        enabled: true,
+        deleted: false,
+        deleted_at: null
+    });
+}
+
+/**
+ * notion has a pinned tool and a searchable one, slack has one pinned tool. Both are on the same
+ * tenant, so one session covers them.
+ */
+async function seedTenant(): Promise<{ account: DBTeam; env: DBEnvironment; apiKey: string }> {
+    const seed = await seeders.seedAccountEnvAndUser();
+    const key = (
+        await customerKeyService.createApiKey(db.knex, {
+            accountId: seed.account.id,
+            environmentId: seed.env.id,
+            displayName: `test-${randomUUID()}`,
+            scopes: ['environment:agent_sessions:write']
+        })
+    ).unwrap();
+
+    const notion = await seeders.createConfigSeed(seed.env, 'notion', 'notion');
+    const slack = await seeders.createConfigSeed(seed.env, 'slack', 'slack');
+
+    await insertAction({ environmentId: seed.env.id, integration: notion, name: 'read_doc' });
+    await insertAction({ environmentId: seed.env.id, integration: notion, name: 'upsert_doc' });
+    await insertAction({ environmentId: seed.env.id, integration: slack, name: 'send_message' });
+
+    await seeders.createConnectionSeed({ env: seed.env, provider: 'notion', connectionId: 'notion-acme', tags: { tenant: 'acme' } });
+    await seeders.createConnectionSeed({ env: seed.env, provider: 'slack', connectionId: 'slack-acme', tags: { tenant: 'acme' } });
+
+    return { account: seed.account, env: seed.env, apiKey: key.secret };
+}
+
+async function createSession(apiKey: string, body: Partial<PostAgentSessionsBody> = {}): Promise<{ sessionId: string; token: string; mcpPath: string }> {
+    const res = await api.fetch('/sessions', {
+        method: 'POST',
+        token: apiKey,
+        body: {
+            tenant: { connections: { any: [{ tags: { tenant: 'acme' } }] } },
+            pinned_tools: { notion: ['read_doc'], slack: ['send_message'] },
+            ...body
+        } as PostAgentSessionsBody
+    });
+
+    if ('error' in res.json) {
+        throw new Error(`Failed to create agent session: ${JSON.stringify(res.json.error)}`);
+    }
+
+    return { sessionId: res.json.data.session_id, token: res.json.data.session_token, mcpPath: new URL(res.json.data.mcp_url).pathname };
+}
+
+async function listTools({ token, mcpPath, cursor }: { token: string; mcpPath: string; cursor?: string }) {
+    return await mcpFetch({
+        token,
+        path: mcpPath,
+        method: 'POST',
+        body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: cursor ? { cursor } : {} }
+    });
+}
+
+describe('POST /session/:sessionId/mcp', () => {
+    beforeAll(async () => {
+        api = await runServer();
+        await keystore.migrate(db.knex);
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('rejects a request without a session token', async () => {
+        const { apiKey } = await seedTenant();
+        const { mcpPath } = await createSession(apiKey);
+
+        const res = await mcpFetch({ token: '', path: mcpPath, method: 'POST', body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} } });
+
+        expect(res.status).toBe(401);
+    });
+
+    it('rejects the environment api key, which is not a session token', async () => {
+        const { apiKey } = await seedTenant();
+        const { mcpPath } = await createSession(apiKey);
+
+        const res = await listTools({ token: apiKey, mcpPath });
+
+        expect(res.status).toBe(401);
+    });
+
+    it('rejects a session token pointed at another session url', async () => {
+        const { apiKey } = await seedTenant();
+        const one = await createSession(apiKey);
+        const two = await createSession(apiKey);
+
+        const res = await listTools({ token: one.token, mcpPath: two.mcpPath });
+
+        expect(res.status).toBe(404);
+        expect(res.json.error.code).toBe('session_not_found');
+    });
+
+    it('lists the meta tools and the pinned tools, and no searchable tool', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await listTools({ token, mcpPath });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual([
+            'nango_tool_search',
+            'nango_execute',
+            'notion__read_doc',
+            'slack__send_message'
+        ]);
+        expect(res.json.result.nextCursor).toBeUndefined();
+    });
+
+    it('names the integration and the unqualified tool in _meta', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await listTools({ token, mcpPath });
+        const pinned = res.json.result.tools.find((tool: { name: string }) => tool.name === 'notion__read_doc');
+
+        expect(pinned._meta).toStrictEqual({ 'nango/integration': 'notion', 'nango/tool': 'read_doc' });
+    });
+
+    it('omits a meta tool the session turned off', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey, { meta_tools: { nango_tool_search: false } });
+
+        const res = await listTools({ token, mcpPath });
+
+        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).not.toContain('nango_tool_search');
+    });
+
+    it('rejects a cursor it did not mint', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await listTools({ token, mcpPath, cursor: 'not-a-cursor' });
+
+        expect(res.json.error.message).toContain('Invalid cursor');
+    });
+
+    it('does not run a tool', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await mcpFetch({
+            token,
+            path: mcpPath,
+            method: 'POST',
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'notion__read_doc', arguments: {} } }
+        });
+
+        expect(res.json.result.isError).toBe(true);
+    });
+});
+
+describe('GET /session/:sessionId/mcp', () => {
+    beforeAll(async () => {
+        api = await runServer();
+        await keystore.migrate(db.knex);
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('does not support SSE', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await mcpFetch({ token, path: mcpPath, method: 'GET' });
+
+        expect(res.status).toBe(405);
+        expect(res.json.error.message).toBe('Method not allowed.');
+    });
+});

--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
@@ -253,18 +253,27 @@ describe('/session/:sessionId/mcp', () => {
         expect(res.json.result.isError).toBe(true);
     });
 
-    it('rejects a call to a meta tool the session turned off', async () => {
+    it('rejects a call to a meta tool the session turned off, and not the same way as one it kept', async () => {
         const { apiKey } = await seedTenant();
         const { token, mcpPath } = await createSession(apiKey, { meta_tools: { nango_tool_search: false } });
 
-        const res = await mcpFetch({
-            token,
-            path: mcpPath,
-            method: 'POST',
-            body: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'nango_tool_search', arguments: { query: 'anything' } } }
-        });
+        const call = async (name: string) =>
+            await mcpFetch({
+                token,
+                path: mcpPath,
+                method: 'POST',
+                body: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: {} } }
+            });
 
-        expect(res.json.result?.isError ?? Boolean(res.json.error)).toBe(true);
+        // Both come back as errors, so the assertion is on which error: a turned-off tool is
+        // refused by the SDK before any handler runs, one the session kept reaches ours.
+        const off = await call('nango_tool_search');
+        expect(off.json.result.isError).toBe(true);
+        expect(off.json.result.content[0].text).toContain('Tool nango_tool_search disabled');
+
+        const on = await call('nango_execute');
+        expect(on.json.result.isError).toBe(true);
+        expect(on.json.result.content[0].text).toContain('cannot be called yet');
     });
 
     it('does not support SSE on GET', async () => {

--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.ts
@@ -9,8 +9,6 @@ import type { GetAgentSessionMcp, PostAgentSessionMcp } from '@nangohq/types';
 export const postAgentSessionMcp = asyncWrapperWithEnvironment<PostAgentSessionMcp>(async (req, res) => {
     const session = res.locals['agentSession'];
 
-    // The token already identifies the session, so the path segment is only ever a mismatch to
-    // catch: one session's token pointed at another session's url.
     if (req.params.sessionId !== session.id) {
         res.status(404).send({ error: { code: 'session_not_found', message: `Agent session '${req.params.sessionId}' not found` } });
         return;

--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.ts
@@ -1,0 +1,44 @@
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
+import { createAgentSessionMcpServer } from './sessionServer.js';
+
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { GetAgentSessionMcp, PostAgentSessionMcp } from '@nangohq/types';
+
+export const postAgentSessionMcp = asyncWrapperWithEnvironment<PostAgentSessionMcp>(async (req, res) => {
+    const session = res.locals['agentSession'];
+
+    // The token already identifies the session, so the path segment is only ever a mismatch to
+    // catch: one session's token pointed at another session's url.
+    if (req.params.sessionId !== session.id) {
+        res.status(404).send({ error: { code: 'session_not_found', message: `Agent session '${req.params.sessionId}' not found` } });
+        return;
+    }
+
+    const server = createAgentSessionMcpServer(session);
+    const transport = new StreamableHTTPServerTransport();
+
+    res.on('close', () => {
+        void transport.close();
+        void server.close();
+    });
+
+    // Casting because 'exactOptionalPropertyTypes: true' says `?: string` is not equal to `string | undefined`
+    await server.connect(transport as Transport);
+    await transport.handleRequest(req, res, req.body);
+});
+
+// We have to be explicit about not supporting SSE
+export const getAgentSessionMcp = asyncWrapperWithEnvironment<GetAgentSessionMcp>((_, res) => {
+    res.writeHead(405).end(
+        JSON.stringify({
+            jsonrpc: '2.0',
+            error: {
+                code: -32000,
+                message: 'Method not allowed.'
+            },
+            id: null
+        })
+    );
+});

--- a/packages/server/lib/controllers/agent/mcp/sessionServer.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionServer.ts
@@ -1,0 +1,167 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
+
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { AgentSession, AgentSessionMetaTools } from '@nangohq/types';
+
+export const TOOLS_PAGE_SIZE = 50;
+
+/**
+ * A tool name is unique across the whole server, but an action name is only unique within its
+ * integration, so the listed name is qualified. `_meta` carries both halves back so a caller
+ * never has to split the name to know what it points at.
+ */
+export const TOOL_NAME_SEPARATOR = '__';
+
+export const INTEGRATION_META_KEY = 'nango/integration';
+export const TOOL_META_KEY = 'nango/tool';
+
+/** A listed tool always describes itself, which `Tool` leaves optional. */
+type SessionTool = Tool & { description: string };
+
+interface MetaToolDefinition {
+    readonly name: string;
+    readonly description: string;
+    readonly inputSchema: Tool['inputSchema'];
+    readonly isEnabled: (metaTools: AgentSessionMetaTools) => boolean;
+}
+
+/**
+ * Input schemas are provisional: NAN-6601 and NAN-6603 own the final argument shapes when they
+ * add the handlers. They are listed now so a client can see what the session offers.
+ */
+const META_TOOLS: MetaToolDefinition[] = [
+    {
+        name: 'nango_tool_search',
+        description:
+            'Search the tools this session can reach that are not already listed. Returns tool names to pass to nango_execute, so start here when no listed tool fits the task.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                query: { type: 'string', description: 'What the tool should do, in plain language.' },
+                integration: { type: 'string', description: 'Restrict the search to one integration id.' }
+            },
+            required: ['query']
+        },
+        isEnabled: (metaTools) => metaTools.nangoToolSearch
+    },
+    {
+        name: 'nango_execute',
+        description: 'Run a tool on one of the session integrations, on the connection the session resolved for it.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                integration: { type: 'string', description: 'The integration id the tool belongs to.' },
+                tool: { type: 'string', description: 'The tool name, unqualified.' },
+                input: { type: 'object', description: 'The arguments to pass to the tool.', additionalProperties: true }
+            },
+            required: ['integration', 'tool']
+        },
+        isEnabled: (metaTools) => metaTools.nangoExecute
+    }
+];
+
+/**
+ * The compiled toolset stores a name and a description per tool, not an argument schema, so a
+ * pinned tool is listed as accepting a free-form object.
+ * TODO(NAN-6601): snapshot the action input schema at compile time and list it here.
+ */
+const PINNED_TOOL_INPUT_SCHEMA: Tool['inputSchema'] = { type: 'object', properties: {}, additionalProperties: true };
+
+export function createAgentSessionMcpServer(session: AgentSession): McpServer {
+    const server = new McpServer(
+        {
+            name: 'Nango Agent Session MCP server',
+            version: '1.0.0'
+        },
+        {
+            capabilities: {
+                tools: {}
+            }
+        }
+    );
+
+    const tools = listSessionTools(session);
+
+    // Registered so a call reaches a handler rather than the SDK's unknown-tool error. Execution
+    // lands in NAN-6601, NAN-6602 and NAN-6603.
+    for (const tool of tools) {
+        server.registerTool(tool.name, { description: tool.description }, () => toolNotImplemented(tool.name));
+    }
+
+    // The high level list handler neither paginates nor emits `_meta`, so the listing is served
+    // from the snapshot instead.
+    server.server.setRequestHandler(ListToolsRequestSchema, (request) => {
+        const offset = decodeCursor(request.params?.cursor);
+        const page = tools.slice(offset, offset + TOOLS_PAGE_SIZE);
+        const next = offset + page.length;
+
+        return {
+            tools: page,
+            ...(next < tools.length ? { nextCursor: encodeCursor(next) } : {})
+        };
+    });
+
+    return server;
+}
+
+/**
+ * The tools the session puts in front of the agent: the meta tools it was created with, then
+ * every pinned tool. Searchable tools are deliberately absent, they are reached through
+ * nango_tool_search so that a large toolset does not fill the context window.
+ *
+ * The order is stable for the life of the session, which is what makes an offset cursor safe.
+ */
+export function listSessionTools(session: AgentSession): SessionTool[] {
+    const metaTools = META_TOOLS.filter((tool) => tool.isEnabled(session.metaTools)).map(
+        (tool): SessionTool => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema
+        })
+    );
+
+    const pinnedTools = Object.entries(session.compiledToolset)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .flatMap(([integrationId, integration]) =>
+            integration.pinned.map(
+                (tool): SessionTool => ({
+                    name: `${integrationId}${TOOL_NAME_SEPARATOR}${tool.name}`,
+                    description: tool.description,
+                    inputSchema: PINNED_TOOL_INPUT_SCHEMA,
+                    _meta: { [INTEGRATION_META_KEY]: integrationId, [TOOL_META_KEY]: tool.name }
+                })
+            )
+        );
+
+    return [...metaTools, ...pinnedTools];
+}
+
+function toolNotImplemented(name: string): CallToolResult {
+    return {
+        isError: true,
+        content: [{ type: 'text', text: `Tool '${name}' cannot be called yet on an agent session.` }]
+    };
+}
+
+function encodeCursor(offset: number): string {
+    return Buffer.from(String(offset), 'utf8').toString('base64url');
+}
+
+/**
+ * A cursor is an offset into a listing that cannot change, so it only has to survive the round
+ * trip. Anything that is not one we minted is rejected rather than treated as the first page,
+ * because silently restarting a listing is how a client loops forever.
+ */
+function decodeCursor(cursor: string | undefined): number {
+    if (cursor === undefined) {
+        return 0;
+    }
+
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    if (!/^\d+$/.test(decoded)) {
+        throw new McpError(ErrorCode.InvalidParams, 'Invalid cursor');
+    }
+
+    return parseInt(decoded, 10);
+}

--- a/packages/server/lib/controllers/agent/mcp/sessionServer.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionServer.ts
@@ -1,20 +1,33 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 
-import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+import { mcpToolError } from '../../mcp/utils.js';
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { AgentSession, AgentSessionMetaTools } from '@nangohq/types';
 
 export const TOOLS_PAGE_SIZE = 50;
 
 /**
  * A tool name is unique across the whole server, but an action name is only unique within its
- * integration, so the listed name is qualified. `_meta` carries both halves back so a caller
- * never has to split the name to know what it points at.
+ * integration, so the listed name is qualified. `_meta` carries both halves back, and it, not
+ * the name, is what a caller reads to know what a tool points at.
  */
 export const TOOL_NAME_SEPARATOR = '__';
 
 export const INTEGRATION_META_KEY = 'nango/integration';
 export const TOOL_META_KEY = 'nango/tool';
+
+/**
+ * Tool names have to match `^[a-zA-Z0-9_-]{1,64}$` to be usable as Claude tool definitions, while
+ * an integration id may hold `~ : . @` and spaces and either half may run to 255 characters. So
+ * each half is sanitised and clipped rather than concatenated as it is stored.
+ */
+const MAX_TOOL_NAME_LENGTH = 64;
+const MAX_NAME_PART_LENGTH = 30;
+const UNSAFE_NAME_CHARACTERS = /[^a-zA-Z0-9_-]/g;
+
+const JSON_SCHEMA_2020_12 = 'https://json-schema.org/draft/2020-12/schema';
 
 /** A listed tool always describes itself, which `Tool` leaves optional. */
 type SessionTool = Tool & { description: string };
@@ -36,6 +49,7 @@ const META_TOOLS: MetaToolDefinition[] = [
         description:
             'Search the tools this session can reach that are not already listed. Returns tool names to pass to nango_execute, so start here when no listed tool fits the task.',
         inputSchema: {
+            $schema: JSON_SCHEMA_2020_12,
             type: 'object',
             properties: {
                 query: { type: 'string', description: 'What the tool should do, in plain language.' },
@@ -49,6 +63,7 @@ const META_TOOLS: MetaToolDefinition[] = [
         name: 'nango_execute',
         description: 'Run a tool on one of the session integrations, on the connection the session resolved for it.',
         inputSchema: {
+            $schema: JSON_SCHEMA_2020_12,
             type: 'object',
             properties: {
                 integration: { type: 'string', description: 'The integration id the tool belongs to.' },
@@ -66,7 +81,12 @@ const META_TOOLS: MetaToolDefinition[] = [
  * pinned tool is listed as accepting a free-form object.
  * TODO(NAN-6601): snapshot the action input schema at compile time and list it here.
  */
-const PINNED_TOOL_INPUT_SCHEMA: Tool['inputSchema'] = { type: 'object', properties: {}, additionalProperties: true };
+const PINNED_TOOL_INPUT_SCHEMA: Tool['inputSchema'] = {
+    $schema: JSON_SCHEMA_2020_12,
+    type: 'object',
+    properties: {},
+    additionalProperties: true
+};
 
 export function createAgentSessionMcpServer(session: AgentSession): McpServer {
     const server = new McpServer(
@@ -82,11 +102,19 @@ export function createAgentSessionMcpServer(session: AgentSession): McpServer {
     );
 
     const tools = listSessionTools(session);
+    const listed = new Set(tools.map((tool) => tool.name));
 
     // Registered so a call reaches a handler rather than the SDK's unknown-tool error. Execution
     // lands in NAN-6601, NAN-6602 and NAN-6603.
-    for (const tool of tools) {
-        server.registerTool(tool.name, { description: tool.description }, () => toolNotImplemented(tool.name));
+    for (const tool of [...tools, ...disabledMetaTools(session.metaTools)]) {
+        const registered = server.registerTool(tool.name, { description: tool.description }, () =>
+            mcpToolError(`Tool '${tool.name}' cannot be called yet on an agent session.`)
+        );
+
+        if (!listed.has(tool.name)) {
+            // Disabled tools are omitted from tools/list and rejected by the SDK if called.
+            registered.disable();
+        }
     }
 
     // The high level list handler neither paginates nor emits `_meta`, so the listing is served
@@ -97,7 +125,7 @@ export function createAgentSessionMcpServer(session: AgentSession): McpServer {
         const next = offset + page.length;
 
         return {
-            tools: page,
+            tools: page.map((tool) => ({ ...tool, execution: { taskSupport: 'forbidden' as const } })),
             ...(next < tools.length ? { nextCursor: encodeCursor(next) } : {})
         };
     });
@@ -111,11 +139,14 @@ export function createAgentSessionMcpServer(session: AgentSession): McpServer {
  * nango_tool_search so that a large toolset does not fill the context window.
  *
  * The order is stable for the life of the session, which is what makes an offset cursor safe.
+ * Meta tools are named first so that no pinned tool can take a meta tool's name.
  */
 export function listSessionTools(session: AgentSession): SessionTool[] {
+    const taken = new Set<string>();
+
     const metaTools = META_TOOLS.filter((tool) => tool.isEnabled(session.metaTools)).map(
         (tool): SessionTool => ({
-            name: tool.name,
+            name: claimToolName(tool.name, taken),
             description: tool.description,
             inputSchema: tool.inputSchema
         })
@@ -126,7 +157,7 @@ export function listSessionTools(session: AgentSession): SessionTool[] {
         .flatMap(([integrationId, integration]) =>
             integration.pinned.map(
                 (tool): SessionTool => ({
-                    name: `${integrationId}${TOOL_NAME_SEPARATOR}${tool.name}`,
+                    name: claimToolName(qualifiedToolName(integrationId, tool.name), taken),
                     description: tool.description,
                     inputSchema: PINNED_TOOL_INPUT_SCHEMA,
                     _meta: { [INTEGRATION_META_KEY]: integrationId, [TOOL_META_KEY]: tool.name }
@@ -137,11 +168,39 @@ export function listSessionTools(session: AgentSession): SessionTool[] {
     return [...metaTools, ...pinnedTools];
 }
 
-function toolNotImplemented(name: string): CallToolResult {
-    return {
-        isError: true,
-        content: [{ type: 'text', text: `Tool '${name}' cannot be called yet on an agent session.` }]
-    };
+function qualifiedToolName(integrationId: string, toolName: string): string {
+    return `${sanitizeNamePart(integrationId)}${TOOL_NAME_SEPARATOR}${sanitizeNamePart(toolName)}`;
+}
+
+function sanitizeNamePart(part: string): string {
+    return part.replace(UNSAFE_NAME_CHARACTERS, '_').slice(0, MAX_NAME_PART_LENGTH);
+}
+
+/**
+ * Sanitising and clipping can map two different tools onto one name, and a duplicate name makes
+ * the listing ambiguous and lets one registration shadow another. The first tool to ask for a
+ * name keeps it and later ones are numbered, which is stable because the listing is built once
+ * from a snapshot in a fixed order.
+ */
+function claimToolName(name: string, taken: Set<string>): string {
+    if (!taken.has(name)) {
+        taken.add(name);
+        return name;
+    }
+
+    for (let suffix = 2; ; suffix++) {
+        const room = MAX_TOOL_NAME_LENGTH - String(suffix).length - 1;
+        const candidate = `${name.slice(0, room)}_${suffix}`;
+        if (!taken.has(candidate)) {
+            taken.add(candidate);
+            return candidate;
+        }
+    }
+}
+
+/** Meta tools the session turned off, registered disabled so calling one is not an unknown tool. */
+function disabledMetaTools(metaTools: AgentSessionMetaTools): { name: string; description: string }[] {
+    return META_TOOLS.filter((tool) => !tool.isEnabled(metaTools)).map((tool) => ({ name: tool.name, description: tool.description }));
 }
 
 function encodeCursor(offset: number): string {

--- a/packages/server/lib/controllers/agent/mcp/sessionServer.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionServer.ts
@@ -18,18 +18,12 @@ export const TOOL_NAME_SEPARATOR = '__';
 export const INTEGRATION_META_KEY = 'nango/integration';
 export const TOOL_META_KEY = 'nango/tool';
 
-/**
- * Tool names have to match `^[a-zA-Z0-9_-]{1,64}$` to be usable as Claude tool definitions, while
- * an integration id may hold `~ : . @` and spaces and either half may run to 255 characters. So
- * each half is sanitised and clipped rather than concatenated as it is stored.
- */
 const MAX_TOOL_NAME_LENGTH = 64;
 const MAX_NAME_PART_LENGTH = 30;
 const UNSAFE_NAME_CHARACTERS = /[^a-zA-Z0-9_-]/g;
 
 const JSON_SCHEMA_2020_12 = 'https://json-schema.org/draft/2020-12/schema';
 
-/** A listed tool always describes itself, which `Tool` leaves optional. */
 type SessionTool = Tool & { description: string };
 
 interface MetaToolDefinition {
@@ -39,10 +33,6 @@ interface MetaToolDefinition {
     readonly isEnabled: (metaTools: AgentSessionMetaTools) => boolean;
 }
 
-/**
- * Input schemas are provisional: NAN-6601 and NAN-6603 own the final argument shapes when they
- * add the handlers. They are listed now so a client can see what the session offers.
- */
 const META_TOOLS: MetaToolDefinition[] = [
     {
         name: 'nango_tool_search',
@@ -117,8 +107,6 @@ export function createAgentSessionMcpServer(session: AgentSession): McpServer {
         }
     }
 
-    // The high level list handler neither paginates nor emits `_meta`, so the listing is served
-    // from the snapshot instead.
     server.server.setRequestHandler(ListToolsRequestSchema, (request) => {
         const offset = decodeCursor(request.params?.cursor);
         const page = tools.slice(offset, offset + TOOLS_PAGE_SIZE);
@@ -177,10 +165,8 @@ function sanitizeNamePart(part: string): string {
 }
 
 /**
- * Sanitising and clipping can map two different tools onto one name, and a duplicate name makes
- * the listing ambiguous and lets one registration shadow another. The first tool to ask for a
- * name keeps it and later ones are numbered, which is stable because the listing is built once
- * from a snapshot in a fixed order.
+ * Sanitising and clipping can map two tools onto one name, which would let one registration
+ * shadow another. First claim wins, later ones are numbered.
  */
 function claimToolName(name: string, taken: Set<string>): string {
     if (!taken.has(name)) {
@@ -198,7 +184,6 @@ function claimToolName(name: string, taken: Set<string>): string {
     }
 }
 
-/** Meta tools the session turned off, registered disabled so calling one is not an unknown tool. */
 function disabledMetaTools(metaTools: AgentSessionMetaTools): { name: string; description: string }[] {
     return META_TOOLS.filter((tool) => !tool.isEnabled(metaTools)).map((tool) => ({ name: tool.name, description: tool.description }));
 }
@@ -207,11 +192,6 @@ function encodeCursor(offset: number): string {
     return Buffer.from(String(offset), 'utf8').toString('base64url');
 }
 
-/**
- * A cursor is an offset into a listing that cannot change, so it only has to survive the round
- * trip. Anything that is not one we minted is rejected rather than treated as the first page,
- * because silently restarting a listing is how a client loops forever.
- */
 function decodeCursor(cursor: string | undefined): number {
     if (cursor === undefined) {
         return 0;

--- a/packages/server/lib/controllers/agent/mcp/sessionServer.unit.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionServer.unit.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { listSessionTools, TOOLS_PAGE_SIZE } from './sessionServer.js';
+
+import type { AgentSession, AgentSessionCompiledToolset, AgentSessionMetaTools } from '@nangohq/types';
+
+function session({
+    compiledToolset = {},
+    metaTools = { nangoToolSearch: true, nangoExecute: true }
+}: {
+    compiledToolset?: AgentSessionCompiledToolset;
+    metaTools?: AgentSessionMetaTools;
+} = {}): AgentSession {
+    return {
+        id: 'session-1',
+        environmentId: 1,
+        accountId: 1,
+        resolvedConnections: {},
+        compiledToolset,
+        metaTools,
+        expiresAt: new Date(),
+        endedAt: null,
+        endedReason: null,
+        createdAt: new Date(),
+        updatedAt: new Date()
+    };
+}
+
+function tool(name: string) {
+    return { name, description: `${name} description` };
+}
+
+describe('listSessionTools', () => {
+    it('lists the meta tools the session was created with', () => {
+        expect(listSessionTools(session()).map((tool) => tool.name)).toStrictEqual(['nango_tool_search', 'nango_execute']);
+        expect(listSessionTools(session({ metaTools: { nangoToolSearch: false, nangoExecute: true } })).map((tool) => tool.name)).toStrictEqual([
+            'nango_execute'
+        ]);
+        expect(listSessionTools(session({ metaTools: { nangoToolSearch: false, nangoExecute: false } }))).toStrictEqual([]);
+    });
+
+    it('lists pinned tools and leaves searchable tools out', () => {
+        const tools = listSessionTools(
+            session({
+                compiledToolset: {
+                    notion: { provider: 'notion', pinned: [tool('read_doc')], searchable: [tool('upsert_doc')] }
+                }
+            })
+        );
+
+        expect(tools.map((tool) => tool.name)).toStrictEqual(['nango_tool_search', 'nango_execute', 'notion__read_doc']);
+    });
+
+    it('qualifies a pinned tool name by integration and carries both halves in _meta', () => {
+        const tools = listSessionTools(
+            session({
+                compiledToolset: {
+                    slack: { provider: 'slack', pinned: [tool('send_message')], searchable: [] },
+                    discord: { provider: 'discord', pinned: [tool('send_message')], searchable: [] }
+                }
+            })
+        );
+
+        expect(tools.slice(2)).toStrictEqual([
+            {
+                name: 'discord__send_message',
+                description: 'send_message description',
+                inputSchema: { type: 'object', properties: {}, additionalProperties: true },
+                _meta: { 'nango/integration': 'discord', 'nango/tool': 'send_message' }
+            },
+            {
+                name: 'slack__send_message',
+                description: 'send_message description',
+                inputSchema: { type: 'object', properties: {}, additionalProperties: true },
+                _meta: { 'nango/integration': 'slack', 'nango/tool': 'send_message' }
+            }
+        ]);
+    });
+
+    it('orders integrations by id so a cursor stays valid across list calls', () => {
+        const toolset: AgentSessionCompiledToolset = {
+            zendesk: { provider: 'zendesk', pinned: [tool('get_ticket')], searchable: [] },
+            asana: { provider: 'asana', pinned: [tool('get_task')], searchable: [] }
+        };
+
+        expect(listSessionTools(session({ compiledToolset: toolset })).map((tool) => tool.name)).toStrictEqual(
+            listSessionTools(session({ compiledToolset: { ...toolset } })).map((tool) => tool.name)
+        );
+        expect(listSessionTools(session({ compiledToolset: toolset })).map((tool) => tool.name)).toStrictEqual([
+            'nango_tool_search',
+            'nango_execute',
+            'asana__get_task',
+            'zendesk__get_ticket'
+        ]);
+    });
+
+    it('does not list meta tools it does not ship', () => {
+        expect(listSessionTools(session()).map((tool) => tool.name)).not.toContain('nango_proxy');
+    });
+
+    it('keeps a page worth of tools listable', () => {
+        const pinned = Array.from({ length: TOOLS_PAGE_SIZE * 2 }, (_, index) => tool(`action_${index}`));
+        const tools = listSessionTools(session({ compiledToolset: { notion: { provider: 'notion', pinned, searchable: [] } } }));
+
+        expect(tools).toHaveLength(TOOLS_PAGE_SIZE * 2 + 2);
+    });
+});

--- a/packages/server/lib/controllers/agent/mcp/sessionServer.unit.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionServer.unit.test.ts
@@ -65,13 +65,13 @@ describe('listSessionTools', () => {
             {
                 name: 'discord__send_message',
                 description: 'send_message description',
-                inputSchema: { type: 'object', properties: {}, additionalProperties: true },
+                inputSchema: { $schema: 'https://json-schema.org/draft/2020-12/schema', type: 'object', properties: {}, additionalProperties: true },
                 _meta: { 'nango/integration': 'discord', 'nango/tool': 'send_message' }
             },
             {
                 name: 'slack__send_message',
                 description: 'send_message description',
-                inputSchema: { type: 'object', properties: {}, additionalProperties: true },
+                inputSchema: { $schema: 'https://json-schema.org/draft/2020-12/schema', type: 'object', properties: {}, additionalProperties: true },
                 _meta: { 'nango/integration': 'slack', 'nango/tool': 'send_message' }
             }
         ]);
@@ -96,6 +96,63 @@ describe('listSessionTools', () => {
 
     it('does not list meta tools it does not ship', () => {
         expect(listSessionTools(session()).map((tool) => tool.name)).not.toContain('nango_proxy');
+    });
+
+    it('sanitises characters an integration id allows but a tool name does not', () => {
+        const tools = listSessionTools(
+            session({
+                compiledToolset: {
+                    'my notion.v2@acme': { provider: 'notion', pinned: [tool('read_doc')], searchable: [] }
+                }
+            })
+        );
+
+        expect(tools[2]!.name).toBe('my_notion_v2_acme__read_doc');
+        expect(tools[2]!.name).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+        expect(tools[2]!._meta).toStrictEqual({ 'nango/integration': 'my notion.v2@acme', 'nango/tool': 'read_doc' });
+    });
+
+    it('keeps every name within the 64 character tool name limit', () => {
+        const tools = listSessionTools(
+            session({
+                compiledToolset: {
+                    ['a'.repeat(200)]: { provider: 'notion', pinned: [tool('b'.repeat(200))], searchable: [] }
+                }
+            })
+        );
+
+        for (const listed of tools) {
+            expect(listed.name).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+        }
+    });
+
+    it('numbers a name two different tools would otherwise share', () => {
+        const tools = listSessionTools(
+            session({
+                compiledToolset: {
+                    // Both sanitise to `a_b__c`, which is exactly the collision the separator cannot prevent.
+                    'a.b': { provider: 'notion', pinned: [tool('c')], searchable: [] },
+                    'a-b': { provider: 'notion', pinned: [tool('c')], searchable: [] }
+                }
+            })
+        );
+
+        expect(tools.slice(2).map((tool) => tool.name)).toStrictEqual(['a-b__c', 'a_b__c']);
+        expect(new Set(tools.map((tool) => tool.name)).size).toBe(tools.length);
+    });
+
+    it('never lets a pinned tool take a meta tool name', () => {
+        const tools = listSessionTools(
+            session({
+                compiledToolset: {
+                    nango: { provider: 'notion', pinned: [tool('execute')], searchable: [] }
+                }
+            })
+        );
+
+        expect(tools.filter((tool) => tool.name === 'nango_execute')).toHaveLength(1);
+        expect(tools[0]!.name).toBe('nango_tool_search');
+        expect(tools[1]!.name).toBe('nango_execute');
     });
 
     it('keeps a page worth of tools listable', () => {

--- a/packages/server/lib/controllers/agent/mcp/sessionServer.unit.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionServer.unit.test.ts
@@ -132,12 +132,12 @@ describe('listSessionTools', () => {
                 compiledToolset: {
                     // Both sanitise to `a_b__c`, which is exactly the collision the separator cannot prevent.
                     'a.b': { provider: 'notion', pinned: [tool('c')], searchable: [] },
-                    'a-b': { provider: 'notion', pinned: [tool('c')], searchable: [] }
+                    a_b: { provider: 'notion', pinned: [tool('c')], searchable: [] }
                 }
             })
         );
 
-        expect(tools.slice(2).map((tool) => tool.name)).toStrictEqual(['a-b__c', 'a_b__c']);
+        expect(tools.slice(2).map((tool) => tool.name)).toStrictEqual(['a_b__c', 'a_b__c_2']);
         expect(new Set(tools.map((tool) => tool.name)).size).toBe(tools.length);
     });
 

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -8,6 +8,7 @@ import { connectUrl, flagEnforceCLIVersion } from '@nangohq/utils';
 
 import { getAsyncActionResult } from './controllers/action/getAsyncActionResult.js';
 import { postPublicTriggerAction } from './controllers/action/postTriggerAction.js';
+import { getAgentSessionMcp, postAgentSessionMcp } from './controllers/agent/mcp/sessionMcp.js';
 import { postAgentSessions } from './controllers/agent/postSessions.js';
 import appAuthController from './controllers/appAuth.controller.js';
 import { postPublicApiKeyAuthorization } from './controllers/auth/postApiKey.js';
@@ -124,6 +125,7 @@ import type { Request, RequestHandler } from 'express';
 
 const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
 const connectSessionAuth: RequestHandler[] = [authMiddleware.connectSessionAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
+const agentSessionAuth: RequestHandler[] = [authMiddleware.agentSessionAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
 const connectSessionAuthBody: RequestHandler[] = [authMiddleware.connectSessionAuthBody.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
 const connectSessionOrApiAuth: RequestHandler[] = [
     authMiddleware.connectSessionOrSecretKeyAuth.bind(authMiddleware),
@@ -404,6 +406,9 @@ publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTe
 // Agent sessions
 publicAPI.use('/sessions', jsonContentTypeMiddleware);
 publicAPI.route('/sessions').post(apiAuth, withScope('environment:agent_sessions:write'), postAgentSessions);
+publicAPI.use('/session/:sessionId/mcp', jsonContentTypeMiddleware);
+publicAPI.route('/session/:sessionId/mcp').post(agentSessionAuth, postAgentSessionMcp);
+publicAPI.route('/session/:sessionId/mcp').get(agentSessionAuth, getAgentSessionMcp);
 
 // V1 passthrough (deprecated) — scope checks are inline in allPublicV1 after action/model resolution
 publicAPI.use('/v1', jsonContentTypeMiddleware);

--- a/packages/types/lib/agent/mcp.api.ts
+++ b/packages/types/lib/agent/mcp.api.ts
@@ -1,0 +1,21 @@
+import type { ApiEndpoint, ApiError } from '../api.js';
+
+export type AgentSessionMcpErrorCode = 'session_not_found';
+
+export type PostAgentSessionMcp = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Method: 'POST';
+    Path: '/session/:sessionId/mcp';
+    Params: { sessionId: string };
+    Body: Record<string, unknown>;
+    Success: Record<string, unknown>;
+    Error: ApiError<AgentSessionMcpErrorCode>;
+}>;
+
+export type GetAgentSessionMcp = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
+    Method: 'GET';
+    Path: '/session/:sessionId/mcp';
+    Params: { sessionId: string };
+    Success: Record<string, unknown>;
+}>;

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -20,6 +20,7 @@ import type {
 import type { GetAsyncActionResult, GetPublicV1, PostInternalTriggerFunction, PostPublicTriggerAction } from './action/api.js';
 import type { PostImpersonate } from './admin/http.api.js';
 import type { PostAgentSessions } from './agent/api.js';
+import type { GetAgentSessionMcp, PostAgentSessionMcp } from './agent/mcp.api.js';
 import type { EndpointMethod } from './api.js';
 import type { GetAuditTrail, GetAuditTrailExport } from './audit-trail/api.js';
 import type {
@@ -168,6 +169,8 @@ export type PublicApiEndpoints =
     | DeletePublicIntegration
     | PostConnectSessions
     | PostAgentSessions
+    | PostAgentSessionMcp
+    | GetAgentSessionMcp
     | PostPublicConnectSessionsReconnect
     | GetPublicConnections
     | GetPublicConnection

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -15,6 +15,7 @@ export type * from './keystore/index.js';
 export type * from './action/api.js';
 export type * from './agent/api.js';
 export type * from './agent/connections.js';
+export type * from './agent/mcp.api.js';
 export type * from './agent/session.js';
 export type * from './agent/toolset.js';
 export type * from './admin/http.api.js';


### PR DESCRIPTION
NAN-6600

Adds the MCP endpoint an agent session is handed at creation.

POST /session/:sessionId/mcp, authenticated by the session token. GET returns 405 like the other MCP routes.

tools/list returns the meta tools the session was created with plus its pinned tools, paginated with a cursor. Each pinned tool carries its integration and unqualified name in `_meta`. Tool calls are not served yet, they land in NAN-6601, NAN-6602 and NAN-6603.

Stacked on #7232.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

