### PR TITLE
feat(mcp): add sync trigger management tool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -13070,11 +13070,12 @@ Use the Actions tool to trigger an action function synchronously for a connectio
 
 ### Syncs
 
-Use the Sync tool to set one or more syncs to the `started` or `paused` state for an integration in the authenticated Nango environment. You can optionally limit the operation to one connection and select named sync variants.
+Use the Sync tools to set sync state or trigger syncs for an integration in the authenticated Nango environment. You can optionally limit either operation to one connection and select named sync variants. Triggering can run a full reset and clear existing synced records.
 
-| Tool           | Description                                       | Required API key scope      |
-| -------------- | ------------------------------------------------- | --------------------------- |
-| `syncs_set_state` | Set one or more syncs to `started` or `paused`.   | `environment:syncs:execute` |
+| Tool              | Description                                                                    | Required API key scope      |
+| ----------------- | ------------------------------------------------------------------------------ | --------------------------- |
+| `syncs_set_state` | Set one or more syncs to `started` or `paused`.                                  | `environment:syncs:execute` |
+| `syncs_trigger`   | Trigger one or more syncs, optionally with a full reset and/or cache clear.    | `environment:syncs:execute` |
 
 ### Proxy requests
 

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -91,11 +91,12 @@ Use the Actions tool to trigger an action function synchronously for a connectio
 
 ### Syncs
 
-Use the Sync tool to set one or more syncs to the `started` or `paused` state for an integration in the authenticated Nango environment. You can optionally limit the operation to one connection and select named sync variants.
+Use the Sync tools to set sync state or trigger syncs for an integration in the authenticated Nango environment. You can optionally limit either operation to one connection and select named sync variants. Triggering can run a full reset and clear existing synced records.
 
