### PR TITLE
fix(audit): add the missing details to failed connection and webhook events

### DIFF
--- a/packages/audit/lib/event.ts
+++ b/packages/audit/lib/event.ts
@@ -96,6 +96,7 @@ interface EnvironmentVariablesChangedMetadata {
     variableNames?: string[];
 }
 interface EnvironmentWebhookMetadata {
+    changedFields?: string[];
     primaryUrl?: string;
     secondaryUrl?: string;
 }

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -623,8 +623,6 @@ export const auditConnectionCreated = maybeAuditable<Endpoint<any> & { Audit: Au
     actor: (req, locals) => connectionCreatedActor(resolveActor(locals), req.audit?.connectionUpsert?.endUser),
     atFinish: (req) => {
         const upsert = req.audit?.connectionUpsert;
-        // A failed attempt sets no upsert, so without this every failure is the same blank row. The OAuth
-        // callback still records neither: its connection is encoded in the state it round-trips.
         const connectionId = upsert?.connectionId ?? nonEmptyString(query(req, 'connection_id')) ?? nonEmptyString(bodyField(req, 'connection_id'));
         const providerConfigKey =
             upsert?.providerConfigKey ?? nonEmptyString(param(req, 'providerConfigKey')) ?? nonEmptyString(bodyField(req, 'provider_config_key'));

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -443,6 +443,9 @@ function param(req: Request<any, any, any, any>, key: string): unknown {
 function query(req: Request<any, any, any, any>, key: string): unknown {
     return (req.query as Record<string, unknown>)[key];
 }
+function bodyField(req: Request<any, any, any, any>, key: string): unknown {
+    return (req.body as Record<string, unknown> | undefined)?.[key];
+}
 /** Resolvers run before the controller validates, so a field the endpoint types as a string can hold anything. */
 function nonEmptyString(value: unknown): string | undefined {
     return typeof value === 'string' && value.length > 0 ? value : undefined;
@@ -620,9 +623,14 @@ export const auditConnectionCreated = maybeAuditable<Endpoint<any> & { Audit: Au
     actor: (req, locals) => connectionCreatedActor(resolveActor(locals), req.audit?.connectionUpsert?.endUser),
     atFinish: (req) => {
         const upsert = req.audit?.connectionUpsert;
+        // A failed attempt sets no upsert, so without this every failure is the same blank row. The OAuth
+        // callback still records neither: its connection is encoded in the state it round-trips.
+        const connectionId = upsert?.connectionId ?? nonEmptyString(query(req, 'connection_id')) ?? nonEmptyString(bodyField(req, 'connection_id'));
+        const providerConfigKey =
+            upsert?.providerConfigKey ?? nonEmptyString(param(req, 'providerConfigKey')) ?? nonEmptyString(bodyField(req, 'provider_config_key'));
         return {
-            target: makeTarget('connection', upsert?.connectionId),
-            metadata: upsert?.providerConfigKey ? { providerConfigKey: upsert.providerConfigKey } : undefined
+            target: makeTarget('connection', connectionId),
+            metadata: providerConfigKeyMeta(providerConfigKey)
         };
     }
 });
@@ -832,6 +840,7 @@ export const auditEnvironmentWebhookUrlsChanged = auditable<PatchWebhook>({
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
     metadata: (req) =>
         omitUndefined({
+            changedFields: changedFields(req.body),
             primaryUrl: safeUrl(req.body.primary_url),
             secondaryUrl: safeUrl(req.body.secondary_url)
         })

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -216,14 +216,6 @@ describe('auditable() middleware behavior (unit)', () => {
         expect(event?.metadata).toEqual({ providerConfigKey: 'algolia' });
     });
 
-    it('connection create: two failures against different integrations are distinguishable', async () => {
-        const first = await runAudit(auditConnectionCreated, fakeReq({ params: { providerConfigKey: 'algolia' } }), fakeRes(locals, 400));
-        recordMock.mockClear();
-        const second = await runAudit(auditConnectionCreated, fakeReq({ params: { providerConfigKey: 'hubspot' } }), fakeRes(locals, 400));
-        expect(first?.metadata).toEqual({ providerConfigKey: 'algolia' });
-        expect(second?.metadata).toEqual({ providerConfigKey: 'hubspot' });
-    });
-
     it('connection create: the OAuth callback carries neither, so it still records the attempt and nothing more', async () => {
         const event = await runAudit(auditConnectionCreated, fakeReq({ body: undefined }), fakeRes(locals, 400));
         expect(event).toMatchObject({ resource: 'connection', action: 'created', outcome: 'failure', accountId: 42, targets: [] });

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -209,6 +209,13 @@ describe('auditable() middleware behavior (unit)', () => {
         });
     });
 
+    it('connection create: no caller-supplied connection id leaves the target empty, never a placeholder', async () => {
+        const event = await runAudit(auditConnectionCreated, fakeReq({ params: { providerConfigKey: 'algolia' } }), fakeRes(locals, 400));
+        expect(event).toMatchObject({ resource: 'connection', action: 'created', outcome: 'failure', accountId: 42 });
+        expect(event?.targets).toEqual([]);
+        expect(event?.metadata).toEqual({ providerConfigKey: 'algolia' });
+    });
+
     it('connection create: two failures against different integrations are distinguishable', async () => {
         const first = await runAudit(auditConnectionCreated, fakeReq({ params: { providerConfigKey: 'algolia' } }), fakeRes(locals, 400));
         recordMock.mockClear();

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flags } from '@nangohq/utils';
 
 import {
+    auditConnectionCreated,
     auditConnectionUpdated,
     auditEnvironmentVariablesChanged,
     auditEnvironmentWebhookUrlsChanged,
@@ -183,15 +184,94 @@ describe('auditable() middleware behavior (unit)', () => {
         expect(JSON.stringify(event)).not.toContain('leaked-value');
     });
 
+    it('connection create: a failed attempt names the integration from the path and the connection from the query', async () => {
+        const req = fakeReq({ params: { providerConfigKey: 'algolia' }, query: { connection_id: 'conn-a' } });
+        const event = await runAudit(auditConnectionCreated, req, fakeRes(locals, 400));
+        expect(event).toMatchObject({
+            resource: 'connection',
+            action: 'created',
+            outcome: 'failure',
+            accountId: 42,
+            environment: { id: 9, display: 'dev' },
+            targets: [{ type: 'connection', id: 'conn-a' }],
+            metadata: { providerConfigKey: 'algolia' }
+        });
+    });
+
+    it('connection create: a failed attempt on POST /connections reads the body instead', async () => {
+        const req = fakeReq({ body: { provider_config_key: 'algolia', connection_id: 'conn-b' } });
+        const event = await runAudit(auditConnectionCreated, req, fakeRes(locals, 400));
+        expect(event).toMatchObject({
+            outcome: 'failure',
+            accountId: 42,
+            targets: [{ type: 'connection', id: 'conn-b' }],
+            metadata: { providerConfigKey: 'algolia' }
+        });
+    });
+
+    it('connection create: two failures against different integrations are distinguishable', async () => {
+        const first = await runAudit(auditConnectionCreated, fakeReq({ params: { providerConfigKey: 'algolia' } }), fakeRes(locals, 400));
+        recordMock.mockClear();
+        const second = await runAudit(auditConnectionCreated, fakeReq({ params: { providerConfigKey: 'hubspot' } }), fakeRes(locals, 400));
+        expect(first?.metadata).toEqual({ providerConfigKey: 'algolia' });
+        expect(second?.metadata).toEqual({ providerConfigKey: 'hubspot' });
+    });
+
+    it('connection create: the OAuth callback carries neither, so it still records the attempt and nothing more', async () => {
+        const event = await runAudit(auditConnectionCreated, fakeReq({ body: undefined }), fakeRes(locals, 400));
+        expect(event).toMatchObject({ resource: 'connection', action: 'created', outcome: 'failure', accountId: 42, targets: [] });
+        expect(event?.metadata).toBeUndefined();
+    });
+
+    it('connection create: what the handler upserted wins over the request', async () => {
+        const req = fakeReq({
+            params: { providerConfigKey: 'from-path' },
+            query: { connection_id: 'from-query' },
+            audit: {
+                connectionUpsert: {
+                    operation: 'creation',
+                    connectionId: 'conn-real',
+                    providerConfigKey: 'algolia',
+                    account: locals.account,
+                    environment: locals.environment
+                }
+            }
+        });
+        const event = await runAudit(auditConnectionCreated, req, fakeRes(locals));
+        expect(event).toMatchObject({
+            outcome: 'success',
+            targets: [{ type: 'connection', id: 'conn-real' }],
+            metadata: { providerConfigKey: 'algolia' }
+        });
+    });
+
     it('webhook settings: records only the URL origin, never the path or secret query params', async () => {
         const req = fakeReq({ body: { primary_url: 'https://hooks.example/primary?token=shh-secret' } });
         const event = await runAudit(auditEnvironmentWebhookUrlsChanged, req, fakeRes(locals));
         expect(event).toMatchObject({
             resource: 'environment',
             action: 'webhook_urls_changed',
-            metadata: { primaryUrl: 'https://hooks.example' }
+            outcome: 'success',
+            accountId: 42,
+            environment: { id: 9, display: 'dev' },
+            metadata: { changedFields: ['primary_url'], primaryUrl: 'https://hooks.example' }
         });
         expect(JSON.stringify(event)).not.toContain('shh-secret');
+    });
+
+    it('webhook settings: a toggled notification is recorded, though the endpoint only ever named URLs', async () => {
+        const req = fakeReq({ body: { on_auth_creation: true, on_sync_error: false } });
+        const event = await runAudit(auditEnvironmentWebhookUrlsChanged, req, fakeRes(locals));
+        expect(event).toMatchObject({
+            resource: 'environment',
+            action: 'webhook_urls_changed',
+            outcome: 'success',
+            accountId: 42,
+            environment: { id: 9, display: 'dev' },
+            metadata: { changedFields: ['on_auth_creation', 'on_sync_error'] }
+        });
+        expect(event?.metadata).not.toHaveProperty('primaryUrl');
+        expect(event?.metadata).not.toHaveProperty('secondaryUrl');
     });
 
     it('maps the response status to an outcome (403 → denied, 5xx → failure)', async () => {


### PR DESCRIPTION
Two audit events were recording almost nothing.

**Failed connection attempts.** When creating a connection fails, the event doesn't say which integration or which connection it was for, so every failure looks the same. A customer with a misconfigured client gets thousands of identical rows and no way to tell whether one integration was hit repeatedly or many were tried once.

It now takes the integration and the connection id from what the handler saved when there is one, and otherwise from the path, the query or the body. On some failures neither is there and the event stays as thin as it is today, but most of the time at least the integration is.

**Webhook notification toggles.** `PATCH /environments/webhook` changes two URLs and five on/off notification settings, and emits one event for all seven. The event only ever looked at the URLs, so flipping a checkbox recorded nothing at all. It now records which fields you changed, next to the URL origins it already recorded.

### Why not just skip the failed ones

The middleware records every outcome deliberately, and we can't drop failures without dropping denials too. A 403 here means an API key was missing a scope, which is exactly what the audit trail is for. So the event is written either way, and the only real choice is whether it says anything.

Logs is still the better place to debug a failed connection — it already has the integration, the provider and the error. This isn't trying to replace that.

## Test plan

- [x] A failure records the integration, from the path or from the body on `POST /connections`
- [x] Leaving out the connection id gives an empty target, not a placeholder
- [x] The OAuth callback still records the attempt and nothing else
- [x] A successful create still uses what the handler saved, not the request
- [x] Flipping a checkbox records the fields; changing a URL still records only its origin
- [x] Reverted each fix to check the tests fail
- [x] 63 unit and 30 integration tests pass; `ts-build`, `lint` and Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

