### PR TITLE
feat(audit): let an impersonated session read a recorded account's trail

### DIFF
--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -3,7 +3,7 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { audit } from '../../../audit.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
-import { canAccessAuditTrail } from '../../../utils/auditTrail.js';
+import { canViewAuditTrail } from '../../../utils/auditTrail.js';
 import { auditListQuery } from './query.js';
 
 import type { GetAuditTrail } from '@nangohq/types';
@@ -13,7 +13,7 @@ const PAGE_SIZE = 25;
 export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
     const { account, plan } = res.locals;
     // Checked ahead of validation: an unentitled account has no trail to read, whatever it asks for.
-    if (!(await canAccessAuditTrail(account.uuid, plan))) {
+    if (!(await canViewAuditTrail(req, account.uuid, plan))) {
         res.status(403).send({ error: { code: 'feature_disabled', message: 'Audit trail is not enabled for this account' } });
         return;
     }

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrailExport.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrailExport.ts
@@ -2,7 +2,7 @@ import { getLogger, zodErrorToHTTP } from '@nangohq/utils';
 
 import { audit } from '../../../audit.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
-import { canAccessAuditTrail } from '../../../utils/auditTrail.js';
+import { canViewAuditTrail } from '../../../utils/auditTrail.js';
 import { auditExportQuery } from './query.js';
 
 import type { GetAuditTrailExport } from '@nangohq/types';
@@ -15,7 +15,7 @@ const FILE_NAME = 'nango-audit-trail.csv';
 
 export const getAuditTrailExport = asyncWrapper<GetAuditTrailExport>(async (req, res) => {
     const { account, plan } = res.locals;
-    if (!(await canAccessAuditTrail(account.uuid, plan))) {
+    if (!(await canViewAuditTrail(req, account.uuid, plan))) {
         res.status(403).send({ error: { code: 'feature_disabled', message: 'Audit trail is not enabled for this account' } });
         return;
     }

--- a/packages/server/lib/controllers/v1/meta/getMeta.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.ts
@@ -2,7 +2,7 @@ import { environmentService } from '@nangohq/shared';
 import { baseUrl, NANGO_VERSION, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
-import { canAccessAuditTrail } from '../../../utils/auditTrail.js';
+import { canViewAuditTrail } from '../../../utils/auditTrail.js';
 
 import type { GetMeta } from '@nangohq/types';
 
@@ -25,7 +25,7 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
             baseUrl,
             debugMode: req.session.debugMode === true,
             gettingStartedClosed: sessionUser.getting_started_closed,
-            auditTrail: await canAccessAuditTrail(account.uuid, plan)
+            auditTrail: await canViewAuditTrail(req, account.uuid, plan)
         }
     });
 });

