### PR TITLE
feat(server): add the nango_tool_search meta tool (NAN-6603)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22371,7 +22371,6 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
             "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10"
@@ -36212,6 +36211,7 @@
                 "express": "5.1.0",
                 "express-session": "1.18.2",
                 "fast-xml-parser": "5.10.1",
+                "fuse.js": "7.1.0",
                 "he": "1.2.0",
                 "helmet": "7.1.0",
                 "json-bigint": "1.0.0",

--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
@@ -9,7 +9,8 @@ import { customerKeyService, seeders } from '@nangohq/shared';
 
 import { runServer } from '../../../utils/tests.js';
 
-import type { DBEnvironment, DBSyncConfig, DBTeam, IntegrationConfig, PostAgentSessionsBody } from '@nangohq/types';
+import type { AgentSessionToolSearchResult, DBEnvironment, DBSyncConfig, DBTeam, IntegrationConfig, PostAgentSessionsBody } from '@nangohq/types';
+import type { JSONSchema7 } from 'json-schema';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -79,7 +80,21 @@ function parseMcpResponse(data: string): any {
     throw new Error('MCP SSE response did not contain a data payload');
 }
 
-async function insertAction({ environmentId, integration, name }: { environmentId: number; integration: IntegrationConfig; name: string }): Promise<void> {
+async function insertAction({
+    environmentId,
+    integration,
+    name,
+    description,
+    input,
+    modelsJsonSchema
+}: {
+    environmentId: number;
+    integration: IntegrationConfig;
+    name: string;
+    description?: string;
+    input?: string;
+    modelsJsonSchema?: { definitions: Record<string, JSONSchema7> };
+}): Promise<void> {
     await db.knex.from<DBSyncConfig>('_nango_sync_configs').insert({
         environment_id: environmentId,
         nango_config_id: integration.id!,
@@ -93,7 +108,9 @@ async function insertAction({ environmentId, integration, name }: { environmentI
         auto_start: false,
         webhook_subscriptions: [],
         models: [],
-        metadata: { description: `${name} description` },
+        metadata: { description: description ?? `${name} description` },
+        ...(input ? { input } : {}),
+        ...(modelsJsonSchema ? { models_json_schema: modelsJsonSchema } : {}),
         active: true,
         enabled: true,
         deleted: false,
@@ -122,9 +139,16 @@ async function seedTenant(): Promise<{ account: DBTeam; env: DBEnvironment; apiK
     const zendesk = await seeders.createConfigSeed(seed.env, 'zendesk', 'zendesk');
 
     await insertAction({ environmentId: seed.env.id, integration: notion, name: 'read_doc' });
-    await insertAction({ environmentId: seed.env.id, integration: notion, name: 'upsert_doc' });
+    await insertAction({
+        environmentId: seed.env.id,
+        integration: notion,
+        name: 'upsert_doc',
+        description: 'Create or update a page in a Notion workspace.',
+        input: 'UpsertDocInput',
+        modelsJsonSchema: { definitions: { UpsertDocInput: { type: 'object', properties: { title: { type: 'string' } }, required: ['title'] } } }
+    });
     await insertAction({ environmentId: seed.env.id, integration: slack, name: 'send_message' });
-    await insertAction({ environmentId: seed.env.id, integration: zendesk, name: 'create_ticket' });
+    await insertAction({ environmentId: seed.env.id, integration: zendesk, name: 'create_ticket', description: 'Open a support ticket for a customer.' });
 
     await seeders.createConnectionSeed({ env: seed.env, provider: 'notion', connectionId: 'notion-acme', tags: { tenant: 'acme' } });
     await seeders.createConnectionSeed({ env: seed.env, provider: 'slack', connectionId: 'slack-acme', tags: { tenant: 'acme' } });
@@ -161,6 +185,10 @@ async function callTool({ token, mcpPath, name, args }: { token: string; mcpPath
         method: 'POST',
         body: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } }
     });
+}
+
+function searchResult(res: { json: any }): AgentSessionToolSearchResult {
+    return JSON.parse(res.json.result.content[0].text) as AgentSessionToolSearchResult;
 }
 
 async function listTools({ token, mcpPath, cursor }: { token: string; mcpPath: string; cursor?: string }) {
@@ -344,6 +372,78 @@ describe('/session/:sessionId/mcp', () => {
         const res = await callTool({ token, mcpPath, name: 'notion__read_doc', args: { id: '1' } });
 
         expect(res.json.result.content[0].text).toBe("Tool 'read_doc' is disabled on integration 'notion'.");
+    });
+
+    it('finds a searchable tool that is deliberately not listed', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'create or update a page' } });
+
+        expect(res.json.result.isError).toBeUndefined();
+        expect(searchResult(res).matches.map((match) => [match.integration, match.tool])).toContainEqual(['notion', 'upsert_doc']);
+        expect(searchResult(res).guidance).toContain('nango_execute');
+    });
+
+    it('returns the input schema of a best match, read back from what is deployed', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'create or update a page' } });
+        const match = searchResult(res).matches.find((match) => match.tool === 'upsert_doc');
+
+        expect(match?.input_schema).toStrictEqual({ type: 'object', properties: { title: { type: 'string' } }, required: ['title'] });
+        expect(match?.connection).toStrictEqual({ status: 'connected', connection_id: 'notion-acme' });
+    });
+
+    it('reports a tool the agent is already holding under the name it is listed as', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'send a message' } });
+        const result = searchResult(res);
+        const match = [...result.matches, ...result.related].find((match) => match.tool === 'send_message');
+
+        expect(match?.listed_as).toBe('slack__send_message');
+        expect(result.guidance).toContain('already in your tool list');
+    });
+
+    /**
+     * An explicit '*' toolset covers every integration in the environment rather than only the ones
+     * the tenant connected, so zendesk arrives with tools and no connection.
+     */
+    it('lists a tool on an unconnected integration and says it will fail', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey, { toolset: '*', pinned_tools: {} });
+
+        const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'open a support ticket' } });
+        const result = searchResult(res);
+        const match = [...result.matches, ...result.related].find((match) => match.tool === 'create_ticket');
+
+        expect(match?.connection).toStrictEqual({ status: 'not_connected' });
+        expect(result.guidance).toContain('no connection in this session');
+    });
+
+    it('answers a query nothing matches without pretending otherwise', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'provision a kubernetes cluster' } });
+        const result = searchResult(res);
+
+        expect(result.matches).toStrictEqual([]);
+        expect(result.related).toStrictEqual([]);
+        expect(result.guidance).toContain('No tool in this session matches');
+    });
+
+    it('takes no integration filter', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'send a message', integration: 'slack' } });
+
+        expect(res.json.result.isError).toBe(true);
+        expect(res.json.result.content[0].text).toContain('Invalid nango_tool_search arguments');
     });
 
     it('rejects a call to a meta tool the session turned off, and not the same way as one it kept', async () => {

--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
@@ -381,7 +381,7 @@ describe('/session/:sessionId/mcp', () => {
         const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'create or update a page' } });
 
         expect(res.json.result.isError).toBeUndefined();
-        expect(searchResult(res).matches.map((match) => [match.integration, match.tool])).toContainEqual(['notion', 'upsert_doc']);
+        expect(searchResult(res).matches.map((match) => [match.integration, match.action])).toContainEqual(['notion', 'upsert_doc']);
         expect(searchResult(res).guidance).toContain('nango_execute');
     });
 
@@ -390,7 +390,7 @@ describe('/session/:sessionId/mcp', () => {
         const { token, mcpPath } = await createSession(apiKey);
 
         const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'create or update a page' } });
-        const match = searchResult(res).matches.find((match) => match.tool === 'upsert_doc');
+        const match = searchResult(res).matches.find((match) => match.action === 'upsert_doc');
 
         expect(match?.input).toStrictEqual({
             kind: 'schema',
@@ -416,7 +416,7 @@ describe('/session/:sessionId/mcp', () => {
 
         const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'read a doc' } });
         const result = searchResult(res);
-        const match = result.matches.find((match) => match.tool === 'read_doc');
+        const match = result.matches.find((match) => match.action === 'read_doc');
 
         expect(match?.input).toStrictEqual({ kind: 'unavailable' });
         expect(result.guidance).toContain('could not be read');
@@ -429,7 +429,7 @@ describe('/session/:sessionId/mcp', () => {
 
         const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'open a support ticket' } });
         const result = searchResult(res);
-        const match = result.matches.find((match) => match.tool === 'create_ticket');
+        const match = result.matches.find((match) => match.action === 'create_ticket');
 
         expect(match?.input).toStrictEqual({ kind: 'none' });
         expect(result.guidance).toContain('no arguments');
@@ -441,10 +441,11 @@ describe('/session/:sessionId/mcp', () => {
 
         const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'send a message' } });
         const result = searchResult(res);
-        const match = [...result.matches, ...result.related].find((match) => match.tool === 'send_message');
+        const match = [...result.matches, ...result.related].find((match) => match.action === 'send_message');
 
-        expect(match?.listed_as).toBe('slack__send_message');
-        expect(result.guidance).toContain('already in your tool list');
+        expect(match?.tool).toBe('slack__send_message');
+        expect(match?.listed).toBe(true);
+        expect(result.guidance).toContain('also in your tool list');
     });
 
     it('lists a tool on an unconnected integration and says it will fail', async () => {
@@ -453,7 +454,7 @@ describe('/session/:sessionId/mcp', () => {
 
         const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'open a support ticket' } });
         const result = searchResult(res);
-        const match = [...result.matches, ...result.related].find((match) => match.tool === 'create_ticket');
+        const match = [...result.matches, ...result.related].find((match) => match.action === 'create_ticket');
 
         expect(match?.connection).toStrictEqual({ status: 'not_connected' });
         expect(result.guidance).toContain('no connection in this session');

--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
@@ -392,7 +392,13 @@ describe('/session/:sessionId/mcp', () => {
         const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'create or update a page' } });
         const match = searchResult(res).matches.find((match) => match.tool === 'upsert_doc');
 
-        expect(match?.input).toStrictEqual({ kind: 'object', schema: { type: 'object', properties: { title: { type: 'string' } }, required: ['title'] } });
+        expect(match?.input).toStrictEqual({
+            kind: 'schema',
+            schema: {
+                definitions: { UpsertDocInput: { type: 'object', properties: { title: { type: 'string' } }, required: ['title'] } },
+                $ref: '#/definitions/UpsertDocInput'
+            }
+        });
         expect(match?.connection).toStrictEqual({ status: 'connected', connection_id: 'notion-acme' });
     });
 

--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
@@ -8,6 +8,7 @@ import * as keystore from '@nangohq/keystore';
 import { customerKeyService, seeders } from '@nangohq/shared';
 
 import { runServer } from '../../../utils/tests.js';
+import { toolSearchOutputSchema } from './toolSearch/schema.js';
 
 import type { AgentSessionToolSearchResult, DBEnvironment, DBSyncConfig, DBTeam, IntegrationConfig, PostAgentSessionsBody } from '@nangohq/types';
 import type { JSONSchema7 } from 'json-schema';
@@ -383,6 +384,31 @@ describe('/session/:sessionId/mcp', () => {
         expect(res.json.result.isError).toBeUndefined();
         expect(searchResult(res).matches.map((match) => [match.integration, match.action])).toContainEqual(['notion', 'upsert_doc']);
         expect(searchResult(res).guidance).toContain('nango_execute');
+    });
+
+    /**
+     * The declared output schema is not enforced at runtime, so nothing but a test stops it drifting
+     * from what search actually returns.
+     */
+    it('returns a result its declared output schema accepts', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey, { toolset: '*', pinned_tools: { notion: ['read_doc'] } });
+
+        const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'create or update a page' } });
+
+        expect(toolSearchOutputSchema.safeParse(searchResult(res)).error).toBeUndefined();
+        expect(res.json.result.structuredContent).toStrictEqual(searchResult(res));
+    });
+
+    it('declares that output schema on the listing', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await listTools({ token, mcpPath });
+        const search = res.json.result.tools.find((tool: { name: string }) => tool.name === 'nango_tool_search');
+
+        expect(search.outputSchema).toMatchObject({ type: 'object' });
+        expect(search.outputSchema.properties).toHaveProperty('matches');
     });
 
     it('returns the input schema of a best match, read back from what is deployed', async () => {

--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
@@ -392,8 +392,41 @@ describe('/session/:sessionId/mcp', () => {
         const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'create or update a page' } });
         const match = searchResult(res).matches.find((match) => match.tool === 'upsert_doc');
 
-        expect(match?.input_schema).toStrictEqual({ type: 'object', properties: { title: { type: 'string' } }, required: ['title'] });
+        expect(match?.input).toStrictEqual({ kind: 'object', schema: { type: 'object', properties: { title: { type: 'string' } }, required: ['title'] } });
         expect(match?.connection).toStrictEqual({ status: 'connected', connection_id: 'notion-acme' });
+    });
+
+    /**
+     * zendesk create_ticket is deployed without an input model, notion read_doc with one this test
+     * makes unreadable, so one genuinely takes no arguments and the other only looks like it does.
+     */
+    it('does not describe a tool whose arguments it could not read as taking none', async () => {
+        const { apiKey, env } = await seedTenant();
+        await db.knex
+            .from<DBSyncConfig>('_nango_sync_configs')
+            .where({ environment_id: env.id, sync_name: 'read_doc' })
+            .update({ input: 'ReadDocInput', models_json_schema: { definitions: {} } });
+        const { token, mcpPath } = await createSession(apiKey);
+
+        const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'read a doc' } });
+        const result = searchResult(res);
+        const match = result.matches.find((match) => match.tool === 'read_doc');
+
+        expect(match?.input).toStrictEqual({ kind: 'unsupported' });
+        expect(result.guidance).toContain('could not be read');
+        expect(result.guidance).not.toContain("'read_doc' takes no arguments");
+    });
+
+    it('says plainly when a tool takes no arguments', async () => {
+        const { apiKey } = await seedTenant();
+        const { token, mcpPath } = await createSession(apiKey, { toolset: '*', pinned_tools: {} });
+
+        const res = await callTool({ token, mcpPath, name: 'nango_tool_search', args: { query: 'open a support ticket' } });
+        const result = searchResult(res);
+        const match = result.matches.find((match) => match.tool === 'create_ticket');
+
+        expect(match?.input).toStrictEqual({ kind: 'none' });
+        expect(result.guidance).toContain('no arguments');
     });
 
     it('reports a tool the agent is already holding under the name it is listed as', async () => {

--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
@@ -412,7 +412,7 @@ describe('/session/:sessionId/mcp', () => {
         const result = searchResult(res);
         const match = result.matches.find((match) => match.tool === 'read_doc');
 
-        expect(match?.input).toStrictEqual({ kind: 'unsupported' });
+        expect(match?.input).toStrictEqual({ kind: 'unavailable' });
         expect(result.guidance).toContain('could not be read');
         expect(result.guidance).not.toContain("'read_doc' takes no arguments");
     });
@@ -441,10 +441,6 @@ describe('/session/:sessionId/mcp', () => {
         expect(result.guidance).toContain('already in your tool list');
     });
 
-    /**
-     * An explicit '*' toolset covers every integration in the environment rather than only the ones
-     * the tenant connected, so zendesk arrives with tools and no connection.
-     */
     it('lists a tool on an unconnected integration and says it will fail', async () => {
         const { apiKey } = await seedTenant();
         const { token, mcpPath } = await createSession(apiKey, { toolset: '*', pinned_tools: {} });

--- a/packages/server/lib/controllers/agent/mcp/sessionServer.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionServer.ts
@@ -77,6 +77,7 @@ export function createAgentSessionMcpServer(params: Omit<AgentSessionMcpContext,
             name: tool.name,
             description: tool.description,
             metric: tool.name,
+            structured: Boolean(tool.outputSchema),
             run: async (args) => await tool.handler(args, context)
         });
 
@@ -108,15 +109,17 @@ export function createAgentSessionMcpServer(params: Omit<AgentSessionMcpContext,
         name,
         description,
         metric,
+        structured = false,
         run
     }: {
         name: string;
         description: string;
         metric: string;
+        structured?: boolean;
         run: (args: unknown) => Promise<Result<unknown>>;
     }): RegisteredTool {
         return server.registerTool(name, { description, inputSchema: REGISTRATION_INPUT_SCHEMA }, async (args: unknown) =>
-            callAgentSessionTool({ metric, accountId: account.id, run: async () => await run(args) })
+            callAgentSessionTool({ metric, accountId: account.id, structured, run: async () => await run(args) })
         );
     }
 
@@ -149,6 +152,7 @@ export function buildSessionTools(session: AgentSession): SessionTools {
             name: claimToolName(tool.name, taken),
             description: tool.description,
             inputSchema: toJsonSchema202012(tool.inputSchema, 'input') ?? emptyObjectJsonSchema,
+            ...(tool.outputSchema ? { outputSchema: toJsonSchema202012(tool.outputSchema, 'output') } : {}),
             ...(tool.annotations ? { annotations: tool.annotations } : {})
         })
     );

