### PR TITLE
feat(functions): support for http trigger

### DIFF
--- a/packages/cli/fixtures/zero/valid/github/functions/fetchIssues.ts
+++ b/packages/cli/fixtures/zero/valid/github/functions/fetchIssues.ts
@@ -3,6 +3,7 @@ import * as z from 'zod';
 
 export default createFunction({
     description: 'Fetch a GitHub issue on demand',
+    trigger: { kind: 'http' },
     input: z.object({ issueNumber: z.number() }),
     output: z.object({ id: z.string(), title: z.string(), state: z.string() }),
     exec: async (nango, trigger) => {

--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -10,6 +10,8 @@ import { bundleFile, compileAllFunctions, detectFeatures } from './compile.js';
 import { getIntegrationId, validateFunction } from './definitions.js';
 import { CompileError } from './utils.js';
 
+import type { FunctionTriggerDefinition } from '@nangohq/types';
+
 const exec = promisify(execCb);
 
 describe('bundleFile', () => {
@@ -64,7 +66,7 @@ describe('compileAll', () => {
             integrationId: 'github',
             filePath: './github/functions/fetchIssues.ts',
             description: 'Fetch a GitHub issue on demand',
-            trigger: { kind: 'none' },
+            trigger: { kind: 'http' },
             requires: { connection: true, outbound: true, invoke: false },
             capabilities: { usesRecords: false, usesOutbound: true, usesCheckpoints: false, usesMetadata: false, usesInvoke: false },
             limits: { concurrency: { perConnection: 'max' } },
@@ -140,10 +142,61 @@ describe('validateFunction', () => {
         expect(res.isOk()).toBe(true);
     });
 
-    it('rejects an http trigger (not supported yet)', () => {
+    it('accepts an http trigger', () => {
         const res = validateFunction({ ...base, params: { trigger: { kind: 'http' } } });
+        expect(res.isOk()).toBe(true);
+    });
+
+    it('rejects an http trigger with subscriptions', () => {
+        const res = validateFunction({ ...base, params: { trigger: { kind: 'http', subscriptions: ['issues'] } } });
         assert(res.isErr());
-        expect(res.error.message).toContain("unsupported trigger kind 'http'");
+        expect(res.error.message).toContain("unsupported HTTP trigger options: 'subscriptions'");
+    });
+
+    it('rejects an http trigger with debounce', () => {
+        const res = validateFunction({ ...base, params: { trigger: { kind: 'http', debounce: { windowMs: 1000 } } } });
+        assert(res.isErr());
+        expect(res.error.message).toContain("unsupported HTTP trigger options: 'debounce'");
+    });
+
+    it('reports all unsupported http trigger options', () => {
+        const res = validateFunction({
+            ...base,
+            params: { trigger: { kind: 'http', subscriptions: [], debounce: { windowMs: 1000 } } }
+        });
+        assert(res.isErr());
+        expect(res.error.message).toContain("unsupported HTTP trigger options: 'subscriptions', 'debounce'");
+    });
+
+    it('rejects unknown http trigger attributes', () => {
+        const res = validateFunction({
+            ...base,
+            params: { trigger: { kind: 'http', subscription: ['issues'], unexpected: true } as unknown as FunctionTriggerDefinition }
+        });
+        assert(res.isErr());
+        expect(res.error.message).toContain('invalid trigger definition');
+        expect(res.error.message).toContain('subscription');
+        expect(res.error.message).toContain('unexpected');
+    });
+
+    it('rejects unknown attributes on a trigger without options', () => {
+        const res = validateFunction({
+            ...base,
+            params: { trigger: { kind: 'none', unexpected: true } as unknown as FunctionTriggerDefinition }
+        });
+        assert(res.isErr());
+        expect(res.error.message).toContain('invalid trigger definition');
+        expect(res.error.message).toContain('unexpected');
+    });
+
+    it('rejects malformed nested trigger options', () => {
+        const res = validateFunction({
+            ...base,
+            params: { trigger: { kind: 'http', debounce: { windowMs: '1000' } } as unknown as FunctionTriggerDefinition }
+        });
+        assert(res.isErr());
+        expect(res.error.message).toContain('invalid trigger definition');
+        expect(res.error.message).toContain('debounce.windowMs');
     });
 
     it('rejects a schedule trigger', () => {

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { pathToFileURL } from 'url';
 
+import * as z from 'zod';
+
 import { getInterval } from '@nangohq/nango-yaml';
 import { deriveFunctionCapabilities } from '@nangohq/runner-sdk';
 
@@ -37,7 +39,33 @@ import type {
     ParsedNangoSync,
     Result
 } from '@nangohq/types';
-import type * as z from 'zod';
+
+const debounceKeySourceSchema = z.union([z.object({ body: z.string() }).strict(), z.object({ header: z.string() }).strict()]);
+const functionTriggerDefinitionSchema = z.discriminatedUnion('kind', [
+    z.object({ kind: z.literal('none') }).strict(),
+    z.object({ kind: z.literal('schedule'), frequency: z.string(), autoStart: z.boolean().optional() }).strict(),
+    z
+        .object({
+            kind: z.literal('http'),
+            subscriptions: z.array(z.string()).optional(),
+            debounce: z
+                .object({
+                    keyBy: z.union([debounceKeySourceSchema, z.array(debounceKeySourceSchema)]).optional(),
+                    windowMs: z.number(),
+                    maxEntities: z.number().optional(),
+                    take: z.enum(['latest', 'first', 'all']).optional()
+                })
+                .strict()
+                .optional()
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('event'),
+            events: z.array(z.enum(['post-connection-creation', 'pre-connection-deletion', 'validate-connection']))
+        })
+        .strict()
+]) satisfies z.ZodType<FunctionTriggerDefinition>;
 
 interface FunctionDefinition {
     description: string;
@@ -315,14 +343,35 @@ export function validateFunction({
 }): Result<void> {
     const fnPath = `${integrationId}/functions/${basename}.ts`;
 
-    // For now only trigger-less functions (triggered manually) are supported, with no data (records, checkpoints or metadata).
-    // TODO: Add support for http, schedule and event triggers, and data
-    const supportedFunctionTriggerKinds: FunctionTriggerDefinition['kind'][] = ['none'];
+    // For now only HTTP-triggered and trigger-less functions are supported, with no data (records, checkpoints or metadata).
+    // TODO: Add support for schedule and event triggers, and data
+    const supportedFunctionTriggerKinds: FunctionTriggerDefinition['kind'][] = ['none', 'http'];
 
     if (params.trigger && !supportedFunctionTriggerKinds.includes(params.trigger.kind)) {
         const supported = supportedFunctionTriggerKinds.map((kind) => `'${kind}'`).join(', ');
         const allowedText = supported ? `${supported} or no trigger` : 'no trigger';
         return Err(new Error(`Function '${fnPath}' uses an unsupported trigger kind '${params.trigger.kind}'. Only ${allowedText} is supported for now.`));
+    }
+    if (params.trigger !== undefined) {
+        const triggerValidation = functionTriggerDefinitionSchema.safeParse(params.trigger);
+        if (!triggerValidation.success) {
+            const details = triggerValidation.error.issues
+                .map((issue) => `${issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''}${issue.message}`)
+                .join('; ');
+            return Err(new Error(`Function '${fnPath}' has an invalid trigger definition: ${details}`));
+        }
+    }
+    // TODO: Add support for HTTP trigger options (subscriptions, debounce)
+    if (params.trigger?.kind === 'http') {
+        const unsupportedOptions = [
+            ...(params.trigger.subscriptions !== undefined ? ['subscriptions'] : []),
+            ...(params.trigger.debounce !== undefined ? ['debounce'] : [])
+        ];
+        if (unsupportedOptions.length > 0) {
+            return Err(
+                new Error(`Function '${fnPath}' uses unsupported HTTP trigger options: ${unsupportedOptions.map((option) => `'${option}'`).join(', ')}.`)
+            );
+        }
     }
     if (params.data) {
         return Err(new Error(`Function '${fnPath}' declares 'data' (records, checkpoint or metadata) which is not supported yet. Remove 'data' for now.`));

--- a/packages/cli/lib/zeroYaml/deploy.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/deploy.unit.cli-test.ts
@@ -180,7 +180,7 @@ describe('deploy', () => {
         const previewRequest = fetchMock.mock.calls[0]?.[1] as RequestInit;
         const previewBody = JSON.parse(previewRequest.body as string) as { reconciliationScope: unknown; functions: FunctionConfig[] };
         expect(previewBody.reconciliationScope).toEqual({ kind: 'integration', integrationId: 'slack' });
-        expect(previewBody.functions).toEqual([expect.objectContaining({ integrationId: 'slack', name: 'other' })]);
+        expect(previewBody.functions).toEqual([expect.objectContaining({ integrationId: 'slack', name: 'other', trigger: { kind: 'http' } })]);
     });
 
     it('deletes the functions of an integration when its last function was removed', async () => {
@@ -422,7 +422,7 @@ function functionConfig({ integrationId, name }: { integrationId: string; name: 
         integrationId,
         filePath: `./${integrationId}/functions/${name}.ts`,
         description: 'Function',
-        trigger: { kind: 'none' },
+        trigger: { kind: 'http' },
         requires: { connection: true, outbound: true, invoke: false },
         capabilities: { usesRecords: false, usesOutbound: true, usesCheckpoints: false, usesMetadata: false, usesInvoke: false },
         limits: { concurrency: { perConnection: 'max' } },

--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -186,7 +186,7 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             nangoProps,
             routingContext,
             logCtx: logCtx,
-            input: task.input
+            arg: task.input
         });
 
         if (res.isErr()) {

--- a/packages/jobs/lib/execution/function.ts
+++ b/packages/jobs/lib/execution/function.ts
@@ -128,7 +128,7 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
         }
 
         void logCtx.info(`Starting function '${task.functionName}'${formatAttempts(task)}`, {
-            input: task.input,
+            input: task.trigger.input,
             function: task.functionName,
             connection: task.connection.connection_id,
             integration: task.connection.provider_config_key
@@ -188,14 +188,7 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
             nangoProps,
             routingContext,
             logCtx: logCtx,
-            input: {
-                kind: 'invoke',
-                input: task.input,
-                connection: {
-                    connection_id: task.connection.connection_id,
-                    integrationId: task.connection.provider_config_key
-                }
-            }
+            input: task.trigger
         });
 
         if (res.isErr()) {

--- a/packages/jobs/lib/execution/function.ts
+++ b/packages/jobs/lib/execution/function.ts
@@ -188,7 +188,7 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
             nangoProps,
             routingContext,
             logCtx: logCtx,
-            input: task.trigger
+            arg: task.trigger
         });
 
         if (res.isErr()) {

--- a/packages/jobs/lib/execution/operations/start.ts
+++ b/packages/jobs/lib/execution/operations/start.ts
@@ -14,13 +14,13 @@ export async function startScript({
     taskId,
     nangoProps,
     routingContext,
-    input,
+    arg,
     logCtx
 }: {
     taskId: string;
     nangoProps: NangoProps;
     routingContext: RoutingContext;
-    input?: JsonValue | undefined;
+    arg?: JsonValue | undefined;
     logCtx: LogContext;
 }): Promise<Result<void>> {
     return tracer.trace(
@@ -62,7 +62,7 @@ export async function startScript({
                     taskId,
                     nangoProps,
                     code: script,
-                    codeParams: (input as object) || {},
+                    codeParams: (arg as object) || {},
                     routingContext
                 });
 

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -181,7 +181,7 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
             nangoProps,
             routingContext,
             logCtx: logCtx,
-            input: task.input
+            arg: task.input
         });
 
         if (res.isErr()) {

--- a/packages/orchestrator/lib/clients/client.unit.test.ts
+++ b/packages/orchestrator/lib/clients/client.unit.test.ts
@@ -132,7 +132,12 @@ function buildFunctionProps(async: boolean): ExecuteFunctionProps {
                 environment_id: 456
             },
             activityLogId: 'activity-log-1',
-            input: { foo: 'bar' },
+            trigger: {
+                kind: 'http',
+                input: { foo: 'bar' },
+                request: { method: 'POST', path: '/functions/invocations', headers: {}, query: {}, body: { foo: 'bar' } },
+                connection: { connectionId: 'connection-1', integrationId: 'provider-config-key-1' }
+            },
             async
         }
     };

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -2,7 +2,7 @@ import type { PostImmediate } from '../routes/v1/postImmediate.js';
 import type { PostRecurring } from '../routes/v1/postRecurring.js';
 import type { PostScheduleRun } from '../routes/v1/schedules/postRun.js';
 import type { ScheduleState, TaskState } from '@nangohq/scheduler';
-import type { ConnectionJobs, HTTP_METHOD, OnEventType } from '@nangohq/types';
+import type { ConnectionJobs, FunctionTrigger } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue, SetOptional } from 'type-fest';
 
@@ -51,34 +51,11 @@ interface OnEventArgs {
     sdkVersion: string | null;
 }
 
-type FunctionTriggerBase = {
-    connection: {
-        connectionId: string;
-        integrationId: string;
-    };
-};
-
-export type FunctionRuntimeTrigger =
-    | (FunctionTriggerBase & { kind: 'invoke'; input: JsonValue })
-    | (FunctionTriggerBase & { kind: 'schedule'; input: null })
-    | (FunctionTriggerBase & {
-          kind: 'http';
-          input: JsonValue;
-          request: {
-              method: HTTP_METHOD;
-              path: string;
-              headers: Record<string, string>;
-              query: Record<string, string>;
-              body: JsonValue;
-          };
-      })
-    | (FunctionTriggerBase & { kind: 'event'; input: { event: OnEventType } });
-
 interface FunctionArgs {
     functionName: string;
     connection: ConnectionJobs;
     activityLogId: string;
-    trigger: FunctionRuntimeTrigger;
+    trigger: FunctionTrigger;
     async: boolean;
 }
 export type SchedulesReturn = Result<OrchestratorSchedule[]>;

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -2,7 +2,7 @@ import type { PostImmediate } from '../routes/v1/postImmediate.js';
 import type { PostRecurring } from '../routes/v1/postRecurring.js';
 import type { PostScheduleRun } from '../routes/v1/schedules/postRun.js';
 import type { ScheduleState, TaskState } from '@nangohq/scheduler';
-import type { ConnectionJobs } from '@nangohq/types';
+import type { ConnectionJobs, HTTP_METHOD, OnEventType } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue, SetOptional } from 'type-fest';
 
@@ -50,11 +50,35 @@ interface OnEventArgs {
     activityLogId: string;
     sdkVersion: string | null;
 }
+
+type FunctionTriggerBase = {
+    connection: {
+        connectionId: string;
+        integrationId: string;
+    };
+};
+
+export type FunctionRuntimeTrigger =
+    | (FunctionTriggerBase & { kind: 'invoke'; input: JsonValue })
+    | (FunctionTriggerBase & { kind: 'schedule'; input: null })
+    | (FunctionTriggerBase & {
+          kind: 'http';
+          input: JsonValue;
+          request: {
+              method: HTTP_METHOD;
+              path: string;
+              headers: Record<string, string>;
+              query: Record<string, string>;
+              body: JsonValue;
+          };
+      })
+    | (FunctionTriggerBase & { kind: 'event'; input: { event: OnEventType } });
+
 interface FunctionArgs {
     functionName: string;
     connection: ConnectionJobs;
     activityLogId: string;
-    input: JsonValue;
+    trigger: FunctionRuntimeTrigger;
     async: boolean;
 }
 export type SchedulesReturn = Result<OrchestratorSchedule[]>;
@@ -284,7 +308,7 @@ export function TaskFunction(props: TaskCommonFields & FunctionArgs): TaskFuncti
         functionName: props.functionName,
         connection: props.connection,
         activityLogId: props.activityLogId,
-        input: props.input,
+        trigger: props.trigger,
         groupKey: props.groupKey,
         groupMaxConcurrency: props.groupMaxConcurrency,
         ownerKey: props.ownerKey,

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -77,7 +77,35 @@ export const functionArgsSchema = z.object({
     type: z.literal('function'),
     functionName: z.string().min(1),
     activityLogId: z.string(),
-    input: jsonSchema,
+    trigger: z.discriminatedUnion('kind', [
+        z.object({
+            kind: z.literal('invoke'),
+            input: jsonSchema,
+            connection: z.object({ connectionId: z.string().min(1), integrationId: z.string().min(1) })
+        }),
+        z.object({
+            kind: z.literal('schedule'),
+            input: z.null(),
+            connection: z.object({ connectionId: z.string().min(1), integrationId: z.string().min(1) })
+        }),
+        z.object({
+            kind: z.literal('http'),
+            input: jsonSchema,
+            request: z.object({
+                method: z.enum(['GET', 'POST', 'PATCH', 'PUT', 'DELETE']),
+                path: z.string(),
+                headers: z.record(z.string(), z.string()),
+                query: z.record(z.string(), z.string()),
+                body: jsonSchema
+            }),
+            connection: z.object({ connectionId: z.string().min(1), integrationId: z.string().min(1) })
+        }),
+        z.object({
+            kind: z.literal('event'),
+            input: z.object({ event: z.enum(['post-connection-creation', 'pre-connection-deletion', 'validate-connection']) }),
+            connection: z.object({ connectionId: z.string().min(1), integrationId: z.string().min(1) })
+        })
+    ]),
     async: z.boolean().optional().default(false),
     ...commonSchemaArgsFields
 });
@@ -250,7 +278,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 functionName: func.data.payload.functionName,
                 connection: func.data.payload.connection,
                 activityLogId: func.data.payload.activityLogId,
-                input: func.data.payload.input,
+                trigger: func.data.payload.trigger,
                 async: func.data.payload.async,
                 groupKey: func.data.groupKey,
                 groupMaxConcurrency: func.data.groupMaxConcurrency,

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -90,13 +90,13 @@ export const functionArgsSchema = z.object({
         }),
         z.object({
             kind: z.literal('http'),
-            input: jsonSchema,
+            input: jsonSchema.optional().default(null),
             request: z.object({
                 method: z.enum(['GET', 'POST', 'PATCH', 'PUT', 'DELETE']),
                 path: z.string(),
                 headers: z.record(z.string(), z.string()),
                 query: z.record(z.string(), z.string()),
-                body: jsonSchema
+                body: jsonSchema.optional().default(null)
             }),
             connection: z.object({ connectionId: z.string().min(1), integrationId: z.string().min(1) })
         }),

--- a/packages/orchestrator/lib/clients/validate.unit.test.ts
+++ b/packages/orchestrator/lib/clients/validate.unit.test.ts
@@ -58,4 +58,56 @@ describe('validateTask', () => {
             });
         }
     });
+
+    it.each(['GET', 'DELETE'] as const)('deserializes a body-less %s function task', (method) => {
+        const result = validateTask({
+            id: '4a14038c-3a57-4a4d-bb9e-c8a5e85474ae',
+            name: 'function-task',
+            groupKey: 'function:environment:2:connection:1:function:my-function',
+            groupMaxConcurrency: 1,
+            state: 'STARTED',
+            retryKey: 'retry-key',
+            retryCount: 0,
+            retryMax: 2,
+            ownerKey: 'environment:2',
+            heartbeatTimeoutSecs: 60,
+            startsAfter: new Date(),
+            createdToStartedTimeoutSecs: 30,
+            startedToCompletedTimeoutSecs: 120,
+            createdAt: new Date(),
+            lastStateTransitionAt: new Date(),
+            lastHeartbeatAt: new Date(),
+            output: null,
+            terminated: false,
+            scheduleId: null,
+            payload: {
+                type: 'function',
+                functionName: 'my-function',
+                activityLogId: 'activity-log-id',
+                trigger: {
+                    kind: 'http',
+                    request: { method, path: '/webhooks/github', headers: {}, query: {} },
+                    connection: { connectionId: 'connection-id', integrationId: 'integration-id' }
+                },
+                async: false,
+                connection: {
+                    id: 1,
+                    connection_id: 'connection-id',
+                    provider_config_key: 'integration-id',
+                    environment_id: 2
+                }
+            }
+        } as Task);
+
+        const task = result.unwrap();
+        expect(task.isFunction()).toBe(true);
+        if (task.isFunction()) {
+            expect(task.trigger).toStrictEqual({
+                kind: 'http',
+                input: null,
+                request: { method, path: '/webhooks/github', headers: {}, query: {}, body: null },
+                connection: { connectionId: 'connection-id', integrationId: 'integration-id' }
+            });
+        }
+    });
 });

--- a/packages/orchestrator/lib/clients/validate.unit.test.ts
+++ b/packages/orchestrator/lib/clients/validate.unit.test.ts
@@ -30,7 +30,12 @@ describe('validateTask', () => {
                 type: 'function',
                 functionName: 'my-function',
                 activityLogId: 'activity-log-id',
-                input: { value: 42 },
+                trigger: {
+                    kind: 'http',
+                    input: { value: 42 },
+                    request: { method: 'POST', path: '/functions/invocations', headers: {}, query: {}, body: { value: 42 } },
+                    connection: { connectionId: 'connection-id', integrationId: 'integration-id' }
+                },
                 async: false,
                 connection: {
                     id: 1,
@@ -46,7 +51,7 @@ describe('validateTask', () => {
         if (task.isFunction()) {
             expect(task).toMatchObject({
                 functionName: 'my-function',
-                input: { value: 42 },
+                trigger: expect.objectContaining({ kind: 'http', input: { value: 42 } }),
                 async: false,
                 attempt: 1,
                 attemptMax: 3

--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -10,64 +10,28 @@ import type {
     FunctionTriggerDefinition,
     GetPublicConnection,
     GetPublicIntegration,
-    HTTP_METHOD,
     MaybePromise,
     MergingStrategy,
-    OnEventType,
-    SdkLogger
+    SdkLogger,
+    Trigger
 } from '@nangohq/types';
 import type * as z from 'zod';
 
-export type { DebounceKeySource, DebounceOptions, FunctionRequires, FunctionTriggerDefinition } from '@nangohq/types';
+export type {
+    CoalescedInfo,
+    DebounceKeySource,
+    DebounceOptions,
+    EventTrigger,
+    FunctionRequires,
+    FunctionTriggerDefinition,
+    HttpRequest,
+    HttpTrigger,
+    InvokeTrigger,
+    ScheduleTrigger,
+    Trigger
+} from '@nangohq/types';
 
 type InferZod<T> = T extends z.ZodTypeAny ? z.infer<T> : never;
-
-// The inbound http request that initiated the run.
-export interface HttpRequest {
-    method: HTTP_METHOD;
-    path: string;
-    headers: Record<string, string>;
-    query: Record<string, string>;
-    body: unknown;
-}
-// Coalescing summary, present on an http trigger when `debounce` is configured and coalescing happened.
-export interface CoalescedInfo {
-    count: number;
-    firstSeenAt: Date;
-    lastSeenAt: Date;
-}
-
-// `debounce.take: 'all'` delivers the whole coalesced batch, so the payload becomes an array; otherwise a single input.
-type HttpPayload<TT, TInput extends z.ZodTypeAny> = TT extends { debounce: { take: 'all' } } ? z.infer<TInput>[] : z.infer<TInput>;
-
-interface TriggerBase {
-    /**
-     * Present when the run carries connection context (invoke calls may pass one;
-     * http/event may resolve one). Undefined for connection-less runs.
-     */
-    connection?: { connectionId: string; integrationId: string };
-}
-
-// The per-kind runtime trigger shapes an `exec` can receive.
-export type InvokeTrigger<TInput extends z.ZodTypeAny> = TriggerBase & { kind: 'invoke'; input: z.infer<TInput> };
-export type ScheduleTrigger = TriggerBase & { kind: 'schedule'; input: null };
-export type HttpTrigger<TT, TInput extends z.ZodTypeAny> = TriggerBase & {
-    kind: 'http';
-    input: HttpPayload<TT, TInput>;
-    request: HttpRequest;
-    subscriptions?: string[];
-    coalesced?: CoalescedInfo;
-};
-export type EventTrigger = TriggerBase & { kind: 'event'; input: { event: OnEventType } };
-
-// The runtime trigger a function `exec` receives.
-export type Trigger<TT extends FunctionTriggerDefinition | undefined, TInput extends z.ZodTypeAny> = TT extends { kind: 'schedule' }
-    ? ScheduleTrigger
-    : TT extends { kind: 'http' }
-      ? HttpTrigger<TT, TInput>
-      : TT extends { kind: 'event' }
-        ? EventTrigger
-        : InvokeTrigger<TInput>;
 
 // Capability-narrowed nango
 
@@ -205,7 +169,7 @@ export interface CreateFunctionProps<
         };
     };
     // The handler. Runs on the runner with the capability-narrowed `nango` surface.
-    exec: (nango: Nango<TModels, TMetadata, TCheckpoint, TRequires>, trigger: Trigger<TTrigger, TInput>) => MaybePromise<z.infer<TOutput>>;
+    exec: (nango: Nango<TModels, TMetadata, TCheckpoint, TRequires>, trigger: Trigger<TTrigger, z.infer<TInput>>) => MaybePromise<z.infer<TOutput>>;
 }
 export interface CreateFunctionResponse<
     TModels extends Record<string, ZodModel> = Record<never, ZodModel>,

--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -45,7 +45,7 @@ interface TriggerBase {
      * Present when the run carries connection context (invoke calls may pass one;
      * http/event may resolve one). Undefined for connection-less runs.
      */
-    connection?: { connection_id: string; integrationId: string };
+    connection?: { connectionId: string; integrationId: string };
 }
 
 // The per-kind runtime trigger shapes an `exec` can receive.
@@ -56,17 +56,11 @@ export type HttpTrigger<TT, TInput extends z.ZodTypeAny> = TriggerBase & {
     input: HttpPayload<TT, TInput>;
     request: HttpRequest;
     subscriptions?: string[];
-    coalesced: CoalescedInfo;
+    coalesced?: CoalescedInfo;
 };
 export type EventTrigger = TriggerBase & { kind: 'event'; input: { event: OnEventType } };
 
-/**
- * The runtime trigger a function `exec` receives. Any function can be invoked by another, but an
- * invoke reuses the declared trigger's shape rather than adding a separate arrival — so `exec` only
- * ever sees its declared kind and never has to discriminate. On the invoke path the runtime
- * synthesizes the envelope (e.g. an http `request`/`coalesced` derived from the invoked input).
- * A function with no declared trigger is invoke-only and receives `InvokeTrigger`.
- */
+// The runtime trigger a function `exec` receives.
 export type Trigger<TT extends FunctionTriggerDefinition | undefined, TInput extends z.ZodTypeAny> = TT extends { kind: 'schedule' }
     ? ScheduleTrigger
     : TT extends { kind: 'http' }

--- a/packages/runner/lib/exec.unit.test.ts
+++ b/packages/runner/lib/exec.unit.test.ts
@@ -57,7 +57,7 @@ describe('Exec', () => {
         const trigger = {
             kind: 'invoke',
             input: { value: 42 },
-            connection: { connection_id: 'connection-id', integrationId: 'provider-config-key' }
+            connection: { connectionId: 'connection-id', integrationId: 'provider-config-key' }
         };
 
         const res = await exec({ nangoProps, code, codeParams: trigger });

--- a/packages/server/lib/controllers/functions/deployments/bundle/validation.ts
+++ b/packages/server/lib/controllers/functions/deployments/bundle/validation.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import { providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
 
-import type { FunctionDeploymentBundleBody, FunctionReconciliationScope } from '@nangohq/types';
+import type { FunctionDeploymentBundleBody, FunctionReconciliationScope, FunctionTriggerDefinition } from '@nangohq/types';
 import type { JSONSchema7 } from 'json-schema';
 
 const schemaReference = z.string().regex(/^#\/definitions\/[a-zA-Z0-9_-]+$/);
@@ -33,7 +33,7 @@ const trigger = z.discriminatedUnion('kind', [
             events: z.array(z.enum(['post-connection-creation', 'pre-connection-deletion', 'validate-connection']))
         })
         .strict()
-]);
+]) satisfies z.ZodType<FunctionTriggerDefinition>;
 const requires = z.union([
     z
         .object({

--- a/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
@@ -8,19 +8,21 @@ import { Err, Ok } from '@nangohq/utils';
 
 import { runServer, shouldBeProtected } from '../../utils/tests.js';
 
-import type { ApiKeyScope, DBFunctionConfigVersion } from '@nangohq/types';
+import type { ApiKeyScope, DBFunctionConfigVersion, FunctionTriggerDefinition } from '@nangohq/types';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
 const endpoint = '/functions/invocations';
 
-function functionVersion(): Omit<DBFunctionConfigVersion, 'id' | 'function_config_id' | 'created_at' | 'updated_at' | 'deleted_at'> {
+function functionVersion(
+    trigger: FunctionTriggerDefinition = { kind: 'http' }
+): Omit<DBFunctionConfigVersion, 'id' | 'function_config_id' | 'created_at' | 'updated_at' | 'deleted_at'> {
     return {
         description: 'Test function',
         file_location: 'functions/github/test-function',
         version: 'test-version',
         source: 'repo',
-        trigger: { kind: 'http' },
+        trigger,
         requires: { connection: true, outbound: false, invoke: false },
         capabilities: { usesRecords: false, usesOutbound: false, usesCheckpoints: false, usesMetadata: false, usesInvoke: false },
         limits: { concurrency: { perConnection: 'max' } },
@@ -61,7 +63,7 @@ async function createApiKeyWithScopes(seed: Awaited<ReturnType<typeof seedAccoun
     return key.unwrap();
 }
 
-async function seedFunction() {
+async function seedFunction(trigger?: FunctionTriggerDefinition) {
     const { apiKey, env } = await seedAccount(['environment:functions:invocations']);
     const integration = await seeders.createConfigSeed(env, 'github', 'github');
     const connection = await seeders.createConnectionSeed({ env, provider: integration.unique_key, connectionId: 'test-connection' });
@@ -69,7 +71,7 @@ async function seedFunction() {
         environmentId: env.id,
         integrationId: integration.unique_key,
         name: 'test-function',
-        version: functionVersion()
+        version: functionVersion(trigger)
     });
 
     return { apiKey, connection, integration, env };
@@ -283,11 +285,71 @@ describe(`POST ${endpoint}`, () => {
         expect(spy).toHaveBeenCalledWith(
             expect.objectContaining({
                 functionName: 'test-function',
-                input: { value: 'test' },
+                trigger: expect.objectContaining({
+                    kind: 'http',
+                    input: { value: 'test' },
+                    request: expect.objectContaining({ method: 'POST', path: endpoint, body: { value: 'test' } })
+                }),
                 async: true,
                 maxConcurrency: 0 // seeded function has perConnection: 'max'
             })
         );
+    });
+
+    it('should deliver the declared trigger when manually invoking a scheduled function', async () => {
+        const { apiKey, connection, integration } = await seedFunction({ kind: 'schedule', frequency: 'every hour' });
+        const spy = vi
+            .spyOn(Orchestrator.prototype, 'invokeFunction')
+            .mockResolvedValue(Ok({ id: 'retry-key-1', statusUrl: '/functions/invocations/retry-key-1' }));
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'no_wait'
+            }
+        });
+
+        expect(res.res.status).toBe(202);
+        expect(spy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                trigger: {
+                    kind: 'schedule',
+                    input: null,
+                    connection: { connectionId: connection.connection_id, integrationId: integration.unique_key }
+                }
+            })
+        );
+    });
+
+    it('should reject event-triggered functions with no configured events', async () => {
+        const { apiKey, connection, integration } = await seedFunction({ kind: 'event', events: [] });
+        const spy = vi.spyOn(Orchestrator.prototype, 'invokeFunction').mockResolvedValue(Ok({ data: null }));
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: integration.unique_key,
+                connection_id: connection.connection_id,
+                name: 'test-function',
+                input: { value: 'test' },
+                invocation_type: 'no_wait'
+            }
+        });
+
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'invalid_invocation',
+                message: 'Event-triggered function has no configured events'
+            }
+        });
+        expect(spy).not.toHaveBeenCalled();
     });
 
     it('should return the function output for wait invocations', async () => {

--- a/packages/server/lib/controllers/functions/postInvocation.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { invokeFunction } from '@nangohq/shared';
-import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { getHeaders, redactHeaders, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema, scriptNameSchema } from '../../helpers/validation.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
@@ -44,6 +44,12 @@ export const postFunctionInvocation = asyncWrapperWithEnvironment<PostFunctionIn
         connectionId: body.data.connection_id,
         functionName: body.data.name,
         input: body.data.input,
+        request: {
+            method: 'POST',
+            path: req.path,
+            headers: redactHeaders({ headers: getHeaders(req.headers) }),
+            query: {}
+        },
         invocationType: body.data.invocation_type,
         options: body.data.options,
         orchestrator: getOrchestrator()
@@ -80,7 +86,7 @@ export const postFunctionInvocation = asyncWrapperWithEnvironment<PostFunctionIn
             res.status(500).send({ error: { code: invoke.error.code, message: invoke.error.message } });
             return;
         default:
-            return ((_exhaustiveCheck: never) => {
+            return void ((_exhaustiveCheck: never) => {
                 res.status(500).send({ error: { code: 'server_error', message: 'Unknown invocation failure' } });
             })(invoke.error.code);
     }

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -29,6 +29,7 @@ import type {
     ExecuteReturn,
     ExecuteSyncProps,
     ExecuteWebhookProps,
+    FunctionRuntimeTrigger,
     GetOutputReturn,
     OrchestratorSchedule,
     OrchestratorTask,
@@ -125,7 +126,7 @@ export class Orchestrator {
         environment,
         connection,
         functionName,
-        input,
+        trigger,
         async,
         retryMax,
         maxConcurrency,
@@ -134,7 +135,7 @@ export class Orchestrator {
         environment: DBEnvironment;
         connection: ConnectionJobs;
         functionName: string;
-        input: JsonValue;
+        trigger: FunctionRuntimeTrigger;
         async: boolean;
         retryMax: number;
         maxConcurrency: number;
@@ -152,7 +153,7 @@ export class Orchestrator {
                     environment_id: connection.environment_id
                 },
                 activityLogId: logCtx.id,
-                input,
+                trigger,
                 async
             };
 

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -29,7 +29,6 @@ import type {
     ExecuteReturn,
     ExecuteSyncProps,
     ExecuteWebhookProps,
-    FunctionRuntimeTrigger,
     GetOutputReturn,
     OrchestratorSchedule,
     OrchestratorTask,
@@ -47,7 +46,8 @@ import type {
     DBConnection,
     DBConnectionDecrypted,
     DBEnvironment,
-    DBSyncConfig
+    DBSyncConfig,
+    FunctionTrigger
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
@@ -135,7 +135,7 @@ export class Orchestrator {
         environment: DBEnvironment;
         connection: ConnectionJobs;
         functionName: string;
-        trigger: FunctionRuntimeTrigger;
+        trigger: FunctionTrigger;
         async: boolean;
         retryMax: number;
         maxConcurrency: number;

--- a/packages/shared/lib/services/functions/invoke.ts
+++ b/packages/shared/lib/services/functions/invoke.ts
@@ -10,14 +10,14 @@ import { validateFunctionInput } from './models/validate.js';
 
 import type { Orchestrator } from '../../clients/orchestrator.js';
 import type { FunctionInputValidationError } from './models/validate.js';
-import type { FunctionRuntimeTrigger } from '@nangohq/nango-orchestrator';
 import type {
     AsyncFunctionResponse,
     DBEnvironment,
     DBFunctionConfigVersion,
     DBTeam,
     FunctionInvocationErrorCode,
-    FunctionInvocationType
+    FunctionInvocationType,
+    FunctionTrigger
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
@@ -57,7 +57,7 @@ export async function invokeFunction({
     connectionId: string;
     functionName: string;
     input?: unknown | undefined;
-    request: Omit<Extract<FunctionRuntimeTrigger, { kind: 'http' }>['request'], 'body'>;
+    request: Omit<Extract<FunctionTrigger, { kind: 'http' }>['request'], 'body'>;
     invocationType: FunctionInvocationType;
     options?: Record<string, unknown> | undefined;
     orchestrator: Orchestrator;
@@ -213,9 +213,9 @@ function buildRuntimeTrigger({
 }: {
     version: DBFunctionConfigVersion;
     input: JsonValue;
-    request: Omit<Extract<FunctionRuntimeTrigger, { kind: 'http' }>['request'], 'body'>;
-    connection: Extract<FunctionRuntimeTrigger, { kind: 'invoke' }>['connection'];
-}): Result<FunctionRuntimeTrigger, FunctionInvokeError> {
+    request: Omit<Extract<FunctionTrigger, { kind: 'http' }>['request'], 'body'>;
+    connection: NonNullable<Extract<FunctionTrigger, { kind: 'invoke' }>['connection']>;
+}): Result<FunctionTrigger, FunctionInvokeError> {
     switch (version.trigger.kind) {
         case 'http': {
             return Ok({

--- a/packages/shared/lib/services/functions/invoke.ts
+++ b/packages/shared/lib/services/functions/invoke.ts
@@ -10,6 +10,7 @@ import { validateFunctionInput } from './models/validate.js';
 
 import type { Orchestrator } from '../../clients/orchestrator.js';
 import type { FunctionInputValidationError } from './models/validate.js';
+import type { FunctionRuntimeTrigger } from '@nangohq/nango-orchestrator';
 import type {
     AsyncFunctionResponse,
     DBEnvironment,
@@ -45,6 +46,7 @@ export async function invokeFunction({
     connectionId,
     functionName,
     input,
+    request,
     invocationType,
     options,
     orchestrator
@@ -55,6 +57,7 @@ export async function invokeFunction({
     connectionId: string;
     functionName: string;
     input?: unknown | undefined;
+    request: Omit<Extract<FunctionRuntimeTrigger, { kind: 'http' }>['request'], 'body'>;
     invocationType: FunctionInvocationType;
     options?: Record<string, unknown> | undefined;
     orchestrator: Orchestrator;
@@ -137,6 +140,19 @@ export async function invokeFunction({
         }
 
         const connection = connectionRes.response!;
+        const triggerRes = buildRuntimeTrigger({
+            version: currentVersion,
+            input: validation.value,
+            request,
+            connection: {
+                connectionId: connection.connection_id,
+                integrationId
+            }
+        });
+        if (triggerRes.isErr()) {
+            return Err(triggerRes.error);
+        }
+        const trigger = triggerRes.value;
         const timeoutMs = executionTimeoutMs(invocationType);
 
         const logCtx = await logContextGetter.create(
@@ -163,7 +179,7 @@ export async function invokeFunction({
             environment,
             connection,
             functionName,
-            input: validation.value,
+            trigger,
             async: invocationType === 'no_wait',
             retryMax: 0,
             maxConcurrency,
@@ -187,6 +203,40 @@ export async function invokeFunction({
         }
         return Ok(invocation.value);
     });
+}
+
+function buildRuntimeTrigger({
+    version,
+    input,
+    request,
+    connection
+}: {
+    version: DBFunctionConfigVersion;
+    input: JsonValue;
+    request: Omit<Extract<FunctionRuntimeTrigger, { kind: 'http' }>['request'], 'body'>;
+    connection: Extract<FunctionRuntimeTrigger, { kind: 'invoke' }>['connection'];
+}): Result<FunctionRuntimeTrigger, FunctionInvokeError> {
+    switch (version.trigger.kind) {
+        case 'http': {
+            return Ok({
+                kind: 'http',
+                input,
+                request: { ...request, body: input },
+                connection
+            });
+        }
+        case 'schedule':
+            return Ok({ kind: 'schedule', input: null, connection });
+        case 'event': {
+            const event = version.trigger.events[0];
+            if (!event) {
+                return Err(new FunctionInvokeError({ code: 'invalid_invocation', message: 'Event-triggered function has no configured events' }));
+            }
+            return Ok({ kind: 'event', input: { event }, connection });
+        }
+        case 'none':
+            return Ok({ kind: 'invoke', input, connection });
+    }
 }
 
 function executionTimeoutMs(invocationType: FunctionInvocationType): number {

--- a/packages/shared/lib/services/functions/version.unit.test.ts
+++ b/packages/shared/lib/services/functions/version.unit.test.ts
@@ -42,4 +42,8 @@ describe(functionVersionHash, () => {
             functionVersionHash(artifact).unwrap()
         );
     });
+
+    it('changes when the trigger changes', () => {
+        expect(functionVersionHash({ ...artifact, trigger: { kind: 'http' } }).unwrap()).not.toBe(functionVersionHash(artifact).unwrap());
+    });
 });

--- a/packages/types/lib/function/trigger.ts
+++ b/packages/types/lib/function/trigger.ts
@@ -1,0 +1,55 @@
+import type { HTTP_METHOD } from '../nangoYaml/index.js';
+import type { OnEventType } from '../scripts/on-events/api.js';
+import type { FunctionTriggerDefinition } from './config.js';
+import type { JsonValue } from 'type-fest';
+
+// The inbound HTTP request that initiated the run.
+export type HttpRequest = {
+    method: HTTP_METHOD;
+    path: string;
+    headers: Record<string, string>;
+    query: Record<string, string>;
+    body: JsonValue;
+};
+
+// Coalescing summary, present on an HTTP trigger when `debounce` is configured and coalescing happened.
+export type CoalescedInfo = {
+    count: number;
+    firstSeenAt: string;
+    lastSeenAt: string;
+};
+
+// `debounce.take: 'all'` delivers the whole coalesced batch, so the payload becomes an array; otherwise a single input.
+type HttpPayload<TTrigger, TInput> = TTrigger extends { debounce: { take: 'all' } } ? TInput[] : TInput;
+
+type TriggerBase = {
+    /**
+     * Present when the run carries connection context (invoke calls may pass one;
+     * HTTP/event may resolve one). Undefined for connection-less runs.
+     */
+    connection?: { connectionId: string; integrationId: string };
+};
+
+// The per-kind runtime trigger shapes an `exec` can receive.
+export type InvokeTrigger<TInput> = TriggerBase & { kind: 'invoke'; input: TInput };
+export type ScheduleTrigger = TriggerBase & { kind: 'schedule'; input: null };
+export type HttpTrigger<TTrigger, TInput> = TriggerBase & {
+    kind: 'http';
+    input: HttpPayload<TTrigger, TInput>;
+    request: HttpRequest;
+    subscriptions?: string[];
+    coalesced?: CoalescedInfo;
+};
+export type EventTrigger = TriggerBase & { kind: 'event'; input: { event: OnEventType } };
+
+// The runtime trigger a function `exec` receives.
+export type Trigger<TTrigger extends FunctionTriggerDefinition | undefined, TInput> = TTrigger extends { kind: 'schedule' }
+    ? ScheduleTrigger
+    : TTrigger extends { kind: 'http' }
+      ? HttpTrigger<TTrigger, TInput>
+      : TTrigger extends { kind: 'event' }
+        ? EventTrigger
+        : InvokeTrigger<TInput>;
+
+// The JSON-safe runtime trigger for transport betwwen services.
+export type FunctionTrigger = Trigger<FunctionTriggerDefinition, JsonValue>;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -121,6 +121,7 @@ export type * from './mfa/credential.js';
 export type * from './mfa/db.js';
 export type * from './function/config.js';
 export type * from './function/db.js';
+export type * from './function/trigger.js';
 export type * from './functions/api.js';
 export type * from './functions/domain.js';
 


### PR DESCRIPTION
Functions with http trigger can now compile, be deployed and executed. 
`debounce` and `subscriptions` support for http trigger is not yet enabled.
The shape of trigger is now zod validated.

Once this PR land and CLI released, it would be possible to write, deploy and execute action-like functions 

Example of function that can be run:
```ts
import { createFunction } from 'nango/experimental';
import * as z from 'zod';

export default createFunction({
    description: '10x',
    trigger: {
        kind: 'http',
    },
    input: z.object({
        n: z.number(),
    }),
    output: z.object({
        tenTimes: z.number(),
    }),
    exec: async (nango, trigger) => {
        nango.setLogger({ level: 'debug' });
        await nango.log('Hello World!');
        await nango.log('Trigger: ' + JSON.stringify(trigger));
        const tenTimes = trigger.input.n * 10
        await nango.log('Result: ' + tenTimes);
        return { tenTimes }
    }
});

```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

