### PR TITLE
feat(audit): count recorded and dropped audit events per resource

### DIFF
--- a/packages/server/lib/audit.ts
+++ b/packages/server/lib/audit.ts
@@ -76,8 +76,18 @@ export const audit = new AuditClient(buildWriter(clickhouseStore), clickhouseSto
 
 export type AuditDropReason = 'write_failed' | 'build_failed';
 
+// Counting must not throw: an escaping error reaches the emitter's catch, which would count a second drop
+// for the same event, or a drop for one that was written.
+function countAuditEvent(metric: metrics.Types, dimensions: Record<string, string>): void {
+    try {
+        metrics.increment(metric, 1, dimensions);
+    } catch (err) {
+        logger.error(`failed to count audit event`, { metric, err });
+    }
+}
+
 export function auditEventDropped(resource: string, reason: AuditDropReason): void {
-    metrics.increment(metrics.Types.AUDIT_EVENT_DROPPED, 1, { resource, reason });
+    countAuditEvent(metrics.Types.AUDIT_EVENT_DROPPED, { resource, reason });
 }
 
 export async function recordAuditEvent(event: AuditEvent): Promise<void> {
@@ -87,5 +97,5 @@ export async function recordAuditEvent(event: AuditEvent): Promise<void> {
         auditEventDropped(event.resource, 'write_failed');
         return;
     }
-    metrics.increment(metrics.Types.AUDIT_EVENT_RECORDED, 1, { resource: event.resource });
+    countAuditEvent(metrics.Types.AUDIT_EVENT_RECORDED, { resource: event.resource });
 }

--- a/packages/server/lib/audit.ts
+++ b/packages/server/lib/audit.ts
@@ -1,10 +1,10 @@
 import { auditClickhouseClient, AuditClient, ClickhouseAuditStore, DropAuditStore, PubSubAuditWriter } from '@nangohq/audit';
 import { pubsub } from '@nangohq/shared';
-import { getLogger } from '@nangohq/utils';
+import { getLogger, metrics } from '@nangohq/utils';
 
 import { envs } from './env.js';
 
-import type { AuditActor, AuditTarget, AuditTargetType, AuditWriter } from '@nangohq/audit';
+import type { AuditActor, AuditEvent, AuditTarget, AuditTargetType, AuditWriter } from '@nangohq/audit';
 import type { InternalEndUser } from '@nangohq/types';
 
 const logger = getLogger('audit');
@@ -73,3 +73,21 @@ function buildWriter(clickhouse: ClickhouseAuditStore | null): AuditWriter {
 
 const clickhouseStore = buildClickhouseStore();
 export const audit = new AuditClient(buildWriter(clickhouseStore), clickhouseStore ?? new DropAuditStore());
+
+export type AuditDropReason = 'write_failed' | 'build_failed';
+
+/** A dropped event is gone: nothing retries it, so the counter is the only trace besides the log. */
+export function auditEventDropped(resource: string, reason: AuditDropReason): void {
+    metrics.increment(metrics.Types.AUDIT_EVENT_DROPPED, 1, { resource, reason });
+}
+
+/** Records the event and counts the outcome, so a new emitter cannot forget either. */
+export async function recordAuditEvent(event: AuditEvent): Promise<void> {
+    const result = await audit.record(event);
+    if (result.isErr()) {
+        logger.error(`failed to record audit event`, { resource: event.resource, action: event.action, err: result.error });
+        auditEventDropped(event.resource, 'write_failed');
+        return;
+    }
+    metrics.increment(metrics.Types.AUDIT_EVENT_RECORDED, 1, { resource: event.resource });
+}

--- a/packages/server/lib/audit.ts
+++ b/packages/server/lib/audit.ts
@@ -76,12 +76,10 @@ export const audit = new AuditClient(buildWriter(clickhouseStore), clickhouseSto
 
 export type AuditDropReason = 'write_failed' | 'build_failed';
 
-/** A dropped event is gone: nothing retries it, so the counter is the only trace besides the log. */
 export function auditEventDropped(resource: string, reason: AuditDropReason): void {
     metrics.increment(metrics.Types.AUDIT_EVENT_DROPPED, 1, { resource, reason });
 }
 
-/** Records the event and counts the outcome, so a new emitter cannot forget either. */
 export async function recordAuditEvent(event: AuditEvent): Promise<void> {
     const result = await audit.record(event);
     if (result.isErr()) {

--- a/packages/server/lib/audit.ts
+++ b/packages/server/lib/audit.ts
@@ -76,18 +76,8 @@ export const audit = new AuditClient(buildWriter(clickhouseStore), clickhouseSto
 
 export type AuditDropReason = 'write_failed' | 'build_failed';
 
-// Counting must not throw: an escaping error reaches the emitter's catch, which would count a second drop
-// for the same event, or a drop for one that was written.
-function countAuditEvent(metric: metrics.Types, dimensions: Record<string, string>): void {
-    try {
-        metrics.increment(metric, 1, dimensions);
-    } catch (err) {
-        logger.error(`failed to count audit event`, { metric, err });
-    }
-}
-
 export function auditEventDropped(resource: string, reason: AuditDropReason): void {
-    countAuditEvent(metrics.Types.AUDIT_EVENT_DROPPED, { resource, reason });
+    metrics.increment(metrics.Types.AUDIT_EVENT_DROPPED, 1, { resource, reason });
 }
 
 export async function recordAuditEvent(event: AuditEvent): Promise<void> {
@@ -97,5 +87,5 @@ export async function recordAuditEvent(event: AuditEvent): Promise<void> {
         auditEventDropped(event.resource, 'write_failed');
         return;
     }
-    countAuditEvent(metrics.Types.AUDIT_EVENT_RECORDED, { resource: event.resource });
+    metrics.increment(metrics.Types.AUDIT_EVENT_RECORDED, 1, { resource: event.resource });
 }

--- a/packages/server/lib/audit.unit.test.ts
+++ b/packages/server/lib/audit.unit.test.ts
@@ -33,6 +33,24 @@ describe('recordAuditEvent', () => {
         expect(increment).not.toHaveBeenCalledWith(metrics.Types.AUDIT_EVENT_RECORDED, 1, expect.anything());
     });
 
+    it('does not escape when counting a written event fails, so the emitter cannot log it as a drop', async () => {
+        vi.spyOn(metrics, 'increment').mockImplementation(() => {
+            throw new Error('no tracer');
+        });
+        vi.spyOn(audit, 'record').mockResolvedValue({ isErr: () => false } as never);
+
+        await expect(recordAuditEvent(event)).resolves.toBeUndefined();
+    });
+
+    it('does not escape when counting a dropped event fails, so the drop is not counted twice', async () => {
+        vi.spyOn(metrics, 'increment').mockImplementation(() => {
+            throw new Error('no tracer');
+        });
+        vi.spyOn(audit, 'record').mockResolvedValue({ isErr: () => true, error: new Error('pubsub down') } as never);
+
+        await expect(recordAuditEvent(event)).resolves.toBeUndefined();
+    });
+
     it('tags a drop that happened before the event was built', () => {
         const increment = vi.spyOn(metrics, 'increment');
 

--- a/packages/server/lib/audit.unit.test.ts
+++ b/packages/server/lib/audit.unit.test.ts
@@ -33,24 +33,6 @@ describe('recordAuditEvent', () => {
         expect(increment).not.toHaveBeenCalledWith(metrics.Types.AUDIT_EVENT_RECORDED, 1, expect.anything());
     });
 
-    it('does not escape when counting a written event fails, so the emitter cannot log it as a drop', async () => {
-        vi.spyOn(metrics, 'increment').mockImplementation(() => {
-            throw new Error('no tracer');
-        });
-        vi.spyOn(audit, 'record').mockResolvedValue({ isErr: () => false } as never);
-
-        await expect(recordAuditEvent(event)).resolves.toBeUndefined();
-    });
-
-    it('does not escape when counting a dropped event fails, so the drop is not counted twice', async () => {
-        vi.spyOn(metrics, 'increment').mockImplementation(() => {
-            throw new Error('no tracer');
-        });
-        vi.spyOn(audit, 'record').mockResolvedValue({ isErr: () => true, error: new Error('pubsub down') } as never);
-
-        await expect(recordAuditEvent(event)).resolves.toBeUndefined();
-    });
-
     it('tags a drop that happened before the event was built', () => {
         const increment = vi.spyOn(metrics, 'increment');
 

--- a/packages/server/lib/audit.unit.test.ts
+++ b/packages/server/lib/audit.unit.test.ts
@@ -1,45 +1,43 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { changedFields, makeAuditTarget, toAuditId } from './audit.js';
+import { metrics } from '@nangohq/utils';
 
-describe('audit utilities', () => {
-    describe('toAuditId', () => {
-        it.each([
-            { value: 'github', expected: 'github' },
-            { value: 42, expected: '42' },
-            { value: '', expected: undefined },
-            { value: null, expected: undefined }
-        ])('converts $value to $expected', ({ value, expected }) => {
-            expect(toAuditId(value)).toBe(expected);
-        });
+import { audit, auditEventDropped, recordAuditEvent } from './audit.js';
+
+import type { AuditEvent } from '@nangohq/audit';
+
+const event = { resource: 'integration', action: 'deleted' } as unknown as AuditEvent;
+
+describe('recordAuditEvent', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
     });
 
-    describe('makeAuditTarget', () => {
-        it('creates a target with an optional display name', () => {
-            expect(makeAuditTarget('integration', 'github', 'GitHub')).toStrictEqual({ type: 'integration', id: 'github', display: 'GitHub' });
-        });
+    it('counts a written event under its resource', async () => {
+        const increment = vi.spyOn(metrics, 'increment');
+        vi.spyOn(audit, 'record').mockResolvedValue({ isErr: () => false } as never);
 
-        it('returns undefined when the value cannot identify a target', () => {
-            expect(makeAuditTarget('integration', undefined)).toBeUndefined();
-        });
+        await recordAuditEvent(event);
+
+        expect(increment).toHaveBeenCalledWith(metrics.Types.AUDIT_EVENT_RECORDED, 1, { resource: 'integration' });
+        expect(increment).not.toHaveBeenCalledWith(metrics.Types.AUDIT_EVENT_DROPPED, 1, expect.anything());
     });
 
-    describe('changedFields', () => {
-        it('returns field names without inspecting their values', () => {
-            expect(changedFields({ credentials: { client_secret: 'secret' }, custom: 'private' })).toStrictEqual(['credentials', 'custom']);
-        });
+    it('counts a write failure as a drop, since nothing retries it', async () => {
+        const increment = vi.spyOn(metrics, 'increment');
+        vi.spyOn(audit, 'record').mockResolvedValue({ isErr: () => true, error: new Error('pubsub down') } as never);
 
-        it('filters long keys and limits the number of fields', () => {
-            const value: Record<string, unknown> = { ['x'.repeat(65)]: true };
-            for (let index = 0; index < 31; index++) {
-                value[`field_${index}`] = index;
-            }
+        await recordAuditEvent(event);
 
-            expect(changedFields(value)).toStrictEqual(Array.from({ length: 30 }, (_, index) => `field_${index}`));
-        });
+        expect(increment).toHaveBeenCalledWith(metrics.Types.AUDIT_EVENT_DROPPED, 1, { resource: 'integration', reason: 'write_failed' });
+        expect(increment).not.toHaveBeenCalledWith(metrics.Types.AUDIT_EVENT_RECORDED, 1, expect.anything());
+    });
 
-        it.each([undefined, null, '', []])('returns undefined for an empty or non-object value', (value) => {
-            expect(changedFields(value)).toBeUndefined();
-        });
+    it('tags a drop that happened before the event was built', () => {
+        const increment = vi.spyOn(metrics, 'increment');
+
+        auditEventDropped('sync', 'build_failed');
+
+        expect(increment).toHaveBeenCalledWith(metrics.Types.AUDIT_EVENT_DROPPED, 1, { resource: 'sync', reason: 'build_failed' });
     });
 });

--- a/packages/server/lib/controllers/mcp/audit.ts
+++ b/packages/server/lib/controllers/mcp/audit.ts
@@ -1,6 +1,6 @@
 import { getLogger } from '@nangohq/utils';
 
-import { audit } from '../../audit.js';
+import { auditEventDropped, recordAuditEvent } from '../../audit.js';
 import { canRecordAuditTrail } from '../../utils/auditTrail.js';
 
 import type { AuditEvent } from '@nangohq/audit';
@@ -49,11 +49,9 @@ async function emit(accountUuid: string, plan: DBPlan | null, event: AuditEvent)
             return;
         }
 
-        const result = await audit.record(event);
-        if (result.isErr()) {
-            logger.error('Failed to record Management MCP audit event', result.error);
-        }
+        await recordAuditEvent(event);
     } catch (err) {
         logger.error('Failed to emit Management MCP audit event', err);
+        auditEventDropped(event.resource, 'build_failed');
     }
 }

--- a/packages/server/lib/hooks/auditConnection.ts
+++ b/packages/server/lib/hooks/auditConnection.ts
@@ -1,6 +1,6 @@
 import { getLogger } from '@nangohq/utils';
 
-import { audit, connectSessionActor, makeAuditTarget as makeTarget, UNKNOWN_ACTOR } from '../audit.js';
+import { auditEventDropped, connectSessionActor, makeAuditTarget as makeTarget, recordAuditEvent, UNKNOWN_ACTOR } from '../audit.js';
 import { canRecordAuditTrailForAccount } from '../utils/auditTrail.js';
 
 import type { AuditActor, AuditAttribution, AuditEvent, NoAttribution } from '@nangohq/audit';
@@ -54,12 +54,10 @@ export async function recordConnectionCreated(params: {
             outcome: 'success',
             metadata: { providerConfigKey: params.providerConfigKey }
         } as AuditEvent;
-        const result = await audit.record(event);
-        if (result.isErr()) {
-            logger.error(`failed to record connection.created audit event`, result.error);
-        }
+        await recordAuditEvent(event);
     } catch (err) {
         logger.error(`failed to emit connection.created audit event`, err);
+        auditEventDropped('connection', 'build_failed');
     }
 }
 

--- a/packages/server/lib/hooks/auditConnection.unit.test.ts
+++ b/packages/server/lib/hooks/auditConnection.unit.test.ts
@@ -10,7 +10,7 @@ import type { Request } from 'express';
 const recordMock = vi.hoisted(() => vi.fn());
 vi.mock('../audit.js', async (importOriginal) => {
     const actual = await importOriginal<typeof AuditModule>();
-    return { ...actual, audit: { record: recordMock } };
+    return { ...actual, recordAuditEvent: recordMock };
 });
 
 describe('recordConnectionCreated (hook-side emitter, unit)', () => {
@@ -24,7 +24,7 @@ describe('recordConnectionCreated (hook-side emitter, unit)', () => {
     };
 
     beforeEach(() => {
-        recordMock.mockReset().mockResolvedValue({ isErr: () => false });
+        recordMock.mockReset().mockResolvedValue(undefined);
         flags.hasAuditTrail = true;
     });
 

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -2,7 +2,15 @@ import db from '@nangohq/database';
 import { accountService, configService, customerKeyService, environmentService, getInvitation, getPlanSafe, userService } from '@nangohq/shared';
 import { getLogger, metrics } from '@nangohq/utils';
 
-import { audit, changedFields, connectSessionActor, makeAuditTarget as makeTarget, toAuditId as toId, UNKNOWN_ACTOR } from '../audit.js';
+import {
+    auditEventDropped,
+    changedFields,
+    connectSessionActor,
+    makeAuditTarget as makeTarget,
+    recordAuditEvent,
+    toAuditId as toId,
+    UNKNOWN_ACTOR
+} from '../audit.js';
 import { normalizeSyncParams, syncTriggerOptions } from '../controllers/sync/helpers.js';
 import { auditExportQuery, auditListQuery } from '../controllers/v1/audit-trail/query.js';
 import { connectionCreatedActor } from '../hooks/auditConnection.js';
@@ -263,12 +271,10 @@ async function emit(
             outcome: outcomeFromStatus(res.statusCode),
             ...(metadata ? { metadata } : {})
         } as AuditEvent;
-        const result = await audit.record(event);
-        if (result.isErr()) {
-            logger.error(`failed to record audit event`, result.error);
-        }
+        await recordAuditEvent(event);
     } catch (err) {
         logger.error(`failed to emit audit event`, err);
+        auditEventDropped(policy.resource, 'build_failed');
     }
 }
 
@@ -1167,11 +1173,9 @@ async function emitMfaVerified(req: Request, res: Response, pendingUserId: numbe
             outcome: outcomeFromStatus(res.statusCode),
             ...(method ? { metadata: { method } } : {})
         };
-        const result = await audit.record(event);
-        if (result.isErr()) {
-            logger.error(`failed to record audit event`, result.error);
-        }
+        await recordAuditEvent(event);
     } catch (err) {
         logger.error(`failed to emit mfa verify audit event`, err);
+        auditEventDropped('mfa', 'build_failed');
     }
 }

--- a/packages/server/lib/middleware/auditAuth.middleware.ts
+++ b/packages/server/lib/middleware/auditAuth.middleware.ts
@@ -4,7 +4,7 @@ import db from '@nangohq/database';
 import { accountService, getPlanSafe, userService } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
 
-import { audit } from '../audit.js';
+import { auditEventDropped, recordAuditEvent } from '../audit.js';
 import { canRecordAuditTrail } from '../utils/auditTrail.js';
 import { auditRequestFields, outcomeFromStatus } from './audit.middleware.js';
 
@@ -142,12 +142,10 @@ async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
                       metadata: { mfaRequired: Boolean(req.session.pendingMfaLogin), ...(options.method ? { method: options.method } : {}) }
                   }
                 : { ...common, resource: 'app_auth', action };
-        const result = await audit.record(event);
-        if (result.isErr()) {
-            logger.error(`failed to record ${action} audit event`, result.error);
-        }
+        await recordAuditEvent(event);
     } catch (err) {
         logger.error('failed to emit auth audit event', err);
+        auditEventDropped('app_auth', 'build_failed');
     }
 }
 

--- a/packages/server/lib/middleware/auditSyncCommand.middleware.ts
+++ b/packages/server/lib/middleware/auditSyncCommand.middleware.ts
@@ -1,7 +1,7 @@
 import { connectionService, SyncCommand } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
 
-import { audit } from '../audit.js';
+import { auditEventDropped, recordAuditEvent } from '../audit.js';
 import { canRecordAuditTrail } from '../utils/auditTrail.js';
 import { auditEnrichmentFailed, auditRequestFields, outcomeFromStatus, resolveActor, syncBaseMeta, syncTargetId } from './audit.middleware.js';
 
@@ -113,11 +113,9 @@ async function emit(req: Request, res: Response): Promise<void> {
             outcome: outcomeFromStatus(res.statusCode),
             ...(Object.keys(metadata).length > 0 ? { metadata } : {})
         } as AuditEvent;
-        const result = await audit.record(event);
-        if (result.isErr()) {
-            logger.error(`failed to record audit event`, result.error);
-        }
+        await recordAuditEvent(event);
     } catch (err) {
         logger.error(`failed to emit audit event`, err);
+        auditEventDropped('sync', 'build_failed');
     }
 }

--- a/packages/server/lib/middleware/auditSyncCommand.unit.test.ts
+++ b/packages/server/lib/middleware/auditSyncCommand.unit.test.ts
@@ -12,7 +12,7 @@ import type * as Shared from '@nangohq/shared';
 import type { RequestHandler } from 'express';
 
 const recordMock = vi.hoisted(() => vi.fn());
-vi.mock('../audit.js', async (importOriginal) => ({ ...(await importOriginal<typeof AuditModule>()), audit: { record: recordMock } }));
+vi.mock('../audit.js', async (importOriginal) => ({ ...(await importOriginal<typeof AuditModule>()), recordAuditEvent: recordMock }));
 
 const getConnectionByIdMock = vi.hoisted(() => vi.fn());
 vi.mock('@nangohq/shared', async (importOriginal) => ({
@@ -61,7 +61,7 @@ function syncCommandReq(command: string, extra: Record<string, unknown> = {}) {
 
 describe('auditSyncCommand middleware behavior (unit)', () => {
     beforeEach(() => {
-        recordMock.mockReset().mockResolvedValue({ isErr: () => false });
+        recordMock.mockReset().mockResolvedValue(undefined);
         // getFlags() returns the stable noop facade in tests; force the audit trail on.
         // No plans in a unit run, so the entitlement path resolves off and the deployment opt-in is what
         // reaches the middleware. Which gate admits a request is covered in utils/auditTrail.unit.test.ts.
@@ -163,7 +163,7 @@ describe('auditSyncCommand middleware behavior (unit)', () => {
     ])('records $label with the same target and metadata as the public route', async ({ command, publicSpec, body, publicBody }) => {
         const privateEvent = await runAudit(auditSyncCommand, syncCommandReq(command, { sync_variant: 'v2', ...body }), fakeRes(locals));
 
-        recordMock.mockReset().mockResolvedValue({ isErr: () => false });
+        recordMock.mockReset().mockResolvedValue(undefined);
         const publicReq = fakeReq({
             body: { syncs: [{ name: 'test-sync', variant: 'v2' }], provider_config_key: 'github', connection_id: 'conn-abc', ...publicBody }
         });

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -41,7 +41,7 @@ import type { RequestHandler } from 'express';
 const recordMock = vi.hoisted(() => vi.fn());
 vi.mock('../audit.js', async (importOriginal) => {
     const actual = await importOriginal<typeof AuditModule>();
-    return { ...actual, audit: { record: recordMock } };
+    return { ...actual, recordAuditEvent: recordMock };
 });
 
 // invite accept/decline resolve the audited account from the invitation (see AuditSpec.account).
@@ -105,7 +105,7 @@ async function runAudit(handler: RequestHandler, req: any, res: any) {
 
 describe('auditable() middleware behavior (unit)', () => {
     beforeEach(() => {
-        recordMock.mockReset().mockResolvedValue({ isErr: () => false });
+        recordMock.mockReset().mockResolvedValue(undefined);
         // No plans in a unit run, so the entitlement path resolves off; the deployment opt-in is what
         // reaches the middleware. Which gate lets a request through is covered in utils/auditTrail.unit.test.ts.
         flags.hasAuditTrail = true;
@@ -468,7 +468,7 @@ describe('auditable() middleware behavior (unit)', () => {
 // (targetFromResponse) stay in audit.integration.test.ts.
 describe('auditable() lifecycle specs (unit)', () => {
     beforeEach(() => {
-        recordMock.mockReset().mockResolvedValue({ isErr: () => false });
+        recordMock.mockReset().mockResolvedValue(undefined);
         flags.hasAuditTrail = true;
         getPlanSafeMock.mockReset().mockResolvedValue(null);
         // Invite accept/decline attribute to the inviting team (account 100), not the caller's account (42).

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -166,6 +166,8 @@ export enum Types {
     AUTH_CALLBACK_STATE_COOKIE = 'nango.server.auth.callback.state_cookie',
 
     AUDIT_EVENT_ENRICHMENT_FAILED = 'nango.audit.event.enrichment.failed',
+    AUDIT_EVENT_RECORDED = 'nango.audit.event.recorded',
+    AUDIT_EVENT_DROPPED = 'nango.audit.event.dropped',
     AUDIT_CLICKHOUSE_INGEST_RESULT = 'nango.audit.clickhouse.ingest.result',
     AUDIT_CONSUMER_BATCH_SIZE = 'nango.audit.consumer.batch.size',
     AUDIT_CONSUMER_REJECTED = 'nango.audit.consumer.rejected',


### PR DESCRIPTION
There was no way to see how many audit events we lose, or which resources they belong to.

A dropped event really is lost. The publish is awaited and a failure does come back to the emitter, but nothing retries it, so the event is gone. All we had was a log line, plus the existing pubsub counter tagged by subject — which tells you `audit` failed, not that a `connection` event failed.

Two new counters, both tagged with the resource:

- `nango.audit.event.recorded` — the write succeeded
- `nango.audit.event.dropped` — tagged `write_failed` when the write came back an error, or `build_failed` when we threw before the event existed

Those two give the error ratio and the traffic per resource off the same pair. The pubsub counter keeps doing its own job on the transport side, and the consumer already has `nango.audit.clickhouse.ingest.result` and `nango.audit.consumer.rejected` for the storage side. Three independent views, which is what you want when working out where events went.

### One function instead of six copies

There are six places that record an event, and each had its own copy of "call record, log if it failed". Adding counters to each would have been six copies of three things, and the seventh emitter would forget them — which is how six copies of the log line happened. They now all call one function that records and counts, and the call sites got shorter.

The unit tests that used to intercept `audit.record` now intercept that function instead, since that's where the seam is.

## Test plan

- [x] A written event counts under its resource and nothing else
- [x] A failed write counts as a drop, not as recorded
- [x] A throw before the event exists counts as a drop, tagged separately
- [x] Removed each counter in turn to check the tests fail
- [x] 106 unit and 30 integration tests pass; `ts-build`, `lint` and Prettier clean
- [ ] Add both to the audit dashboard (`tm4-q5h-9c6`) once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

