### PR TITLE
feat(usage): reconcile usage and billable data transfer

### DIFF
--- a/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
@@ -10,6 +10,8 @@ import type { ClickhouseRawUsageEvent } from '@nangohq/usage';
 const database = `billing_events_s3_export_test`;
 const targetDay = '2026-05-06'; // events seeded here are what the export SQL should pick up
 const otherDay = '2026-05-07'; // events seeded here must be excluded by WHERE day = ...
+const EXPORT_SOURCE_PROPERTY_PATTERN = /'([^']+)',\s+toFloat64\(SUMIf\(egressed_bytes, source = '([^']+)'\)\)/g;
+const BILLABLE_VIEW_SOURCE_TUPLE_PATTERN = /\(\s*'([^']+)'\s*,\s*'([^']+)'\s*\)/g;
 
 // ---------- fixture builders (declared first so per-metric fixture constants can reference them at module-load time) ----------
 
@@ -361,6 +363,24 @@ describe('billingEventsS3Export', () => {
                 'server.webhook_forward': 250
             });
         });
+
+        it('keeps per-source export properties in sync with the billable view', async () => {
+            const viewSources = await getBillableDataTransferViewSources();
+            const metric = METRICS.find((metric) => metric.canonicalEventName === 'data_transfer');
+            if (!metric) throw new Error('data_transfer metric missing');
+
+            const exportSourceProperties = [...metric.select(targetDay, database).matchAll(EXPORT_SOURCE_PROPERTY_PATTERN)].map(([, property, source]) => {
+                if (!property || !source) throw new Error('invalid data-transfer source property');
+                return { property, source };
+            });
+
+            expect(exportSourceProperties).not.toEqual([]);
+            expect(exportSourceProperties.every(({ property, source }) => property === source)).toBe(true);
+            const compareSources = (left: string, right: string) => left.localeCompare(right);
+            const sortedExportSources = [...new Set(exportSourceProperties.map(({ source }) => source))].sort(compareSources);
+            const sortedBillableViewSources = [...new Set(viewSources)].sort(compareSources);
+            expect(sortedExportSources).toEqual(sortedBillableViewSources);
+        });
     });
 
     // Cross-cutting checks that exercise behaviour shared by every metric.
