### PR TITLE
docs: refresh coding agent MCP setup

### DIFF
--- a/docs/getting-started/coding-agent-setup.mdx
+++ b/docs/getting-started/coding-agent-setup.mdx
@@ -1,25 +1,22 @@
 ---
 title: 'Coding agent setup'
 sidebarTitle: '✨ Coding agent setup'
-description: 'Give coding agents the Nango docs, core skill, and MCP tools.'
+description: 'Connect your coding agent to Nango'
 ---
 
 Coding agents can speed up Nango integration work in two places: wiring Nango into your product and building [Nango Functions](/guides/functions/functions-guide).
 
-<Tip>
-Getting started with Nango and want to use a coding agent? Check out the [AI-assisted quickstart](/getting-started/quickstart).
-</Tip>
 <Info>
-This page is about generating integrations with AI. To expose Nango integrations to your product's agents, see [Tool calling & MCP](/guides/functions/tool-calling).
+This page is about configuring Nango with your coding agent. To expose Nango integrations to your product's agents, see [Tool calling & MCP](/guides/functions/tool-calling).
 </Info>
 
 ## Management MCP server (Beta)
 
-Add Nango's Management MCP server to give your coding agent Nango documentation and tools for managing your environment. It can search the docs, create connect sessions, manage integrations, inspect connections, deploy functions, make provider API requests through the proxy, and explore logs.
-
-The documentation tools are included in the Management MCP server and require no additional environment operation scope. The full tool list and required API key scopes are in the [Management MCP reference](/reference/backend/management-mcp#tools).
+Give your coding agent tools to manage your Nango account and search the Nango docs.
 
 Create an API key in **Environment Settings > API Keys**, then replace `<NANGO-API-KEY>` in the relevant configuration below.
+
+Refer to the [Management MCP reference](/reference/backend/management-mcp#tools) for the full tools list and required API key scopes for each.
 
 <Tabs>
   <Tab title="Claude Code">
@@ -166,7 +163,7 @@ https://nango.dev/docs/mcp
 ```
 
 <Info>
-    This is an unauthenticated alternative to the documentation tools included in the Management MCP server. You do not need to configure both servers.
+    This is an unauthenticated alternative to the documentation tools included in the Management MCP server. If you use the management MCP, you can skip this one.
 </Info>
 
 ## Just-in-time integrations

--- a/docs/getting-started/coding-agent-setup.mdx
+++ b/docs/getting-started/coding-agent-setup.mdx
@@ -13,19 +13,11 @@ Getting started with Nango and want to use a coding agent? Check out the [AI-ass
 This page is about generating integrations with AI. To expose Nango integrations to your product's agents, see [Tool calling & MCP](/guides/functions/tool-calling).
 </Info>
 
-## Docs MCP server
-
-Add Nango's documentation MCP server to your coding agent to allow it to research docs & examples:
-
-```text
-https://nango.dev/docs/mcp
-```
-
-It is public and does not require authentication.
-
 ## Management MCP server (Beta)
 
-Add Nango's Management MCP server to let your coding agent manage your Nango environment. Today, it can explore logs, and we are progressively adding capabilities so that everything you can do in the Nango UI can also be done from an LLM interface. The available tools are listed in the [Management MCP reference](/reference/backend/management-mcp#tools).
+Add Nango's Management MCP server to give your coding agent Nango documentation and tools for managing your environment. It can search the docs, create connect sessions, manage integrations, inspect connections, deploy functions, make provider API requests through the proxy, and explore logs.
+
+The documentation tools are included in the Management MCP server and require no additional environment operation scope. The full tool list and required API key scopes are in the [Management MCP reference](/reference/backend/management-mcp#tools).
 
 Create an API key in **Environment Settings > API Keys**, then replace `<NANGO-API-KEY>` in the relevant configuration below.
 
@@ -165,6 +157,18 @@ npx skills add NangoHQ/skills -s building-nango-functions
 
 See the [functions guide](/guides/functions/functions-guide) for more details.
 
+## Docs MCP server
+
+If your coding agent only needs documentation, connect it directly to Mintlify's public Nango documentation MCP server:
+
+```text
+https://nango.dev/docs/mcp
+```
+
+<Info>
+    This is an unauthenticated alternative to the documentation tools included in the Management MCP server. You do not need to configure both servers.
+</Info>
+
 ## Just-in-time integrations
 
 Nango integrations are defined as code. Usually, you or your coding agent write functions in a Git repo, review them like application code, and deploy them to Nango.
@@ -179,7 +183,7 @@ These resources help agents discover Nango docs, provider slugs, API shapes, and
 
 | Tool | URL | Use it for |
 | --- | --- | --- |
-| Docs MCP server | `https://nango.dev/docs/mcp` | Live docs context inside coding agents. |
+| Docs MCP server | `https://nango.dev/docs/mcp` | Live docs context without authentication. |
 | `llms.txt` | `https://nango.dev/docs/llms.txt` | Compact index of core Nango docs for LLM context windows. |
 | `llms-full.txt` | `https://nango.dev/docs/llms-full.txt` | Full generated docs text for deeper offline context. |
 | `api-catalog.txt` | `https://nango.dev/docs/api-catalog.txt` | Provider and integration slug discovery. |

--- a/docs/getting-started/coding-agent-setup.mdx
+++ b/docs/getting-started/coding-agent-setup.mdx
@@ -163,7 +163,7 @@ https://nango.dev/docs/mcp
 ```
 
 <Info>
-    This is an unauthenticated alternative to the documentation tools included in the Management MCP server. If you use the management MCP, you can skip this one.
+    This is an unauthenticated alternative to the documentation tools included in the Management MCP server. If you use the Management MCP, you can skip this one.
 </Info>
 
 ## Just-in-time integrations

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -245,11 +245,11 @@ This page is about generating integrations with AI. To expose Nango integrations
 
 ## Management MCP server (Beta)
 
-Add Nango's Management MCP server to give your coding agent Nango documentation and tools for managing your environment. It can search the docs, create connect sessions, manage integrations, inspect connections, deploy functions, make provider API requests through the proxy, and explore logs.
-
-The documentation tools are included in the Management MCP server and require no additional environment operation scope. The full tool list and required API key scopes are in the [Management MCP reference](/reference/backend/management-mcp#tools).
+Give your coding agent tools to manage your Nango account and search the Nango docs.
 
 Create an API key in **Environment Settings > API Keys**, then replace `<NANGO-API-KEY>` in the relevant configuration below.
+
+Refer to the [Management MCP reference](/reference/backend/management-mcp#tools) for the full tools list and required API key scopes for each.
 
 <Tabs>
   <Tab title="Claude Code">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -393,7 +393,7 @@ https://nango.dev/docs/mcp
 ```
 
 <Info>
-    This is an unauthenticated alternative to the documentation tools included in the Management MCP server. If you use the management MCP, you can skip this one.
+    This is an unauthenticated alternative to the documentation tools included in the Management MCP server. If you use the Management MCP, you can skip this one.
 </Info>
 
 ## Just-in-time integrations

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -243,19 +243,11 @@ Getting started with Nango and want to use a coding agent? Check out the [AI-ass
 This page is about generating integrations with AI. To expose Nango integrations to your product's agents, see [Tool calling & MCP](/guides/functions/tool-calling).
 </Info>
 
-## Docs MCP server
-
-Add Nango's documentation MCP server to your coding agent to allow it to research docs & examples:
-
-```text
-https://nango.dev/docs/mcp
-```
-
-It is public and does not require authentication.
-
 ## Management MCP server (Beta)
 
-Add Nango's Management MCP server to let your coding agent manage your Nango environment. Today, it can explore logs, and we are progressively adding capabilities so that everything you can do in the Nango UI can also be done from an LLM interface. The available tools are listed in the [Management MCP reference](/reference/backend/management-mcp#tools).
+Add Nango's Management MCP server to give your coding agent Nango documentation and tools for managing your environment. It can search the docs, create connect sessions, manage integrations, inspect connections, deploy functions, make provider API requests through the proxy, and explore logs.
+
+The documentation tools are included in the Management MCP server and require no additional environment operation scope. The full tool list and required API key scopes are in the [Management MCP reference](/reference/backend/management-mcp#tools).
 
 Create an API key in **Environment Settings > API Keys**, then replace `<NANGO-API-KEY>` in the relevant configuration below.
 
@@ -395,6 +387,18 @@ npx skills add NangoHQ/skills -s building-nango-functions
 
 See the [functions guide](/guides/functions/functions-guide) for more details.
 
+## Docs MCP server
+
+If your coding agent only needs documentation, connect it directly to Mintlify's public Nango documentation MCP server:
+
+```text
+https://nango.dev/docs/mcp
+```
+
+<Info>
+    This is an unauthenticated alternative to the documentation tools included in the Management MCP server. You do not need to configure both servers.
+</Info>
+
 ## Just-in-time integrations
 
 Nango integrations are defined as code. Usually, you or your coding agent write functions in a Git repo, review them like application code, and deploy them to Nango.
@@ -409,7 +413,7 @@ These resources help agents discover Nango docs, provider slugs, API shapes, and
 
 | Tool | URL | Use it for |
 | --- | --- | --- |
-| Docs MCP server | `https://nango.dev/docs/mcp` | Live docs context inside coding agents. |
+| Docs MCP server | `https://nango.dev/docs/mcp` | Live docs context without authentication. |
 | `llms.txt` | `https://nango.dev/docs/llms.txt` | Compact index of core Nango docs for LLM context windows. |
 | `llms-full.txt` | `https://nango.dev/docs/llms-full.txt` | Full generated docs text for deeper offline context. |
 | `api-catalog.txt` | `https://nango.dev/docs/api-catalog.txt` | Provider and integration slug discovery. |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -232,15 +232,12 @@ The steps below show the flow end to end. This quickstart uses the GitHub API as
 ## Coding agent setup
 
 Source: https://nango.dev/docs/getting-started/coding-agent-setup.md
-Description: Give coding agents the Nango docs, core skill, and MCP tools.
+Description: Connect your coding agent to Nango
 
 Coding agents can speed up Nango integration work in two places: wiring Nango into your product and building [Nango Functions](/guides/functions/functions-guide).
 
-<Tip>
-Getting started with Nango and want to use a coding agent? Check out the [AI-assisted quickstart](/getting-started/quickstart).
-</Tip>
 <Info>
-This page is about generating integrations with AI. To expose Nango integrations to your product's agents, see [Tool calling & MCP](/guides/functions/tool-calling).
+This page is about configuring Nango with your coding agent. To expose Nango integrations to your product's agents, see [Tool calling & MCP](/guides/functions/tool-calling).
 </Info>
 
 ## Management MCP server (Beta)
@@ -396,7 +393,7 @@ https://nango.dev/docs/mcp
 ```
 
 <Info>
-    This is an unauthenticated alternative to the documentation tools included in the Management MCP server. You do not need to configure both servers.
+    This is an unauthenticated alternative to the documentation tools included in the Management MCP server. If you use the management MCP, you can skip this one.
 </Info>
 
 ## Just-in-time integrations

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -13,7 +13,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 
 - [Introduction](https://nango.dev/docs/getting-started/intro-to-nango.md): Build product integrations with AI, using code you control and infrastructure built for scale.
 - [Quickstart](https://nango.dev/docs/getting-started/quickstart.md): Authorize an API and run your first Nango function
-- [Coding agent setup](https://nango.dev/docs/getting-started/coding-agent-setup.md): Give coding agents the Nango docs, core skill, and MCP tools.
+- [Coding agent setup](https://nango.dev/docs/getting-started/coding-agent-setup.md): Connect your coding agent to Nango
 - [Use cases: Tool calling for AI agents](https://nango.dev/docs/getting-started/use-cases/tool-calling.md): Give agents scoped, observable access to external APIs through Nango action functions.
 - [Use cases: Sync external API data](https://nango.dev/docs/getting-started/use-cases/syncs.md): Keep external API data fresh for your product, RAG pipeline, or change-detection workflow.
 - [Use cases: Run external API operations](https://nango.dev/docs/getting-started/use-cases/actions.md): Use Nango functions to read, write, and automate external APIs on demand.


### PR DESCRIPTION
Updates the Coding agent setup page to describe the current Management MCP capabilities and clarify that documentation tools are included.

Moves the direct Mintlify docs MCP guidance further down the page and positions it as an unauthenticated alternative. Regenerates the full LLM docs index to match.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