--- a/packages/server/lib/controllers/agent/mcp/sessionTool.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionTool.ts
@@ -1,6 +1,6 @@
 import { Err, metrics } from '@nangohq/utils';
 
-import { formatMcpArgumentsError, handleMcpToolError, jsonContent, PublicMcpError } from '../../mcp/utils.js';
+import { formatMcpArgumentsError, handleMcpToolError, jsonContent, jsonStructuredContent, PublicMcpError } from '../../mcp/utils.js';
 
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { AgentSession, AgentSessionMetaTools, DBEnvironment, DBTeam } from '@nangohq/types';
@@ -34,6 +34,8 @@ export interface AgentSessionMcpTool {
     name: string;
     description: string;
     inputSchema: z.ZodType;
+    /** Declared only by a tool whose result is an object. nango_execute returns whatever an action returns. */
+    outputSchema?: z.ZodType;
     annotations?: ToolAnnotations;
     isEnabled: (metaTools: AgentSessionMetaTools) => boolean;
     handler: (args: unknown, context: AgentSessionMcpContext) => Promise<Result<unknown>>;
@@ -61,10 +63,12 @@ export function defineAgentSessionMcpTool<TInputSchema extends z.ZodType>(tool: 
 export async function callAgentSessionTool({
     metric,
     accountId,
+    structured = false,
     run
 }: {
     metric: string;
     accountId: number;
+    structured?: boolean;
     run: () => Promise<Result<unknown>>;
 }): Promise<CallToolResult> {
     let result: Result<unknown>;
@@ -86,5 +90,11 @@ export async function callAgentSessionTool({
         return handleMcpToolError(result.error, metric);
     }
 
-    return jsonContent(result.value ?? null);
+    // structuredContent has to be a JSON object, and only a tool that declared an output schema
+    // promises one. Anything else falls back to plain content rather than rendering an invalid result.
+    return structured && isJsonObject(result.value) ? jsonStructuredContent(result.value) : jsonContent(result.value ?? null);
+}
+
+function isJsonObject(value: unknown): value is object {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/server/lib/controllers/agent/mcp/sessionTool.unit.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionTool.unit.test.ts
@@ -11,6 +11,10 @@ async function call(run: () => Promise<Result<unknown>>) {
     return await callAgentSessionTool({ metric: 'nango_execute', accountId: 1, run });
 }
 
+async function callStructured(run: () => Promise<Result<unknown>>) {
+    return await callAgentSessionTool({ metric: 'nango_tool_search', accountId: 1, structured: true, run });
+}
+
 describe('callAgentSessionTool', () => {
     it('renders a result as json', async () => {
         const result = await call(() => Promise.resolve(Ok({ ok: true })));
@@ -45,5 +49,34 @@ describe('callAgentSessionTool', () => {
 
         expect(result.isError).toBe(true);
         expect(result.content[0]).toStrictEqual({ type: 'text', text: 'Internal error' });
+    });
+});
+
+describe('callAgentSessionTool in structured mode', () => {
+    it('renders an object as structured content as well as text', async () => {
+        const result = await callStructured(() => Promise.resolve(Ok({ matches: [] })));
+
+        expect(result.structuredContent).toStrictEqual({ matches: [] });
+        expect(result.content[0]).toStrictEqual({ type: 'text', text: JSON.stringify({ matches: [] }, null, 2) });
+    });
+
+    /**
+     * structuredContent has to be a JSON object. jsonStructuredContent is typed for one but checks
+     * nothing, so anything else has to fall back rather than render a result its own schema rejects.
+     */
+    it('falls back to plain content for anything that is not a JSON object', async () => {
+        for (const value of [undefined, null, [1, 2], 'text', 7, true]) {
+            const result = await callStructured(() => Promise.resolve(Ok(value)));
+
+            expect(result.structuredContent).toBeUndefined();
+            expect(result.content[0]).toMatchObject({ type: 'text' });
+        }
+    });
+
+    it('still reports an error as an error', async () => {
+        const result = await callStructured(() => Promise.resolve(Err(new PublicMcpError('nope'))));
+
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toBeUndefined();
     });
 });

--- a/packages/server/lib/controllers/agent/mcp/toolSearch/schema.ts
+++ b/packages/server/lib/controllers/agent/mcp/toolSearch/schema.ts
@@ -1,0 +1,7 @@
+import * as z from 'zod/v4';
+
+export const toolSearchInputSchema = z
+    .object({
+        query: z.string().trim().min(1).max(255).describe('What the tool should do, in plain language. Describe the operation rather than naming a product.')
+    })
+    .strict();

--- a/packages/server/lib/controllers/agent/mcp/toolSearch/schema.ts
+++ b/packages/server/lib/controllers/agent/mcp/toolSearch/schema.ts
@@ -5,3 +5,44 @@ export const toolSearchInputSchema = z
         query: z.string().trim().min(1).max(255).describe('What the tool should do, in plain language. Describe the operation rather than naming a product.')
     })
     .strict();
+
+const connectionSchema = z.discriminatedUnion('status', [
+    z.object({ status: z.literal('connected'), connection_id: z.string() }).strict(),
+    z.object({ status: z.literal('not_connected') }).strict()
+]);
+
+const inputSchema = z.discriminatedUnion('kind', [
+    z
+        .object({ kind: z.literal('schema'), schema: z.looseObject({}) })
+        .strict()
+        .describe('A JSON Schema document rooted at its $ref.'),
+    z
+        .object({ kind: z.literal('none') })
+        .strict()
+        .describe('The tool takes no input.'),
+    z
+        .object({ kind: z.literal('unavailable') })
+        .strict()
+        .describe('The input could not be read, so it has to be guessed.')
+]);
+
+const matchSchema = z
+    .object({
+        tool: z.string().describe("Pass as nango_execute's tool argument, exactly as given."),
+        integration: z.string(),
+        action: z.string().describe('The action this tool runs, for context rather than for calling.'),
+        provider: z.string(),
+        description: z.string(),
+        listed: z.boolean().describe('Whether the same name is in your tool list.'),
+        connection: connectionSchema.describe('An integration with no connection in this session fails when one of its tools is called.'),
+        input: inputSchema.optional().describe('Only on a close match. A weaker match is a lead to search again on.')
+    })
+    .strict();
+
+export const toolSearchOutputSchema = z
+    .object({
+        guidance: z.string(),
+        matches: z.array(matchSchema).describe('Tools that fit the query, returned with their input and ready to call.'),
+        related: z.array(matchSchema).describe('Weaker matches, without their input. Leads to search again on rather than tools to call.')
+    })
+    .strict();

--- a/packages/server/lib/controllers/agent/mcp/toolSearch/search.ts
+++ b/packages/server/lib/controllers/agent/mcp/toolSearch/search.ts
@@ -1,43 +1,41 @@
 import { Ok } from '@nangohq/utils';
 
 import { searchSessionTools } from '../../../../services/agentSessionToolSearch.service.js';
-import { INTEGRATION_META_KEY, listSessionTools, TOOL_META_KEY } from '../sessionServer.js';
 import { defineAgentSessionMcpTool } from '../sessionTool.js';
 import { toolSearchInputSchema } from './schema.js';
 
-import type { AgentSession } from '@nangohq/types';
+import type { ToolSlugLookup } from '../../../../services/agentSessionToolSearch.service.js';
+import type { AgentSessionCallableTools } from '../sessionTool.js';
 
 export const toolSearchTool = defineAgentSessionMcpTool({
     name: 'nango_tool_search',
     description:
-        'Search the tools this session can reach, including ones not in your tool list. Start here when no listed tool fits the task. Each result carries an integration and a tool name to pass to nango_execute, and a result already in your tool list also carries listed_as, the name you can call it by directly.',
+        'Search the tools this session can reach, including ones not in your tool list. Start here when no listed tool fits the task. Each result carries a tool name to pass to nango_execute, and the integration and action it stands for.',
     inputSchema: toolSearchInputSchema,
     annotations: { readOnlyHint: true },
     isEnabled: (metaTools) => metaTools.nangoToolSearch,
-    async handler({ args, session }) {
-        return Ok(await searchSessionTools({ session, query: args.query, listedNameFor: listedNameLookup(session) }));
+    async handler({ args, session, callable }) {
+        return Ok(await searchSessionTools({ session, query: args.query, slugOf: slugLookup(callable) }));
     }
 });
 
-function listedNameLookup(session: AgentSession): (tool: { integration: string; tool: string }) => string | undefined {
-    const listed = new Map<string, Map<string, string>>();
+/**
+ * Read off the names the session already resolved, never rebuilt, because sanitising and clipping can
+ * put two tools on one name and the loser is numbered, so a name is only correct in the listing that
+ * produced it.
+ */
+function slugLookup(callable: AgentSessionCallableTools): ToolSlugLookup {
+    const byIntegration = new Map<string, Map<string, string>>();
 
-    for (const tool of listSessionTools(session)) {
-        const integrationId = tool._meta?.[INTEGRATION_META_KEY];
-        const toolName = tool._meta?.[TOOL_META_KEY];
-
-        if (typeof integrationId !== 'string' || typeof toolName !== 'string') {
-            continue;
+    for (const [slug, tool] of callable) {
+        let byAction = byIntegration.get(tool.integrationId);
+        if (!byAction) {
+            byAction = new Map<string, string>();
+            byIntegration.set(tool.integrationId, byAction);
         }
 
-        let byTool = listed.get(integrationId);
-        if (!byTool) {
-            byTool = new Map<string, string>();
-            listed.set(integrationId, byTool);
-        }
-
-        byTool.set(toolName, tool.name);
+        byAction.set(tool.name, slug);
     }
 
-    return ({ integration, tool }) => listed.get(integration)?.get(tool);
+    return ({ integration, action }) => byIntegration.get(integration)?.get(action);
 }

--- a/packages/server/lib/controllers/agent/mcp/toolSearch/search.ts
+++ b/packages/server/lib/controllers/agent/mcp/toolSearch/search.ts
@@ -1,19 +1,45 @@
-// TODO: implemented in NAN-6603
-import * as z from 'zod/v4';
+import { Ok } from '@nangohq/utils';
 
-import { Err } from '@nangohq/utils';
-
-import { PublicMcpError } from '../../../mcp/utils.js';
+import { searchSessionTools } from '../../../../services/agentSessionToolSearch.service.js';
+import { INTEGRATION_META_KEY, listSessionTools, TOOL_META_KEY } from '../sessionServer.js';
 import { defineAgentSessionMcpTool } from '../sessionTool.js';
+import { toolSearchInputSchema } from './schema.js';
+
+import type { AgentSession } from '@nangohq/types';
 
 export const toolSearchTool = defineAgentSessionMcpTool({
     name: 'nango_tool_search',
     description:
         'Search the tools this session can reach that are not already listed. Returns tool names to pass to nango_execute, so start here when no listed tool fits the task.',
-    inputSchema: z.object({ query: z.string().trim().min(1).max(255).describe('What the tool should do, in plain language.') }).strict(),
+    inputSchema: toolSearchInputSchema,
     annotations: { readOnlyHint: true },
     isEnabled: (metaTools) => metaTools.nangoToolSearch,
-    handler() {
-        return Err(new PublicMcpError("Tool 'nango_tool_search' cannot be called yet on an agent session."));
+    async handler({ args, session }) {
+        return Ok(await searchSessionTools({ session, query: args.query, listedNameFor: listedNameLookup(session) }));
     }
 });
+
+// Read off the listing rather than re-derived, so a tool renamed to keep its name unique is
+// reported under the name the agent actually holds.
+function listedNameLookup(session: AgentSession): (tool: { integration: string; tool: string }) => string | undefined {
+    const listed = new Map<string, Map<string, string>>();
+
+    for (const tool of listSessionTools(session)) {
+        const integrationId = tool._meta?.[INTEGRATION_META_KEY];
+        const toolName = tool._meta?.[TOOL_META_KEY];
+
+        if (typeof integrationId !== 'string' || typeof toolName !== 'string') {
+            continue;
+        }
+
+        let byTool = listed.get(integrationId);
+        if (!byTool) {
+            byTool = new Map<string, string>();
+            listed.set(integrationId, byTool);
+        }
+
+        byTool.set(toolName, tool.name);
+    }
+
+    return ({ integration, tool }) => listed.get(integration)?.get(tool);
+}

--- a/packages/server/lib/controllers/agent/mcp/toolSearch/search.ts
+++ b/packages/server/lib/controllers/agent/mcp/toolSearch/search.ts
@@ -19,8 +19,6 @@ export const toolSearchTool = defineAgentSessionMcpTool({
     }
 });
 
-// Read off the listing rather than re-derived, so a tool renamed to keep its name unique is
-// reported under the name the agent actually holds.
 function listedNameLookup(session: AgentSession): (tool: { integration: string; tool: string }) => string | undefined {
     const listed = new Map<string, Map<string, string>>();
 

--- a/packages/server/lib/controllers/agent/mcp/toolSearch/search.ts
+++ b/packages/server/lib/controllers/agent/mcp/toolSearch/search.ts
@@ -2,7 +2,7 @@ import { Ok } from '@nangohq/utils';
 
 import { searchSessionTools } from '../../../../services/agentSessionToolSearch.service.js';
 import { defineAgentSessionMcpTool } from '../sessionTool.js';
-import { toolSearchInputSchema } from './schema.js';
+import { toolSearchInputSchema, toolSearchOutputSchema } from './schema.js';
 
 import type { ToolSlugLookup } from '../../../../services/agentSessionToolSearch.service.js';
 import type { AgentSessionCallableTools } from '../sessionTool.js';
@@ -12,6 +12,7 @@ export const toolSearchTool = defineAgentSessionMcpTool({
     description:
         'Search the tools this session can reach, including ones not in your tool list. Start here when no listed tool fits the task. Each result carries a tool name to pass to nango_execute, and the integration and action it stands for.',
     inputSchema: toolSearchInputSchema,
+    outputSchema: toolSearchOutputSchema,
     annotations: { readOnlyHint: true },
     isEnabled: (metaTools) => metaTools.nangoToolSearch,
     async handler({ args, session, callable }) {

--- a/packages/server/lib/controllers/agent/mcp/toolSearch/search.ts
+++ b/packages/server/lib/controllers/agent/mcp/toolSearch/search.ts
@@ -10,7 +10,7 @@ import type { AgentSession } from '@nangohq/types';
 export const toolSearchTool = defineAgentSessionMcpTool({
     name: 'nango_tool_search',
     description:
-        'Search the tools this session can reach that are not already listed. Returns tool names to pass to nango_execute, so start here when no listed tool fits the task.',
+        'Search the tools this session can reach, including ones not in your tool list. Start here when no listed tool fits the task. Each result carries an integration and a tool name to pass to nango_execute, and a result already in your tool list also carries listed_as, the name you can call it by directly.',
     inputSchema: toolSearchInputSchema,
     annotations: { readOnlyHint: true },
     isEnabled: (metaTools) => metaTools.nangoToolSearch,

--- a/packages/server/lib/services/agentSessionToolSearch.service.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.ts
@@ -8,7 +8,7 @@ import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 const DEFINITIONS_POINTER = '#/definitions/';
 
-/** Guards against a union that nests into itself. Real input models are nowhere near this deep. */
+// Guards against a union that nests into itself. Real input models are nowhere near this deep.
 const MAX_SCHEMA_DEPTH = 8;
 
 const FUSE_OPTIONS: NonNullable<ConstructorParameters<typeof Fuse<SearchCandidate>>[1]> = {
@@ -71,11 +71,7 @@ const STOPWORDS = new Set([
     'your'
 ]);
 
-/**
- * Scores run from 0 for a tool that matches every word in the query to 1 for one that matches none.
- * At or under the best score a tool is worth handing back ready to call, and past the match score a
- * tool caught one incidental word and is noise.
- */
+// Ranked from 0, everything matched, to 1, nothing matched.
 const BEST_MATCH_SCORE = 0.4;
 const MAX_MATCH_SCORE = 0.85;
 
@@ -105,9 +101,8 @@ export async function searchSessionTools({
     const ranked = rankSessionTools({ session, query, listedNameFor });
     const inputs = await findToolInputs({ environmentId: session.environmentId, candidates: ranked.best });
 
-    // A best match with no row left to read is one whose action went away after the session compiled
-    // its toolset, which is a tool whose arguments we cannot state rather than one that takes none.
-    const matches = ranked.best.map((candidate) => toMatch(candidate, inputs.get(candidate.integration)?.get(candidate.tool) ?? { kind: 'unsupported' }));
+    // It's possible a tool was removed after the session compiled, so we set input as unavailable.
+    const matches = ranked.best.map((candidate) => toMatch(candidate, inputs.get(candidate.integration)?.get(candidate.tool) ?? { kind: 'unavailable' }));
     const related = ranked.related.map((candidate) => toMatch(candidate, undefined));
 
     return { guidance: guidanceFor({ query, matches, related }), matches, related };
@@ -117,7 +112,7 @@ export function rankSessionTools({ session, query, listedNameFor }: { session: A
     best: SearchCandidate[];
     related: SearchCandidate[];
 } {
-    const candidates = searchCandidates({ session, listedNameFor });
+    const candidates = buildSearchCandidateList({ session, listedNameFor });
     const scored = scoreCandidates({ candidates, query });
 
     const best: SearchCandidate[] = [];
@@ -180,12 +175,7 @@ function queryTerms(query: string): string[] {
     return meaningful.length > 0 ? meaningful : words;
 }
 
-/**
- * Every tool the session can reach, pinned ones included. A pinned tool is already in the agent's
- * tool list, but leaving it out of the results would answer "nothing here does that" about a tool
- * the agent is holding, so it is returned and marked with the name it is listed under.
- */
-function searchCandidates({ session, listedNameFor }: { session: AgentSession; listedNameFor: ListedNameLookup }): SearchCandidate[] {
+function buildSearchCandidateList({ session, listedNameFor }: { session: AgentSession; listedNameFor: ListedNameLookup }): SearchCandidate[] {
     return Object.entries(session.compiledToolset).flatMap(([integration, compiled]) => {
         const connection = connectionStateFor({ session, integration });
 
@@ -241,11 +231,6 @@ async function findToolInputs({
     return inputs;
 }
 
-/**
- * An action declares its input as a model name resolved against the schema definitions it was
- * deployed with. Three shapes mean it takes nothing: no input model at all, an input model typed as
- * null, and, on rows deployed before the input model was always written, a missing definition.
- */
 export function toolInputOf(row: ActionInputSchemaRow): AgentSessionToolInput {
     if (!row.input) {
         return { kind: 'none' };
@@ -255,7 +240,7 @@ export function toolInputOf(row: ActionInputSchemaRow): AgentSessionToolInput {
     const schema = definitions ? own(definitions, row.input) : undefined;
 
     if (!schema) {
-        return { kind: 'unsupported' };
+        return { kind: 'unavailable' };
     }
 
     const resolved = resolveRef(schema, definitions);
@@ -264,29 +249,20 @@ export function toolInputOf(row: ActionInputSchemaRow): AgentSessionToolInput {
         return { kind: 'none' };
     }
 
-    // An input that cannot be an object cannot be expressed as the arguments a tool call carries.
     if (!acceptsObject(schema, definitions, 0)) {
-        return { kind: 'unsupported' };
+        return { kind: 'unavailable' };
     }
 
     return { kind: 'object', schema: withReferencedDefinitions(schema, definitions) };
 }
 
-/**
- * Whether the schema can accept the JSON object a tool call carries.
- *
- * Deployed schemas are stored without their bodies being inspected, so the input model is not always
- * a plain `type: 'object'`: it can point at one, name several types, or offer an object as one branch
- * of a union. Rejecting those would withhold the arguments of a tool that is perfectly callable.
- */
+/** Whether the schema can accept the JSON object a tool call carries. */
 function acceptsObject(schema: JSONSchema7, definitions: Record<string, JSONSchema7> | undefined, depth: number): boolean {
     const resolved = depth <= MAX_SCHEMA_DEPTH ? resolveRef(schema, definitions) : undefined;
     if (!resolved) {
         return false;
     }
 
-    // Each keyword present is a constraint the same value has to satisfy at once, so all of them are
-    // checked rather than whichever appears first. A keyword that is absent constrains nothing.
     const { type, allOf, oneOf, anyOf } = resolved;
     const accepts = (branch: JSONSchema7Definition) => (typeof branch === 'boolean' ? branch : acceptsObject(branch, definitions, depth + 1));
 
@@ -294,7 +270,6 @@ function acceptsObject(schema: JSONSchema7, definitions: Record<string, JSONSche
         return false;
     }
 
-    // Every member of an allOf has to hold, where one member of a oneOf or an anyOf is enough.
     if (allOf && allOf.length > 0 && !allOf.every(accepts)) {
         return false;
     }
@@ -431,10 +406,10 @@ function guidanceFor({ query, matches, related }: { query: string; matches: Agen
             lines.push(`${toolNames(takesNothing)} ${takesNothing.length === 1 ? 'takes' : 'take'} no arguments.`);
         }
 
-        const unreadable = matches.filter((match) => match.input?.kind === 'unsupported');
+        const unreadable = matches.filter((match) => match.input?.kind === 'unavailable');
         if (unreadable.length > 0) {
             lines.push(
-                `The arguments of ${toolNames(unreadable)} could not be read, or are not the JSON object a tool call takes, so calling ${unreadable.length === 1 ? 'it' : 'them'} may fail.`
+                `The arguments of ${toolNames(unreadable)} could not be read, so ${unreadable.length === 1 ? 'it has' : 'they have'} to be called on a guess at the shape, and may fail.`
             );
         }
     } else {

--- a/packages/server/lib/services/agentSessionToolSearch.service.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.ts
@@ -4,7 +4,7 @@ import { legacyFunctionService } from '@nangohq/shared';
 
 import type { ActionInputSchemaRow } from '@nangohq/shared';
 import type { AgentSession, AgentSessionToolConnectionState, AgentSessionToolInput, AgentSessionToolMatch, AgentSessionToolSearchResult } from '@nangohq/types';
-import type { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 const DEFINITIONS_POINTER = '#/definitions/';
 
@@ -285,25 +285,28 @@ function acceptsObject(schema: JSONSchema7, definitions: Record<string, JSONSche
         return false;
     }
 
-    if (Array.isArray(resolved.type)) {
-        return resolved.type.includes('object');
+    // Each keyword present is a constraint the same value has to satisfy at once, so all of them are
+    // checked rather than whichever appears first. A keyword that is absent constrains nothing.
+    const { type, allOf, oneOf, anyOf } = resolved;
+    const accepts = (branch: JSONSchema7Definition) => (typeof branch === 'boolean' ? branch : acceptsObject(branch, definitions, depth + 1));
+
+    if (type !== undefined && !(Array.isArray(type) ? type.includes('object') : type === 'object')) {
+        return false;
     }
 
-    if (typeof resolved.type === 'string') {
-        return resolved.type === 'object';
+    // Every member of an allOf has to hold, where one member of a oneOf or an anyOf is enough.
+    if (allOf && allOf.length > 0 && !allOf.every(accepts)) {
+        return false;
     }
 
-    // Every member of an allOf has to be satisfied at once, where one member of a oneOf or an anyOf is enough.
-    if (resolved.allOf && resolved.allOf.length > 0) {
-        return resolved.allOf.every((branch) => typeof branch === 'object' && acceptsObject(branch, definitions, depth + 1));
+    if (oneOf && oneOf.length > 0 && !oneOf.some(accepts)) {
+        return false;
     }
 
-    const branches = [...(resolved.oneOf ?? []), ...(resolved.anyOf ?? [])];
-    if (branches.length > 0) {
-        return branches.some((branch) => typeof branch === 'object' && acceptsObject(branch, definitions, depth + 1));
+    if (anyOf && anyOf.length > 0 && !anyOf.some(accepts)) {
+        return false;
     }
 
-    // A schema that names no type constrains nothing, so an object satisfies it.
     return true;
 }
 

--- a/packages/server/lib/services/agentSessionToolSearch.service.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.ts
@@ -18,7 +18,7 @@ const FUSE_OPTIONS: NonNullable<ConstructorParameters<typeof Fuse<SearchCandidat
     threshold: 0.4,
     minMatchCharLength: 2,
     keys: [
-        { name: 'tool', weight: 0.45 },
+        { name: 'action', weight: 0.45 },
         { name: 'description', weight: 0.35 },
         { name: 'integration', weight: 0.1 },
         { name: 'provider', weight: 0.1 }
@@ -76,40 +76,45 @@ const MAX_BEST_MATCHES = 5;
 const MAX_RELATED_MATCHES = 15;
 
 interface SearchCandidate {
+    slug: string;
     integration: string;
+    action: string;
     provider: string;
-    tool: string;
     description: string;
     connection: AgentSessionToolConnectionState;
-    listedAs: string | undefined;
+    listed: boolean;
 }
 
-export type ListedNameLookup = (tool: { integration: string; tool: string }) => string | undefined;
+/**
+ * The name nango_execute takes for a tool. It cannot be derived from the integration and action,
+ * since sanitising and clipping can collide and the loser gets numbered.
+ */
+export type ToolSlugLookup = (tool: { integration: string; action: string }) => string | undefined;
 
 export async function searchSessionTools({
     session,
     query,
-    listedNameFor
+    slugOf
 }: {
     session: AgentSession;
     query: string;
-    listedNameFor: ListedNameLookup;
+    slugOf: ToolSlugLookup;
 }): Promise<AgentSessionToolSearchResult> {
-    const ranked = rankSessionTools({ session, query, listedNameFor });
+    const ranked = rankSessionTools({ session, query, slugOf });
     const inputs = await findToolInputs({ environmentId: session.environmentId, candidates: ranked.best });
 
     // It's possible a tool was removed after the session compiled, so we set input as unavailable.
-    const matches = ranked.best.map((candidate) => toMatch(candidate, inputs.get(candidate.integration)?.get(candidate.tool) ?? { kind: 'unavailable' }));
+    const matches = ranked.best.map((candidate) => toMatch(candidate, inputs.get(candidate.integration)?.get(candidate.action) ?? { kind: 'unavailable' }));
     const related = ranked.related.map((candidate) => toMatch(candidate, undefined));
 
     return { guidance: guidanceFor({ query, matches, related }), matches, related };
 }
 
-export function rankSessionTools({ session, query, listedNameFor }: { session: AgentSession; query: string; listedNameFor: ListedNameLookup }): {
+export function rankSessionTools({ session, query, slugOf }: { session: AgentSession; query: string; slugOf: ToolSlugLookup }): {
     best: SearchCandidate[];
     related: SearchCandidate[];
 } {
-    const candidates = buildSearchCandidateList({ session, listedNameFor });
+    const candidates = buildSearchCandidateList({ session, slugOf });
     const scored = scoreCandidates({ candidates, query });
 
     const best: SearchCandidate[] = [];
@@ -154,7 +159,8 @@ function scoreCandidates({ candidates, query }: { candidates: SearchCandidate[];
             return candidate && score <= MAX_MATCH_SCORE ? [{ candidate, score }] : [];
         })
         .sort(
-            (a, b) => a.score - b.score || a.candidate.integration.localeCompare(b.candidate.integration) || a.candidate.tool.localeCompare(b.candidate.tool)
+            (a, b) =>
+                a.score - b.score || a.candidate.integration.localeCompare(b.candidate.integration) || a.candidate.action.localeCompare(b.candidate.action)
         );
 }
 
@@ -172,20 +178,31 @@ function queryTerms(query: string): string[] {
     return meaningful.length > 0 ? meaningful : words;
 }
 
-function buildSearchCandidateList({ session, listedNameFor }: { session: AgentSession; listedNameFor: ListedNameLookup }): SearchCandidate[] {
+function buildSearchCandidateList({ session, slugOf }: { session: AgentSession; slugOf: ToolSlugLookup }): SearchCandidate[] {
     return Object.entries(session.compiledToolset).flatMap(([integration, compiled]) => {
         const connection = connectionStateFor({ session, integration });
 
-        return [...compiled.pinned, ...compiled.searchable].map(
-            (tool): SearchCandidate => ({
-                integration,
-                provider: compiled.provider,
-                tool: tool.name,
-                description: tool.description,
-                connection,
-                listedAs: listedNameFor({ integration, tool: tool.name })
-            })
-        );
+        // Pinned is exactly what the session lists, so it is also what an agent can name directly.
+        const tools = [...compiled.pinned.map((tool) => ({ tool, listed: true })), ...compiled.searchable.map((tool) => ({ tool, listed: false }))];
+
+        return tools.flatMap(({ tool, listed }): SearchCandidate[] => {
+            // A tool with no name cannot be called, so returning it would only waste the agent's turn.
+            const slug = slugOf({ integration, action: tool.name });
+
+            return slug
+                ? [
+                      {
+                          slug,
+                          integration,
+                          action: tool.name,
+                          provider: compiled.provider,
+                          description: tool.description,
+                          connection,
+                          listed
+                      }
+                  ]
+                : [];
+        });
     });
 }
 
@@ -211,7 +228,7 @@ async function findToolInputs({
 }): Promise<Map<string, Map<string, AgentSessionToolInput>>> {
     const rows = await legacyFunctionService.findActionInputSchemas({
         environmentId,
-        actions: candidates.map((candidate) => ({ integrationId: candidate.integration, name: candidate.tool }))
+        actions: candidates.map((candidate) => ({ integrationId: candidate.integration, name: candidate.action }))
     });
 
     const inputs = new Map<string, Map<string, AgentSessionToolInput>>();
@@ -253,12 +270,13 @@ export function toolInputOf(row: ActionInputSchemaRow): AgentSessionToolInput {
 
 function toMatch(candidate: SearchCandidate, input: AgentSessionToolInput | undefined): AgentSessionToolMatch {
     return {
+        tool: candidate.slug,
         integration: candidate.integration,
+        action: candidate.action,
         provider: candidate.provider,
-        tool: candidate.tool,
         description: candidate.description,
+        listed: candidate.listed,
         connection: candidate.connection,
-        ...(candidate.listedAs ? { listed_as: candidate.listedAs } : {}),
         ...(input ? { input } : {})
     };
 }
@@ -272,7 +290,7 @@ function guidanceFor({ query, matches, related }: { query: string; matches: Agen
 
     if (matches.length > 0) {
         lines.push(
-            `${matches.length} ${matches.length === 1 ? 'tool matches' : 'tools match'} '${query}'. Call nango_execute with the integration and tool of the one you want, and the input its schema describes. A schema is a JSON Schema document rooted at its \`$ref\`.`
+            `${matches.length} ${matches.length === 1 ? 'tool matches' : 'tools match'} '${query}'. Call nango_execute with the tool of the one you want, exactly as given, and the input its schema describes. A schema is a JSON Schema document rooted at its \`$ref\`.`
         );
 
         const takesNothing = matches.filter((match) => match.input?.kind === 'none');
@@ -298,11 +316,9 @@ function guidanceFor({ query, matches, related }: { query: string; matches: Agen
         );
     }
 
-    const alreadyListed = [...matches, ...related].filter((match) => match.listed_as);
+    const alreadyListed = [...matches, ...related].filter((match) => match.listed);
     if (alreadyListed.length > 0) {
-        lines.push(
-            `${alreadyListed.map((match) => `'${match.listed_as}'`).join(', ')} ${alreadyListed.length === 1 ? 'is' : 'are'} already in your tool list and can be called directly.`
-        );
+        lines.push(`${toolNames(alreadyListed)} ${alreadyListed.length === 1 ? 'is' : 'are'} also in your tool list under the same name.`);
     }
 
     const unconnected = [...new Set([...matches, ...related].filter((match) => match.connection.status === 'not_connected').map((match) => match.integration))];

--- a/packages/server/lib/services/agentSessionToolSearch.service.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.ts
@@ -1,0 +1,301 @@
+import Fuse from 'fuse.js';
+
+import { legacyFunctionService } from '@nangohq/shared';
+
+import type { ActionInputSchemaRow } from '@nangohq/shared';
+import type { AgentSession, AgentSessionToolConnectionState, AgentSessionToolMatch, AgentSessionToolSearchResult } from '@nangohq/types';
+import type { JSONSchema7 } from 'json-schema';
+
+const FUSE_OPTIONS: NonNullable<ConstructorParameters<typeof Fuse<SearchCandidate>>[1]> = {
+    includeScore: true,
+    // Both default to false, and both quietly rank a tool that describes itself properly below one
+    // whose description is little more than its own name: the first scores on where in a field a
+    // match falls, the second discounts a match by the length of the field holding it.
+    ignoreLocation: true,
+    ignoreFieldNorm: true,
+    threshold: 0.4,
+    minMatchCharLength: 2,
+    keys: [
+        { name: 'tool', weight: 0.45 },
+        { name: 'description', weight: 0.35 },
+        { name: 'integration', weight: 0.1 },
+        { name: 'provider', weight: 0.1 }
+    ]
+};
+
+// Dropped so the words carrying the meaning are not diluted by the ones around them.
+const STOPWORDS = new Set([
+    'a',
+    'an',
+    'and',
+    'are',
+    'as',
+    'at',
+    'be',
+    'by',
+    'can',
+    'do',
+    'for',
+    'from',
+    'get',
+    'how',
+    'i',
+    'in',
+    'is',
+    'it',
+    'me',
+    'my',
+    'need',
+    'of',
+    'on',
+    'or',
+    'that',
+    'the',
+    'their',
+    'them',
+    'then',
+    'this',
+    'to',
+    'want',
+    'was',
+    'what',
+    'when',
+    'which',
+    'with',
+    'you',
+    'your'
+]);
+
+/**
+ * Scores run from 0 for a tool that matches every word in the query to 1 for one that matches none.
+ * At or under the best score a tool is worth handing back ready to call, and past the match score a
+ * tool caught one incidental word and is noise.
+ */
+const BEST_MATCH_SCORE = 0.4;
+const MAX_MATCH_SCORE = 0.85;
+
+const MAX_BEST_MATCHES = 5;
+const MAX_RELATED_MATCHES = 15;
+
+interface SearchCandidate {
+    integration: string;
+    provider: string;
+    tool: string;
+    description: string;
+    connection: AgentSessionToolConnectionState;
+    listedAs: string | undefined;
+}
+
+export type ListedNameLookup = (tool: { integration: string; tool: string }) => string | undefined;
+
+export async function searchSessionTools({
+    session,
+    query,
+    listedNameFor
+}: {
+    session: AgentSession;
+    query: string;
+    listedNameFor: ListedNameLookup;
+}): Promise<AgentSessionToolSearchResult> {
+    const ranked = rankSessionTools({ session, query, listedNameFor });
+    const schemas = await findInputSchemas({ environmentId: session.environmentId, candidates: ranked.best });
+
+    const matches = ranked.best.map((candidate) => toMatch(candidate, schemas.get(candidate.integration)?.get(candidate.tool)));
+    const related = ranked.related.map((candidate) => toMatch(candidate, undefined));
+
+    return { guidance: guidanceFor({ query, matches, related }), matches, related };
+}
+
+export function rankSessionTools({ session, query, listedNameFor }: { session: AgentSession; query: string; listedNameFor: ListedNameLookup }): {
+    best: SearchCandidate[];
+    related: SearchCandidate[];
+} {
+    const candidates = searchCandidates({ session, listedNameFor });
+    const scored = scoreCandidates({ candidates, query });
+
+    const best: SearchCandidate[] = [];
+    const related: SearchCandidate[] = [];
+
+    for (const { candidate, score } of scored) {
+        if (score <= BEST_MATCH_SCORE && best.length < MAX_BEST_MATCHES) {
+            best.push(candidate);
+        } else if (related.length < MAX_RELATED_MATCHES) {
+            related.push(candidate);
+        }
+    }
+
+    return { best, related };
+}
+
+/**
+ * Scored a word at a time rather than as one string, because Fuse matches a query as a single
+ * pattern and a use case phrased as a sentence then matches nothing at all. Every word counts the
+ * same, so a tool answering three of four words outranks one that answers a single word exactly.
+ */
+function scoreCandidates({ candidates, query }: { candidates: SearchCandidate[]; query: string }): { candidate: SearchCandidate; score: number }[] {
+    const terms = queryTerms(query);
+    if (terms.length === 0) {
+        return [];
+    }
+
+    const fuse = new Fuse(candidates, FUSE_OPTIONS);
+    const matched = new Map<number, number>();
+
+    for (const term of terms) {
+        for (const hit of fuse.search(term)) {
+            matched.set(hit.refIndex, (matched.get(hit.refIndex) ?? 0) + (1 - (hit.score ?? 1)));
+        }
+    }
+
+    return [...matched.entries()]
+        .flatMap(([index, accounted]) => {
+            const candidate = candidates[index];
+            const score = 1 - accounted / terms.length;
+
+            return candidate && score <= MAX_MATCH_SCORE ? [{ candidate, score }] : [];
+        })
+        .sort(
+            (a, b) => a.score - b.score || a.candidate.integration.localeCompare(b.candidate.integration) || a.candidate.tool.localeCompare(b.candidate.tool)
+        );
+}
+
+/**
+ * A query with nothing but stopwords in it is searched as written, on the grounds that a caller who
+ * searched for 'how to' meant something by it and an empty result teaches them nothing.
+ */
+function queryTerms(query: string): string[] {
+    const words = query
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(Boolean);
+    const meaningful = words.filter((word) => word.length > 1 && !STOPWORDS.has(word));
+
+    return meaningful.length > 0 ? meaningful : words;
+}
+
+/**
+ * Every tool the session can reach, pinned ones included. A pinned tool is already in the agent's
+ * tool list, but leaving it out of the results would answer "nothing here does that" about a tool
+ * the agent is holding, so it is returned and marked with the name it is listed under.
+ */
+function searchCandidates({ session, listedNameFor }: { session: AgentSession; listedNameFor: ListedNameLookup }): SearchCandidate[] {
+    return Object.entries(session.compiledToolset).flatMap(([integration, compiled]) => {
+        const connection = connectionStateFor({ session, integration });
+
+        return [...compiled.pinned, ...compiled.searchable].map(
+            (tool): SearchCandidate => ({
+                integration,
+                provider: compiled.provider,
+                tool: tool.name,
+                description: tool.description,
+                connection,
+                listedAs: listedNameFor({ integration, tool: tool.name })
+            })
+        );
+    });
+}
+
+function connectionStateFor({ session, integration }: { session: AgentSession; integration: string }): AgentSessionToolConnectionState {
+    const resolved = session.resolvedConnections[integration];
+
+    return resolved ? { status: 'connected', connection_id: resolved.connectionId } : { status: 'not_connected' };
+}
+
+async function findInputSchemas({
+    environmentId,
+    candidates
+}: {
+    environmentId: number;
+    candidates: SearchCandidate[];
+}): Promise<Map<string, Map<string, JSONSchema7>>> {
+    const rows = await legacyFunctionService.findActionInputSchemas({
+        environmentId,
+        actions: candidates.map((candidate) => ({ integrationId: candidate.integration, name: candidate.tool }))
+    });
+
+    const schemas = new Map<string, Map<string, JSONSchema7>>();
+    for (const row of rows) {
+        const schema = inputSchemaOf(row);
+        if (schema) {
+            let byTool = schemas.get(row.integration_id);
+            if (!byTool) {
+                byTool = new Map<string, JSONSchema7>();
+                schemas.set(row.integration_id, byTool);
+            }
+
+            byTool.set(row.name, schema);
+        }
+    }
+
+    return schemas;
+}
+
+/**
+ * An action declares its input as a model name resolved against the schema definitions it was
+ * deployed with. An action that takes nothing has no input model, or one typed as null, and an
+ * input that is not an object cannot be expressed as tool arguments.
+ */
+function inputSchemaOf(row: ActionInputSchemaRow): JSONSchema7 | undefined {
+    if (!row.input) {
+        return undefined;
+    }
+
+    const schema = row.models_json_schema?.definitions?.[row.input];
+    if (!schema || schema.type !== 'object') {
+        return undefined;
+    }
+
+    return schema;
+}
+
+function toMatch(candidate: SearchCandidate, inputSchema: JSONSchema7 | undefined): AgentSessionToolMatch {
+    return {
+        integration: candidate.integration,
+        provider: candidate.provider,
+        tool: candidate.tool,
+        description: candidate.description,
+        connection: candidate.connection,
+        ...(candidate.listedAs ? { listed_as: candidate.listedAs } : {}),
+        ...(inputSchema ? { input_schema: inputSchema } : {})
+    };
+}
+
+function guidanceFor({ query, matches, related }: { query: string; matches: AgentSessionToolMatch[]; related: AgentSessionToolMatch[] }): string {
+    if (matches.length === 0 && related.length === 0) {
+        return `No tool in this session matches '${query}'. Try a shorter query, or words describing the operation rather than the product, and note that this session may simply not carry a tool for it.`;
+    }
+
+    const lines: string[] = [];
+
+    if (matches.length > 0) {
+        lines.push(
+            `${matches.length} ${matches.length === 1 ? 'tool matches' : 'tools match'} '${query}'. Call nango_execute with the integration and tool of the one you want, and the arguments its input_schema describes. A match with no input_schema takes no arguments.`
+        );
+    } else {
+        lines.push(
+            `No tool closely matches '${query}', but ${related.length} ${related.length === 1 ? 'is' : 'are'} related. Search again with wording closer to one of them to get its input schema.`
+        );
+    }
+
+    if (matches.length > 0 && related.length > 0) {
+        lines.push(
+            `${related.length} more ${related.length === 1 ? 'tool is' : 'tools are'} loosely related, listed without their input schemas. Search again to pull one up.`
+        );
+    }
+
+    const alreadyListed = [...matches, ...related].filter((match) => match.listed_as);
+    if (alreadyListed.length > 0) {
+        lines.push(
+            `${alreadyListed.map((match) => `'${match.listed_as}'`).join(', ')} ${alreadyListed.length === 1 ? 'is' : 'are'} already in your tool list and can be called directly.`
+        );
+    }
+
+    const unconnected = [...new Set([...matches, ...related].filter((match) => match.connection.status === 'not_connected').map((match) => match.integration))];
+    if (unconnected.length > 0) {
+        lines.push(
+            `${unconnected.map((integration) => `'${integration}'`).join(', ')} ${unconnected.length === 1 ? 'has' : 'have'} no connection in this session. Their tools are listed for completeness and will fail if you call them.`
+        );
+    }
+
+    return lines.join(' ');
+}

--- a/packages/server/lib/services/agentSessionToolSearch.service.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.ts
@@ -8,6 +8,9 @@ import type { JSONSchema7 } from 'json-schema';
 
 const DEFINITIONS_POINTER = '#/definitions/';
 
+/** Guards against a union that nests into itself. Real input models are nowhere near this deep. */
+const MAX_SCHEMA_DEPTH = 8;
+
 const FUSE_OPTIONS: NonNullable<ConstructorParameters<typeof Fuse<SearchCandidate>>[1]> = {
     includeScore: true,
     // Both default to false, and both quietly rank a tool that describes itself properly below one
@@ -200,9 +203,16 @@ function searchCandidates({ session, listedNameFor }: { session: AgentSession; l
 }
 
 function connectionStateFor({ session, integration }: { session: AgentSession; integration: string }): AgentSessionToolConnectionState {
-    const resolved = session.resolvedConnections[integration];
+    // An integration id may be any of `constructor`, `toString` and friends, so an inherited property
+    // would otherwise report an integration as connected with no connection id. The execute path
+    // rejects the same id, which is the disagreement this avoids.
+    const resolved = own(session.resolvedConnections, integration);
 
     return resolved ? { status: 'connected', connection_id: resolved.connectionId } : { status: 'not_connected' };
+}
+
+function own<T>(record: Record<string, T>, key: string): T | undefined {
+    return Object.hasOwn(record, key) ? record[key] : undefined;
 }
 
 async function findToolInputs({
@@ -242,22 +252,78 @@ export function toolInputOf(row: ActionInputSchemaRow): AgentSessionToolInput {
     }
 
     const definitions = row.models_json_schema?.definitions;
-    const schema = definitions?.[row.input];
+    const schema = definitions ? own(definitions, row.input) : undefined;
 
     if (!schema) {
         return { kind: 'unsupported' };
     }
 
-    if (schema.type === 'null') {
+    const resolved = resolveRef(schema, definitions);
+
+    if (resolved?.type === 'null') {
         return { kind: 'none' };
     }
 
-    // An input that is not an object cannot be expressed as the arguments nango_execute takes.
-    if (schema.type !== 'object') {
+    // An input that cannot be an object cannot be expressed as the arguments a tool call carries.
+    if (!acceptsObject(schema, definitions, 0)) {
         return { kind: 'unsupported' };
     }
 
     return { kind: 'object', schema: withReferencedDefinitions(schema, definitions) };
+}
+
+/**
+ * Whether the schema can accept the JSON object a tool call carries.
+ *
+ * Deployed schemas are stored without their bodies being inspected, so the input model is not always
+ * a plain `type: 'object'`: it can point at one, name several types, or offer an object as one branch
+ * of a union. Rejecting those would withhold the arguments of a tool that is perfectly callable.
+ */
+function acceptsObject(schema: JSONSchema7, definitions: Record<string, JSONSchema7> | undefined, depth: number): boolean {
+    const resolved = depth <= MAX_SCHEMA_DEPTH ? resolveRef(schema, definitions) : undefined;
+    if (!resolved) {
+        return false;
+    }
+
+    if (Array.isArray(resolved.type)) {
+        return resolved.type.includes('object');
+    }
+
+    if (typeof resolved.type === 'string') {
+        return resolved.type === 'object';
+    }
+
+    // Every member of an allOf has to be satisfied at once, where one member of a oneOf or an anyOf is enough.
+    if (resolved.allOf && resolved.allOf.length > 0) {
+        return resolved.allOf.every((branch) => typeof branch === 'object' && acceptsObject(branch, definitions, depth + 1));
+    }
+
+    const branches = [...(resolved.oneOf ?? []), ...(resolved.anyOf ?? [])];
+    if (branches.length > 0) {
+        return branches.some((branch) => typeof branch === 'object' && acceptsObject(branch, definitions, depth + 1));
+    }
+
+    // A schema that names no type constrains nothing, so an object satisfies it.
+    return true;
+}
+
+/** Follows a chain of `$ref`s to the schema that actually states a shape, or undefined if it dangles. */
+function resolveRef(schema: JSONSchema7, definitions: Record<string, JSONSchema7> | undefined): JSONSchema7 | undefined {
+    const seen = new Set<string>();
+    let current: JSONSchema7 | undefined = schema;
+
+    while (current?.$ref) {
+        const pointer: string = current.$ref;
+        if (!pointer.startsWith(DEFINITIONS_POINTER) || seen.has(pointer)) {
+            return undefined;
+        }
+
+        seen.add(pointer);
+        const name = pointer.slice(DEFINITIONS_POINTER.length);
+        current = definitions ? own(definitions, name) : undefined;
+    }
+
+    return current;
 }
 
 /**
@@ -270,7 +336,11 @@ export function toolInputOf(row: ActionInputSchemaRow): AgentSessionToolInput {
  * lifted schema exactly as they should. Overwriting them with the document's own definitions would
  * break the schemas this is meant to repair.
  */
-function withReferencedDefinitions(schema: JSONSchema7, definitions: Record<string, JSONSchema7>): JSONSchema7 {
+function withReferencedDefinitions(schema: JSONSchema7, definitions: Record<string, JSONSchema7> | undefined): JSONSchema7 {
+    if (!definitions) {
+        return schema;
+    }
+
     const reachable: Record<string, JSONSchema7> = {};
     const seen = new Set<string>();
     let frontier: unknown[] = [schema];
@@ -293,7 +363,7 @@ function withReferencedDefinitions(schema: JSONSchema7, definitions: Record<stri
             }
             seen.add(name);
 
-            const sibling = definitions[name];
+            const sibling = own(definitions, name);
             if (sibling) {
                 reachable[name] = sibling;
                 frontier.push(sibling);

--- a/packages/server/lib/services/agentSessionToolSearch.service.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.ts
@@ -1,15 +1,12 @@
 import Fuse from 'fuse.js';
 
 import { legacyFunctionService } from '@nangohq/shared';
+import { filterJsonSchemaForModels } from '@nangohq/utils';
 
 import type { ActionInputSchemaRow } from '@nangohq/shared';
 import type { AgentSession, AgentSessionToolConnectionState, AgentSessionToolInput, AgentSessionToolMatch, AgentSessionToolSearchResult } from '@nangohq/types';
-import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 const DEFINITIONS_POINTER = '#/definitions/';
-
-// Guards against a union that nests into itself. Real input models are nowhere near this deep.
-const MAX_SCHEMA_DEPTH = 8;
 
 const FUSE_OPTIONS: NonNullable<ConstructorParameters<typeof Fuse<SearchCandidate>>[1]> = {
     includeScore: true,
@@ -231,150 +228,27 @@ async function findToolInputs({
     return inputs;
 }
 
+/**
+ * An action's arguments are the schema it was deployed with, rooted at its input model. The document
+ * is handed over as it is stored, pointers and all, which is the same shape the function input
+ * validator compiles, so search cannot advertise a schema execution would reject.
+ */
 export function toolInputOf(row: ActionInputSchemaRow): AgentSessionToolInput {
     if (!row.input) {
         return { kind: 'none' };
     }
 
-    const definitions = row.models_json_schema?.definitions;
-    const schema = definitions ? own(definitions, row.input) : undefined;
-
-    if (!schema) {
+    const document = row.models_json_schema;
+    if (!document?.definitions || Object.keys(document.definitions).length === 0) {
         return { kind: 'unavailable' };
     }
 
-    const resolved = resolveRef(schema, definitions);
-
-    if (resolved?.type === 'null') {
-        return { kind: 'none' };
-    }
-
-    if (!acceptsObject(schema, definitions, 0)) {
+    const filtered = filterJsonSchemaForModels(document, [row.input]);
+    if (filtered.isErr()) {
         return { kind: 'unavailable' };
     }
 
-    return { kind: 'object', schema: withReferencedDefinitions(schema, definitions) };
-}
-
-/** Whether the schema can accept the JSON object a tool call carries. */
-function acceptsObject(schema: JSONSchema7, definitions: Record<string, JSONSchema7> | undefined, depth: number): boolean {
-    const resolved = depth <= MAX_SCHEMA_DEPTH ? resolveRef(schema, definitions) : undefined;
-    if (!resolved) {
-        return false;
-    }
-
-    const { type, allOf, oneOf, anyOf } = resolved;
-    const accepts = (branch: JSONSchema7Definition) => (typeof branch === 'boolean' ? branch : acceptsObject(branch, definitions, depth + 1));
-
-    if (type !== undefined && !(Array.isArray(type) ? type.includes('object') : type === 'object')) {
-        return false;
-    }
-
-    if (allOf && allOf.length > 0 && !allOf.every(accepts)) {
-        return false;
-    }
-
-    if (oneOf && oneOf.length > 0 && !oneOf.some(accepts)) {
-        return false;
-    }
-
-    if (anyOf && anyOf.length > 0 && !anyOf.some(accepts)) {
-        return false;
-    }
-
-    return true;
-}
-
-/** Follows a chain of `$ref`s to the schema that actually states a shape, or undefined if it dangles. */
-function resolveRef(schema: JSONSchema7, definitions: Record<string, JSONSchema7> | undefined): JSONSchema7 | undefined {
-    const seen = new Set<string>();
-    let current: JSONSchema7 | undefined = schema;
-
-    while (current?.$ref) {
-        const pointer: string = current.$ref;
-        if (!pointer.startsWith(DEFINITIONS_POINTER) || seen.has(pointer)) {
-            return undefined;
-        }
-
-        seen.add(pointer);
-        const name = pointer.slice(DEFINITIONS_POINTER.length);
-        current = definitions ? own(definitions, name) : undefined;
-    }
-
-    return current;
-}
-
-/**
- * Pulls in the sibling definitions a schema points at, because a definition lifted out of the
- * document it was stored in takes its `#/definitions/...` pointers with it and no longer resolves
- * them.
- *
- * Definitions already nested inside the schema win. The current generator inlines a reused model and
- * emits a pointer only for a cycle, whose target it nests, so those pointers resolve against the
- * lifted schema exactly as they should. Overwriting them with the document's own definitions would
- * break the schemas this is meant to repair.
- */
-function withReferencedDefinitions(schema: JSONSchema7, definitions: Record<string, JSONSchema7> | undefined): JSONSchema7 {
-    if (!definitions) {
-        return schema;
-    }
-
-    const reachable: Record<string, JSONSchema7> = {};
-    const seen = new Set<string>();
-    let frontier: unknown[] = [schema];
-
-    while (frontier.length > 0) {
-        const pointers = new Set<string>();
-        for (const node of frontier) {
-            collectRefs(node, pointers);
-        }
-
-        frontier = [];
-        for (const pointer of pointers) {
-            if (!pointer.startsWith(DEFINITIONS_POINTER)) {
-                continue;
-            }
-
-            const name = pointer.slice(DEFINITIONS_POINTER.length);
-            if (seen.has(name)) {
-                continue;
-            }
-            seen.add(name);
-
-            const sibling = own(definitions, name);
-            if (sibling) {
-                reachable[name] = sibling;
-                frontier.push(sibling);
-            }
-        }
-    }
-
-    if (Object.keys(reachable).length === 0) {
-        return schema;
-    }
-
-    return { ...schema, definitions: { ...reachable, ...schema.definitions } };
-}
-
-function collectRefs(node: unknown, into: Set<string>): void {
-    if (Array.isArray(node)) {
-        for (const item of node) {
-            collectRefs(item, into);
-        }
-        return;
-    }
-
-    if (!node || typeof node !== 'object') {
-        return;
-    }
-
-    for (const [key, value] of Object.entries(node)) {
-        if (key === '$ref' && typeof value === 'string') {
-            into.add(value);
-        } else {
-            collectRefs(value, into);
-        }
-    }
+    return { kind: 'schema', schema: { ...filtered.value, $ref: `${DEFINITIONS_POINTER}${row.input}` } };
 }
 
 function toMatch(candidate: SearchCandidate, input: AgentSessionToolInput | undefined): AgentSessionToolMatch {
@@ -398,7 +272,7 @@ function guidanceFor({ query, matches, related }: { query: string; matches: Agen
 
     if (matches.length > 0) {
         lines.push(
-            `${matches.length} ${matches.length === 1 ? 'tool matches' : 'tools match'} '${query}'. Call nango_execute with the integration and tool of the one you want, and the arguments its input schema describes.`
+            `${matches.length} ${matches.length === 1 ? 'tool matches' : 'tools match'} '${query}'. Call nango_execute with the integration and tool of the one you want, and the input its schema describes. A schema is a JSON Schema document rooted at its \`$ref\`.`
         );
 
         const takesNothing = matches.filter((match) => match.input?.kind === 'none');

--- a/packages/server/lib/services/agentSessionToolSearch.service.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.ts
@@ -3,8 +3,10 @@ import Fuse from 'fuse.js';
 import { legacyFunctionService } from '@nangohq/shared';
 
 import type { ActionInputSchemaRow } from '@nangohq/shared';
-import type { AgentSession, AgentSessionToolConnectionState, AgentSessionToolMatch, AgentSessionToolSearchResult } from '@nangohq/types';
+import type { AgentSession, AgentSessionToolConnectionState, AgentSessionToolInput, AgentSessionToolMatch, AgentSessionToolSearchResult } from '@nangohq/types';
 import type { JSONSchema7 } from 'json-schema';
+
+const DEFINITIONS_POINTER = '#/definitions/';
 
 const FUSE_OPTIONS: NonNullable<ConstructorParameters<typeof Fuse<SearchCandidate>>[1]> = {
     includeScore: true,
@@ -98,9 +100,11 @@ export async function searchSessionTools({
     listedNameFor: ListedNameLookup;
 }): Promise<AgentSessionToolSearchResult> {
     const ranked = rankSessionTools({ session, query, listedNameFor });
-    const schemas = await findInputSchemas({ environmentId: session.environmentId, candidates: ranked.best });
+    const inputs = await findToolInputs({ environmentId: session.environmentId, candidates: ranked.best });
 
-    const matches = ranked.best.map((candidate) => toMatch(candidate, schemas.get(candidate.integration)?.get(candidate.tool)));
+    // A best match with no row left to read is one whose action went away after the session compiled
+    // its toolset, which is a tool whose arguments we cannot state rather than one that takes none.
+    const matches = ranked.best.map((candidate) => toMatch(candidate, inputs.get(candidate.integration)?.get(candidate.tool) ?? { kind: 'unsupported' }));
     const related = ranked.related.map((candidate) => toMatch(candidate, undefined));
 
     return { guidance: guidanceFor({ query, matches, related }), matches, related };
@@ -201,54 +205,131 @@ function connectionStateFor({ session, integration }: { session: AgentSession; i
     return resolved ? { status: 'connected', connection_id: resolved.connectionId } : { status: 'not_connected' };
 }
 
-async function findInputSchemas({
+async function findToolInputs({
     environmentId,
     candidates
 }: {
     environmentId: number;
     candidates: SearchCandidate[];
-}): Promise<Map<string, Map<string, JSONSchema7>>> {
+}): Promise<Map<string, Map<string, AgentSessionToolInput>>> {
     const rows = await legacyFunctionService.findActionInputSchemas({
         environmentId,
         actions: candidates.map((candidate) => ({ integrationId: candidate.integration, name: candidate.tool }))
     });
 
-    const schemas = new Map<string, Map<string, JSONSchema7>>();
+    const inputs = new Map<string, Map<string, AgentSessionToolInput>>();
     for (const row of rows) {
-        const schema = inputSchemaOf(row);
-        if (schema) {
-            let byTool = schemas.get(row.integration_id);
-            if (!byTool) {
-                byTool = new Map<string, JSONSchema7>();
-                schemas.set(row.integration_id, byTool);
-            }
-
-            byTool.set(row.name, schema);
+        let byTool = inputs.get(row.integration_id);
+        if (!byTool) {
+            byTool = new Map<string, AgentSessionToolInput>();
+            inputs.set(row.integration_id, byTool);
         }
+
+        byTool.set(row.name, toolInputOf(row));
     }
 
-    return schemas;
+    return inputs;
 }
 
 /**
  * An action declares its input as a model name resolved against the schema definitions it was
- * deployed with. An action that takes nothing has no input model, or one typed as null, and an
- * input that is not an object cannot be expressed as tool arguments.
+ * deployed with. Three shapes mean it takes nothing: no input model at all, an input model typed as
+ * null, and, on rows deployed before the input model was always written, a missing definition.
  */
-function inputSchemaOf(row: ActionInputSchemaRow): JSONSchema7 | undefined {
+export function toolInputOf(row: ActionInputSchemaRow): AgentSessionToolInput {
     if (!row.input) {
-        return undefined;
+        return { kind: 'none' };
     }
 
-    const schema = row.models_json_schema?.definitions?.[row.input];
-    if (!schema || schema.type !== 'object') {
-        return undefined;
+    const definitions = row.models_json_schema?.definitions;
+    const schema = definitions?.[row.input];
+
+    if (!schema) {
+        return { kind: 'unsupported' };
     }
 
-    return schema;
+    if (schema.type === 'null') {
+        return { kind: 'none' };
+    }
+
+    // An input that is not an object cannot be expressed as the arguments nango_execute takes.
+    if (schema.type !== 'object') {
+        return { kind: 'unsupported' };
+    }
+
+    return { kind: 'object', schema: withReferencedDefinitions(schema, definitions) };
 }
 
-function toMatch(candidate: SearchCandidate, inputSchema: JSONSchema7 | undefined): AgentSessionToolMatch {
+/**
+ * Pulls in the sibling definitions a schema points at, because a definition lifted out of the
+ * document it was stored in takes its `#/definitions/...` pointers with it and no longer resolves
+ * them.
+ *
+ * Definitions already nested inside the schema win. The current generator inlines a reused model and
+ * emits a pointer only for a cycle, whose target it nests, so those pointers resolve against the
+ * lifted schema exactly as they should. Overwriting them with the document's own definitions would
+ * break the schemas this is meant to repair.
+ */
+function withReferencedDefinitions(schema: JSONSchema7, definitions: Record<string, JSONSchema7>): JSONSchema7 {
+    const reachable: Record<string, JSONSchema7> = {};
+    const seen = new Set<string>();
+    let frontier: unknown[] = [schema];
+
+    while (frontier.length > 0) {
+        const pointers = new Set<string>();
+        for (const node of frontier) {
+            collectRefs(node, pointers);
+        }
+
+        frontier = [];
+        for (const pointer of pointers) {
+            if (!pointer.startsWith(DEFINITIONS_POINTER)) {
+                continue;
+            }
+
+            const name = pointer.slice(DEFINITIONS_POINTER.length);
+            if (seen.has(name)) {
+                continue;
+            }
+            seen.add(name);
+
+            const sibling = definitions[name];
+            if (sibling) {
+                reachable[name] = sibling;
+                frontier.push(sibling);
+            }
+        }
+    }
+
+    if (Object.keys(reachable).length === 0) {
+        return schema;
+    }
+
+    return { ...schema, definitions: { ...reachable, ...schema.definitions } };
+}
+
+function collectRefs(node: unknown, into: Set<string>): void {
+    if (Array.isArray(node)) {
+        for (const item of node) {
+            collectRefs(item, into);
+        }
+        return;
+    }
+
+    if (!node || typeof node !== 'object') {
+        return;
+    }
+
+    for (const [key, value] of Object.entries(node)) {
+        if (key === '$ref' && typeof value === 'string') {
+            into.add(value);
+        } else {
+            collectRefs(value, into);
+        }
+    }
+}
+
+function toMatch(candidate: SearchCandidate, input: AgentSessionToolInput | undefined): AgentSessionToolMatch {
     return {
         integration: candidate.integration,
         provider: candidate.provider,
@@ -256,7 +337,7 @@ function toMatch(candidate: SearchCandidate, inputSchema: JSONSchema7 | undefine
         description: candidate.description,
         connection: candidate.connection,
         ...(candidate.listedAs ? { listed_as: candidate.listedAs } : {}),
-        ...(inputSchema ? { input_schema: inputSchema } : {})
+        ...(input ? { input } : {})
     };
 }
 
@@ -269,8 +350,20 @@ function guidanceFor({ query, matches, related }: { query: string; matches: Agen
 
     if (matches.length > 0) {
         lines.push(
-            `${matches.length} ${matches.length === 1 ? 'tool matches' : 'tools match'} '${query}'. Call nango_execute with the integration and tool of the one you want, and the arguments its input_schema describes. A match with no input_schema takes no arguments.`
+            `${matches.length} ${matches.length === 1 ? 'tool matches' : 'tools match'} '${query}'. Call nango_execute with the integration and tool of the one you want, and the arguments its input schema describes.`
         );
+
+        const takesNothing = matches.filter((match) => match.input?.kind === 'none');
+        if (takesNothing.length > 0) {
+            lines.push(`${toolNames(takesNothing)} ${takesNothing.length === 1 ? 'takes' : 'take'} no arguments.`);
+        }
+
+        const unreadable = matches.filter((match) => match.input?.kind === 'unsupported');
+        if (unreadable.length > 0) {
+            lines.push(
+                `The arguments of ${toolNames(unreadable)} could not be read, or are not the JSON object a tool call takes, so calling ${unreadable.length === 1 ? 'it' : 'them'} may fail.`
+            );
+        }
     } else {
         lines.push(
             `No tool closely matches '${query}', but ${related.length} ${related.length === 1 ? 'is' : 'are'} related. Search again with wording closer to one of them to get its input schema.`
@@ -298,4 +391,8 @@ function guidanceFor({ query, matches, related }: { query: string; matches: Agen
     }
 
     return lines.join(' ');
+}
+
+function toolNames(matches: AgentSessionToolMatch[]): string {
+    return matches.map((match) => `'${match.tool}'`).join(', ');
 }

--- a/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
@@ -138,6 +138,22 @@ describe('rankSessionTools', () => {
         expect(unconnected.best[0]?.connection).toStrictEqual({ status: 'not_connected' });
     });
 
+    /**
+     * An integration id may be `constructor`, `toString` or any other property Object carries, and
+     * reading one off the resolved connections would report it connected with no connection id while
+     * the execute path refuses to run it.
+     */
+    it('does not read an inherited property as a resolved connection', () => {
+        const { best, related } = rank({
+            compiledToolset: {
+                constructor: { provider: 'notion', pinned: [], searchable: [{ name: 'read_doc', description: 'Read a document.' }] }
+            },
+            query: 'read a document'
+        });
+
+        expect([...best, ...related][0]?.connection).toStrictEqual({ status: 'not_connected' });
+    });
+
     it('caps each tier so a large toolset cannot flood the context window', () => {
         const searchable = Array.from({ length: 100 }, (_, index) => ({ name: `send_email_${index}`, description: 'Send an email message.' }));
         const { best, related } = rank({ compiledToolset: { gmail: { provider: 'google-mail', pinned: [], searchable } }, query: 'send an email' });
@@ -183,9 +199,50 @@ describe('toolInputOf', () => {
         expect(toolInputOf(row('UpsertDocInput', {}))).toStrictEqual({ kind: 'unsupported' });
         expect(toolInputOf(row('UpsertDocInput'))).toStrictEqual({ kind: 'unsupported' });
         expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'array', items: { type: 'string' } } }))).toStrictEqual({ kind: 'unsupported' });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { oneOf: [{ type: 'object' }, { type: 'string' }] } }))).toStrictEqual({
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'string' } }))).toStrictEqual({ kind: 'unsupported' });
+    });
+
+    /**
+     * Definition bodies are stored without being inspected, so an input model is not always a plain
+     * `type: 'object'`. Anything an object can satisfy is callable and keeps its arguments.
+     */
+    it('accepts every shape an object can satisfy', () => {
+        const shapes: JSONSchema7[] = [
+            { type: ['object', 'null'] },
+            { $ref: '#/definitions/Real' },
+            { oneOf: [{ type: 'object' }, { type: 'string' }] },
+            { anyOf: [{ type: 'string' }, { $ref: '#/definitions/Real' }] },
+            { allOf: [{ type: 'object' }, { properties: { a: { type: 'string' } } }] },
+            { properties: { title: { type: 'string' } } }
+        ];
+
+        for (const shape of shapes) {
+            expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: shape, Real: { type: 'object' } })).kind).toBe('object');
+        }
+    });
+
+    it('rejects a union no branch of which is an object, and an allOf one member forbids', () => {
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { oneOf: [{ type: 'string' }, { type: 'array' }] } }))).toStrictEqual({
             kind: 'unsupported'
         });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { allOf: [{ type: 'object' }, { type: 'string' }] } }))).toStrictEqual({
+            kind: 'unsupported'
+        });
+    });
+
+    it('follows a reference to a null input, and refuses one that dangles', () => {
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Nothing' }, Nothing: { type: 'null' } }))).toStrictEqual({
+            kind: 'none'
+        });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Missing' } }))).toStrictEqual({ kind: 'unsupported' });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Loop' }, Loop: { $ref: '#/definitions/Loop' } }))).toStrictEqual({
+            kind: 'unsupported'
+        });
+    });
+
+    it('does not read an inherited property as a definition', () => {
+        expect(toolInputOf(row('constructor', { UpsertDocInput: { type: 'object' } }))).toStrictEqual({ kind: 'unsupported' });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/toString' } }))).toStrictEqual({ kind: 'unsupported' });
     });
 
     it('carries the sibling definitions the schema points at, following them transitively', () => {

--- a/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
@@ -183,101 +183,47 @@ function row(input: string | null, definitions?: Record<string, JSONSchema7>) {
 }
 
 describe('toolInputOf', () => {
-    it('returns the input model as an object schema', () => {
+    it('roots the deployed document at the input model', () => {
         const schema: JSONSchema7 = { type: 'object', properties: { title: { type: 'string' } }, required: ['title'] };
 
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: schema }))).toStrictEqual({ kind: 'object', schema });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: schema }))).toStrictEqual({
+            kind: 'schema',
+            schema: { definitions: { UpsertDocInput: schema }, $ref: '#/definitions/UpsertDocInput' }
+        });
     });
 
-    it('reports a tool that takes nothing, however that was deployed', () => {
+    it('reports a tool with no input model as taking nothing', () => {
         expect(toolInputOf(row(null))).toStrictEqual({ kind: 'none' });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'null' } }))).toStrictEqual({ kind: 'none' });
     });
 
-    /**
-     * The distinction the guidance rests on: a tool whose arguments could not be read must not be
-     * described as one that takes none, because nango_execute only accepts a JSON object.
-     */
-    it('does not pass an unreadable or non-object input off as taking no arguments', () => {
-        expect(toolInputOf(row('UpsertDocInput', {}))).toStrictEqual({ kind: 'unavailable' });
+    it('reports an input it cannot read as unavailable rather than as taking nothing', () => {
         expect(toolInputOf(row('UpsertDocInput'))).toStrictEqual({ kind: 'unavailable' });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'array', items: { type: 'string' } } }))).toStrictEqual({ kind: 'unavailable' });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'string' } }))).toStrictEqual({ kind: 'unavailable' });
+        expect(toolInputOf(row('UpsertDocInput', {}))).toStrictEqual({ kind: 'unavailable' });
+        expect(toolInputOf(row('Missing', { UpsertDocInput: { type: 'object' } }))).toStrictEqual({ kind: 'unavailable' });
     });
 
     /**
-     * An input model is not always a plain `type: 'object'`. Anything an object can satisfy is
-     * callable and keeps its arguments.
+     * The schema is passed through rather than interpreted, so a root that is not an object is handed
+     * over like any other. nango_execute takes any JSON value, and the deployed schema decides.
      */
-    it('accepts every shape an object can satisfy', () => {
-        const shapes: JSONSchema7[] = [
-            { type: ['object', 'null'] },
-            { $ref: '#/definitions/Real' },
+    it('passes through a root that is not an object', () => {
+        const roots: JSONSchema7[] = [
+            { type: 'array', items: { type: 'string' } },
+            { type: 'null' },
+            { type: 'string' },
             { oneOf: [{ type: 'object' }, { type: 'string' }] },
-            { anyOf: [{ type: 'string' }, { $ref: '#/definitions/Real' }] },
-            { allOf: [{ type: 'object' }, { properties: { a: { type: 'string' } } }] },
-            { properties: { title: { type: 'string' } } }
+            { not: { type: 'object' } }
         ];
 
-        for (const shape of shapes) {
-            expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: shape, Real: { type: 'object' } })).kind).toBe('object');
+        for (const schema of roots) {
+            expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: schema }))).toStrictEqual({
+                kind: 'schema',
+                schema: { definitions: { UpsertDocInput: schema }, $ref: '#/definitions/UpsertDocInput' }
+            });
         }
     });
 
-    it('rejects a union no branch of which is an object, and an allOf one member forbids', () => {
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { oneOf: [{ type: 'string' }, { type: 'array' }] } }))).toStrictEqual({
-            kind: 'unavailable'
-        });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { allOf: [{ type: 'object' }, { type: 'string' }] } }))).toStrictEqual({
-            kind: 'unavailable'
-        });
-    });
-
-    /**
-     * Keywords combine rather than compete, so a schema is only callable when all of them leave room
-     * for an object. Judging by whichever keyword came first made the answer depend on key order.
-     */
-    it('refuses a schema whose keywords cannot be satisfied together', () => {
-        const unsatisfiable: JSONSchema7[] = [
-            { allOf: [{ type: 'object' }], oneOf: [{ type: 'string' }] },
-            { oneOf: [{ type: 'string' }], anyOf: [{ type: 'object' }] },
-            { type: 'object', oneOf: [{ type: 'string' }] },
-            { type: 'string', allOf: [{ type: 'object' }] }
-        ];
-
-        for (const shape of unsatisfiable) {
-            expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: shape }))).toStrictEqual({ kind: 'unavailable' });
-        }
-    });
-
-    it('accepts a schema whose keywords agree an object will do', () => {
-        const satisfiable: JSONSchema7[] = [
-            { allOf: [{ type: 'object' }], anyOf: [{ type: 'object' }, { type: 'string' }] },
-            { type: 'object', oneOf: [{ properties: { a: { type: 'string' } } }, { type: 'string' }] },
-            { allOf: [true], oneOf: [{ type: 'object' }] }
-        ];
-
-        for (const shape of satisfiable) {
-            expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: shape })).kind).toBe('object');
-        }
-    });
-
-    it('follows a reference to a null input, and refuses one that dangles', () => {
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Nothing' }, Nothing: { type: 'null' } }))).toStrictEqual({
-            kind: 'none'
-        });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Missing' } }))).toStrictEqual({ kind: 'unavailable' });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Loop' }, Loop: { $ref: '#/definitions/Loop' } }))).toStrictEqual({
-            kind: 'unavailable'
-        });
-    });
-
-    it('does not read an inherited property as a definition', () => {
-        expect(toolInputOf(row('constructor', { UpsertDocInput: { type: 'object' } }))).toStrictEqual({ kind: 'unavailable' });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/toString' } }))).toStrictEqual({ kind: 'unavailable' });
-    });
-
-    it('carries the sibling definitions the schema points at, following them transitively', () => {
+    it('carries the definitions the input model points at, transitively, and leaves the rest out', () => {
         const input = toolInputOf(
             row('UpsertDocInput', {
                 UpsertDocInput: { type: 'object', properties: { parent: { $ref: '#/definitions/Page' } } },
@@ -287,48 +233,20 @@ describe('toolInputOf', () => {
             })
         );
 
-        expect(input.kind).toBe('object');
-        expect(input.kind === 'object' && input.schema.definitions).toStrictEqual({
-            Page: { type: 'object', properties: { icon: { $ref: '#/definitions/Icon' } } },
-            Icon: { type: 'object', properties: { emoji: { type: 'string' } } }
-        });
+        expect(input.kind === 'schema' && Object.keys(input.schema.definitions ?? {}).sort()).toStrictEqual(['Icon', 'Page', 'UpsertDocInput']);
     });
 
-    /**
-     * The current generator inlines a reused model and emits a pointer only for a cycle, whose target
-     * it nests inside the model. Those already resolve against the lifted schema, so pulling siblings
-     * in must not overwrite them.
-     */
-    it('keeps a definition nested in the model over a sibling of the same name', () => {
-        const nested: JSONSchema7 = { type: 'object', properties: { self: { $ref: '#/definitions/__schema0' } } };
-        const input = toolInputOf(
-            row('UpsertDocInput', {
-                UpsertDocInput: {
-                    type: 'object',
-                    properties: { patch: { $ref: '#/definitions/__schema0' } },
-                    definitions: { __schema0: nested }
-                },
-                __schema0: { type: 'object', properties: { wrong: { type: 'string' } } }
-            })
-        );
-
-        expect(input.kind === 'object' && input.schema.definitions?.['__schema0']).toStrictEqual(nested);
-    });
-
-    it('leaves a schema that points at nothing untouched', () => {
-        const schema: JSONSchema7 = { type: 'object', properties: { title: { type: 'string' } } };
-        const input = toolInputOf(row('UpsertDocInput', { UpsertDocInput: schema, Unrelated: { type: 'object' } }));
-
-        expect(input.kind === 'object' && input.schema).toStrictEqual(schema);
-    });
-
-    it('terminates on a schema that references itself', () => {
+    it('terminates on a model that references itself', () => {
         const input = toolInputOf(
             row('UpsertDocInput', {
                 UpsertDocInput: { type: 'object', properties: { child: { $ref: '#/definitions/UpsertDocInput' } } }
             })
         );
 
-        expect(input.kind).toBe('object');
+        expect(input.kind).toBe('schema');
+    });
+
+    it('does not read an inherited property as a definition', () => {
+        expect(toolInputOf(row('constructor', { UpsertDocInput: { type: 'object' } }))).toStrictEqual({ kind: 'unavailable' });
     });
 });

--- a/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
@@ -233,6 +233,35 @@ describe('toolInputOf', () => {
         });
     });
 
+    /**
+     * Keywords combine rather than compete, so a schema is only callable when all of them leave room
+     * for an object. Judging by whichever keyword came first made the answer depend on key order.
+     */
+    it('refuses a schema whose keywords cannot be satisfied together', () => {
+        const unsatisfiable: JSONSchema7[] = [
+            { allOf: [{ type: 'object' }], oneOf: [{ type: 'string' }] },
+            { oneOf: [{ type: 'string' }], anyOf: [{ type: 'object' }] },
+            { type: 'object', oneOf: [{ type: 'string' }] },
+            { type: 'string', allOf: [{ type: 'object' }] }
+        ];
+
+        for (const shape of unsatisfiable) {
+            expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: shape }))).toStrictEqual({ kind: 'unsupported' });
+        }
+    });
+
+    it('accepts a schema whose keywords agree an object will do', () => {
+        const satisfiable: JSONSchema7[] = [
+            { allOf: [{ type: 'object' }], anyOf: [{ type: 'object' }, { type: 'string' }] },
+            { type: 'object', oneOf: [{ properties: { a: { type: 'string' } } }, { type: 'string' }] },
+            { allOf: [true], oneOf: [{ type: 'object' }] }
+        ];
+
+        for (const shape of satisfiable) {
+            expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: shape })).kind).toBe('object');
+        }
+    });
+
     it('follows a reference to a null input, and refuses one that dangles', () => {
         expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Nothing' }, Nothing: { type: 'null' } }))).toStrictEqual({
             kind: 'none'

--- a/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
@@ -93,14 +93,16 @@ describe('rankSessionTools', () => {
                     pinned: [],
                     searchable: [
                         { name: 'upsert_doc', description: 'Create or update a page in a Notion workspace, by title or by id.' },
-                        { name: 'read_doc', description: 'read_doc' }
+                        { name: 'read_doc', description: 'Read a page.' }
                     ]
                 }
             },
             query: 'create or update a page'
         });
 
