### PR TITLE
feat(metering): export runner->persist data transfer to Orb

### DIFF
--- a/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
@@ -196,14 +196,18 @@ function data_transfer_gen({
 //   (server, proxy)   egress=500   → included
 //   (server, webhook_forward) egress=250 → included
 //   (runner, uncontrolled_fetch) egress=0, ingress=7777 → included pair but egress-only, contributes 0
+//   (runner, persist_customer_logs) egress=125 → included
+//   (runner, persist_records) egress=75 → included
 //   (server, unlisted)  egress=9999 → excluded (not a billable pair)
 //   (runner, proxy) on otherDay egress=100000 → excluded by WHERE day
-// → count (total egress) = 1000+500+250+0 = 1750.
+// → count (total egress) = 1000+500+250+0+125+75 = 1950.
 const dataTransferFixtures: ClickhouseRawUsageEvent[] = [
     data_transfer_gen({ day: targetDay, package: 'runner', callsite: 'proxy', egressedBytes: 1000 }),
     data_transfer_gen({ day: targetDay, package: 'server', callsite: 'proxy', egressedBytes: 500 }),
     data_transfer_gen({ day: targetDay, package: 'server', callsite: 'webhook_forward', egressedBytes: 250 }),
     data_transfer_gen({ day: targetDay, package: 'runner', callsite: 'uncontrolled_fetch', egressedBytes: 0, ingressedBytes: 7777 }),
+    data_transfer_gen({ day: targetDay, package: 'runner', callsite: 'persist_customer_logs', egressedBytes: 125 }),
+    data_transfer_gen({ day: targetDay, package: 'runner', callsite: 'persist_records', egressedBytes: 75 }),
     data_transfer_gen({ day: targetDay, package: 'server', callsite: 'unlisted', egressedBytes: 9999 }),
     data_transfer_gen({ day: otherDay, package: 'runner', callsite: 'proxy', egressedBytes: 100000 })
 ];
@@ -341,13 +345,15 @@ describe('billingEventsS3Export', () => {
             const rows = await runQuery('data_transfer', 'data_transfer_test');
             expect(rows).toHaveLength(1);
             expect(rows[0]!.properties).toEqual({
-                count: 1750,
+                count: 1950,
                 'server.get_/records': 0,
                 'runner.proxy': 1000,
                 'server.get_/proxy': 0,
                 'server.proxy': 500,
                 'server.post_/proxy': 0,
                 'runner.uncontrolled_fetch': 0,
+                'runner.persist_customer_logs': 125,
+                'runner.persist_records': 75,
                 'server.patch_/proxy': 0,
                 'server.put_/proxy': 0,
                 'server.delete_/proxy': 0,

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -179,7 +179,9 @@ export const METRICS: MetricSpec[] = [
                     'server.proxy',              toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'proxy')),
                     'server.webhook_forward',    toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'webhook_forward')),
                     'runner.proxy',              toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'proxy')),
-                    'runner.uncontrolled_fetch', toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'uncontrolled_fetch'))
+                    'runner.uncontrolled_fetch', toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'uncontrolled_fetch')),
+                    'runner.persist_customer_logs', toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'persist_customer_logs')),
+                    'runner.persist_records',    toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'persist_records'))
                 ) AS properties
             FROM ${database}.daily_data_transfer
             WHERE day = toDate('${day}')
