### PR TITLE
fix(design-system): align toast and compact Alert with the Figma spec

### DIFF
--- a/packages/design-system/src/components/ui/alert.stories.tsx
+++ b/packages/design-system/src/components/ui/alert.stories.tsx
@@ -58,10 +58,9 @@ const SHAPES: Shape[] = [
     { label: 'Description only, no icon or dismiss', icon: false, dismissible: false }
 ];
 
-// Figma models a toast with and without a title, but never with an action. The webapp's deploy toast
-// passes one, so that third shape ships too.
 const TOAST_SHAPES: Shape[] = [
     { label: 'Description only', allVariants: true },
+    { label: 'Description only, with action', withAction: true },
     { label: 'With title', title: true },
     { label: 'With title and action', title: true, withAction: true }
 ];

--- a/packages/design-system/src/components/ui/alert.tsx
+++ b/packages/design-system/src/components/ui/alert.tsx
@@ -17,7 +17,7 @@ export const alertVariants = cva(
         'relative grid w-full items-start gap-y-0.5',
         'rounded-ds-sm border-ds-hairline',
         // 16px icon, top-aligned so it stays on the first line when the description wraps. Each size nudges
-        // it down to sit optically centred on that line — see the wide/compact variants for the amounts.
+        // it down to sit optically centred on that line — see the size variants for the amounts.
         // Figma colours the icon from status/{s}/icon, a more vibrant stop than the status text colour, so it
         // takes --alert-icon rather than inheriting currentColor.
         '[&>svg]:col-start-1 [&>svg]:row-start-1 [&>svg]:size-4 [&>svg]:text-[var(--alert-icon)] [&>svg]:mr-2'
@@ -81,15 +81,20 @@ export const alertVariants = cva(
                     '[&>[data-slot=alert-actions]]:col-start-2 [&>[data-slot=alert-actions]]:gap-2 [&>[data-slot=alert-actions]]:mt-1',
                     '[&>[data-slot=alert-close]]:col-start-3 [&>[data-slot=alert-close]]:row-start-1 [&>[data-slot=alert-close]]:self-start [&>[data-slot=alert-close]]:ml-2'
                 ],
-                // single line, tighter vertical padding
                 toast: [
-                    'grid-cols-[auto_1fr_auto_auto] items-center px-2 py-1',
-                    '[&>[data-slot=alert-actions]]:col-start-3 [&>[data-slot=alert-actions]]:row-start-1 [&>[data-slot=alert-actions]]:self-center [&>[data-slot=alert-actions]]:ml-2',
-                    '[&>[data-slot=alert-close]]:col-start-4 [&>[data-slot=alert-close]]:row-start-1 [&>[data-slot=alert-close]]:self-center [&>[data-slot=alert-close]]:ml-2',
-                    // Same two-row centring as wide: a titled toast with an action would otherwise pin both slots to
-                    // the title line. See the wide variant for why start and span share one declaration.
-                    'has-[>[data-slot=alert-title]]:has-[>[data-slot=alert-description]]:[&>[data-slot=alert-actions]]:row-[1/span_2]',
-                    'has-[>[data-slot=alert-title]]:has-[>[data-slot=alert-description]]:[&>[data-slot=alert-close]]:row-[1/span_2]'
+                    'grid-cols-[auto_1fr_auto_auto] px-2 py-2',
+                    // Figma tightens the toast to 4px as soon as it carries a title; description-only keeps the standard 8px.
+                    'has-[>[data-slot=alert-title]]:py-1',
+                    // Figma "CTA": the action sits inline at the end of the description row, or beneath it when
+                    // there is a title.
+                    '[&>[data-slot=alert-actions]]:col-start-3 [&>[data-slot=alert-actions]]:row-start-1 [&>[data-slot=alert-actions]]:self-start [&>[data-slot=alert-actions]]:gap-2 [&>[data-slot=alert-actions]]:ml-2',
+                    'has-[>[data-slot=alert-title]]:[&>[data-slot=alert-actions]]:col-start-2 has-[>[data-slot=alert-title]]:[&>[data-slot=alert-actions]]:row-start-auto has-[>[data-slot=alert-title]]:[&>[data-slot=alert-actions]]:ml-0',
+                    '[&>[data-slot=alert-close]]:col-start-4 [&>[data-slot=alert-close]]:row-start-1 [&>[data-slot=alert-close]]:self-start [&>[data-slot=alert-close]]:ml-2',
+                    // A title or an inline action makes the first row taller than a bare description line, so the
+                    // icon and close need 2px there instead of 1 to stay optically centred on it.
+                    '[&>svg]:translate-y-px [&>[data-slot=alert-close]]:translate-y-px',
+                    'has-[>[data-slot=alert-title]]:[&>svg]:translate-y-0.5 has-[>[data-slot=alert-title]]:[&>[data-slot=alert-close]]:translate-y-0.5',
+                    'has-[>[data-slot=alert-actions]]:[&>svg]:translate-y-0.5 has-[>[data-slot=alert-actions]]:[&>[data-slot=alert-close]]:translate-y-0.5'
                 ]
             }
         },