-        expect(best[0]?.tool).toBe('upsert_doc');
+        // Fails with ignoreFieldNorm off: the long description drops out of the best tier entirely,
+        // beaten by the short one that answers a third of the query.
+        expect(best.map((match) => match.tool)).toStrictEqual(['upsert_doc']);
     });
 
     it('returns nothing for a query no tool relates to', () => {
@@ -111,9 +113,10 @@ describe('rankSessionTools', () => {
     });
 
     it('demotes a weak match to related rather than dropping it', () => {
-        const { best, related } = rank({ compiledToolset: mailbox, query: 'label' });
+        const { best, related } = rank({ compiledToolset: mailbox, query: 'archive an old label from the mailbox' });
 
-        expect([...best, ...related].map((match) => match.tool)).toContain('list_labels');
+        expect(best).toStrictEqual([]);
+        expect(related.map((match) => match.tool)).toStrictEqual(['list_labels']);
     });
 
     it('searches pinned tools too and marks the name they are listed under', () => {

--- a/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { rankSessionTools } from './agentSessionToolSearch.service.js';
+import { rankSessionTools, toolInputOf } from './agentSessionToolSearch.service.js';
 
 import type { ListedNameLookup } from './agentSessionToolSearch.service.js';
 import type { AgentSession, AgentSessionCompiledToolset, AgentSessionResolvedConnections } from '@nangohq/types';
+import type { JSONSchema7 } from 'json-schema';
 
 function session({
     compiledToolset = {},
@@ -150,5 +151,95 @@ describe('rankSessionTools', () => {
         const twice = rank({ compiledToolset: mailbox, query: 'send an email' });
 
         expect(once).toStrictEqual(twice);
+    });
+});
+
+function row(input: string | null, definitions?: Record<string, JSONSchema7>) {
+    return {
+        integration_id: 'notion',
+        name: 'upsert_doc',
+        input,
+        models_json_schema: definitions ? { definitions } : null
+    };
+}
+
+describe('toolInputOf', () => {
+    it('returns the input model as an object schema', () => {
+        const schema: JSONSchema7 = { type: 'object', properties: { title: { type: 'string' } }, required: ['title'] };
+
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: schema }))).toStrictEqual({ kind: 'object', schema });
+    });
+
+    it('reports a tool that takes nothing, however that was deployed', () => {
+        expect(toolInputOf(row(null))).toStrictEqual({ kind: 'none' });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'null' } }))).toStrictEqual({ kind: 'none' });
+    });
+
+    /**
+     * The distinction the guidance rests on: a tool whose arguments could not be read must not be
+     * described as one that takes none, because nango_execute only accepts a JSON object.
+     */
+    it('does not pass an unreadable or non-object input off as taking no arguments', () => {
+        expect(toolInputOf(row('UpsertDocInput', {}))).toStrictEqual({ kind: 'unsupported' });
+        expect(toolInputOf(row('UpsertDocInput'))).toStrictEqual({ kind: 'unsupported' });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'array', items: { type: 'string' } } }))).toStrictEqual({ kind: 'unsupported' });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { oneOf: [{ type: 'object' }, { type: 'string' }] } }))).toStrictEqual({
+            kind: 'unsupported'
+        });
+    });
+
+    it('carries the sibling definitions the schema points at, following them transitively', () => {
+        const input = toolInputOf(
+            row('UpsertDocInput', {
+                UpsertDocInput: { type: 'object', properties: { parent: { $ref: '#/definitions/Page' } } },
+                Page: { type: 'object', properties: { icon: { $ref: '#/definitions/Icon' } } },
+                Icon: { type: 'object', properties: { emoji: { type: 'string' } } },
+                Unrelated: { type: 'object' }
+            })
+        );
+
+        expect(input.kind).toBe('object');
+        expect(input.kind === 'object' && input.schema.definitions).toStrictEqual({
+            Page: { type: 'object', properties: { icon: { $ref: '#/definitions/Icon' } } },
+            Icon: { type: 'object', properties: { emoji: { type: 'string' } } }
+        });
+    });
+
+    /**
+     * The current generator inlines a reused model and emits a pointer only for a cycle, whose target
+     * it nests inside the model. Those already resolve against the lifted schema, so pulling siblings
+     * in must not overwrite them.
+     */
+    it('keeps a definition nested in the model over a sibling of the same name', () => {
+        const nested: JSONSchema7 = { type: 'object', properties: { self: { $ref: '#/definitions/__schema0' } } };
+        const input = toolInputOf(
+            row('UpsertDocInput', {
+                UpsertDocInput: {
+                    type: 'object',
+                    properties: { patch: { $ref: '#/definitions/__schema0' } },
+                    definitions: { __schema0: nested }
+                },
+                __schema0: { type: 'object', properties: { wrong: { type: 'string' } } }
+            })
+        );
+
+        expect(input.kind === 'object' && input.schema.definitions?.['__schema0']).toStrictEqual(nested);
+    });
+
+    it('leaves a schema that points at nothing untouched', () => {
+        const schema: JSONSchema7 = { type: 'object', properties: { title: { type: 'string' } } };
+        const input = toolInputOf(row('UpsertDocInput', { UpsertDocInput: schema, Unrelated: { type: 'object' } }));
+
+        expect(input.kind === 'object' && input.schema).toStrictEqual(schema);
+    });
+
+    it('terminates on a schema that references itself', () => {
+        const input = toolInputOf(
+            row('UpsertDocInput', {
+                UpsertDocInput: { type: 'object', properties: { child: { $ref: '#/definitions/UpsertDocInput' } } }
+            })
+        );
+
+        expect(input.kind).toBe('object');
     });
 });

