### PR TITLE
feat(runner): split persist_logs DT telemetry callsites

### DIFF
--- a/packages/persist/lib/routes/runner/telemetry/validate.ts
+++ b/packages/persist/lib/routes/runner/telemetry/validate.ts
@@ -12,7 +12,7 @@ export const telemetryEntrySchema = z.discriminatedUnion('type', [
             bytesSent: z.number().int().nonnegative(),
             bytesReceived: z.number().int().nonnegative(),
             count: z.number().int().positive().default(1),
-            callsite: z.enum(['proxy', 'uncontrolled_fetch', 'persist_records', 'persist_logs'])
+            callsite: z.enum(['proxy', 'uncontrolled_fetch', 'persist_records', 'persist_customer_logs', 'persist_system_logs', 'persist_logs'])
         })
         .strict()
 ]);

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -337,7 +337,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
         }
         this.telemetryRecorder?.record({
             type: 'data_transfer',
-            callsite: 'persist_logs',
+            callsite: log.source === 'user' ? 'persist_customer_logs' : 'persist_system_logs',
             bytesSent: Buffer.byteLength(data, 'utf8'),
             bytesReceived: 0,
             integrationId: this.providerConfigKey,

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -11,6 +11,7 @@ import { PersistClient } from '../clients/persist.js';
 import { MapLocks } from './locks.js';
 import { createFunctionFacade, NangoActionRunner, NangoSyncRunner } from './sdk.js';
 
+import type { TelemetryRecorder } from '../telemetry.js';
 import type { CursorPagination, DBSyncConfig, LinkPagination, NangoProps, OffsetPagination, Pagination, Provider } from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
 import type { Mock } from 'vitest';
@@ -519,6 +520,26 @@ describe('Log', () => {
             environmentId: 1,
             data: expect.stringMatching('{"activityLogId":"1","log":{"createdAt":".*","level":"error","message":"hello","source":"user","type":"log"}}')
         });
+    });
+
+    it('records customer and system log data-transfers as separate telemetry callsites', async () => {
+        const telemetryRecorder = {
+            record: vi.fn(),
+            shutdown: vi.fn().mockResolvedValue(Ok(undefined))
+        } satisfies TelemetryRecorder;
+        const nangoAction = new NangoActionRunner({ ...nangoProps }, { persistClient, telemetryRecorder, locks });
+
+        await nangoAction.log('customer log');
+        await nangoAction['sendLogToPersist']({
+            type: 'log',
+            level: 'info',
+            source: 'internal',
+            message: 'system log',
+            createdAt: new Date().toISOString()
+        });
+
+        expect(telemetryRecorder.record).toHaveBeenNthCalledWith(1, expect.objectContaining({ callsite: 'persist_customer_logs' }));
+        expect(telemetryRecorder.record).toHaveBeenNthCalledWith(2, expect.objectContaining({ callsite: 'persist_system_logs' }));
     });
 
     it('should enforce type: log message + object + level', async () => {

--- a/packages/types/lib/persist/api.ts
+++ b/packages/types/lib/persist/api.ts
@@ -23,7 +23,7 @@ type WithTags<T> = T & { integrationId: string; connectionId: string; syncId?: s
 
 export type RunnerDataTransferTelemetry = WithTags<{
     type: 'data_transfer';
-    callsite: 'proxy' | 'uncontrolled_fetch' | 'persist_records' | 'persist_logs';
+    callsite: 'proxy' | 'uncontrolled_fetch' | 'persist_records' | 'persist_customer_logs' | 'persist_system_logs' | 'persist_logs';
     bytesSent: number;
     bytesReceived: number;
     count: number;

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -162,6 +162,8 @@ export type DataTransferCallsite =
     | 'webhook_forward'
     | 'proxy'
     | 'uncontrolled_fetch'
+    | 'persist_customer_logs'
+    | 'persist_system_logs'
     | 'persist_logs'
     | 'persist_records'
     | 'get_/records'


### PR DESCRIPTION
Separate persisted-log data-transfer telemetry into customer and system logs. SDK nango.log() calls now emit persist_customer_logs, while internal customer-visible logs such as HTTP activity emit persist_system_logs.

Persist temporarily continues accepting the legacy persist_logs callsite for mixed-version rollout compatibility.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