--- a/packages/design-system/src/components/ui/alert.tsx
+++ b/packages/design-system/src/components/ui/alert.tsx
@@ -74,9 +74,10 @@ export const alertVariants = cva(
                 // actions drop to their own row, aligned right under the text column; close stays top-right
                 compact: [
                     'grid-cols-[auto_1fr_auto] px-2 py-2',
-                    // 1px centres the 16px icon on a 12px description line (18px box); a 13px title line
+                    // 1px centres a 16px glyph on a 12px description line (18px box); a 13px title line
                     // (19.5px box) needs 2px. Nudged rather than centred so it stays on the first line.
                     '[&>svg]:translate-y-px has-[>[data-slot=alert-title]]:[&>svg]:translate-y-0.5',
+                    '[&>[data-slot=alert-close]]:translate-y-px has-[>[data-slot=alert-title]]:[&>[data-slot=alert-close]]:translate-y-0.5',
                     // Actions sit left-aligned under the text, 8px apart — tighter than wide's 16px.
                     '[&>[data-slot=alert-actions]]:col-start-2 [&>[data-slot=alert-actions]]:gap-2 [&>[data-slot=alert-actions]]:mt-1',
                     '[&>[data-slot=alert-close]]:col-start-3 [&>[data-slot=alert-close]]:row-start-1 [&>[data-slot=alert-close]]:self-start [&>[data-slot=alert-close]]:ml-2'


### PR DESCRIPTION
## Problem

The `toast` size of the design-system `Alert` drifted from Figma. It was lifted with one 4px vertical padding for every shape and with the trailing-slot placement copied from `wide`, but Figma splits both on whether the toast carries a title — and has since gained a `CTA` property that places the action differently again. `compact` had a smaller related bug: its close button carried no optical nudge, so it sat 1px above the status icon on the same line.

## Solution

**Toast**

- Vertical padding is 8px for a description-only toast and 4px once it has a title; the description-only shape was 6px short.
- The action sits inline at the end of the description row, and only drops beneath the text when there is a title.
- Close sits on the first line instead of centring over both rows, and takes the icon's optical nudge so the two line up.
- A title or an inline action makes the first row taller, so icon and close nudge 2px there instead of 1.

**Compact**

- Close takes the icon's nudge too, so the two glyphs stay locked together.

## Testing

Measured every shape in Storybook against the Figma nodes (`6:44503`, `1789:250`, `1919:735`, `1919:673`, `6:44453`, `1714:166`) — padding, slot offsets and heights match, with a consistent 1px from the browser painting the 0.5px hairline border at 1px. Design-system tests pass.

## Stories

[Storybook preview → Alert](https://pr-7244-storybook.app-development.nango.dev/?path=/story/design-system-components-alert--toast)

**Toast** now covers all four Figma variants (Title × CTA). New shape: *Description only, with action* — what the template deploy toast actually renders, previously uncovered.