--- a/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import { rankSessionTools } from './agentSessionToolSearch.service.js';
+
+import type { ListedNameLookup } from './agentSessionToolSearch.service.js';
+import type { AgentSession, AgentSessionCompiledToolset, AgentSessionResolvedConnections } from '@nangohq/types';
+
+function session({
+    compiledToolset = {},
+    resolvedConnections = {}
+}: {
+    compiledToolset?: AgentSessionCompiledToolset;
+    resolvedConnections?: AgentSessionResolvedConnections;
+} = {}): AgentSession {
+    return {
+        id: 'session-1',
+        environmentId: 1,
+        accountId: 1,
+        resolvedConnections,
+        compiledToolset,
+        metaTools: { nangoToolSearch: true, nangoExecute: true },
+        expiresAt: new Date(),
+        endedAt: null,
+        endedReason: null,
+        createdAt: new Date(),
+        updatedAt: new Date()
+    };
+}
+
+function connection(integrationId: string, connectionId: string): AgentSessionResolvedConnections {
+    return {
+        [integrationId]: { integrationId, provider: integrationId, connectionId, internalConnectionId: 1, configId: 1 }
+    };
+}
+
+function rank({
+    compiledToolset,
+    query,
+    resolvedConnections = {},
+    listedNameFor = () => undefined
+}: {
+    compiledToolset: AgentSessionCompiledToolset;
+    query: string;
+    resolvedConnections?: AgentSessionResolvedConnections;
+    listedNameFor?: ListedNameLookup;
+}) {
+    return rankSessionTools({ session: session({ compiledToolset, resolvedConnections }), query, listedNameFor });
+}
+
+const mailbox: AgentSessionCompiledToolset = {
+    gmail: {
+        provider: 'google-mail',
+        pinned: [],
+        searchable: [
+            { name: 'send_email', description: 'Send an email message to one or more recipients.' },
+            { name: 'list_labels', description: 'List the labels in the mailbox.' }
+        ]
+    },
+    zendesk: {
+        provider: 'zendesk',
+        pinned: [],
+        searchable: [{ name: 'create_ticket', description: 'Open a support ticket for a customer.' }]
+    }
+};
+
+describe('rankSessionTools', () => {
+    it('finds a tool by what it does rather than by its name', () => {
+        const { best } = rank({ compiledToolset: mailbox, query: 'send a message to a recipient' });
+
+        expect(best[0]?.tool).toBe('send_email');
+    });
+
+    it('matches a tool name the query only approximates', () => {
+        const { best } = rank({ compiledToolset: mailbox, query: 'create tickets' });
+
+        expect(best[0]?.tool).toBe('create_ticket');
+    });
+
+    it('matches on the integration and the provider name', () => {
+        const byIntegration = rank({ compiledToolset: mailbox, query: 'zendesk' });
+        const byProvider = rank({ compiledToolset: mailbox, query: 'google-mail' });
+
+        expect(byIntegration.best.map((match) => match.integration)).toContain('zendesk');
+        expect([...byProvider.best, ...byProvider.related].map((match) => match.integration)).toContain('gmail');
+    });
+
+    it('does not penalise a tool for describing itself at length', () => {
+        const { best } = rank({
+            compiledToolset: {
+                notion: {
+                    provider: 'notion',
+                    pinned: [],
+                    searchable: [
+                        { name: 'upsert_doc', description: 'Create or update a page in a Notion workspace, by title or by id.' },
+                        { name: 'read_doc', description: 'read_doc' }
+                    ]
+                }
+            },
+            query: 'create or update a page'
+        });
+
+        expect(best[0]?.tool).toBe('upsert_doc');
+    });
+
+    it('returns nothing for a query no tool relates to', () => {
+        const { best, related } = rank({ compiledToolset: mailbox, query: 'provision a kubernetes cluster' });
+
+        expect(best).toStrictEqual([]);
+        expect(related).toStrictEqual([]);
+    });
+
+    it('demotes a weak match to related rather than dropping it', () => {
+        const { best, related } = rank({ compiledToolset: mailbox, query: 'label' });
+
+        expect([...best, ...related].map((match) => match.tool)).toContain('list_labels');
+    });
+
+    it('searches pinned tools too and marks the name they are listed under', () => {
+        const { best, related } = rank({
+            compiledToolset: {
+                gmail: { provider: 'google-mail', pinned: [{ name: 'send_email', description: 'Send an email message.' }], searchable: [] }
+            },
+            query: 'send an email',
+            listedNameFor: ({ integration, tool }) => (integration === 'gmail' && tool === 'send_email' ? 'gmail__send_email' : undefined)
+        });
+
+        expect([...best, ...related][0]).toMatchObject({ tool: 'send_email', listedAs: 'gmail__send_email' });
+    });
+
+    it('carries the resolved connection, and reports an integration the session never connected', () => {
+        const { best } = rank({ compiledToolset: mailbox, query: 'send an email', resolvedConnections: connection('gmail', 'gmail-acme') });
+
+        expect(best[0]?.connection).toStrictEqual({ status: 'connected', connection_id: 'gmail-acme' });
+
+        const unconnected = rank({ compiledToolset: mailbox, query: 'open a support ticket' });
+
+        expect(unconnected.best[0]?.connection).toStrictEqual({ status: 'not_connected' });
+    });
+
+    it('caps each tier so a large toolset cannot flood the context window', () => {
+        const searchable = Array.from({ length: 100 }, (_, index) => ({ name: `send_email_${index}`, description: 'Send an email message.' }));
+        const { best, related } = rank({ compiledToolset: { gmail: { provider: 'google-mail', pinned: [], searchable } }, query: 'send an email' });
+
+        expect(best).toHaveLength(5);
+        expect(related).toHaveLength(15);
+    });
+
+    it('ranks the same way every time it is asked', () => {
+        const once = rank({ compiledToolset: mailbox, query: 'send an email' });
+        const twice = rank({ compiledToolset: mailbox, query: 'send an email' });
+
+        expect(once).toStrictEqual(twice);
+    });
+});