--- a/packages/server/lib/utils/auditTrail.ts
+++ b/packages/server/lib/utils/auditTrail.ts
@@ -42,9 +42,8 @@ export async function canAccessAuditTrail(accountUuid: string, plan: Pick<DBPlan
 }
 
 /**
- * A customer sees the trail if their plan has audit access. Nango staff impersonating them see it if we are
- * recording the account, even when the plan does not allow access. If we are not recording, nobody sees it,
- * because an empty page looks broken rather than turned off.
+ * A customer sees the trail when their plan includes audit access. Nango staff impersonating them see it
+ * when we are recording the account instead, because an empty page would look broken rather than switched off.
  */
 export async function canViewAuditTrail(
     req: Pick<Request, 'session'>,

--- a/packages/server/lib/utils/auditTrail.ts
+++ b/packages/server/lib/utils/auditTrail.ts
@@ -4,6 +4,7 @@ import { getPlanSafe } from '@nangohq/shared';
 import { flagHasPlan, flags } from '@nangohq/utils';
 
 import type { DBPlan } from '@nangohq/types';
+import type { Request } from 'express';
 
 type AuditTrailEntitlement = 'has_audit_trail_control_plane' | 'has_audit_trail_access';
 type EntitlementPlan = Partial<Pick<DBPlan, AuditTrailEntitlement>> | null | undefined;
@@ -38,4 +39,13 @@ export async function canRecordAuditTrailForAccount(account: { id: number; uuid:
 /** Whether the account can reach its own trail, through the dashboard, the API or export. */
 export async function canAccessAuditTrail(accountUuid: string, plan: Pick<DBPlan, 'has_audit_trail_access'> | null | undefined): Promise<boolean> {
     return await isEntitled(accountUuid, () => plan, 'has_audit_trail_access');
+}
+
+/** Whether the current session can reach the trail. */
+export async function canViewAuditTrail(
+    req: Pick<Request, 'session'>,
+    accountUuid: string,
+    plan: Pick<DBPlan, 'has_audit_trail_control_plane' | 'has_audit_trail_access'> | null | undefined
+): Promise<boolean> {
+    return req.session?.impersonatedBy ? await canRecordAuditTrail(accountUuid, plan) : await canAccessAuditTrail(accountUuid, plan);
 }

--- a/packages/server/lib/utils/auditTrail.ts
+++ b/packages/server/lib/utils/auditTrail.ts
@@ -41,7 +41,10 @@ export async function canAccessAuditTrail(accountUuid: string, plan: Pick<DBPlan
     return await isEntitled(accountUuid, () => plan, 'has_audit_trail_access');
 }
 
-/** Whether the current session can reach the trail. */
+/**
+ * A customer is held to the access entitlement; an impersonating operator to ingestion instead, since an
+ * unrecorded account has no trail and an empty page would read as a broken one.
+ */
 export async function canViewAuditTrail(
     req: Pick<Request, 'session'>,
     accountUuid: string,

--- a/packages/server/lib/utils/auditTrail.ts
+++ b/packages/server/lib/utils/auditTrail.ts
@@ -42,8 +42,9 @@ export async function canAccessAuditTrail(accountUuid: string, plan: Pick<DBPlan
 }
 
 /**
- * A customer is held to the access entitlement; an impersonating operator to ingestion instead, since an
- * unrecorded account has no trail and an empty page would read as a broken one.
+ * A customer sees the trail if their plan has audit access. Nango staff impersonating them see it if we are
+ * recording the account, even when the plan does not allow access. If we are not recording, nobody sees it,
+ * because an empty page looks broken rather than turned off.
  */
 export async function canViewAuditTrail(
     req: Pick<Request, 'session'>,

--- a/packages/server/lib/utils/auditTrail.unit.test.ts
+++ b/packages/server/lib/utils/auditTrail.unit.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as featureFlags from '@nangohq/feature-flags';
 import { flags } from '@nangohq/utils';
 
-import { canAccessAuditTrail, canRecordAuditTrail } from './auditTrail.js';
+import { canAccessAuditTrail, canRecordAuditTrail, canViewAuditTrail } from './auditTrail.js';
 
 import type * as NangoUtils from '@nangohq/utils';
 
@@ -20,6 +20,8 @@ vi.mock('@nangohq/utils', async () => {
 });
 
 const UUID = 'acc-uuid';
+const customer = { session: {} } as Parameters<typeof canViewAuditTrail>[0];
+const operator = { session: { impersonatedBy: { accountId: 1, accountName: 'Nango', actorId: 7 } } } as Parameters<typeof canViewAuditTrail>[0];
 const entitled = { has_audit_trail_control_plane: true, has_audit_trail_access: true };
 const notEntitled = { has_audit_trail_control_plane: false, has_audit_trail_access: false };
 
@@ -100,6 +102,34 @@ describe('audit trail entitlement', () => {
 
             await expect(canRecordAuditTrail(UUID, entitled)).resolves.toBe(false);
             await expect(canAccessAuditTrail(UUID, entitled)).resolves.toBe(false);
+        });
+    });
+
+    describe('what a session can view', () => {
+        it('holds the customer to the access entitlement', async () => {
+            setup({ optIn: false, hasPlan: true, unleash: true });
+
+            await expect(canViewAuditTrail(customer, UUID, { has_audit_trail_control_plane: true, has_audit_trail_access: false })).resolves.toBe(false);
+            await expect(canViewAuditTrail(customer, UUID, entitled)).resolves.toBe(true);
+        });
+
+        it('lets an impersonating operator past the access entitlement', async () => {
+            setup({ optIn: false, hasPlan: true, unleash: true });
+
+            await expect(canViewAuditTrail(operator, UUID, { has_audit_trail_control_plane: true, has_audit_trail_access: false })).resolves.toBe(true);
+        });
+
+        it('still hides it from the operator when the account is not recorded, so an empty page cannot mislead', async () => {
+            setup({ optIn: false, hasPlan: true, unleash: true });
+
+            await expect(canViewAuditTrail(operator, UUID, { has_audit_trail_control_plane: false, has_audit_trail_access: true })).resolves.toBe(false);
+            await expect(canViewAuditTrail(operator, UUID, notEntitled)).resolves.toBe(false);
+        });
+
+        it('cannot be reached by an operator once the rollout flag is off', async () => {
+            setup({ optIn: false, hasPlan: true, unleash: false });
+
+            await expect(canViewAuditTrail(operator, UUID, entitled)).resolves.toBe(false);
         });
     });
 });


### PR DESCRIPTION
When someone from Nango impersonates a customer to help them, they can't see that customer's audit trail unless the customer's plan has `has_audit_trail_access`. Today no plan definition sets it, so in practice that's nobody.

There are two separate plan flags here and they do different jobs. `has_audit_trail_access` decides whether the customer has bought the feature. `has_audit_trail_control_plane` decides whether we record their activity at all — it's already on for every paid plan.

An operator shouldn't be blocked by the first one. But they should still be blocked by the second, because if we never recorded anything, the page would come up empty and look like a broken trail rather than a disabled one.

So an impersonated session swaps the access flag for the ingestion flag instead of skipping the check. A paid account being recorded is visible during support; a free account, where nothing was ever recorded, stays hidden. Ingestion itself doesn't change.

Reads by an operator land in the customer's own trail as `audit_trail.queried` or `audit_trail.exported`, marked with `via` as reached through impersonation. That was already true and stays true.

## Test plan

- [x] A customer is still held to the access flag
- [x] An operator gets past the access flag
- [x] An operator is still refused when the account isn't recorded, so an empty page can't mislead
- [x] The rollout flag being off still refuses everyone, operator included
- [x] Made the gate too strict and too permissive in turn to check the tests fail
- [x] 12 unit and 25 integration tests pass; `ts-build`, `lint` and Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