-| Tool           | Description                                       | Required API key scope      |
-| -------------- | ------------------------------------------------- | --------------------------- |
-| `syncs_set_state` | Set one or more syncs to `started` or `paused`.   | `environment:syncs:execute` |
+| Tool              | Description                                                                    | Required API key scope      |
+| ----------------- | ------------------------------------------------------------------------------ | --------------------------- |
+| `syncs_set_state` | Set one or more syncs to `started` or `paused`.                                  | `environment:syncs:execute` |
+| `syncs_trigger`   | Trigger one or more syncs, optionally with a full reset and/or cache clear.    | `environment:syncs:execute` |
 
 ### Proxy requests
 

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -174,6 +174,7 @@ describe('POST /mcp management server', () => {
             'connections_list',
             'connections_get',
             'syncs_set_state',
+            'syncs_trigger',
             'actions_trigger',
             'proxy_request',
             'functions_list',
@@ -208,6 +209,7 @@ describe('POST /mcp management server', () => {
             'connections_list',
             'connections_get',
             'syncs_set_state',
+            'syncs_trigger',
             'actions_trigger',
             'proxy_request',
             'functions_list',
@@ -591,7 +593,7 @@ describe('POST /mcp management server', () => {
                 token: secret,
                 body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
             });
-            expect(withoutDocsTools(listed.json.result.tools).map((tool: { name: string }) => tool.name)).toStrictEqual(['syncs_set_state']);
+            expect(withoutDocsTools(listed.json.result.tools).map((tool: { name: string }) => tool.name)).toStrictEqual(['syncs_set_state', 'syncs_trigger']);
 
             const syncs = ['issues', { name: 'users', variant: 'incremental' }];
             for (const [id, state] of ['started', 'paused'].entries()) {
@@ -702,6 +704,73 @@ describe('POST /mcp management server', () => {
             expect(events).toHaveLength(2);
             expect(events.find((event) => event.action === 'paused')).not.toHaveProperty('metadata');
         });
+    });
+
+    it('executes and audits the sync trigger tool with reset and cache options', async () => {
+        const { secret, env, account } = await createKeyWithScopes(['environment:syncs:execute']);
+        const runSyncCommandSpy = vi.spyOn(syncManager, 'runSyncCommand').mockResolvedValue({ success: true, response: true, error: null });
+
+        try {
+            const res = await mcpPost({
+                token: secret,
+                body: {
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/call',
+                    params: {
+                        name: 'syncs_trigger',
+                        arguments: {
+                            integration_id: 'github',
+                            connection_id: 'connection-id',
+                            syncs: ['issues', { name: 'users', variant: 'incremental' }],
+                            reset: true,
+                            empty_cache: true
+                        }
+                    }
+                }
+            });
+
+            expect(res.status).toBe(200);
+            expect(parseToolText(res)).toStrictEqual({ success: true });
+            expect(res.json.result.structuredContent).toStrictEqual({ success: true });
+            expect(runSyncCommandSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    environment: env,
+                    providerConfigKey: 'github',
+                    connectionId: 'connection-id',
+                    syncIdentifiers: [
+                        { syncName: 'issues', syncVariant: 'base' },
+                        { syncName: 'users', syncVariant: 'incremental' }
+                    ],
+                    command: 'RUN_FULL',
+                    deleteRecords: true,
+                    initiator: 'MCP call'
+                })
+            );
+
+            await vi.waitFor(() => {
+                expect(auditSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        accountId: account.id,
+                        resource: 'sync',
+                        action: 'triggered',
+                        outcome: 'success',
+                        targets: [
+                            { type: 'sync', id: 'issues' },
+                            { type: 'sync', id: 'users::incremental' }
+                        ],
+                        metadata: {
+                            providerConfigKey: 'github',
+                            connectionId: 'connection-id',
+                            reset: true,
+                            emptyCache: true
+                        }
+                    })
+                );
+            });
+        } finally {
+            runSyncCommandSpy.mockRestore();
+        }
     });
 
     it.each(['environment:connections:list', 'environment:connections:list_credentials'] as const)('lists the connections tool with %s', async (scope) => {

--- a/packages/server/lib/controllers/mcp/managementServer.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.ts
@@ -23,6 +23,7 @@ import { getLogOperationTool } from './logs/getOperation.js';
 import { listLogOperationsTool } from './logs/listOperations.js';
 import { proxyRequestTool } from './proxy/request.js';
 import { setSyncsStateTool } from './syncs/setState.js';
+import { triggerSyncsTool } from './syncs/trigger.js';
 import { emptyObjectJsonSchema, handleMcpToolError, jsonStructuredContent, toJsonSchema202012 } from './utils.js';
 
 import type { ManagementMcpContext, ManagementMcpRequiredScopes, ManagementMcpTool } from './managementTool.js';
@@ -44,6 +45,7 @@ const managementMcpTools: ManagementMcpTool[] = [
     listConnectionsTool,
     getConnectionsTool,
     setSyncsStateTool,
+    triggerSyncsTool,
     triggerActionTool,
     proxyRequestTool,
     listFunctionsTool,

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -20,6 +20,7 @@ import { listLogOperationsTool } from './logs/listOperations.js';
 import { createManagementMcpServer } from './managementServer.js';
 import { proxyRequestTool } from './proxy/request.js';
 import { setSyncsStateTool } from './syncs/setState.js';
+import { triggerSyncsTool } from './syncs/trigger.js';
 import { withoutDocsTools } from './testUtils.js';
 import { PublicMcpError } from './utils.js';
 
@@ -73,6 +74,10 @@ describe('createManagementMcpServer', () => {
                 {
                     name: 'syncs_set_state',
                     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false }
+                },
+                {
+                    name: 'syncs_trigger',
+                    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false }
                 },
                 {
                     name: 'actions_trigger',
@@ -676,14 +681,14 @@ describe('createManagementMcpServer', () => {
         }
     });
 
-    it.each(['environment:syncs:execute', 'environment:syncs:*'])('exposes the sync state tool with %s', async (scope) => {
+    it.each(['environment:syncs:execute', 'environment:syncs:*'])('exposes the sync tools with %s', async (scope) => {
         const { client, server } = await createTestClient([scope]);
 
         try {
             const result = await client.listTools();
             const scopedTools = withoutDocsTools(result.tools);
 
-            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools).toHaveLength(2);
             expect(scopedTools[0]).toMatchObject({
                 name: 'syncs_set_state',
                 inputSchema: {
@@ -718,6 +723,24 @@ describe('createManagementMcpServer', () => {
                 integration_id: { type: 'string', maxLength: 255, pattern: '^[a-zA-Z0-9~:.@ _-]+$' },
                 connection_id: { type: 'string', maxLength: 255, pattern: `^[a-zA-Z0-9,.;:=+~[\\]|@\${}"'\\\\/_ -]+$` },
                 state: { type: 'string', enum: ['started', 'paused'] }
+            });
+            expect(scopedTools[1]).toMatchObject({
+                name: 'syncs_trigger',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        reset: expect.objectContaining({ type: 'boolean', default: false }),
+                        empty_cache: expect.objectContaining({ type: 'boolean', default: false })
+                    },
+                    required: ['syncs', 'integration_id'],
+                    additionalProperties: false
+                },
+                outputSchema: {
+                    type: 'object',
+                    required: ['success'],
+                    additionalProperties: false
+                },
+                annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false }
             });
         } finally {
             await client.close();
@@ -756,6 +779,51 @@ describe('createManagementMcpServer', () => {
             const result = await client.callTool({
                 name: 'syncs_set_state',
                 arguments: { integration_id: 'github', syncs: ['issues'], state: 'started' }
+            });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],
+                structuredContent: response
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('authorizes syncs_trigger before invoking the tool', async () => {
+        const handlerSpy = vi.spyOn(triggerSyncsTool, 'handler');
+        const { client, server } = await createTestClient(['environment:mcp']);
+
+        try {
+            const result = await client.callTool({
+                name: 'syncs_trigger',
+                arguments: { integration_id: 'github', syncs: ['issues'] }
+            });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: 'MCP error -32602: Tool syncs_trigger disabled' }],
+                isError: true
+            });
+            expect(handlerSpy).not.toHaveBeenCalled();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('returns syncs_trigger results as JSON text and structured content', async () => {
+        const response = { success: true as const };
+        const handlerSpy = vi.spyOn(triggerSyncsTool, 'handler').mockResolvedValueOnce(Ok(response));
+        const { client, server } = await createTestClient(['environment:syncs:execute']);
+
+        try {
+            const result = await client.callTool({
+                name: 'syncs_trigger',
+                arguments: { integration_id: 'github', syncs: ['issues'], reset: true, empty_cache: true }
             });
 
             expect(result).toStrictEqual({

--- a/packages/server/lib/controllers/mcp/syncs/schema.ts
+++ b/packages/server/lib/controllers/mcp/syncs/schema.ts
@@ -30,7 +30,11 @@ export const triggerSyncsArgumentsSchema = z
         integration_id: providerConfigKeySchema,
         connection_id: connectionIdSchema.optional(),
         reset: z.boolean().optional().default(false).describe('Run a full sync instead of an incremental sync.'),
-        empty_cache: z.boolean().optional().default(false).describe('Delete existing synced records before running the sync.')
+        empty_cache: z
+            .boolean()
+            .optional()
+            .default(false)
+            .describe('Delete existing synced records before a full sync. Only applies when reset is true; otherwise ignored.')
     })
     .strict();
 

--- a/packages/server/lib/controllers/mcp/syncs/schema.ts
+++ b/packages/server/lib/controllers/mcp/syncs/schema.ts
@@ -2,12 +2,14 @@ import * as z from 'zod/v4';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
 
+const syncsSchema = z
+    .array(z.union([z.string(), z.object({ name: z.string(), variant: z.string() }).strict()]))
+    .min(0)
+    .max(256);
+
 export const setSyncsStateArgumentsSchema = z
     .object({
-        syncs: z
-            .array(z.union([z.string(), z.object({ name: z.string(), variant: z.string() }).strict()]))
-            .min(0)
-            .max(256),
+        syncs: syncsSchema,
         integration_id: providerConfigKeySchema,
         connection_id: connectionIdSchema.optional(),
         state: z.enum(['started', 'paused'])
@@ -21,3 +23,21 @@ export const setSyncsStateOutputSchema = z
     .strict();
 
 export type SetSyncsStateOutput = z.infer<typeof setSyncsStateOutputSchema>;
+
+export const triggerSyncsArgumentsSchema = z
+    .object({
+        syncs: syncsSchema,
+        integration_id: providerConfigKeySchema,
+        connection_id: connectionIdSchema.optional(),
+        reset: z.boolean().optional().default(false).describe('Run a full sync instead of an incremental sync.'),
+        empty_cache: z.boolean().optional().default(false).describe('Delete existing synced records before running the sync.')
+    })
+    .strict();
+
+export const triggerSyncsOutputSchema = z
+    .object({
+        success: z.literal(true)
+    })
+    .strict();
+
+export type TriggerSyncsOutput = z.infer<typeof triggerSyncsOutputSchema>;

--- a/packages/server/lib/controllers/mcp/syncs/trigger.ts
+++ b/packages/server/lib/controllers/mcp/syncs/trigger.ts
@@ -1,0 +1,64 @@
+import { logContextGetter } from '@nangohq/logs';
+import { normalizedSyncParams, SyncCommand, syncManager } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import { syncTargets } from '../../../middleware/audit/index.js';
+import { getOrchestrator } from '../../../utils/utils.js';
+import { defineManagementMcpTool } from '../managementTool.js';
+import { PublicMcpError } from '../utils.js';
+import { syncCommandErrorToMcp } from './errors.js';
+import { triggerSyncsArgumentsSchema, triggerSyncsOutputSchema } from './schema.js';
+
+import type { TriggerSyncsOutput } from './schema.js';
+
+const orchestrator = getOrchestrator();
+
+export const triggerSyncsTool = defineManagementMcpTool<typeof triggerSyncsArgumentsSchema, TriggerSyncsOutput>({
+    name: 'syncs_trigger',
+    description: 'Trigger one or more syncs, optionally performing a full reset and/or clearing existing synced records.',
+    inputSchema: triggerSyncsArgumentsSchema,
+    outputSchema: triggerSyncsOutputSchema,
+    requiredScopes: { every: ['environment:syncs:execute'] },
+    audit: {
+        kind: 'audit',
+        resource: 'sync',
+        action: 'triggered',
+        scope: 'environment',
+        targetFromOutput: ({ args }) => syncTargets(args.syncs, args.integration_id),
+        metadata: ({ args }) => ({
+            providerConfigKey: args.integration_id,
+            ...(args.connection_id ? { connectionId: args.connection_id } : {}),
+            reset: args.reset,
+            emptyCache: args.empty_cache
+        })
+    },
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false
+    },
+    async handler({ args, environment }) {
+        const syncIdentifiers = normalizedSyncParams(args.syncs);
+        if (syncIdentifiers.isErr()) {
+            return Err(new PublicMcpError(syncIdentifiers.error.message));
+        }
+
+        const result = await syncManager.runSyncCommand({
+            orchestrator,
+            environment,
+            providerConfigKey: args.integration_id,
+            syncIdentifiers: syncIdentifiers.value,
+            command: args.reset ? SyncCommand.RUN_FULL : SyncCommand.RUN,
+            deleteRecords: args.empty_cache,
+            logContextGetter,
+            connectionId: args.connection_id,
+            initiator: 'MCP call'
+        });
+        if (!result.success) {
+            return Err(syncCommandErrorToMcp(result.error));
+        }
+
+        return Ok({ success: true as const });
+    }
+});

--- a/packages/server/lib/controllers/mcp/syncs/trigger.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/syncs/trigger.unit.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { NangoError, syncManager } from '@nangohq/shared';
+import { RunSyncCommandError, syncManager } from '@nangohq/shared';
 
 import { PublicMcpError } from '../utils.js';
 import { triggerSyncsTool } from './trigger.js';
@@ -65,7 +65,7 @@ describe('triggerSyncsTool', () => {
         vi.spyOn(syncManager, 'runSyncCommand').mockResolvedValue({
             success: false,
             response: false,
-            error: new NangoError('unknown_connection')
+            error: new RunSyncCommandError('unknown_connection')
         });
 
         const result = await triggerSyncsTool.handler({ integration_id: 'github', connection_id: 'missing', syncs: ['issues'] }, context);
@@ -74,19 +74,6 @@ describe('triggerSyncsTool', () => {
         if (result.isErr()) {
             expect(result.error).toBeInstanceOf(PublicMcpError);
             expect(result.error.message).toBe('Connection does not exist');
-        }
-    });
-
-    it('keeps unexpected sync manager errors private', async () => {
-        const serviceError = new NangoError('sensitive_sync_failure');
-        vi.spyOn(syncManager, 'runSyncCommand').mockResolvedValue({ success: false, response: false, error: serviceError });
-
-        const result = await triggerSyncsTool.handler({ integration_id: 'github', syncs: ['issues'] }, context);
-
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
-            expect(result.error).toBe(serviceError);
-            expect(result.error).not.toBeInstanceOf(PublicMcpError);
         }
     });
 });

--- a/packages/server/lib/controllers/mcp/syncs/trigger.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/syncs/trigger.unit.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NangoError, syncManager } from '@nangohq/shared';
+
+import { PublicMcpError } from '../utils.js';
+import { triggerSyncsTool } from './trigger.js';
+
+import type { ManagementMcpContext } from '../managementTool.js';
+
+describe('triggerSyncsTool', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it.each([
+        { options: {}, command: 'RUN', deleteRecords: false },
+        { options: { reset: true }, command: 'RUN_FULL', deleteRecords: false },
+        { options: { reset: true, empty_cache: true }, command: 'RUN_FULL', deleteRecords: true }
+    ])('maps trigger options to $command with deleteRecords=$deleteRecords', async ({ options, command, deleteRecords }) => {
+        const runSyncCommandSpy = vi.spyOn(syncManager, 'runSyncCommand').mockResolvedValue({ success: true, response: true, error: null });
+        const syncs = ['issues', { name: 'users', variant: 'incremental' }];
+
+        const result = await triggerSyncsTool.handler({ syncs, integration_id: 'github', connection_id: 'connection-id', ...options }, context);
+
+        expect(runSyncCommandSpy).toHaveBeenCalledOnce();
+        expect(runSyncCommandSpy.mock.calls[0]?.[0]).toMatchObject({
+            environment: context.environment,
+            providerConfigKey: 'github',
+            connectionId: 'connection-id',
+            syncIdentifiers: [
+                { syncName: 'issues', syncVariant: 'base' },
+                { syncName: 'users', syncVariant: 'incremental' }
+            ],
+            command,
+            deleteRecords,
+            initiator: 'MCP call'
+        });
+        expect(runSyncCommandSpy.mock.calls[0]?.[0].orchestrator).toBeDefined();
+        expect(runSyncCommandSpy.mock.calls[0]?.[0].logContextGetter).toBeDefined();
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({ success: true });
+        }
+    });
+
+    it.each([
+        { name: 'unknown argument', args: { integration_id: 'github', syncs: [], unexpected: true } },
+        { name: 'invalid reset', args: { integration_id: 'github', syncs: [], reset: 'true' } },
+        { name: 'invalid empty cache', args: { integration_id: 'github', syncs: [], empty_cache: 1 } },
+        { name: 'malformed variant', args: { integration_id: 'github', syncs: [{ name: 'issues' }] } }
+    ])('rejects $name before calling the sync manager', async ({ args }) => {
+        const runSyncCommandSpy = vi.spyOn(syncManager, 'runSyncCommand');
+
+        const result = await triggerSyncsTool.handler(args, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toContain('Invalid syncs_trigger arguments:');
+        }
+        expect(runSyncCommandSpy).not.toHaveBeenCalled();
+    });
+
+    it('maps public sync manager errors', async () => {
+        vi.spyOn(syncManager, 'runSyncCommand').mockResolvedValue({
+            success: false,
+            response: false,
+            error: new NangoError('unknown_connection')
+        });
+
+        const result = await triggerSyncsTool.handler({ integration_id: 'github', connection_id: 'missing', syncs: ['issues'] }, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toBe('Connection does not exist');
+        }
+    });
+
+    it('keeps unexpected sync manager errors private', async () => {
+        const serviceError = new NangoError('sensitive_sync_failure');
+        vi.spyOn(syncManager, 'runSyncCommand').mockResolvedValue({ success: false, response: false, error: serviceError });
+
+        const result = await triggerSyncsTool.handler({ integration_id: 'github', syncs: ['issues'] }, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBe(serviceError);
+            expect(result.error).not.toBeInstanceOf(PublicMcpError);
+        }
+    });
+});
+
+const context = {
+    account: {},
+    environment: { id: 42 },
+    grantedScopes: ['environment:syncs:execute']
+} as ManagementMcpContext;


### PR DESCRIPTION
## Summary

- add `syncs_trigger` as a separate Management MCP tool
- support incremental runs, full resets, and optional cache clearing
- reuse `syncManager` and record `sync.triggered` audit events
- document the tool and cover registration, authorization, errors, structured results, and auditing

## Linear

- [NAN-6318](https://linear.app/nango/issue/NAN-6318/mcp-tool-syncs-trigger)

## Stack

- Depends on #7256
- Base branch: `marcin/NAN-6319/mcp-tool-syncs-set-state`

## Testing

- `npm run ts-build`
- 70 focused unit tests
- 3 focused Management MCP integration tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

