### PR TITLE
fix(audit): record which environment a public API key was created in

### DIFF
--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -420,8 +420,6 @@ describe('audit middleware — live-stack contract', () => {
                 action: 'created',
                 outcome: 'success',
                 accountId: account.id,
-                // The key is made in the environment the body names, not the one the account key authenticated
-                // against — recording it here is what separates an environment key from an account key.
                 environment: { id: env.id, display: env.name },
                 actor: { type: 'api_key', id: String(accountKey.id), display: 'Key automation' },
                 targets: [{ type: 'api_key', id: createdId, display: 'provisioned-ci' }],

--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -420,11 +420,14 @@ describe('audit middleware — live-stack contract', () => {
                 action: 'created',
                 outcome: 'success',
                 accountId: account.id,
-                environment: null,
+                // The key is made in the environment the body names, not the one the account key authenticated
+                // against — recording it here is what separates an environment key from an account key.
+                environment: { id: env.id, display: env.name },
                 actor: { type: 'api_key', id: String(accountKey.id), display: 'Key automation' },
                 targets: [{ type: 'api_key', id: createdId, display: 'provisioned-ci' }],
-                metadata: { displayName: 'provisioned-ci', environmentId: env.id, scopes: ['environment:*'] }
+                metadata: { displayName: 'provisioned-ci', scopes: ['environment:*'] }
             });
+            expect(auditEvent('api_key', 'created')?.metadata).not.toHaveProperty('environmentId');
             expect(JSON.stringify(auditEvent('api_key', 'created'))).not.toContain(secret);
 
             auditSpy.mockClear();
@@ -443,10 +446,9 @@ describe('audit middleware — live-stack contract', () => {
                 action: 'deleted',
                 outcome: 'success',
                 accountId: account.id,
-                environment: null,
+                environment: { id: env.id, display: env.name },
                 actor: { type: 'api_key', id: String(accountKey.id), display: 'Key automation' },
-                targets: [{ type: 'api_key', id: createdId, display: 'provisioned-ci' }],
-                metadata: { environmentId: env.id }
+                targets: [{ type: 'api_key', id: createdId, display: 'provisioned-ci' }]
             });
         });
 

--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -425,7 +425,7 @@ describe('audit middleware — live-stack contract', () => {
                 targets: [{ type: 'api_key', id: createdId, display: 'provisioned-ci' }],
                 metadata: { displayName: 'provisioned-ci', scopes: ['environment:*'] }
             });
-            expect(auditEvent('api_key', 'created')?.metadata).not.toHaveProperty('environmentId');
+            expect(JSON.stringify(auditEvent('api_key', 'created'))).not.toContain('environmentId');
             expect(JSON.stringify(auditEvent('api_key', 'created'))).not.toContain(secret);
 
             auditSpy.mockClear();

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -465,6 +465,10 @@ function bodyField(req: Request<any, any, any, any>, key: string): unknown {
     return (req.body as Record<string, unknown> | undefined)?.[key];
 }
 /** Resolvers run before the controller validates, so a field the endpoint types as a string can hold anything. */