@@ -419,6 +439,30 @@ async function runQuery(canonicalEventName: string, eventName: string): Promise<
     try {
         const result = await c.query({ query: sql, format: 'JSONEachRow' });
         return await result.json();
+    } finally {
+        await c.close();
+    }
+}
+
+async function getBillableDataTransferViewSources(): Promise<string[]> {
+    const c = clickhouseClient();
+    if (!c) throw new Error('CLICKHOUSE_URL not set');
+    try {
+        const result = await c.query({
+            query: `
+                SELECT create_table_query
+                FROM system.tables
+                WHERE database = {database:String}
+                  AND name = 'daily_billable_data_transfer'
+            `,
+            query_params: { database },
+            format: 'JSONEachRow'
+        });
+        const rows = await result.json<{ create_table_query: string }>();
+        const viewDefinition = rows[0]?.create_table_query;
+        if (!viewDefinition) throw new Error('daily_billable_data_transfer view missing');
+
+        return [...viewDefinition.matchAll(BILLABLE_VIEW_SOURCE_TUPLE_PATTERN)].map(([, pkg, callsite]) => `${pkg}.${callsite}`);
     } finally {
         await c.close();
     }

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -37,7 +37,6 @@ const lockTtlMs = 30 * 60 * 1000;
 const s3 = new S3Client({ region });
 
 const DEFAULT_DATABASE = 'usage';
-
 export interface MetricSpec {
     /** Canonical Orb event_name; the suffix is appended at SQL gen time. */
     canonicalEventName:
@@ -162,44 +161,29 @@ export const METRICS: MetricSpec[] = [
     {
         canonicalEventName: 'data_transfer',
         // We only bill for egress traffic that can be labeled as DTO.
-        // `count` here is the sum of all egressing bytes matching the where clause;
-        // the per-package-x-callsite-pair properties break that total down into its individual contributors.
+        // `count` here is the sum of all egressing bytes in the billable view;
+        // the per-source properties break that total down into its individual contributors.
         select: (day, database) => `
             SELECT
                 account_id, day,
                 map(
-                    'count',                     toFloat64(SUM(egressed_bytes)),
-                    'server.get_/records',       toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'get_/records')),
-                    'server.get_/proxy',         toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'get_/proxy')),
-                    'server.post_/proxy',        toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'post_/proxy')),
-                    'server.patch_/proxy',       toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'patch_/proxy')),
-                    'server.put_/proxy',         toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'put_/proxy')),
-                    'server.delete_/proxy',      toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'delete_/proxy')),
-                    'server.unknown_/proxy',     toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'unknown_/proxy')),
-                    'server.proxy',              toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'proxy')),
-                    'server.webhook_forward',    toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'webhook_forward')),
-                    'runner.proxy',              toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'proxy')),
-                    'runner.uncontrolled_fetch', toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'uncontrolled_fetch')),
-                    'runner.persist_customer_logs', toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'persist_customer_logs')),
-                    'runner.persist_records',    toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'persist_records'))
+                    'count',                       toFloat64(SUM(egressed_bytes)),
+                    'server.get_/records',         toFloat64(SUMIf(egressed_bytes, source = 'server.get_/records')),
+                    'server.get_/proxy',           toFloat64(SUMIf(egressed_bytes, source = 'server.get_/proxy')),
+                    'server.post_/proxy',          toFloat64(SUMIf(egressed_bytes, source = 'server.post_/proxy')),
+                    'server.patch_/proxy',         toFloat64(SUMIf(egressed_bytes, source = 'server.patch_/proxy')),
+                    'server.put_/proxy',           toFloat64(SUMIf(egressed_bytes, source = 'server.put_/proxy')),
+                    'server.delete_/proxy',        toFloat64(SUMIf(egressed_bytes, source = 'server.delete_/proxy')),
+                    'server.unknown_/proxy',       toFloat64(SUMIf(egressed_bytes, source = 'server.unknown_/proxy')),
+                    'server.proxy',                toFloat64(SUMIf(egressed_bytes, source = 'server.proxy')),
+                    'server.webhook_forward',      toFloat64(SUMIf(egressed_bytes, source = 'server.webhook_forward')),
+                    'runner.proxy',                toFloat64(SUMIf(egressed_bytes, source = 'runner.proxy')),
+                    'runner.uncontrolled_fetch',   toFloat64(SUMIf(egressed_bytes, source = 'runner.uncontrolled_fetch')),
+                    'runner.persist_customer_logs', toFloat64(SUMIf(egressed_bytes, source = 'runner.persist_customer_logs')),
+                    'runner.persist_records',      toFloat64(SUMIf(egressed_bytes, source = 'runner.persist_records'))
                 ) AS properties
-            FROM ${database}.daily_data_transfer
+            FROM ${database}.daily_billable_data_transfer
             WHERE day = toDate('${day}')
-              AND (package, callsite) IN (
-                  ('server', 'get_/records'),
-                  ('server', 'get_/proxy'),
-                  ('server', 'proxy'),
-                  ('server', 'post_/proxy'),
-                  ('server', 'patch_/proxy'),
-                  ('server', 'put_/proxy'),
-                  ('server', 'delete_/proxy'),
-                  ('server', 'unknown_/proxy'),
-                  ('server', 'webhook_forward'),
-                  ('runner', 'proxy'),
-                  ('runner', 'uncontrolled_fetch'),
-                  ('runner', 'persist_customer_logs'),
-                  ('runner', 'persist_records')
-              )
             GROUP BY account_id, day
         `
     }

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.integration.test.ts
@@ -103,6 +103,41 @@ function seedFixture(accountId: number): ClickhouseRawUsageEvent[] {
             value: 4,
             attributes: { ...base, success: true, integrationId: 'hubspot', connectionId: 'c-h' }
         },
+        // data_transfer — billable runner egress on day 0 and server egress on day 1.
+        // `value` and ingress deliberately differ from egress so the assertions prove
+        // billing uses egressed bytes only.
+        {
+            ts: day0.getTime(),
+            type: 'usage.data_transfer',
+            idempotency_key: randomUUID(),
+            account_id: accountId,
+            value: 999,
+            attributes: {
+                ...base,
+                integrationId: 'hubspot',
+                connectionId: 'c-h',
+                package: 'runner',
+                callsite: 'proxy',
+                egressedBytes: 100,
+                ingressedBytes: 1000
+            }
+        },
+        {
+            ts: day1.getTime(),
+            type: 'usage.data_transfer',
+            idempotency_key: randomUUID(),
+            account_id: accountId,
+            value: 777,
+            attributes: {
+                ...base,
+                integrationId: 'salesforce',
+                connectionId: 'c-s',
+                package: 'server',
+                callsite: 'proxy',
+                egressedBytes: 50,
+                ingressedBytes: 2000
+            }
+        },
         // records — 1000 on day 0 (integration=hubspot), 500 on day 0 (integration=salesforce), 700 on day 1 (hubspot)
         {
             ts: day0.getTime(),
@@ -229,7 +264,7 @@ describe(`GET ${route}`, () => {
     });
 
     describe('ClickHouse happy path', () => {
-        it('returns all 8 metrics populated from the seeded CH data', async () => {
+        it('returns all metrics populated from the seeded CH data', async () => {
             const { apiKey } = await seedAccount();
             const res = await api.fetch(route, {
                 token: apiKey.secret,
@@ -246,6 +281,7 @@ describe(`GET ${route}`, () => {
             expect(usage.function_duration_seconds.total).toBe(2); // one raw event on each day, each rounded to one second
             expect(usage.function_logs.total).toBe(0); // no custom_logs in fixture
             expect(usage.webhook_forwards.total).toBe(4);
+            expect(usage.data_transfer.total).toBe(150);
             // records: AVG(per-batch sum) running across the window.
             // day 0: sum=1500, batches=1; day 1: sum=700, batches=1.
             // running avg after day 0 = 1500; after day 1 = (1500+700)/2 = 1100.
@@ -277,7 +313,8 @@ describe(`GET ${route}`, () => {
                 'function_logs',
                 'function_compute_gbms',
                 'function_duration_seconds',
-                'webhook_forwards'
+                'webhook_forwards',
+                'data_transfer'
             ];
             for (const m of counterMetrics) {
                 expect(usage[m].total).toBe(0);
@@ -386,6 +423,26 @@ describe(`GET ${route}`, () => {
             for (const series of proxy.breakdown!) {
                 expect(series.group!.key).toBe('success');
             }
+        });
+
+        it('data_transfer by source — counter-metric breakdown array', async () => {
+            const { apiKey } = await seedAccount();
+            const res = await api.fetch(route, {
+                token: apiKey.secret,
+                query: {
+                    env: 'dev',
+                    from: day0.toISOString(),
+                    to: end.toISOString(),
+                    metrics: ['data_transfer'],
+                    breakdown: { data_transfer: 'source' }
+                } as any
+            });
+            isSuccess(res.json);
+            const dataTransfer = res.json.data.usage.data_transfer;
+            expect(dataTransfer.usage).toEqual([]);
+            expect(dataTransfer.total).toBe(150);
+            expect(dataTransfer.breakdown!.map((series) => series.group!.value).sort()).toEqual(['runner.proxy', 'server.proxy']);
+            expect(dataTransfer.breakdown!.reduce((sum, series) => sum + series.total, 0)).toBe(150);
         });
 
         it('respects top — only N+1 series come back when distinct values exceed top', async () => {

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -124,7 +124,7 @@ export interface BreakdownDimensions {
     webhook_forwards: 'environment_id' | 'integration_id' | 'connection_id' | 'success';
     records: 'environment_id' | 'integration_id' | 'connection_id' | 'model';
     connections: 'environment_id' | 'integration_id';
-    data_transfer: 'environment_id' | 'integration_id' | 'connection_id' | 'package' | 'callsite';
+    data_transfer: 'environment_id' | 'integration_id' | 'connection_id' | 'source';
 }
 
 // `'none'` is the in-band sentinel for "no breakdown" used by the CH query

--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -19,7 +19,7 @@ describe('Clickhouse', () => {
         const cleanupClient = clickhouseClient();
         await cleanupClient?.command({ query: `DROP DATABASE IF EXISTS ${database}` });
         await cleanupClient?.close();
-        await migrate({ database });
+        (await migrate({ database })).unwrap();
     };
 
     describe('should ingest and retrieve usage', () => {
@@ -847,7 +847,7 @@ describe('Clickhouse', () => {
             const client = clickhouseClient();
             await client?.command({ query: `DROP DATABASE IF EXISTS ${dedupDatabase}` });
             await client?.close();
-            await migrate({ database: dedupDatabase });
+            (await migrate({ database: dedupDatabase })).unwrap();
 
             // Plain ReplacingMergeTree has block dedup disabled by default
             // (non_replicated_deduplication_window=0). CH Cloud's SharedReplacingMergeTree

--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -95,7 +95,7 @@ describe('Clickhouse', () => {
                     attributes: { egressedBytes: 1000, ingressedBytes: 0, package: 'runner', callsite: 'proxy' },
                     value: 1000
                 }),
-                // day 1: 2 events × 500 bytes via server = 1000 bytes
+                // day 1: ingress via a billable callsite is observed but not billed.
                 ...genEventsN({
                     n: 2,
                     date: dayFromNow(1),
@@ -103,6 +103,14 @@ describe('Clickhouse', () => {
                     accountId,
                     attributes: { egressedBytes: 0, ingressedBytes: 500, package: 'server', callsite: 'proxy' },
                     value: 500
+                }),
+                // Non-billable callsites are observed but not billed even when egressing.
+                genEvent({
+                    date: dayFromNow(),
+                    type: 'usage.data_transfer',
+                    accountId,
+                    value: 9_999,
+                    attributes: { egressedBytes: 9_999, ingressedBytes: 0, package: 'runner', callsite: 'persist_system_logs' }
                 }),
                 // different account (must be excluded)
                 ...genEventsN({
@@ -310,7 +318,12 @@ describe('Clickhouse', () => {
             });
 
             it('data_transfer, no dimension', async () => {
-                const res = await clickhouse.getDailyCounter({ accountId, metric: 'data_transfer', dimension: 'none', timeframe: { start, end } });
+                const res = await clickhouse.getDailyCounter({
+                    accountId,
+                    metric: 'data_transfer',
+                    dimension: 'none',
+                    timeframe: { start, end }
+                });
                 expect(res.unwrap()).toStrictEqual({
                     accountId,
                     metric: 'data_transfer',
@@ -318,28 +331,33 @@ describe('Clickhouse', () => {
                         {
                             days: [
                                 { day: dayFromNow(), value: 3000 },
-                                { day: dayFromNow(1), value: 1000 }
+                                { day: dayFromNow(1), value: 0 }
                             ]
                         }
                     ]
                 });
             });
 
-            it('data_transfer broken down by package', async () => {
-                const res = await clickhouse.getDailyCounter({ accountId, metric: 'data_transfer', dimension: 'package', timeframe: { start, end } });
+            it('data_transfer broken down by source', async () => {
+                const res = await clickhouse.getDailyCounter({
+                    accountId,
+                    metric: 'data_transfer',
+                    dimension: 'source',
+                    timeframe: { start, end }
+                });
                 expect(res.unwrap()).toStrictEqual({
                     accountId,
                     metric: 'data_transfer',
                     series: [
                         {
-                            dimension: 'package',
-                            dimensionValue: 'runner',
+                            dimension: 'source',
+                            dimensionValue: 'runner.proxy',
                             days: [{ day: dayFromNow(), value: 3000 }]
                         },
                         {
-                            dimension: 'package',
-                            dimensionValue: 'server',
-                            days: [{ day: dayFromNow(1), value: 1000 }]
+                            dimension: 'source',
+                            dimensionValue: 'server.proxy',
+                            days: [{ day: dayFromNow(1), value: 0 }]
                         }
                     ]
                 });
@@ -559,6 +577,17 @@ describe('Clickhouse', () => {
         });
 
         describe('getTopDimensionValues', () => {
+            it('only returns billable data-transfer sources', async () => {
+                const res = await clickhouse.getTopDimensionValues({
+                    accountId,
+                    metric: 'data_transfer',
+                    dimension: 'source',
+                    timeframe: { start, end },
+                    page: 0
+                });
+                expect(res.unwrap().values).toEqual(['runner.proxy', 'server.proxy']);
+            });
+
             it('returns dimension values ordered by SUM(value) DESC', async () => {
                 // records fixture: integrationId=a → 1000+1100+1100=3200; b → 500+500=1000.
                 const res = await clickhouse.getTopDimensionValues({

--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -46,7 +46,7 @@ export const BREAKDOWN_DIMENSIONS = {
     webhook_forwards: ['environment_id', 'integration_id', 'connection_id', 'success'],
     records: ['environment_id', 'integration_id', 'connection_id', 'model'],
     connections: ['environment_id', 'integration_id'],
-    data_transfer: ['environment_id', 'integration_id', 'connection_id', 'package', 'callsite']
+    data_transfer: ['environment_id', 'integration_id', 'connection_id', 'source']
 } as const satisfies { [M in keyof BreakdownDimensions]: readonly BreakdownDimensions[M][] };
 
 export function isAllowedDimensionFor(metric: UsageMetric, dimension: string): boolean {
@@ -127,7 +127,7 @@ export function tableForMetric(metric: UsageMetric): string {
         case 'connections':
             return `daily_raw_connections`;
         case 'data_transfer':
-            return `daily_data_transfer`;
+            return `daily_billable_data_transfer`;
     }
 }
 
@@ -191,7 +191,7 @@ export function quantityForMetric(metric: CounterUsageMetric): string {
         case 'function_duration_seconds':
             return `SUM(duration_seconds)`;
         case 'data_transfer':
-            return `SUM(ingressed_bytes + egressed_bytes)`;
+            return `SUM(egressed_bytes)`;
     }
 }
 

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -545,7 +545,7 @@ export class Clickhouse {
     }
 
     // Month-to-date COUNTER totals scoped to the calendar month containing
-    // `now`. Returns all five COUNTER billing metrics in one call. `records` /
+    // `now`. Returns all COUNTER billing metrics in one call. `records` /
     // `connections` are not included; capping reads those from Postgres.
     //
     // One revalidate amortises the cache refresh across every billing metric
@@ -558,9 +558,13 @@ export class Clickhouse {
 
         const results = await Promise.all(
             COUNTER_METRICS.map((metric) =>
-                this.getDailyCounter({ accountId, metric, dimension: 'none', timeframe, ...maxExecOpt } as GetDailyCounterQuery).then(
-                    (r) => [metric, r] as const
-                )
+                this.getDailyCounter({
+                    accountId,
+                    metric,
+                    dimension: 'none',
+                    timeframe,
+                    ...maxExecOpt
+                } as GetDailyCounterQuery).then((r) => [metric, r] as const)
             )
         );
 

--- a/packages/usage/lib/clickhouse/migrations/20260826000012_create_daily_billable_data_transfer.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260826000012_create_daily_billable_data_transfer.ts
@@ -1,0 +1,29 @@
+export const sql = [
+    `
+    CREATE VIEW IF NOT EXISTS {database:Identifier}.daily_billable_data_transfer AS
+    SELECT
+        day,
+        account_id,
+        environment_id,
+        integration_id,
+        connection_id,
+        concat(package, '.', callsite) AS source,
+        egressed_bytes
+    FROM {database:Identifier}.daily_data_transfer
+    WHERE (package, callsite) IN (
+        ('server', 'get_/records'),
+        ('server', 'get_/proxy'),
+        ('server', 'proxy'),
+        ('server', 'post_/proxy'),
+        ('server', 'patch_/proxy'),
+        ('server', 'put_/proxy'),
+        ('server', 'delete_/proxy'),
+        ('server', 'unknown_/proxy'),
+        ('server', 'webhook_forward'),
+        ('runner', 'proxy'),
+        ('runner', 'uncontrolled_fetch'),
+        ('runner', 'persist_customer_logs'),
+        ('runner', 'persist_records')
+    )
+    `
+];

--- a/packages/usage/lib/clickhouse/migrations/20260826000012_create_daily_billable_data_transfer.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260826000012_create_daily_billable_data_transfer.ts
@@ -9,7 +9,7 @@ export const sql = [
         connection_id,
         concat(package, '.', callsite) AS source,
         egressed_bytes
-    FROM {database:Identifier}.daily_data_transfer
+    FROM daily_data_transfer
     WHERE (package, callsite) IN (
         ('server', 'get_/records'),
         ('server', 'get_/proxy'),

--- a/packages/usage/lib/usage.integration.test.ts
+++ b/packages/usage/lib/usage.integration.test.ts
@@ -5,6 +5,13 @@ import { Ok } from '@nangohq/utils';
 
 import { UsageTracker } from './usage.js';
 
+import type { UsageMetric } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+type UsageTrackerInternals = {
+    getBillingMetrics(accountId: number): Promise<Result<Record<UsageMetric, number>>>;
+};
+
 describe('Usage', () => {
     let redis: Awaited<ReturnType<typeof getRedis>>;
     let usageTracker: UsageTracker;
@@ -193,6 +200,18 @@ describe('Usage', () => {
             // (but may be called for other null metrics)
             const callsForMetric = revalidateSpy.mock.calls.filter((call) => call[0].metric === metric);
             expect(callsForMetric).toHaveLength(0);
+        });
+    });
+
+    describe('revalidate', () => {
+        it('stores the revalidated data-transfer total from the billing metrics source', async () => {
+            const accountId = 42;
+            vi.spyOn(usageTracker as unknown as UsageTrackerInternals, 'getBillingMetrics').mockResolvedValue(
+                Ok({ data_transfer: 12_345 } as Record<UsageMetric, number>)
+            );
+
+            expect((await usageTracker.revalidate({ accountId, metric: 'data_transfer' })).isOk()).toBe(true);
+            expect((await usageTracker.get({ accountId, metric: 'data_transfer' })).unwrap()).toEqual({ accountId, metric: 'data_transfer', current: 12_345 });
         });
     });
 });

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -270,18 +270,13 @@ export class UsageTracker implements IUsageTracker {
                     span?.setTag('count', count.value);
                     return Ok(undefined);
                 }
-                case 'data_transfer': {
-                    // Not yet tracked via Orb; write 0 so the cache entry exists and avoids a revalidate loop
-                    const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
-                    await this.cache.overwrite(cacheKey, 0);
-                    return Ok(undefined);
-                }
                 case 'proxy':
                 case 'function_executions':
                 case 'function_compute_gbms':
                 case 'function_duration_seconds':
                 case 'webhook_forwards':
-                case 'function_logs': {
+                case 'function_logs':
+                case 'data_transfer': {
                     const billingUsage = await this.getBillingMetrics(accountId);
                     if (billingUsage.isErr()) {
                         if (billingUsage.error.message === 'rate_limit_exceeded') {
@@ -382,7 +377,6 @@ export class UsageTracker implements IUsageTracker {
             const f = filterFor(m);
             return f ? { filter: f } : {};
         };
-
         // Base calls — `dimension: 'none'` is valid for every variant.
         // Filter forces a cast to the discriminated union because TS can't
         // narrow `BreakdownDimensions[M]` while iterating a union-typed `m`;
@@ -413,7 +407,14 @@ export class UsageTracker implements IUsageTracker {
         const counterBreakdownCalls = [
             inScope('proxy') && breakdown?.proxy
                 ? ch
-                      .getDailyCounter({ accountId, metric: 'proxy', dimension: breakdown.proxy, timeframe, ...topOpt, ...filterOpt('proxy') })
+                      .getDailyCounter({
+                          accountId,
+                          metric: 'proxy',
+                          dimension: breakdown.proxy,
+                          timeframe,
+                          ...topOpt,
+                          ...filterOpt('proxy')
+                      })
                       .then((r) => ['proxy' as const, r] as const)
                 : null,
             inScope('function_executions') && breakdown?.function_executions
@@ -475,6 +476,18 @@ export class UsageTracker implements IUsageTracker {
                           ...filterOpt('webhook_forwards')
                       })
                       .then((r) => ['webhook_forwards' as const, r] as const)
+                : null,
+            inScope('data_transfer') && breakdown?.data_transfer
+                ? ch
+                      .getDailyCounter({
+                          accountId,
+                          metric: 'data_transfer',
+                          dimension: breakdown.data_transfer,
+                          timeframe,
+                          ...topOpt,
+                          ...filterOpt('data_transfer')
+                      })
+                      .then((r) => ['data_transfer' as const, r] as const)
                 : null
         ].filter((p): p is NonNullable<typeof p> => p !== null);
         const counterBreakdownP = Promise.all(counterBreakdownCalls);

--- a/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
@@ -15,7 +15,7 @@ export const BREAKDOWN_DIMENSIONS = {
     function_compute_gbms: ['integration_id', 'connection_id', 'function_name', 'function_type', 'success', 'environment_id'],
     function_duration_seconds: ['integration_id', 'connection_id', 'function_name', 'function_type', 'success', 'environment_id'],
     function_logs: ['integration_id', 'connection_id', 'function_name', 'function_type', 'success', 'environment_id'],
-    data_transfer: ['environment_id', 'integration_id', 'connection_id', 'package', 'callsite']
+    data_transfer: ['environment_id', 'integration_id', 'connection_id', 'source']
 } as const satisfies { [M in UsageMetric]: readonly BreakdownDimensions[M][] };
 
 /** Union of every breakdown dimension across all metrics. */
@@ -39,8 +39,7 @@ export const DIMENSION_LABELS: Record<AnyBreakdownDimension, string> = {
     function_type: 'Function type',
     success: 'Status',
     environment_id: 'Environment',
-    package: 'Package',
-    callsite: 'Callsite'
+    source: 'Source'
 };
 
 /**
@@ -76,10 +75,10 @@ export function parseFilterParam(raw: string, allowed: readonly AnyBreakdownDime
 /**
  * Dimensions whose values are a small, fully-listed, closed set, so their Filter value pane shows
  * no search box: `environment_id` (a handful of envs), `success` (true/false), `function_type`
- * (sync/action/webhook/…), and data-transfer `package` / `callsite` (a fixed handful each). The
+ * (sync/action/webhook/…), and data-transfer `source` (a fixed handful). The
  * rest are open, high-cardinality id/name dimensions where server-side search earns its place.
  */
-const ENUMERATED_DIMENSIONS = new Set<AnyBreakdownDimension>(['environment_id', 'success', 'function_type', 'package', 'callsite']);
+const ENUMERATED_DIMENSIONS = new Set<AnyBreakdownDimension>(['environment_id', 'success', 'function_type', 'source']);
 
 /** Whether the Filter value pane shows a search box for this dimension. */
 export function isSearchableDimension(dimension: AnyBreakdownDimension): boolean {

--- a/packages/webapp/src/pages/Team/Billing/usageBreakdown.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageBreakdown.unit.test.ts
@@ -89,7 +89,7 @@ describe('parseFilterParam', () => {
 
 describe('isSearchableDimension', () => {
     it('is false for small, fully-listed enum dimensions (no search box)', () => {
-        for (const dim of ['environment_id', 'success', 'function_type', 'package', 'callsite'] as const) {
+        for (const dim of ['environment_id', 'success', 'function_type', 'source'] as const) {
             expect(isSearchableDimension(dim), `${dim} should not be searchable`).toBe(false);
         }
     });
@@ -104,7 +104,7 @@ describe('isSearchableDimension', () => {
         // Guards against a new dimension silently defaulting to "searchable" without a deliberate choice.
         const referenced = new Set<AnyBreakdownDimension>(Object.values(BREAKDOWN_DIMENSIONS).flat());
         const open = new Set<AnyBreakdownDimension>(['integration_id', 'connection_id', 'model', 'function_name']);
-        const closed = new Set<AnyBreakdownDimension>(['environment_id', 'success', 'function_type', 'package', 'callsite']);
+        const closed = new Set<AnyBreakdownDimension>(['environment_id', 'success', 'function_type', 'source']);
         for (const dim of referenced) {
             expect(open.has(dim) || closed.has(dim), `unclassified dimension "${dim}"`).toBe(true);
             expect(isSearchableDimension(dim)).toBe(open.has(dim));
@@ -122,7 +122,7 @@ describe('breakdownSeriesHref', () => {
     });
 
     it('returns undefined for every other dimension (not linkable yet)', () => {
-        for (const dim of ['connection_id', 'model', 'function_name', 'environment_id', 'success', 'package', 'callsite'] as const) {
+        for (const dim of ['connection_id', 'model', 'function_name', 'environment_id', 'success', 'source'] as const) {
             expect(breakdownSeriesHref('prod', dim, 'anything'), `${dim} should not be linkable`).toBeUndefined();
         }
     });
@@ -134,7 +134,7 @@ describe('breakdownSeriesCopyValue', () => {
     });
 
     it('returns undefined for every other dimension (no copy button)', () => {
-        for (const dim of ['integration_id', 'model', 'function_name', 'function_type', 'success', 'environment_id', 'package', 'callsite'] as const) {
+        for (const dim of ['integration_id', 'model', 'function_name', 'function_type', 'success', 'environment_id', 'source'] as const) {
             expect(breakdownSeriesCopyValue(dim, 'anything'), `${dim} should not be copyable`).toBeUndefined();
         }
     });


### PR DESCRIPTION
Add a billable data-transfer ClickHouse view that scopes traffic to Orb’s allowed sources and exposes only egressed bytes.

Use the view for usage reporting and Orb exports, so reported usage matches billable data transfer. Replace the public package/callsite breakdown with a single source dimension, include data transfer in billing-usage cache refreshes, and add coverage for filtering excluded traffic, source breakdowns, cache revalidation, and Orb export properties.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

