### PR TITLE
feat(server): Track account ID in management MCP metrics

### DIFF
--- a/packages/server/lib/controllers/mcp/managementTool.ts
+++ b/packages/server/lib/controllers/mcp/managementTool.ts
@@ -66,12 +66,18 @@ export function defineManagementMcpTool<TInputSchema extends z.ZodType, TRespons
             try {
                 result = await tool.handler(handlerContext);
             } catch (err) {
-                metrics.increment(metrics.Types.MCP_TOOL_CALLS, 1, { mcp_type: 'management', tool: tool.name, outcome: 'error' });
+                metrics.increment(metrics.Types.MCP_TOOL_CALLS, 1, {
+                    accountId: context.account.id,
+                    mcp_type: 'management',
+                    tool: tool.name,
+                    outcome: 'error'
+                });
                 recordToolAudit({ tool, context, args: parsedArgs.data, outcome: 'failure' });
                 throw err;
             }
 
             metrics.increment(metrics.Types.MCP_TOOL_CALLS, 1, {
+                accountId: context.account.id,
                 mcp_type: 'management',
                 tool: tool.name,
                 outcome: result.isOk() ? 'success' : 'error'

--- a/packages/server/lib/controllers/mcp/managementTool.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementTool.unit.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as z from 'zod/v4';
 
-import { Err, flags, Ok } from '@nangohq/utils';
+import { Err, flags, metrics, Ok } from '@nangohq/utils';
 
 import { audit } from '../../audit.js';
 import { defineManagementMcpTool } from './managementTool.js';
@@ -11,7 +11,7 @@ import type { ManagementMcpContext } from './managementTool.js';
 import type { Result } from '@nangohq/utils';
 
 const context = {
-    account: {},
+    account: { id: 123 },
     environment: {},
     grantedScopes: ['environment:mcp']
 } as ManagementMcpContext;
@@ -53,6 +53,49 @@ describe('defineManagementMcpTool', () => {
         if (result.isOk()) {
             expect(result.value).toStrictEqual({ limit: 10 });
         }
+    });
+
+    it('records the account ID for successful tool executions', async () => {
+        const metricSpy = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        const tool = defineManagementMcpTool({
+            name: 'test_tool',
+            description: 'Test tool',
+            inputSchema: z.object({}).strict(),
+            requiredScopes: { every: ['environment:mcp'] },
+            audit: { kind: 'no-audit', reason: 'read-only' },
+            handler: () => Ok({})
+        });
+
+        await tool.handler({}, context);
+
+        expect(metricSpy).toHaveBeenCalledWith(metrics.Types.MCP_TOOL_CALLS, 1, {
+            accountId: 123,
+            mcp_type: 'management',
+            tool: 'test_tool',
+            outcome: 'success'
+        });
+    });
+
+    it('records the account ID for thrown tool errors', async () => {
+        const metricSpy = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        const tool = defineManagementMcpTool({
+            name: 'test_tool',
+            description: 'Test tool',
+            inputSchema: z.object({}).strict(),
+            requiredScopes: { every: ['environment:mcp'] },
+            audit: { kind: 'no-audit', reason: 'read-only' },
+            handler: () => {
+                throw new Error('Tool failed');
+            }
+        });
+
+        await expect(tool.handler({}, context)).rejects.toThrow('Tool failed');
+        expect(metricSpy).toHaveBeenCalledWith(metrics.Types.MCP_TOOL_CALLS, 1, {
+            accountId: 123,
+            mcp_type: 'management',
+            tool: 'test_tool',
+            outcome: 'error'
+        });
     });
 
     it('returns a public error for invalid arguments', async () => {

--- a/packages/server/lib/controllers/mcp/managementTool.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementTool.unit.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as z from 'zod/v4';
 
-import { Err, flags, metrics, Ok } from '@nangohq/utils';
+import { Err, flags, Ok } from '@nangohq/utils';
 
 import { audit } from '../../audit.js';
 import { defineManagementMcpTool } from './managementTool.js';
@@ -11,7 +11,7 @@ import type { ManagementMcpContext } from './managementTool.js';
 import type { Result } from '@nangohq/utils';
 
 const context = {
-    account: { id: 123 },
+    account: {},
     environment: {},
     grantedScopes: ['environment:mcp']
 } as ManagementMcpContext;
@@ -53,49 +53,6 @@ describe('defineManagementMcpTool', () => {
         if (result.isOk()) {
             expect(result.value).toStrictEqual({ limit: 10 });
         }
-    });
-
-    it('records the account ID for successful tool executions', async () => {
-        const metricSpy = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
-        const tool = defineManagementMcpTool({
-            name: 'test_tool',
-            description: 'Test tool',
-            inputSchema: z.object({}).strict(),
-            requiredScopes: { every: ['environment:mcp'] },
-            audit: { kind: 'no-audit', reason: 'read-only' },
-            handler: () => Ok({})
-        });
-
-        await tool.handler({}, context);
-
-        expect(metricSpy).toHaveBeenCalledWith(metrics.Types.MCP_TOOL_CALLS, 1, {
-            accountId: 123,
-            mcp_type: 'management',
-            tool: 'test_tool',
-            outcome: 'success'
-        });
-    });
-
-    it('records the account ID for thrown tool errors', async () => {
-        const metricSpy = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
-        const tool = defineManagementMcpTool({
-            name: 'test_tool',
-            description: 'Test tool',
-            inputSchema: z.object({}).strict(),
-            requiredScopes: { every: ['environment:mcp'] },
-            audit: { kind: 'no-audit', reason: 'read-only' },
-            handler: () => {
-                throw new Error('Tool failed');
-            }
-        });
-
-        await expect(tool.handler({}, context)).rejects.toThrow('Tool failed');
-        expect(metricSpy).toHaveBeenCalledWith(metrics.Types.MCP_TOOL_CALLS, 1, {
-            accountId: 123,
-            mcp_type: 'management',
-            tool: 'test_tool',
-            outcome: 'error'
-        });
     });
 
     it('returns a public error for invalid arguments', async () => {


### PR DESCRIPTION
Adds the management account ID to Datadog's nango.mcp.tool_calls metric for successful and failed Management MCP tool executions. Legacy connection tools MCP metrics remain unchanged.

Traffic is low so it shouldn't cost us too much, when traffic increases we'll remove the attribute

NAN-6716: https://linear.app/nango/issue/NAN-6716/track-management-mcp-tool-usage-in-dd

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