+function positiveInt(value: unknown): number | undefined {
+    const parsed = typeof value === 'number' || (typeof value === 'string' && value.trim() !== '') ? Number(value) : NaN;
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
 function nonEmptyString(value: unknown): string | undefined {
     return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
@@ -526,7 +530,7 @@ function memberTarget(req: Request<{ id: number }>, locals: Partial<RequestLocal
 }
 
 async function environmentFromBody(value: unknown, locals: Partial<RequestLocals>): Promise<{ id: number; name: string } | null> {
-    const environmentId = typeof value === 'number' ? value : undefined;
+    const environmentId = positiveInt(value);
     if (environmentId === undefined || !locals.account) {
         return null;
     }
@@ -586,9 +590,9 @@ function accountApiKeyTarget(value: unknown, locals: Partial<RequestLocals>): Pr
 
 function publicEnvApiKeyTarget(keyId: unknown, environmentId: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
     return dbTarget('api_key', keyId, async (id) => {
-        const numericId = Number(id);
-        const numericEnvId = Number(environmentId);
-        if (Number.isNaN(numericId) || Number.isNaN(numericEnvId) || !locals.account) {
+        const numericId = positiveInt(id);
+        const numericEnvId = positiveInt(environmentId);
+        if (numericId === undefined || numericEnvId === undefined || !locals.account) {
             return undefined;
         }
         const result = await customerKeyService.getApiKeyDisplayName(db.knex, numericId, numericEnvId, locals.account.id);

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -143,8 +143,6 @@ type AuditSpec<TEndpoint extends AuditableEndpoint> = {
     // Defaults to the authenticated account (res.locals.account). Override when the audited account is not
     // the caller's — e.g. accepting/declining an invite is recorded under the inviting team, not the invitee.
     account?: (req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>) => Promise<{ id: number; uuid: string } | undefined>;
-    // Defaults to the authenticated environment (res.locals.environment). Override when the route acts on an
-    // environment named in the request rather than the one it authenticated against.
     environment?: (
         req: AuditRequest<TEndpoint>,
         locals: Partial<RequestLocals>
@@ -521,9 +519,6 @@ function memberTarget(req: Request<{ id: number }>, locals: Partial<RequestLocal
     });
 }
 
-// The public key routes take the environment in the body, so the one they authenticated against is not the
-// one they act on. Scoped by account: the id is the caller's to choose, and an unscoped read would write
-// another tenant's environment name into this account's trail.
 async function environmentFromBody(value: unknown, locals: Partial<RequestLocals>): Promise<{ id: number; name: string } | undefined> {
     const environmentId = typeof value === 'number' ? value : undefined;
     if (environmentId === undefined || !locals.account) {

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -143,6 +143,12 @@ type AuditSpec<TEndpoint extends AuditableEndpoint> = {
     // Defaults to the authenticated account (res.locals.account). Override when the audited account is not
     // the caller's — e.g. accepting/declining an invite is recorded under the inviting team, not the invitee.
     account?: (req: AuditRequest<TEndpoint>, locals: Partial<RequestLocals>) => Promise<{ id: number; uuid: string } | undefined>;
+    // Defaults to the authenticated environment (res.locals.environment). Override when the route acts on an
+    // environment named in the request rather than the one it authenticated against.
+    environment?: (
+        req: AuditRequest<TEndpoint>,
+        locals: Partial<RequestLocals>
+    ) => Promise<{ id: number; name: string } | undefined> | { id: number; name: string } | undefined;
 };
 
 function omitUndefined(obj: Record<string, unknown>): Record<string, unknown> | undefined {
@@ -368,7 +374,15 @@ function build<TEndpoint extends AuditableEndpoint>(
                 // account other than the caller's (see AuditSpec.account), and the gate must use that one.
                 const account = spec.account ? await spec.account(req, locals) : locals.account;
                 // Freeze account + environment before the handler runs, for the same reason as target/metadata below.
-                const environment = locals.environment;
+                let environment = locals.environment as { id: number; name: string } | undefined;
+                if (spec.environment) {
+                    try {
+                        environment = await spec.environment(req, locals);
+                    } catch (err) {
+                        auditEnrichmentFailed('target', spec.policy.resource, err);
+                        environment = undefined;
+                    }
+                }
                 if (account && (await canRecordAuditTrail(account.uuid, await auditedAccountPlan(account, locals)))) {
                     // Capture the response body only when a spec needs it — the id of a created resource is
                     // known only after the handler responds. Wrap res.json before next() runs the handler.
@@ -507,6 +521,17 @@ function memberTarget(req: Request<{ id: number }>, locals: Partial<RequestLocal
     });
 }
 
+// The public key routes take the environment in the body, so the one they authenticated against is not the
+// one they act on. Scoped by account: the id is the caller's to choose, and an unscoped read would write
+// another tenant's environment name into this account's trail.
+async function environmentFromBody(value: unknown, locals: Partial<RequestLocals>): Promise<{ id: number; name: string } | undefined> {
+    const environmentId = typeof value === 'number' ? value : undefined;
+    if (environmentId === undefined || !locals.account) {
+        return undefined;
+    }
+    const environment = await environmentService.getByIdWithoutSecrets(environmentId, locals.account.id);
+    return environment ? { id: environment.id, name: environment.name } : undefined;
+}
 function apiKeyTarget(value: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
     return dbTarget('api_key', value, async (id) => {
         if (!locals.environment) {
@@ -714,9 +739,9 @@ export const auditApiKeyDeleted = auditable<DeleteApiKey>({
     target: (req, locals) => apiKeyTarget(req.params.keyId, locals)
 });
 export const auditPublicApiKeyDeleted = auditable<DeletePublicApiKey>({
-    policy: Audit.auditable({ resource: 'api_key', action: 'deleted', scope: 'account' }),
-    target: (req, locals) => publicEnvApiKeyTarget(req.body.key_id, req.body.environment_id, locals),
-    metadata: (req) => omitUndefined({ environmentId: req.body.environment_id })
+    policy: Audit.auditable({ resource: 'api_key', action: 'deleted', scope: 'environment' }),
+    environment: (req, locals) => environmentFromBody(req.body.environment_id, locals),
+    target: (req, locals) => publicEnvApiKeyTarget(req.body.key_id, req.body.environment_id, locals)
 });
 export const auditAccountApiKeyDeleted = auditable<DeleteAccountApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'deleted', scope: 'account' }),
@@ -946,9 +971,10 @@ export const auditApiKeyCreated = auditable<CreateApiKey>({
     metadataFromResponse: (response) => omitUndefined({ scopes: response.data.scopes })
 });
 export const auditPublicApiKeyCreated = auditable<PostPublicApiKey>({
-    policy: Audit.auditable({ resource: 'api_key', action: 'created', scope: 'account' }),
+    policy: Audit.auditable({ resource: 'api_key', action: 'created', scope: 'environment' }),
+    environment: (req, locals) => environmentFromBody(req.body.environment_id, locals),
     targetFromResponse: (response) => makeTarget('api_key', response.data.id, response.data.display_name),
-    metadata: (req) => omitUndefined({ displayName: req.body.display_name, environmentId: req.body.environment_id }),
+    metadata: (req) => omitUndefined({ displayName: nonEmptyString(req.body.display_name) }),
     metadataFromResponse: (response) => omitUndefined({ scopes: response.data.scopes })
 });
 export const auditAccountApiKeyCreated = auditable<CreateAccountApiKey>({

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -221,7 +221,7 @@ export function outcomeFromStatus(status: number): AuditOutcome {
 }
 
 /** The event still records; the named field is what it lost. */
-export function auditEnrichmentFailed(field: 'target' | 'metadata' | 'display', resource: string, err: unknown): void {
+export function auditEnrichmentFailed(field: 'target' | 'metadata' | 'display' | 'environment', resource: string, err: unknown): void {
     logger.warning(`audit event enrichment failed`, { field, resource, err });
     metrics.increment(metrics.Types.AUDIT_EVENT_ENRICHMENT_FAILED, 1, { field, resource });
 }
@@ -377,7 +377,7 @@ function build<TEndpoint extends AuditableEndpoint>(
                     try {
                         environment = await spec.environment(req, locals);
                     } catch (err) {
-                        auditEnrichmentFailed('target', spec.policy.resource, err);
+                        auditEnrichmentFailed('environment', spec.policy.resource, err);
                         environment = undefined;
                     }
                 }

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -398,6 +398,27 @@ describe('auditable() middleware behavior (unit)', () => {
         expect(accountKey?.environment).toBeNull();
     });
 
+    it('public api key create: an environment id sent as a string still resolves, as the endpoint accepts it', async () => {
+        const event = await runAudit(auditPublicApiKeyCreated, fakeReq({ body: { environment_id: '12', display_name: 'ci-key' } }), fakeRes(secretKeyLocals));
+        expect(event).toMatchObject({ resource: 'api_key', action: 'created', accountId: 42, environment: { id: 12, display: 'prod' } });
+        expect(getEnvironmentByIdMock).toHaveBeenCalledWith(12, 42);
+    });
+
+    it.each([
+        ['a boolean', true],
+        ['an empty string', ''],
+        ['null', null],
+        ['an array', []],
+        ['zero', 0],
+        ['a negative', -1],
+        ['a fraction', 1.5]
+    ])('public api key create: %s is not an environment id', async (_name, environment_id) => {
+        const event = await runAudit(auditPublicApiKeyCreated, fakeReq({ body: { environment_id, display_name: 'ci-key' } }), fakeRes(secretKeyLocals));
+        expect(event).toMatchObject({ resource: 'api_key', action: 'created', accountId: 42 });
+        expect(event?.environment).toBeNull();
+        expect(getEnvironmentByIdMock).not.toHaveBeenCalled();
+    });
+
     it("public api key create: another account's environment is never named", async () => {
         getEnvironmentByIdMock.mockResolvedValue(null);
         const event = await runAudit(auditPublicApiKeyCreated, fakeReq({ body: { environment_id: 999, display_name: 'ci-key' } }), fakeRes(secretKeyLocals));

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flags } from '@nangohq/utils';
 
 import {
+    auditAccountApiKeyCreated,
     auditConnectionCreated,
     auditConnectionUpdated,
     auditEnvironmentUpdated,
@@ -21,6 +22,8 @@ import {
     auditMemberInviteRevoked,
     auditMfaEnabled,
     auditPreBuiltDeployed,
+    auditPublicApiKeyCreated,
+    auditPublicApiKeyDeleted,
     auditPublicConnectionDeleted,
     auditPublicFunctionDeleted,
     auditSyncPaused,
@@ -44,12 +47,16 @@ vi.mock('../audit.js', async (importOriginal) => {
 const getInvitationMock = vi.hoisted(() => vi.fn());
 const getAccountByIdMock = vi.hoisted(() => vi.fn());
 const getPlanSafeMock = vi.hoisted(() => vi.fn());
+const getEnvironmentByIdMock = vi.hoisted(() => vi.fn());
+const getApiKeyDisplayNameMock = vi.hoisted(() => vi.fn());
 vi.mock('@nangohq/shared', async (importOriginal) => {
     const actual = await importOriginal<typeof NangoShared>();
     return {
         ...actual,
         getInvitation: getInvitationMock,
         getPlanSafe: getPlanSafeMock,
+        environmentService: { ...actual.environmentService, getByIdWithoutSecrets: getEnvironmentByIdMock },
+        customerKeyService: { ...actual.customerKeyService, getApiKeyDisplayName: getApiKeyDisplayNameMock },
         accountService: { ...actual.accountService, getAccountById: getAccountByIdMock }
     };
 });
@@ -103,6 +110,8 @@ describe('auditable() middleware behavior (unit)', () => {
         // No plans in a unit run, so the entitlement path resolves off; the deployment opt-in is what
         // reaches the middleware. Which gate lets a request through is covered in utils/auditTrail.unit.test.ts.
         flags.hasAuditTrail = true;
+        getEnvironmentByIdMock.mockReset().mockResolvedValue({ id: 12, name: 'prod' });
+        getApiKeyDisplayNameMock.mockReset().mockResolvedValue({ isErr: () => false, value: 'ci-key' });
     });
 
     afterEach(() => {
@@ -304,6 +313,49 @@ describe('auditable() middleware behavior (unit)', () => {
             targets: [{ type: 'connection', id: 'conn-real' }],
             metadata: { providerConfigKey: 'algolia' }
         });
+    });
+
+    it('public api key create: names the environment the key was made in, not the one it authenticated against', async () => {
+        const req = fakeReq({ body: { environment_id: 12, display_name: 'ci-key' } });
+        const res = fakeRes(secretKeyLocals);
+        await new Promise<void>((resolve) => auditPublicApiKeyCreated(req, res, () => resolve()));
+        res.json({ data: { id: 2551, display_name: 'ci-key', scopes: ['environment:*'] } });
+        res.emit('finish');
+        await vi.waitFor(() => expect(recordMock).toHaveBeenCalled());
+        const event = recordMock.mock.calls[0]?.[0];
+        expect(event).toMatchObject({
+            resource: 'api_key',
+            action: 'created',
+            outcome: 'success',
+            accountId: 42,
+            environment: { id: 12, display: 'prod' },
+            targets: [{ type: 'api_key', id: '2551', display: 'ci-key' }],
+            metadata: { displayName: 'ci-key', scopes: ['environment:*'] }
+        });
+        expect(event?.metadata).not.toHaveProperty('environmentId');
+    });
+
+    it('public api key delete: an environment key is separable from an account key by the environment alone', async () => {
+        const envKey = await runAudit(auditPublicApiKeyDeleted, fakeReq({ body: { environment_id: 12, key_id: 2551 } }), fakeRes(secretKeyLocals));
+        recordMock.mockClear();
+        const accountKey = await runAudit(auditAccountApiKeyCreated, fakeReq({ body: { display_name: 'acct-key' } }), fakeRes(locals));
+        expect(envKey).toMatchObject({ resource: 'api_key', action: 'deleted', accountId: 42, environment: { id: 12, display: 'prod' } });
+        expect(accountKey?.environment).toBeNull();
+    });
+
+    it("public api key create: another account's environment is never named", async () => {
+        getEnvironmentByIdMock.mockResolvedValue(null);
+        const event = await runAudit(auditPublicApiKeyCreated, fakeReq({ body: { environment_id: 999, display_name: 'ci-key' } }), fakeRes(secretKeyLocals));
+        expect(event).toMatchObject({ resource: 'api_key', action: 'created', accountId: 42 });
+        expect(event?.environment).toBeNull();
+        expect(getEnvironmentByIdMock).toHaveBeenCalledWith(999, 42);
+    });
+
+    it('public api key create: an environment lookup failure still records the event', async () => {
+        getEnvironmentByIdMock.mockRejectedValue(new Error('db down'));
+        const event = await runAudit(auditPublicApiKeyCreated, fakeReq({ body: { environment_id: 12, display_name: 'ci-key' } }), fakeRes(secretKeyLocals));
+        expect(event).toMatchObject({ resource: 'api_key', action: 'created', accountId: 42 });
+        expect(event?.environment).toBeNull();
     });
 
     it('webhook settings: records only the URL origin, never the path or secret query params', async () => {

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:events';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { flags } from '@nangohq/utils';
+import { flags, metrics } from '@nangohq/utils';
 
 import {
     auditAccountApiKeyCreated,
@@ -351,11 +351,13 @@ describe('auditable() middleware behavior (unit)', () => {
         expect(getEnvironmentByIdMock).toHaveBeenCalledWith(999, 42);
     });
 
-    it('public api key create: an environment lookup failure still records the event', async () => {
+    it('public api key create: an environment lookup failure still records the event, and counts the degradation', async () => {
+        const increment = vi.spyOn(metrics, 'increment');
         getEnvironmentByIdMock.mockRejectedValue(new Error('db down'));
         const event = await runAudit(auditPublicApiKeyCreated, fakeReq({ body: { environment_id: 12, display_name: 'ci-key' } }), fakeRes(secretKeyLocals));
         expect(event).toMatchObject({ resource: 'api_key', action: 'created', accountId: 42 });
         expect(event?.environment).toBeNull();
+        expect(increment).toHaveBeenCalledWith(metrics.Types.AUDIT_EVENT_ENRICHMENT_FAILED, 1, { field: 'environment', resource: 'api_key' });
     });
 
     it('webhook settings: records only the URL origin, never the path or secret query params', async () => {

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -171,7 +171,7 @@ export type CreateApiKey = ApiEndpoint<{
 }>;
 
 export type PostPublicApiKey = ApiEndpoint<{
-    Audit: AuditPolicy<'api_key', 'created', 'account'>;
+    Audit: AuditPolicy<'api_key', 'created', 'environment'>;
     Method: 'POST';
     Path: '/environment/api-keys';
     Body: {
@@ -191,7 +191,7 @@ export type PostPublicApiKey = ApiEndpoint<{
 }>;
 
 export type DeletePublicApiKey = ApiEndpoint<{
-    Audit: AuditPolicy<'api_key', 'deleted', 'account'>;
+    Audit: AuditPolicy<'api_key', 'deleted', 'environment'>;
     Method: 'DELETE';
     Path: '/environment/api-keys';
     Body: {


### PR DESCRIPTION
Nango has account API keys and environment API keys. When you create an environment key through the public API, the endpoint takes the environment id in the body. Because of that the audit event was marked account-level, and account-level events don't carry an environment.

So creating an environment key produced an event that looked exactly like creating an account key. You couldn't tell the two apart, and filtering by environment didn't help either, because the field was empty on both.

A spec can now say which environment it acts on, the same way it can already say which account. The two public key routes use that, so their events carry the environment the key was created in. `environmentId` comes out of metadata, since the real field replaces it.

The lookup is scoped to the caller's account. The environment id arrives in the request body, so without that scoping we'd write another customer's environment name into this account's trail. If the lookup fails, the event is still recorded — just without an environment — and it counts under `field: environment` so the degradation is visible.

One detail worth knowing when reading the spec: no resolver means "use the environment the request authenticated against", and a resolver returning `null` means "this event has no environment". They're different, which is why the resolver returns `null` rather than `undefined`.

## Test plan

- [x] Creating a key records the environment from the body, not the one the key authenticated against
- [x] An environment key and an account key can be told apart by the environment alone
- [x] An environment id belonging to another account resolves to nothing
- [x] A failed lookup still records the event, and counts under its own field
- [x] Reverted the scope, the account scoping, the null return and the metric in turn to check the tests fail
- [x] 79 unit and 30 integration tests pass; `ts-build`, `lint` and Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)