--- a/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
@@ -199,15 +199,15 @@ describe('toolInputOf', () => {
      * described as one that takes none, because nango_execute only accepts a JSON object.
      */
     it('does not pass an unreadable or non-object input off as taking no arguments', () => {
-        expect(toolInputOf(row('UpsertDocInput', {}))).toStrictEqual({ kind: 'unsupported' });
-        expect(toolInputOf(row('UpsertDocInput'))).toStrictEqual({ kind: 'unsupported' });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'array', items: { type: 'string' } } }))).toStrictEqual({ kind: 'unsupported' });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'string' } }))).toStrictEqual({ kind: 'unsupported' });
+        expect(toolInputOf(row('UpsertDocInput', {}))).toStrictEqual({ kind: 'unavailable' });
+        expect(toolInputOf(row('UpsertDocInput'))).toStrictEqual({ kind: 'unavailable' });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'array', items: { type: 'string' } } }))).toStrictEqual({ kind: 'unavailable' });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { type: 'string' } }))).toStrictEqual({ kind: 'unavailable' });
     });
 
     /**
-     * Definition bodies are stored without being inspected, so an input model is not always a plain
-     * `type: 'object'`. Anything an object can satisfy is callable and keeps its arguments.
+     * An input model is not always a plain `type: 'object'`. Anything an object can satisfy is
+     * callable and keeps its arguments.
      */
     it('accepts every shape an object can satisfy', () => {
         const shapes: JSONSchema7[] = [
@@ -226,10 +226,10 @@ describe('toolInputOf', () => {
 
     it('rejects a union no branch of which is an object, and an allOf one member forbids', () => {
         expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { oneOf: [{ type: 'string' }, { type: 'array' }] } }))).toStrictEqual({
-            kind: 'unsupported'
+            kind: 'unavailable'
         });
         expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { allOf: [{ type: 'object' }, { type: 'string' }] } }))).toStrictEqual({
-            kind: 'unsupported'
+            kind: 'unavailable'
         });
     });
 
