### PR TITLE
fix(server): count every shadow comparison, not just the failures

### DIFF
--- a/packages/server/lib/authz/shadow.role.unit.test.ts
+++ b/packages/server/lib/authz/shadow.role.unit.test.ts
@@ -5,12 +5,15 @@ import { flags, metrics } from '@nangohq/utils';
 import { recordRoleDivergence } from './shadow.js';
 
 import type { RequestLocals } from '../utils/express.js';
-import type { DBEnvironment, DBTeam, DBUser, Permission } from '@nangohq/types';
+import type { DBEnvironment, DBPlan, DBTeam, DBUser, Permission } from '@nangohq/types';
 import type { MockInstance } from 'vitest';
 
 const account = { id: 1 } as DBTeam;
 const environment = { id: 5, account_id: 1, is_production: true } as DBEnvironment;
 const user = { id: 7, role: 'administrator', email: 'a@b.c' } as DBUser;
+// Named explicitly so the role applies whether or not `flagHasPlan` is on: `rbacApplies` short-circuits
+// on `!flagHasPlan`, so without a plan these tests would only assert what this environment happens to set.
+const plan = { has_rbac: true } as DBPlan;
 
 describe('recordRoleDivergence', () => {
     const originalFlag = flags.hasAuthRoles;
@@ -31,28 +34,28 @@ describe('recordRoleDivergence', () => {
     const record = (permission: Permission, locals: Partial<RequestLocals>) => recordRoleDivergence({ locals, permission, legacy: true });
 
     it('reports a permission the map cannot resolve, the case that blinds a route forever', () => {
-        record({ resource: '*', action: '*', scope: 'global' }, { account, environment, user });
+        record({ resource: '*', action: '*', scope: 'global' }, { account, plan, environment, user });
         expect(reasons()).toEqual(['no_scope_mapping']);
     });
 
     it('reports a missing principal separately', () => {
-        record({ resource: 'log', action: 'read', scope: 'production' }, { account, environment });
+        record({ resource: 'log', action: 'read', scope: 'production' }, { account, plan, environment });
         expect(reasons()).toEqual(['no_principal']);
     });
 
     it('reports a missing target separately', () => {
-        record({ resource: 'log', action: 'read', scope: 'production' }, { account, user });
+        record({ resource: 'log', action: 'read', scope: 'production' }, { account, plan, user });
         expect(reasons()).toEqual(['no_target']);
     });
 
     it('counts a comparison it could make, so the graph has a denominator', () => {
-        record({ resource: 'log', action: 'read', scope: 'production' }, { account, environment, user });
+        record({ resource: 'log', action: 'read', scope: 'production' }, { account, plan, environment, user });
         expect(results()).toEqual([{ resource: 'log', action: 'read', tier: 'production', result: 'agree' }]);
     });
 
     it('counts a disagreement as the same metric', () => {
         recordRoleDivergence({
-            locals: { account, environment, user: { ...user, role: 'development_full_access' } as DBUser },
+            locals: { account, plan, environment, user: { ...user, role: 'development_full_access' } as DBUser },
             permission: { resource: 'log', action: 'read', scope: 'production' },
             legacy: true
         });

--- a/packages/server/lib/authz/shadow.role.unit.test.ts
+++ b/packages/server/lib/authz/shadow.role.unit.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { metrics } from '@nangohq/utils';
+import { flags, metrics } from '@nangohq/utils';
 
 import { recordRoleDivergence } from './shadow.js';
 
@@ -13,16 +13,20 @@ const environment = { id: 5, account_id: 1, is_production: true } as DBEnvironme
 const user = { id: 7, role: 'administrator', email: 'a@b.c' } as DBUser;
 
 describe('recordRoleDivergence', () => {
+    const originalFlag = flags.hasAuthRoles;
     let increment: MockInstance<typeof metrics.increment>;
     beforeEach(() => {
+        flags.hasAuthRoles = true;
         increment = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
     });
     afterEach(() => {
+        flags.hasAuthRoles = originalFlag;
         increment.mockRestore();
     });
 
-    const reasons = () =>
-        increment.mock.calls.filter(([type]) => type === metrics.Types.AUTHZ_ROLE_UNMAPPED).map(([, , tags]) => (tags as { reason: string }).reason);
+    const results = () =>
+        increment.mock.calls.filter(([type]) => type === metrics.Types.AUTHZ_ROLE_COMPARISON).map(([, , tags]) => tags as { result: string; reason?: string });
+    const reasons = () => results().map((tags) => tags.reason);
 
     const record = (permission: Permission, locals: Partial<RequestLocals>) => recordRoleDivergence({ locals, permission, legacy: true });
 
@@ -41,8 +45,17 @@ describe('recordRoleDivergence', () => {
         expect(reasons()).toEqual(['no_target']);
     });
 
-    it('records nothing when it can compare', () => {
+    it('counts a comparison it could make, so the graph has a denominator', () => {
         record({ resource: 'log', action: 'read', scope: 'production' }, { account, environment, user });
-        expect(reasons()).toEqual([]);
+        expect(results()).toEqual([{ resource: 'log', action: 'read', tier: 'production', result: 'agree' }]);
+    });
+
+    it('counts a disagreement as the same metric', () => {
+        recordRoleDivergence({
+            locals: { account, environment, user: { ...user, role: 'development_full_access' } as DBUser },
+            permission: { resource: 'log', action: 'read', scope: 'production' },
+            legacy: true
+        });
+        expect(results().map((t) => t.result)).toEqual(['diverge']);
     });
 });

--- a/packages/server/lib/authz/shadow.ts
+++ b/packages/server/lib/authz/shadow.ts
@@ -35,26 +35,29 @@ export function recordRoleDivergence({ locals, permission, legacy }: { locals: P
     const scopes = scopesForPermission(permission);
     const target = targetFor(locals, planeForPermission(permission));
 
-    const unmapped = (reason: string) => metrics.increment(metrics.Types.AUTHZ_ROLE_UNMAPPED, 1, { ...tags, reason });
+    const compared = (result: string, extra?: Record<string, string>) =>
+        metrics.increment(metrics.Types.AUTHZ_ROLE_COMPARISON, 1, { ...tags, result, ...extra });
 
     // Checked first: a missing mapping is a property of the permission, so it holds on every request
     // rather than being a transient miss, and it leaves the route permanently uncompared.
     if (scopes.length === 0) {
-        unmapped('no_scope_mapping');
+        compared('unmapped', { reason: 'no_scope_mapping' });
         return;
     }
     if (!principal) {
-        unmapped('no_principal');
+        compared('unmapped', { reason: 'no_principal' });
         return;
     }
     if (!target) {
-        unmapped('no_target');
+        compared('unmapped', { reason: 'no_target' });
         return;
     }
 
     if (authorizeAny(principal, scopes, target) !== legacy) {
-        metrics.increment(metrics.Types.AUTHZ_ROLE_DIVERGENCE, 1, { ...tags, expected: String(legacy) });
+        compared('diverge', { expected: String(legacy) });
+        return;
     }
+    compared('agree');
 }
 
 /**
@@ -77,23 +80,26 @@ export function recordScopeDivergence({
     // Each scope carries its own plane, so a mixed any-of set gets a target per scope.
     const targeted = requiredScopes.map((scope) => ({ scope, target: targetFor(locals, scope.startsWith('account:') ? 'account' : 'environment') }));
 
-    const unmapped = (reason: string) => metrics.increment(metrics.Types.AUTHZ_KEY_DERIVATION_UNMAPPED, 1, { ...tags, reason });
+    const compared = (result: string, extra?: Record<string, string>) =>
+        metrics.increment(metrics.Types.AUTHZ_KEY_DERIVATION_COMPARISON, 1, { ...tags, result, ...extra });
 
     // No mapping step on this path: the required scope is already a scope.
     if (requiredScopes.length === 0) {
-        unmapped('no_scope_required');
+        compared('unmapped', { reason: 'no_scope_required' });
         return;
     }
     if (!principal) {
-        unmapped('no_principal');
+        compared('unmapped', { reason: 'no_principal' });
         return;
     }
     if (targeted.some(({ target }) => !target)) {
-        unmapped('no_target');
+        compared('unmapped', { reason: 'no_target' });
         return;
     }
 
     if (targeted.some(({ scope, target }) => authorize(principal, scope as Scope, target!)) !== legacy) {
-        metrics.increment(metrics.Types.AUTHZ_KEY_DERIVATION_DIVERGENCE, 1, { ...tags, expected: String(legacy) });
+        compared('diverge', { expected: String(legacy) });
+        return;
     }
+    compared('agree');
 }

--- a/packages/server/lib/authz/shadow.unit.test.ts
+++ b/packages/server/lib/authz/shadow.unit.test.ts
@@ -25,11 +25,15 @@ describe('recordScopeDivergence', () => {
         increment.mockRestore();
     });
 
-    const divergences = () => increment.mock.calls.filter(([type]) => type === metrics.Types.AUTHZ_KEY_DERIVATION_DIVERGENCE);
+    const results = () =>
+        increment.mock.calls
+            .filter(([type]) => type === metrics.Types.AUTHZ_KEY_DERIVATION_COMPARISON)
+            .map(([, , tags]) => tags as { result: string; reason?: string });
+    const divergences = () => results().filter((tags) => tags.result === 'diverge');
 
-    it('records nothing when the grants agree', () => {
+    it('counts an agreement, so the graph has a denominator', () => {
         recordScopeDivergence({ locals: localsFor(['environment:*']), requiredScopes: ['environment:connections:read'], legacy: true });
-        expect(divergences()).toHaveLength(0);
+        expect(results().map((tags) => tags.result)).toEqual(['agree']);
     });
 
     it('records when they disagree', () => {
@@ -50,7 +54,9 @@ describe('recordScopeDivergence', () => {
     });
 
     const unmappedReasons = () =>
-        increment.mock.calls.filter(([type]) => type === metrics.Types.AUTHZ_KEY_DERIVATION_UNMAPPED).map(([, , tags]) => (tags as { reason: string }).reason);
+        results()
+            .filter((tags) => tags.result === 'unmapped')
+            .map((tags) => tags.reason);
 
     it('says why it could not compare', () => {
         recordScopeDivergence({ locals: { account }, requiredScopes: ['environment:connections:read'], legacy: true });

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -6,10 +6,8 @@ export enum Types {
     ACTION_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.action.incoming.payloadSizeBytes',
 
     AUTH_SECRET_KEY_HASH_CACHE = 'nango.auth.secretKeyHashCache',
-    AUTHZ_KEY_DERIVATION_DIVERGENCE = 'nango.authz.keyDerivationDivergence',
-    AUTHZ_KEY_DERIVATION_UNMAPPED = 'nango.authz.keyDerivationUnmapped',
-    AUTHZ_ROLE_DIVERGENCE = 'nango.authz.roleDivergence',
-    AUTHZ_ROLE_UNMAPPED = 'nango.authz.roleUnmapped',
+    AUTHZ_KEY_DERIVATION_COMPARISON = 'nango.authz.keyDerivationComparison',
+    AUTHZ_ROLE_COMPARISON = 'nango.authz.roleComparison',
     AUTH_SHADOW_CACHE = 'nango.auth.shadowCache',
     AUTH_CONTEXT_CACHE = 'nango.auth.contextCache',
     AUTH_GET_ENV_BY_AGENT_SESSION = 'nango.auth.getEnvByAgentSession',


### PR DESCRIPTION
Just a tweak to the temporary metrics I've added to check for divergencies between the current RBAC authz and the one I'm replacing it with. We're currently metering divergencies, but I don't see any metrics in datadog. This either means there is no divergence, or that I screwed the metric. To confirm, I'm tweaking it to record a metric always, and using a tag to identify failures.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