@@ -194,7 +196,9 @@ export const METRICS: MetricSpec[] = [
                   ('server', 'unknown_/proxy'),
                   ('server', 'webhook_forward'),
                   ('runner', 'proxy'),
-                  ('runner', 'uncontrolled_fetch')
+                  ('runner', 'uncontrolled_fetch'),
+                  ('runner', 'persist_customer_logs'),
+                  ('runner', 'persist_records')
               )
             GROUP BY account_id, day
         `

--- a/packages/persist/lib/routes/runner/telemetry/validate.ts
+++ b/packages/persist/lib/routes/runner/telemetry/validate.ts
@@ -12,7 +12,7 @@ export const telemetryEntrySchema = z.discriminatedUnion('type', [
             bytesSent: z.number().int().nonnegative(),
             bytesReceived: z.number().int().nonnegative(),
             count: z.number().int().positive().default(1),
-            callsite: z.enum(['proxy', 'uncontrolled_fetch', 'persist_records', 'persist_logs'])
+            callsite: z.enum(['proxy', 'uncontrolled_fetch', 'persist_records', 'persist_customer_logs', 'persist_system_logs', 'persist_logs'])
         })
         .strict()
 ]);

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -337,7 +337,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
         }
         this.telemetryRecorder?.record({
             type: 'data_transfer',
-            callsite: 'persist_logs',
+            callsite: log.source === 'user' ? 'persist_customer_logs' : 'persist_system_logs',
             bytesSent: Buffer.byteLength(data, 'utf8'),
             bytesReceived: 0,
             integrationId: this.providerConfigKey,

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -11,6 +11,7 @@ import { PersistClient } from '../clients/persist.js';
 import { MapLocks } from './locks.js';
 import { createFunctionFacade, NangoActionRunner, NangoSyncRunner } from './sdk.js';
 
+import type { TelemetryRecorder } from '../telemetry.js';
 import type { CursorPagination, DBSyncConfig, LinkPagination, NangoProps, OffsetPagination, Pagination, Provider } from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
 import type { Mock } from 'vitest';
@@ -519,6 +520,26 @@ describe('Log', () => {
             environmentId: 1,
             data: expect.stringMatching('{"activityLogId":"1","log":{"createdAt":".*","level":"error","message":"hello","source":"user","type":"log"}}')
         });
+    });
+
+    it('records customer and system log data-transfers as separate telemetry callsites', async () => {
+        const telemetryRecorder = {
+            record: vi.fn(),
+            shutdown: vi.fn().mockResolvedValue(Ok(undefined))
+        } satisfies TelemetryRecorder;
+        const nangoAction = new NangoActionRunner({ ...nangoProps }, { persistClient, telemetryRecorder, locks });
+
+        await nangoAction.log('customer log');
+        await nangoAction['sendLogToPersist']({
+            type: 'log',
+            level: 'info',
+            source: 'internal',
+            message: 'system log',
+            createdAt: new Date().toISOString()
+        });
+
+        expect(telemetryRecorder.record).toHaveBeenNthCalledWith(1, expect.objectContaining({ callsite: 'persist_customer_logs' }));
+        expect(telemetryRecorder.record).toHaveBeenNthCalledWith(2, expect.objectContaining({ callsite: 'persist_system_logs' }));
     });
 
     it('should enforce type: log message + object + level', async () => {

--- a/packages/types/lib/persist/api.ts
+++ b/packages/types/lib/persist/api.ts
@@ -23,7 +23,7 @@ type WithTags<T> = T & { integrationId: string; connectionId: string; syncId?: s
 
 export type RunnerDataTransferTelemetry = WithTags<{
     type: 'data_transfer';
-    callsite: 'proxy' | 'uncontrolled_fetch' | 'persist_records' | 'persist_logs';
+    callsite: 'proxy' | 'uncontrolled_fetch' | 'persist_records' | 'persist_customer_logs' | 'persist_system_logs' | 'persist_logs';
     bytesSent: number;
     bytesReceived: number;
     count: number;

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -162,6 +162,8 @@ export type DataTransferCallsite =
     | 'webhook_forward'
     | 'proxy'
     | 'uncontrolled_fetch'
+    | 'persist_customer_logs'
+    | 'persist_system_logs'
     | 'persist_logs'
     | 'persist_records'
     | 'get_/records'


### PR DESCRIPTION
Include runner data-transfer egress for persist_customer_logs and persist_records in the Orb export, with dedicated per-callsite properties. Keep system persisted logs excluded, and extend metering coverage for both new billable callsites.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