@@ -246,7 +246,7 @@ describe('toolInputOf', () => {
         ];
 
         for (const shape of unsatisfiable) {
-            expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: shape }))).toStrictEqual({ kind: 'unsupported' });
+            expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: shape }))).toStrictEqual({ kind: 'unavailable' });
         }
     });
 
@@ -266,15 +266,15 @@ describe('toolInputOf', () => {
         expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Nothing' }, Nothing: { type: 'null' } }))).toStrictEqual({
             kind: 'none'
         });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Missing' } }))).toStrictEqual({ kind: 'unsupported' });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Missing' } }))).toStrictEqual({ kind: 'unavailable' });
         expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/Loop' }, Loop: { $ref: '#/definitions/Loop' } }))).toStrictEqual({
-            kind: 'unsupported'
+            kind: 'unavailable'
         });
     });
 
     it('does not read an inherited property as a definition', () => {
-        expect(toolInputOf(row('constructor', { UpsertDocInput: { type: 'object' } }))).toStrictEqual({ kind: 'unsupported' });
-        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/toString' } }))).toStrictEqual({ kind: 'unsupported' });
+        expect(toolInputOf(row('constructor', { UpsertDocInput: { type: 'object' } }))).toStrictEqual({ kind: 'unavailable' });
+        expect(toolInputOf(row('UpsertDocInput', { UpsertDocInput: { $ref: '#/definitions/toString' } }))).toStrictEqual({ kind: 'unavailable' });
     });
 
     it('carries the sibling definitions the schema points at, following them transitively', () => {

--- a/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionToolSearch.service.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { rankSessionTools, toolInputOf } from './agentSessionToolSearch.service.js';
 
-import type { ListedNameLookup } from './agentSessionToolSearch.service.js';
+import type { ToolSlugLookup } from './agentSessionToolSearch.service.js';
 import type { AgentSession, AgentSessionCompiledToolset, AgentSessionResolvedConnections } from '@nangohq/types';
 import type { JSONSchema7 } from 'json-schema';
 
@@ -34,18 +34,20 @@ function connection(integrationId: string, connectionId: string): AgentSessionRe
     };
 }
 
