### PR TITLE
fix(audit): record the login when SSO holds it for MFA

### DIFF
--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -22,7 +22,7 @@ export async function loginOrStartPendingMfa(req: Request, user: DBUser, returnT
     await regenerateSession(req);
     req.session.pendingMfaLogin = { userId: user.id, returnTo: safeReturnTo(returnTo), createdAt: Date.now() };
     await saveSession(req);
-    req.audit = { ...req.audit, authPendingMfa: true };
+    req.audit = { ...req.audit, authPendingMfa: { userId: user.id } };
     return true;
 }
 

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -22,6 +22,7 @@ export async function loginOrStartPendingMfa(req: Request, user: DBUser, returnT
     await regenerateSession(req);
     req.session.pendingMfaLogin = { userId: user.id, returnTo: safeReturnTo(returnTo), createdAt: Date.now() };
     await saveSession(req);
+    req.audit = { ...req.audit, authPendingMfa: true };
     return true;
 }
 

--- a/packages/server/lib/express.d.ts
+++ b/packages/server/lib/express.d.ts
@@ -16,7 +16,7 @@ declare global {
         interface AuditFacts {
             managedSignup?: boolean;
             authSucceeded?: boolean;
-            authPendingMfa?: boolean;
+            authPendingMfa?: { userId: number };
             connectionUpsert?: {
                 operation: import('@nangohq/types').AuthOperationType;
                 connectionId: string;

--- a/packages/server/lib/express.d.ts
+++ b/packages/server/lib/express.d.ts
@@ -16,6 +16,7 @@ declare global {
         interface AuditFacts {
             managedSignup?: boolean;
             authSucceeded?: boolean;
+            authPendingMfa?: boolean;
             connectionUpsert?: {
                 operation: import('@nangohq/types').AuthOperationType;
                 connectionId: string;

--- a/packages/server/lib/middleware/audit.auth.private.integration.test.ts
+++ b/packages/server/lib/middleware/audit.auth.private.integration.test.ts
@@ -312,6 +312,34 @@ describe('audit — auth flows', () => {
             });
         });
 
+        it('records app_auth/login (method sso) when the SSO callback holds the login for MFA', async () => {
+            const { user } = await enrollMfaUser();
+            auditSpy.mockClear();
+
+            workosMocks.authenticateWithCode.mockResolvedValue({
+                user: { email: user.email, firstName: 'Managed', lastName: 'User' },
+                organizationId: undefined
+            });
+
+            const res = await fetch(`${api.url}/api/v1/login/callback?code=oauth_code_123`, { redirect: 'manual' });
+            expect(res.status).toBe(302);
+            expect(res.headers.get('location')).toBe('http://localhost:3003/signin/mfa');
+
+            await vi.waitFor(() => {
+                expect(authEvent('login')).toBeDefined();
+            });
+            expect(authEvent('login')).toMatchObject({
+                resource: 'app_auth',
+                action: 'login',
+                outcome: 'success',
+                accountId: user.account_id,
+                environment: null,
+                actor: { type: 'user', id: String(user.id), display: user.email },
+                targets: [{ type: 'user', id: String(user.id), display: user.email }],
+                metadata: { mfaRequired: true, method: 'sso' }
+            });
+        });
+
         it('records app_auth/signup when the SSO callback creates a new user', async () => {
             const email = `${nanoid()}@example.com`;
 

--- a/packages/server/lib/middleware/audit.auth.private.integration.test.ts
+++ b/packages/server/lib/middleware/audit.auth.private.integration.test.ts
@@ -383,6 +383,35 @@ describe('audit — auth flows', () => {
             expect(auditSpy).not.toHaveBeenCalled();
         });
 
+        it('attributes a held login to the user who authenticated, not to whoever was already signed in', async () => {
+            // regenerateSession replaces the session but leaves passport's req.user from the old one, so the
+            // pending challenge is the only thing that names who authenticated this request.
+            const other = await signupVerifiedUser();
+            const session = await signin(other.email, other.password);
+            const { user } = await enrollMfaUser();
+            auditSpy.mockClear();
+
+            workosMocks.authenticateWithCode.mockResolvedValue({
+                user: { email: user.email, firstName: 'Managed', lastName: 'User' },
+                organizationId: undefined
+            });
+
+            const res = await fetch(`${api.url}/api/v1/login/callback?code=oauth_code_123`, { headers: { Cookie: session }, redirect: 'manual' });
+            expect(res.status).toBe(302);
+            expect(res.headers.get('location')).toBe('http://localhost:3003/signin/mfa');
+
+            await vi.waitFor(() => {
+                expect(authEvent('login')).toBeDefined();
+            });
+            expect(authEvent('login')).toMatchObject({
+                accountId: user.account_id,
+                actor: { type: 'user', id: String(user.id), display: user.email },
+                targets: [{ type: 'user', id: String(user.id), display: user.email }],
+                metadata: { mfaRequired: true, method: 'sso' }
+            });
+            expect(JSON.stringify(authEvent('login'))).not.toContain(other.email);
+        });
+
         it('does not record a login when a failed SSO attempt is made with an existing session', async () => {
             // An already-signed-in user has req.user populated by passport.session(). A FAILED SSO attempt
             // must not be recorded as a successful login for them — it never called req.login this request.

--- a/packages/server/lib/middleware/auditAuth.middleware.ts
+++ b/packages/server/lib/middleware/auditAuth.middleware.ts
@@ -75,15 +75,16 @@ async function principalFromBodyEmail<TEndpoint extends EmailBodyEndpoint>(req: 
     return principalFromUser(await userService.getUserByEmail(email));
 }
 
-// Actor is the session user req.login established, or the user a login held for MFA authenticated as.
-// Neither means the flow never authenticated → skip.
+// Actor is the user a login held for MFA authenticated as, or the session user req.login established.
+// Pending wins: regenerateSession leaves an earlier session's req.user in place, which would attribute the
+// challenge to whoever was signed in before. Neither means the flow never authenticated → skip.
 async function principalFromSessionUser(req: Request): Promise<AuthPrincipal | null> {
-    const sessionUser = req.user;
-    if (sessionUser) {
-        return principalFromUser({ id: sessionUser.id, email: sessionUser.email, account_id: sessionUser.account_id });
-    }
     const pendingUserId = req.audit?.authPendingMfa?.userId;
-    return pendingUserId == null ? null : principalFromUser(await userService.getUserById(pendingUserId, true));
+    if (pendingUserId != null) {
+        return principalFromUser(await userService.getUserById(pendingUserId, true));
+    }
+    const sessionUser = req.user;
+    return sessionUser ? principalFromUser({ id: sessionUser.id, email: sessionUser.email, account_id: sessionUser.account_id }) : null;
 }
 
 async function recordAuthEvent<TEndpoint extends Endpoint<any>>(

--- a/packages/server/lib/middleware/auditAuth.middleware.ts
+++ b/packages/server/lib/middleware/auditAuth.middleware.ts
@@ -78,10 +78,12 @@ async function principalFromBodyEmail<TEndpoint extends EmailBodyEndpoint>(req: 
 // Actor is the session user req.login established; no session user means the flow never authenticated → skip.
 async function principalFromSessionUser(req: Request): Promise<AuthPrincipal | null> {
     const sessionUser = req.user;
-    if (!sessionUser) {
-        return null;
+    if (sessionUser) {
+        return principalFromUser({ id: sessionUser.id, email: sessionUser.email, account_id: sessionUser.account_id });
     }
-    return principalFromUser({ id: sessionUser.id, email: sessionUser.email, account_id: sessionUser.account_id });
+    // A login held for MFA has no session user yet, so the pending challenge names who authenticated.
+    const pendingUserId = req.session?.pendingMfaLogin?.userId;
+    return pendingUserId == null ? null : principalFromUser(await userService.getUserById(pendingUserId, true));
 }
 
 async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
@@ -100,7 +102,7 @@ async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
             // Only a login this request actually established (req.login → req.audit?.authSucceeded) is a
             // success. Without it, req.user may just be a pre-existing session, so a failed attempt by an
             // already-signed-in user would otherwise be recorded as a successful login for that user.
-            if (!req.audit?.authSucceeded) {
+            if (!req.audit?.authSucceeded && !req.audit?.authPendingMfa) {
                 return;
             }
             outcome = 'success';

--- a/packages/server/lib/middleware/auditAuth.middleware.ts
+++ b/packages/server/lib/middleware/auditAuth.middleware.ts
@@ -75,14 +75,14 @@ async function principalFromBodyEmail<TEndpoint extends EmailBodyEndpoint>(req: 
     return principalFromUser(await userService.getUserByEmail(email));
 }
 
-// Actor is the session user req.login established; no session user means the flow never authenticated → skip.
+// Actor is the session user req.login established, or the user a login held for MFA authenticated as.
+// Neither means the flow never authenticated → skip.
 async function principalFromSessionUser(req: Request): Promise<AuthPrincipal | null> {
     const sessionUser = req.user;
     if (sessionUser) {
         return principalFromUser({ id: sessionUser.id, email: sessionUser.email, account_id: sessionUser.account_id });
     }
-    // A login held for MFA has no session user yet, so the pending challenge names who authenticated.
-    const pendingUserId = req.session?.pendingMfaLogin?.userId;
+    const pendingUserId = req.audit?.authPendingMfa?.userId;
     return pendingUserId == null ? null : principalFromUser(await userService.getUserById(pendingUserId, true));
 }
 
@@ -133,15 +133,15 @@ async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
             ...auditRequestFields(req, principal.account.id),
             outcome
         };
-        // Read MFA state from the session (not the response body) so we don't wrap res.json: a login
-        // that started an MFA challenge leaves req.session.pendingMfaLogin set at finish.
+        // Read MFA state from the request, not the response body, so we don't wrap res.json. Per-request
+        // rather than the session, which can still hold a challenge started by an earlier attempt.
         const event: AuditEvent =
             action === 'login'
                 ? {
                       ...common,
                       resource: 'app_auth',
                       action: 'login',
-                      metadata: { mfaRequired: Boolean(req.session.pendingMfaLogin), ...(options.method ? { method: options.method } : {}) }
+                      metadata: { mfaRequired: Boolean(req.audit?.authPendingMfa), ...(options.method ? { method: options.method } : {}) }
                   }
                 : { ...common, resource: 'app_auth', action };
         await recordAuditEvent(event);


### PR DESCRIPTION
With MFA on, signing in through SSO records no login at all — the only trace is the `mfa.verified` event that comes after. Signing in with a password is fine.

A login held for a second factor is still a successful first factor, and that's how the local route records it: outcome `success` with `metadata.mfaRequired: true`, then `mfa.verified` separately. Two rows, which is what you want, because a successful first factor that never completes MFA is what a stolen password looks like.

The SSO and managed-email routes never reached that code. They take their outcome from `req.audit.authSucceeded`, which is set when the user is actually logged in — and when MFA is pending we deliberately don't log them in. So the emitter returned early. Attribution had the same problem: it reads the session user, which doesn't exist yet either.

Both now come from one fact set when a login is held for MFA, carrying the user who authenticated. `mfaRequired` reads the same fact rather than the session, which also fixes a smaller thing: a session can still hold a challenge started by an earlier attempt, so a later failed login could have reported `mfaRequired: true` for a request that never started one.

The local route is untouched — it takes its outcome from the HTTP status and resolves the user from the email in the body, so neither missing session signal ever affected it. Both managed routes share `finalizeManagedAuthentication`, so the SSO callback and the email-verification login are both covered.

## Test plan

- [x] SSO callback with MFA enabled records `app_auth/login`, outcome success, `metadata: { mfaRequired: true, method: 'sso' }`
- [x] The existing SSO, managed and local cases still record as before
- [x] Removing the fact breaks both the SSO and the local MFA test, so one signal drives both
- [x] Reverted the outcome check and the attribution separately — each alone breaks the new test
- [x] 13 auth and 18 audit integration tests pass; `ts-build`, `lint` and Prettier clean

Checked in staging, both flows with and without MFA loged the succeful login, and the former the specific required metadata

```
{
  "occurredAt": "2026-08-26T15:09:29.832Z",
  "accountId": 485,
  "environment": null,
  "actor": {
    "type": "user",
    "id": "554",
    "display": "pfreixes@gmail.com"
  },
  "targets": [
    {
      "type": "user",
      "id": "554",
      "display": "pfreixes@gmail.com"
    }
  ],
  "context": {},
  "outcome": "success",
  "resource": "app_auth",
  "action": "login",
  "metadata": {
    "mfaRequired": true,
    "method": "sso"
  },
  "id": "bf9658b1-7a9d-4906-94b5-4d1e6ffcc21a",
  "version": "2026-07-16"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)