### PR TITLE
fix(node-client): addQueryParams drops all but the last value of an array query param

### DIFF
--- a/packages/node-client/lib/utils.ts
+++ b/packages/node-client/lib/utils.ts
@@ -49,8 +49,9 @@ export function addQueryParams(url: URL, queries?: Record<string, any>) {
 
     Object.entries(queries).forEach(([name, value]) => {
         if (Array.isArray(value)) {
+            url.searchParams.delete(name);
             for (const el of value) {
-                url.searchParams.set(name, el);
+                url.searchParams.append(name, el);
             }
         } else if (value !== null && value !== undefined) {
             url.searchParams.set(name, value);

--- a/packages/node-client/lib/utils.unit.test.ts
+++ b/packages/node-client/lib/utils.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getUserAgent } from './utils.js';
+import { addQueryParams, getUserAgent } from './utils.js';
 
 const regex = 'nango-node-client/[0-9.]+ .[a-z0-9]+/[0-9a-zA-Z.-]+; node.js/[0-9.]+.';
 describe('getUserAgent', () => {
@@ -9,5 +9,57 @@ describe('getUserAgent', () => {
     });
     it('should output additional user agent ', () => {
         expect(getUserAgent('cli')).toMatch(new RegExp(`${regex}; cli`));
+    });
+});
+
+describe('addQueryParams', () => {
+    it('should be a no-op when no queries are passed', () => {
+        const url = new URL('https://api.nango.dev/providers');
+        addQueryParams(url);
+        expect(url.search).toBe('');
+    });
+
+    it('should set a scalar value', () => {
+        const url = new URL('https://api.nango.dev/providers');
+        addQueryParams(url, { search: 'github' });
+        expect(url.search).toBe('?search=github');
+    });
+
+    it('should keep every element of an array', () => {
+        const url = new URL('https://api.nango.dev/providers');
+        addQueryParams(url, { ids: ['a', 'b', 'c'] });
+        expect(url.search).toBe('?ids=a&ids=b&ids=c');
+        expect(url.searchParams.getAll('ids')).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should replace values already present for an array key rather than appending to them', () => {
+        const url = new URL('https://api.nango.dev/providers?ids=stale');
+        addQueryParams(url, { ids: ['a', 'b'] });
+        expect(url.searchParams.getAll('ids')).toEqual(['a', 'b']);
+    });
+
+    it('should remove the param when the array is empty', () => {
+        const url = new URL('https://api.nango.dev/providers?ids=stale');
+        addQueryParams(url, { ids: [] });
+        expect(url.searchParams.has('ids')).toBe(false);
+    });
+
+    it('should replace values already present for a scalar key', () => {
+        const url = new URL('https://api.nango.dev/providers?search=stale');
+        addQueryParams(url, { search: 'github' });
+        expect(url.searchParams.getAll('search')).toEqual(['github']);
+    });
+
+    it('should skip null and undefined values', () => {
+        const url = new URL('https://api.nango.dev/providers');
+        addQueryParams(url, { a: null, b: undefined, c: 'kept' });
+        expect(url.search).toBe('?c=kept');
+    });
+
+    it('should handle arrays and scalars in the same object', () => {
+        const url = new URL('https://api.nango.dev/integrations/github');
+        addQueryParams(url, { include: ['webhook', 'credentials'], limit: 10 });
+        expect(url.searchParams.getAll('include')).toEqual(['webhook', 'credentials']);
+        expect(url.searchParams.get('limit')).toBe('10');
     });
 });


### PR DESCRIPTION
`addQueryParams` builds array-valued query params with `URLSearchParams.set` inside a loop. `set` replaces every existing value for a key, so only the final element of the array survives. This is reachable from the public SDK — `getIntegration(..., { include: ['webhook', 'credentials'] })` sends only `?include=credentials` — so callers lose parameters silently, with no error.

The server side already expects the repeated-param form: the `include` validator is `z.union([valInclude, z.array(valInclude)])` with a normalizing transform (`packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts`), so `?include=webhook&include=credentials` parses cleanly today — the client just never sends it.

The fix uses `delete` + `append` rather than a bare `set`→`append` swap. All six current call sites build a fresh `URL` with no query string, so the two are equivalent for them — but `addQueryParams` is an exported helper, and a bare `append` would change its replace-semantics for any URL that already carries a value for the key (existing values would survive with the array added on top). Deleting first keeps the contract: the key's values become exactly the array's elements, and an empty array removes the key.

Tests cover the reported case (`['a','b','c']` → `?ids=a&ids=b&ids=c`), replace-semantics for both array and scalar keys, the empty-array case, and the mixed array+scalar shape that mirrors the real `include` call — plus regression guards for the untouched scalar branch.

Deliberately out of scope: the array branch does not skip `null`/`undefined` elements the way the scalar branch does. That asymmetry exists on master and is unreported; changing it here would be scope creep on a bugfix.

Fixes #7092.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