+const slugEverything: ToolSlugLookup = ({ integration, action }) => `${integration}__${action}`;
+
 function rank({
     compiledToolset,
     query,
     resolvedConnections = {},
-    listedNameFor = () => undefined
+    slugOf = slugEverything
 }: {
     compiledToolset: AgentSessionCompiledToolset;
     query: string;
     resolvedConnections?: AgentSessionResolvedConnections;
-    listedNameFor?: ListedNameLookup;
+    slugOf?: ToolSlugLookup;
 }) {
-    return rankSessionTools({ session: session({ compiledToolset, resolvedConnections }), query, listedNameFor });
+    return rankSessionTools({ session: session({ compiledToolset, resolvedConnections }), query, slugOf });
 }
 
 const mailbox: AgentSessionCompiledToolset = {
@@ -68,13 +70,13 @@ describe('rankSessionTools', () => {
     it('finds a tool by what it does rather than by its name', () => {
         const { best } = rank({ compiledToolset: mailbox, query: 'send a message to a recipient' });
 
-        expect(best[0]?.tool).toBe('send_email');
+        expect(best[0]?.action).toBe('send_email');
     });
 
     it('matches a tool name the query only approximates', () => {
         const { best } = rank({ compiledToolset: mailbox, query: 'create tickets' });
 
-        expect(best[0]?.tool).toBe('create_ticket');
+        expect(best[0]?.action).toBe('create_ticket');
     });
 
     it('matches on the integration and the provider name', () => {
@@ -102,7 +104,7 @@ describe('rankSessionTools', () => {
 
         // Fails with ignoreFieldNorm off: the long description drops out of the best tier entirely,
         // beaten by the short one that answers a third of the query.
-        expect(best.map((match) => match.tool)).toStrictEqual(['upsert_doc']);
+        expect(best.map((match) => match.action)).toStrictEqual(['upsert_doc']);
     });
 
     it('returns nothing for a query no tool relates to', () => {
@@ -116,19 +118,35 @@ describe('rankSessionTools', () => {
         const { best, related } = rank({ compiledToolset: mailbox, query: 'archive an old label from the mailbox' });
 
         expect(best).toStrictEqual([]);
-        expect(related.map((match) => match.tool)).toStrictEqual(['list_labels']);
+        expect(related.map((match) => match.action)).toStrictEqual(['list_labels']);
     });
 
-    it('searches pinned tools too and marks the name they are listed under', () => {
+    it('searches pinned tools too and carries the slug they are listed under', () => {
         const { best, related } = rank({
             compiledToolset: {
                 gmail: { provider: 'google-mail', pinned: [{ name: 'send_email', description: 'Send an email message.' }], searchable: [] }
             },
             query: 'send an email',
-            listedNameFor: ({ integration, tool }) => (integration === 'gmail' && tool === 'send_email' ? 'gmail__send_email' : undefined)
+            slugOf: ({ integration, action }) => (integration === 'gmail' && action === 'send_email' ? 'gmail__send_email' : undefined)
         });
 
-        expect([...best, ...related][0]).toMatchObject({ tool: 'send_email', listedAs: 'gmail__send_email' });
+        expect([...best, ...related][0]).toMatchObject({ slug: 'gmail__send_email', action: 'send_email', listed: true });
+    });
+
+    /**
+     * A slug cannot be derived from the integration and action, so a tool the listing has no address
+     * for cannot be called and is left out rather than returned uncallable.
+     */
+    it('leaves out a tool the listing has no address for', () => {
+        const { best, related } = rank({
+            compiledToolset: {
+                gmail: { provider: 'google-mail', pinned: [], searchable: [{ name: 'send_email', description: 'Send an email message.' }] }
+            },
+            query: 'send an email',
+            slugOf: () => undefined
+        });
+
+        expect([...best, ...related]).toStrictEqual([]);
     });
 
     it('carries the resolved connection, and reports an integration the session never connected', () => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -54,6 +54,7 @@
         "express": "5.1.0",
         "express-session": "1.18.2",
         "fast-xml-parser": "5.10.1",
+        "fuse.js": "7.1.0",
         "he": "1.2.0",
         "helmet": "7.1.0",
         "json-bigint": "1.0.0",

--- a/packages/shared/lib/services/functions/index.ts
+++ b/packages/shared/lib/services/functions/index.ts
@@ -2,7 +2,7 @@ export { deployBundle, prepareDeploymentBundle } from './deploy.js';
 export type { DeploymentBundleError, DeploymentBundlePreparationError } from './deploy.js';
 export * as legacyFunctionService from './legacy/index.js';
 export type { ListFunctionsError, ListFunctionsErrorCode } from './legacy/service.js';
-export type { IntegrationFunctionCatalogRow } from './legacy/models/functions.js';
+export type { ActionInputSchemaRow, IntegrationFunctionCatalogRow } from './legacy/models/functions.js';
 export * as functionConfigService from './models/functions.js';
 export { reconcile } from './reconcile.js';
 export type { DeploymentBundleReconciliation } from './reconcile.js';

--- a/packages/shared/lib/services/functions/legacy/index.ts
+++ b/packages/shared/lib/services/functions/legacy/index.ts
@@ -1,5 +1,5 @@
 // Legacy unification over `_nango_sync_configs` and `on_event_scripts`.
 export { getFunction, ListFunctionsError, listFunctions } from './service.js';
 export type { ListFunctionsErrorCode } from './service.js';
-export { findActiveDeployedMeta, findIntegrationFunctionCatalog } from './models/functions.js';
-export type { IntegrationFunctionCatalogRow } from './models/functions.js';
+export { findActionInputSchemas, findActiveDeployedMeta, findIntegrationFunctionCatalog } from './models/functions.js';
+export type { ActionInputSchemaRow, IntegrationFunctionCatalogRow } from './models/functions.js';

--- a/packages/shared/lib/services/functions/legacy/models/functions.integration.test.ts
+++ b/packages/shared/lib/services/functions/legacy/models/functions.integration.test.ts
@@ -5,9 +5,10 @@ import db, { multipleMigrations } from '@nangohq/database';
 import { createAccount } from '../../../../seeders/account.seeder.js';
 import { createConfigSeed } from '../../../../seeders/config.seeder.js';
 import { createEnvironmentSeed } from '../../../../seeders/environment.seeder.js';
-import { findIntegrationFunctionCatalog } from './functions.js';
+import { findActionInputSchemas, findIntegrationFunctionCatalog } from './functions.js';
 
 import type { DBSyncConfig, IntegrationConfig, NangoConfigMetadata } from '@nangohq/types';
+import type { JSONSchema7 } from 'json-schema';
 
 async function insertSyncConfig({
     environmentId,
@@ -15,6 +16,8 @@ async function insertSyncConfig({
     name,
     type,
     metadata,
+    input,
+    modelsJsonSchema,
     enabled = true,
     active = true,
     deleted = false
@@ -24,6 +27,8 @@ async function insertSyncConfig({
     name: string;
     type: 'sync' | 'action';
     metadata?: NangoConfigMetadata;
+    input?: string;
+    modelsJsonSchema?: { definitions: Record<string, JSONSchema7> };
     enabled?: boolean;
     active?: boolean;
     deleted?: boolean;
@@ -46,12 +51,18 @@ async function insertSyncConfig({
         webhook_subscriptions: [],
         models: [],
         metadata: metadata ?? {},
+        ...(input ? { input } : {}),
+        ...(modelsJsonSchema ? { models_json_schema: modelsJsonSchema } : {}),
         active,
         enabled,
         deleted,
         deleted_at: deleted ? new Date() : null
     });
 }
+
+const objectInput: { definitions: Record<string, JSONSchema7> } = {
+    definitions: { SendEmailInput: { type: 'object', properties: { to: { type: 'string' } }, required: ['to'] } }
+};
 
 describe(findIntegrationFunctionCatalog, () => {
     beforeAll(async () => {
@@ -133,5 +144,105 @@ describe(findIntegrationFunctionCatalog, () => {
         const catalog = await findIntegrationFunctionCatalog({ environmentId: environment.id });
 
         expect(catalog).toStrictEqual([{ integration_id: 'notion', provider: 'notion', name: null, type: null, description: null, enabled: null }]);
+    });
+});
+
+describe(findActionInputSchemas, () => {
+    beforeAll(async () => {
+        await multipleMigrations();
+    });
+
+    it('returns the input model and the schema definitions for the actions asked for', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const gmail = await createConfigSeed(environment, 'gmail', 'google');
+
+        await insertSyncConfig({
+            environmentId: environment.id,
+            integration: gmail,
+            name: 'send_email',
+            type: 'action',
+            input: 'SendEmailInput',
+            modelsJsonSchema: objectInput
+        });
+
+        const rows = await findActionInputSchemas({ environmentId: environment.id, actions: [{ integrationId: 'gmail', name: 'send_email' }] });
+
+        expect(rows).toStrictEqual([{ integration_id: 'gmail', name: 'send_email', input: 'SendEmailInput', models_json_schema: objectInput }]);
+    });
+
+    it('reads several integrations in one query and returns nothing when asked for nothing', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const gmail = await createConfigSeed(environment, 'gmail', 'google');
+        const zendesk = await createConfigSeed(environment, 'zendesk', 'zendesk');
+
+        await insertSyncConfig({ environmentId: environment.id, integration: gmail, name: 'send_email', type: 'action' });
+        await insertSyncConfig({ environmentId: environment.id, integration: zendesk, name: 'create_ticket', type: 'action' });
+
+        const rows = await findActionInputSchemas({
+            environmentId: environment.id,
+            actions: [
+                { integrationId: 'gmail', name: 'send_email' },
+                { integrationId: 'zendesk', name: 'create_ticket' }
+            ]
+        });
+
+        expect(rows.map((row) => row.name).sort()).toStrictEqual(['create_ticket', 'send_email']);
+        expect(await findActionInputSchemas({ environmentId: environment.id, actions: [] })).toStrictEqual([]);
+    });
+
+    it("does not pair an integration with another integration's tool of the same name", async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const gmail = await createConfigSeed(environment, 'gmail', 'google');
+        const outlook = await createConfigSeed(environment, 'outlook', 'microsoft');
+
+        await insertSyncConfig({ environmentId: environment.id, integration: gmail, name: 'send_email', type: 'action' });
+        await insertSyncConfig({ environmentId: environment.id, integration: outlook, name: 'send_email', type: 'action' });
+
+        const rows = await findActionInputSchemas({ environmentId: environment.id, actions: [{ integrationId: 'gmail', name: 'send_email' }] });
+
+        expect(rows.map((row) => row.integration_id)).toStrictEqual(['gmail']);
+    });
+
+    it('leaves out a sync, a disabled action, and a superseded or deleted version', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const notion = await createConfigSeed(environment, 'notion', 'notion');
+
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'sync_pages', type: 'sync' });
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'turned_off', type: 'action', enabled: false });
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'old_version', type: 'action', active: false });
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'removed', type: 'action', deleted: true });
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'kept', type: 'action' });
+
+        const rows = await findActionInputSchemas({
+            environmentId: environment.id,
+            actions: ['sync_pages', 'turned_off', 'old_version', 'removed', 'kept'].map((name) => ({ integrationId: 'notion', name }))
+        });
+
+        expect(rows.map((row) => row.name)).toStrictEqual(['kept']);
+    });
+
+    it('does not leak another environment', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const other = await createEnvironmentSeed(account.id);
+        const notion = await createConfigSeed(environment, 'notion', 'notion');
+        const otherNotion = await createConfigSeed(other, 'notion', 'notion');
+
+        await insertSyncConfig({ environmentId: environment.id, integration: notion, name: 'mine', type: 'action' });
+        await insertSyncConfig({ environmentId: other.id, integration: otherNotion, name: 'theirs', type: 'action' });
+
+        const rows = await findActionInputSchemas({
+            environmentId: environment.id,
+            actions: [
+                { integrationId: 'notion', name: 'mine' },
+                { integrationId: 'notion', name: 'theirs' }
+            ]
+        });
+
+        expect(rows.map((row) => row.name)).toStrictEqual(['mine']);
     });
 });

--- a/packages/shared/lib/services/functions/legacy/models/functions.ts
+++ b/packages/shared/lib/services/functions/legacy/models/functions.ts
@@ -158,10 +158,8 @@ export interface ActionInputSchemaRow {
  * Returns the input model name and the deployed schema definitions for named actions, across
  * as many integrations as the caller asks for in one query.
  *
- * An agent session's compiled toolset stores only a name and a description per tool, so a tool's
- * real argument schema has to be read back at the point it is handed to an agent. Only actions
- * that are still active and enabled come back, which is the same bar the toolset compiler holds
- * a tool to.
+ * Only actions that are still active and enabled come back, so a stale name resolves to nothing
+ * rather than to a schema that cannot be run.
  */
 export async function findActionInputSchemas({
     environmentId,

--- a/packages/shared/lib/services/functions/legacy/models/functions.ts
+++ b/packages/shared/lib/services/functions/legacy/models/functions.ts
@@ -147,6 +147,50 @@ export async function findIntegrationFunctionCatalog({
     return query;
 }
 
+export interface ActionInputSchemaRow {
+    integration_id: string;
+    name: string;
+    input: string | null;
+    models_json_schema: { definitions?: Record<string, JSONSchema7> } | null;
+}
+
+/**
+ * Returns the input model name and the deployed schema definitions for named actions, across
+ * as many integrations as the caller asks for in one query.
+ *
+ * An agent session's compiled toolset stores only a name and a description per tool, so a tool's
+ * real argument schema has to be read back at the point it is handed to an agent. Only actions
+ * that are still active and enabled come back, which is the same bar the toolset compiler holds
+ * a tool to.
+ */
+export async function findActionInputSchemas({
+    environmentId,
+    actions
+}: {
+    environmentId: number;
+    actions: { integrationId: string; name: string }[];
+}): Promise<ActionInputSchemaRow[]> {
+    if (actions.length === 0) {
+        return [];
+    }
+
+    return db.knex
+        .from({ sc: '_nango_sync_configs' })
+        .join({ nc: '_nango_configs' }, 'sc.nango_config_id', 'nc.id')
+        .where('nc.environment_id', environmentId)
+        .andWhere('nc.deleted', false)
+        .andWhere('sc.environment_id', environmentId)
+        .andWhere('sc.deleted', false)
+        .andWhere('sc.active', true)
+        .andWhere('sc.enabled', true)
+        .andWhere('sc.type', 'action')
+        .whereIn(
+            ['nc.unique_key', 'sc.sync_name'],
+            actions.map((action) => [action.integrationId, action.name])
+        )
+        .select<ActionInputSchemaRow[]>('nc.unique_key AS integration_id', 'sc.sync_name AS name', 'sc.input', 'sc.models_json_schema');
+}
+
 function activeSyncConfigBase({ environmentId, providerConfigKey }: { environmentId: number; providerConfigKey: string }): Knex.QueryBuilder {
     return db.knex
         .from({ sc: '_nango_sync_configs' })

--- a/packages/types/lib/agent/toolSearch.ts
+++ b/packages/types/lib/agent/toolSearch.ts
@@ -7,6 +7,13 @@ import type { JSONSchema7 } from 'json-schema';
  */
 export type AgentSessionToolConnectionState = { readonly status: 'connected'; readonly connection_id: string } | { readonly status: 'not_connected' };
 
+/**
+ * `unsupported` is not the same as `none`: the tool's arguments could not be read, or cannot be
+ * expressed as the JSON object nango_execute takes, so calling it may fail. Telling the two apart
+ * is the difference between an agent calling a tool bare and an agent knowing not to trust it.
+ */
+export type AgentSessionToolInput = { readonly kind: 'object'; readonly schema: JSONSchema7 } | { readonly kind: 'none' } | { readonly kind: 'unsupported' };
+
 export interface AgentSessionToolMatch {
     readonly integration: string;
     readonly provider: string;
@@ -16,7 +23,7 @@ export interface AgentSessionToolMatch {
     /** Set when the tool is already in the agent's tool list, holding the name it is listed under. */
     readonly listed_as?: string;
     /** Only on a best match. A soft match is a lead to narrow down, not something to call yet. */
-    readonly input_schema?: JSONSchema7;
+    readonly input?: AgentSessionToolInput;
 }
 
 export interface AgentSessionToolSearchResult {

--- a/packages/types/lib/agent/toolSearch.ts
+++ b/packages/types/lib/agent/toolSearch.ts
@@ -1,18 +1,9 @@
 import type { JSONSchema7 } from 'json-schema';
 
-/**
- * An integration is connected when the session resolved a connection for it. A session can carry
- * tools for an integration it never resolved, so an unconnected tool is still searchable and still
- * described, it just fails when it is called.
- */
 export type AgentSessionToolConnectionState = { readonly status: 'connected'; readonly connection_id: string } | { readonly status: 'not_connected' };
 
-/**
- * `unsupported` is not the same as `none`: the tool's arguments could not be read, or cannot be
- * expressed as the JSON object nango_execute takes, so calling it may fail. Telling the two apart
- * is the difference between an agent calling a tool bare and an agent knowing not to trust it.
- */
-export type AgentSessionToolInput = { readonly kind: 'object'; readonly schema: JSONSchema7 } | { readonly kind: 'none' } | { readonly kind: 'unsupported' };
+/** `object` carries the arguments, `none` means there are none, `unavailable` means they could not be read. */
+export type AgentSessionToolInput = { readonly kind: 'object'; readonly schema: JSONSchema7 } | { readonly kind: 'none' } | { readonly kind: 'unavailable' };
 
 export interface AgentSessionToolMatch {
     readonly integration: string;
@@ -20,7 +11,6 @@ export interface AgentSessionToolMatch {
     readonly tool: string;
     readonly description: string;
     readonly connection: AgentSessionToolConnectionState;
-    /** Set when the tool is already in the agent's tool list, holding the name it is listed under. */
     readonly listed_as?: string;
     /** Only on a best match. A soft match is a lead to narrow down, not something to call yet. */
     readonly input?: AgentSessionToolInput;

--- a/packages/types/lib/agent/toolSearch.ts
+++ b/packages/types/lib/agent/toolSearch.ts
@@ -2,8 +2,8 @@ import type { JSONSchema7 } from 'json-schema';
 
 export type AgentSessionToolConnectionState = { readonly status: 'connected'; readonly connection_id: string } | { readonly status: 'not_connected' };
 
-/** `object` carries the arguments, `none` means there are none, `unavailable` means they could not be read. */
-export type AgentSessionToolInput = { readonly kind: 'object'; readonly schema: JSONSchema7 } | { readonly kind: 'none' } | { readonly kind: 'unavailable' };
+/** `schema` carries the arguments, `none` means there are none, `unavailable` means they could not be read. */
+export type AgentSessionToolInput = { readonly kind: 'schema'; readonly schema: JSONSchema7 } | { readonly kind: 'none' } | { readonly kind: 'unavailable' };
 
 export interface AgentSessionToolMatch {
     readonly integration: string;

--- a/packages/types/lib/agent/toolSearch.ts
+++ b/packages/types/lib/agent/toolSearch.ts
@@ -1,0 +1,26 @@
+import type { JSONSchema7 } from 'json-schema';
+
+/**
+ * An integration is connected when the session resolved a connection for it. A session can carry
+ * tools for an integration it never resolved, so an unconnected tool is still searchable and still
+ * described, it just fails when it is called.
+ */
+export type AgentSessionToolConnectionState = { readonly status: 'connected'; readonly connection_id: string } | { readonly status: 'not_connected' };
+
+export interface AgentSessionToolMatch {
+    readonly integration: string;
+    readonly provider: string;
+    readonly tool: string;
+    readonly description: string;
+    readonly connection: AgentSessionToolConnectionState;
+    /** Set when the tool is already in the agent's tool list, holding the name it is listed under. */
+    readonly listed_as?: string;
+    /** Only on a best match. A soft match is a lead to narrow down, not something to call yet. */
+    readonly input_schema?: JSONSchema7;
+}
+
+export interface AgentSessionToolSearchResult {
+    readonly guidance: string;
+    readonly matches: AgentSessionToolMatch[];
+    readonly related: AgentSessionToolMatch[];
+}

--- a/packages/types/lib/agent/toolSearch.ts
+++ b/packages/types/lib/agent/toolSearch.ts
@@ -6,12 +6,15 @@ export type AgentSessionToolConnectionState = { readonly status: 'connected'; re
 export type AgentSessionToolInput = { readonly kind: 'schema'; readonly schema: JSONSchema7 } | { readonly kind: 'none' } | { readonly kind: 'unavailable' };
 
 export interface AgentSessionToolMatch {
-    readonly integration: string;
-    readonly provider: string;
+    /** What to pass to nango_execute. Names are sanitised and clipped, so use it as given. */
     readonly tool: string;
+    readonly integration: string;
+    readonly action: string;
+    readonly provider: string;
     readonly description: string;
+    /** Whether the tool is in the agent's tool list, under the same name. */
+    readonly listed: boolean;
     readonly connection: AgentSessionToolConnectionState;
-    readonly listed_as?: string;
     /** Only on a best match. A soft match is a lead to narrow down, not something to call yet. */
     readonly input?: AgentSessionToolInput;
 }

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -18,6 +18,7 @@ export type * from './agent/api.js';
 export type * from './agent/connections.js';
 export type * from './agent/mcp.api.js';
 export type * from './agent/session.js';
+export type * from './agent/toolSearch.js';
 export type * from './agent/toolset.js';
 export type * from './admin/http.api.js';
 export type * from './account/api.js';


### PR DESCRIPTION
NAN-6603

Stacked on #7261.

Adds the `nango_tool_search` meta tool. It fuzzy matches a use case against the tools an agent session can reach and returns the ones that fit, with their input schemas, alongside weaker matches carrying a name and description only. Every result names an integration and an unqualified tool to pass to `nango_execute`, and carries the integration's connection state.

Matching is deterministic and runs in process, no model involved.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

