### PR TITLE
feat(audit): stop auditing the public metadata and sync trigger endpoints

### DIFF
--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -11,7 +11,7 @@ import {
     toAuditId as toId,
     UNKNOWN_ACTOR
 } from '../audit.js';
-import { normalizeSyncParams, syncTriggerOptions } from '../controllers/sync/helpers.js';
+import { normalizeSyncParams } from '../controllers/sync/helpers.js';
 import { auditExportQuery, auditListQuery } from '../controllers/v1/audit-trail/query.js';
 import { connectionCreatedActor } from '../hooks/auditConnection.js';
 import { canRecordAuditTrail } from '../utils/auditTrail.js';
@@ -92,7 +92,6 @@ import type {
     PostPublicRotateWebhookSigningKey,
     PostPublicSyncPause,
     PostPublicSyncStart,
-    PostPublicTrigger,
     PostRotateWebhookSigningKey,
     PostStripeCollectPayment,
     PostSyncVariant,
@@ -101,9 +100,7 @@ import type {
     PutSpendAlert,
     PutTeam,
     PutUpgradePreBuiltFlow,
-    PutUserPassword,
-    SetMetadata,
-    UpdateMetadata
+    PutUserPassword
 } from '@nangohq/types';
 import type { Request, RequestHandler, Response } from 'express';
 
@@ -457,10 +454,6 @@ function build<TEndpoint extends AuditableEndpoint>(
     };
 }
 
-// The deprecated single-connection metadata routes (POST/PATCH /connection/:connectionId/metadata)
-// reuse the batch SetMetadata/UpdateMetadata endpoints but carry the connection in the path/query
-// instead of the body. Those routes have no typed contract (their controllers take a raw Request), so
-// these two reads stay untyped — the batch body fields they fall back to ARE typed on the resolver.
 function param(req: Request<any, any, any, any>, key: string): unknown {
     return (req.params as Record<string, unknown>)[key];
 }
@@ -480,14 +473,6 @@ function nonEmptyString(value: unknown): string | undefined {
 }
 function providerConfigKeyMeta(value: unknown): Record<string, unknown> | undefined {
     return omitUndefined({ providerConfigKey: nonEmptyString(value) });
-}
-// The batch metadata endpoints accept connection_id as an array (body) — record one target per
-// connection; the deprecated single-connection routes carry it in the path instead.
-function connectionTargets(paramId: unknown, bodyId: string | string[] | undefined): AuditTarget | AuditTarget[] | undefined {
-    if (Array.isArray(bodyId)) {
-        return bodyId.map((id) => makeTarget('connection', id)).filter((t): t is AuditTarget => Boolean(t));
-    }
-    return makeTarget('connection', paramId ?? bodyId);
 }
 function connectionUpdatedMeta(providerConfigKey: string | undefined, fields: string[] | undefined): Record<string, unknown> | undefined {
     return omitUndefined({
@@ -700,16 +685,6 @@ export const auditConnectionMetadataUpdated = auditable<PostConnectionMetadata>(
     policy: Audit.auditable({ resource: 'connection', action: 'metadata_updated', scope: 'environment' }),
     target: (req) => makeTarget('connection', req.params.connectionId),
     metadata: (req) => providerConfigKeyMeta(req.query.provider_config_key)
-});
-export const auditPublicConnectionMetadataSet = auditable<SetMetadata>({
-    policy: Audit.auditable({ resource: 'connection', action: 'metadata_updated', scope: 'environment' }),
-    target: (req) => connectionTargets(param(req, 'connectionId'), req.body.connection_id),
-    metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key') ?? req.body.provider_config_key)
-});
-export const auditPublicConnectionMetadataUpdated = auditable<UpdateMetadata>({
-    policy: Audit.auditable({ resource: 'connection', action: 'metadata_updated', scope: 'environment' }),
-    target: (req) => connectionTargets(param(req, 'connectionId'), req.body.connection_id),
-    metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key') ?? req.body.provider_config_key)
 });
 export const auditConnectionDeleted = auditable<DeleteConnection>({
     policy: Audit.auditable({ resource: 'connection', action: 'deleted', scope: 'environment' }),
@@ -1121,14 +1096,6 @@ export const auditSyncStarted = auditable<PostPublicSyncStart>({
     policy: Audit.auditable({ resource: 'sync', action: 'started', scope: 'environment' }),
     target: (req) => syncTargetsFromBody(req.body?.syncs),
     metadata: (req) => syncBaseMeta(req.body.provider_config_key, req.body.connection_id)
-});
-export const auditSyncTriggered = auditable<PostPublicTrigger>({
-    policy: Audit.auditable({ resource: 'sync', action: 'triggered', scope: 'environment' }),
-    target: (req) => syncTargetsFromBody(req.body?.syncs),
-    metadata: (req) => ({
-        ...syncBaseMeta(req.body?.provider_config_key || req.get('provider-config-key'), req.body?.connection_id || req.get('connection-id')),
-        ...syncTriggerOptions(req.body)
-    })
 });
 
 // MFA factors are per-user and account-scoped; the acting user is always the target. No metadata is

--- a/packages/server/lib/middleware/auditSyncCommand.unit.test.ts
+++ b/packages/server/lib/middleware/auditSyncCommand.unit.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { flags, metrics } from '@nangohq/utils';
 
-import { auditSyncPaused, auditSyncStarted, auditSyncTriggered } from './audit.middleware.js';
+import { auditSyncPaused, auditSyncStarted } from './audit.middleware.js';
 import { auditSyncCommand } from './auditSyncCommand.middleware.js';
 
 import type * as AuditModule from '../audit.js';
@@ -151,15 +151,7 @@ describe('auditSyncCommand middleware behavior (unit)', () => {
     // Every per-route test passes while the two surfaces disagree, so only a comparison catches drift.
     it.each([
         { command: 'PAUSE', publicSpec: auditSyncPaused, label: 'paused', body: {}, publicBody: {} },
-        { command: 'UNPAUSE', publicSpec: auditSyncStarted, label: 'started', body: {}, publicBody: {} },
-        { command: 'RUN', publicSpec: auditSyncTriggered, label: 'triggered', body: {}, publicBody: {} },
-        {
-            command: 'RUN_FULL',
-            publicSpec: auditSyncTriggered,
-            label: 'a full trigger that clears records',
-            body: { delete_records: true },
-            publicBody: { sync_mode: 'full_refresh_and_clear_cache' }
-        }
+        { command: 'UNPAUSE', publicSpec: auditSyncStarted, label: 'started', body: {}, publicBody: {} }
     ])('records $label with the same target and metadata as the public route', async ({ command, publicSpec, body, publicBody }) => {
         const privateEvent = await runAudit(auditSyncCommand, syncCommandReq(command, { sync_variant: 'v2', ...body }), fakeRes(locals));
 

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -32,7 +32,6 @@ import {
     auditPublicIntegrationDeleted,
     auditSyncPaused,
     auditSyncStarted,
-    auditSyncTriggered,
     auditUserUpdated,
     resolveActor
 } from './audit.middleware.js';
@@ -770,8 +769,7 @@ describe('auditable() lifecycle specs (unit)', () => {
 
     it.each([
         ['pause', auditSyncPaused],
-        ['start', auditSyncStarted],
-        ['trigger', auditSyncTriggered]
+        ['start', auditSyncStarted]
     ])('sync %s: names the connection the action was scoped to', async (_name, handler) => {
         const req = fakeReq({ body: { syncs: ['sync-a'], provider_config_key: 'algolia', connection_id: 'conn-1' } });
         const event = await runAudit(handler as RequestHandler, req, fakeRes(secretKeyLocals));
@@ -791,75 +789,6 @@ describe('auditable() lifecycle specs (unit)', () => {
         const req = fakeReq({ body: { syncs: ['sync-a'], provider_config_key: 12345, connection_id: {} } });
         const event = await runAudit(auditSyncPaused, req, fakeRes(secretKeyLocals));
         expect(event?.metadata).toBeUndefined();
-    });
-
-    it('sync trigger: records the options the caller asked for, alongside the targets', async () => {
-        const req = fakeReq({ body: { syncs: ['sync-a', { name: 'sync-b', variant: 'v2' }], provider_config_key: 'algolia' } });
-        const event = await runAudit(auditSyncTriggered, req, fakeRes(secretKeyLocals));
-        expect(event).toMatchObject({
-            resource: 'sync',
-            action: 'triggered',
-            outcome: 'success',
-            accountId: 42,
-            environment: { id: 9, display: 'dev' },
-            targets: [
-                { type: 'sync', id: 'sync-a' },
-                { type: 'sync', id: 'sync-b::v2' }
-            ],
-            metadata: { providerConfigKey: 'algolia', reset: false, emptyCache: false }
-        });
-    });
-
-    it('sync trigger: records emptyCache as asked, without inferring what the run will do with it', async () => {
-        const req = fakeReq({ body: { syncs: ['sync-a'], provider_config_key: 'algolia', opts: { emptyCache: true } } });
-        const event = await runAudit(auditSyncTriggered, req, fakeRes(secretKeyLocals));
-        expect(event?.metadata).toEqual({ providerConfigKey: 'algolia', reset: false, emptyCache: true });
-    });
-
-    it('sync trigger: keeps the name::variant form as the id', async () => {
-        const req = fakeReq({ body: { syncs: ['sync-a::v1'], provider_config_key: 'algolia' } });
-        const event = await runAudit(auditSyncTriggered, req, fakeRes(secretKeyLocals));
-        expect(event?.targets).toEqual([{ type: 'sync', id: 'sync-a::v1' }]);
-    });
-
-    it('sync trigger: records what it can when the body never parsed', async () => {
-        const req = fakeReq({
-            body: undefined,
-            get: (h: string) => (h.toLowerCase() === 'provider-config-key' ? 'algolia' : undefined)
-        });
-        const event = await runAudit(auditSyncTriggered, req, fakeRes(secretKeyLocals));
-        expect(event).toMatchObject({ resource: 'sync', action: 'triggered', targets: [] });
-        expect(event?.metadata).toEqual({ providerConfigKey: 'algolia', reset: false, emptyCache: false });
-    });
-
-    it('sync trigger: takes the integration and connection from the headers when the body omits them', async () => {
-        const headers: Record<string, string> = { 'provider-config-key': 'algolia', 'connection-id': 'conn-1', 'user-agent': 'vitest' };
-        const req = fakeReq({ body: { syncs: ['sync-a'] }, get: (h: string) => headers[h.toLowerCase()] });
-        const event = await runAudit(auditSyncTriggered, req, fakeRes(secretKeyLocals));
-        expect(event?.metadata).toEqual({ providerConfigKey: 'algolia', connectionId: 'conn-1', reset: false, emptyCache: false });
-    });
-
-    it.each([
-        ['a non-boolean emptyCache', { opts: { emptyCache: 'yes please' } }],
-        ['a non-boolean reset', { opts: { reset: 1 } }],
-        ['an unknown sync_mode', { sync_mode: 'sideways' }],
-        ['a non-boolean full_resync', { full_resync: 'true' }]
-    ])('sync trigger: %s cannot reach the row, since nothing has validated the body yet', async (_name, body) => {
-        const req = fakeReq({ body: { syncs: ['sync-a'], provider_config_key: 'algolia', ...body } });
-        const event = await runAudit(auditSyncTriggered, req, fakeRes(secretKeyLocals));
-        expect(event?.metadata).toEqual({ providerConfigKey: 'algolia', reset: false, emptyCache: false });
-    });
-
-    it.each([
-        ['incremental sync_mode', { sync_mode: 'incremental' }, { reset: false, emptyCache: false }],
-        ['full_refresh sync_mode', { sync_mode: 'full_refresh' }, { reset: true, emptyCache: false }],
-        ['full_refresh_and_clear_cache sync_mode', { sync_mode: 'full_refresh_and_clear_cache' }, { reset: true, emptyCache: true }],
-        ['deprecated full_resync', { full_resync: true }, { reset: true, emptyCache: false }],
-        ['opts.reset with opts.emptyCache', { opts: { reset: true, emptyCache: true } }, { reset: true, emptyCache: true }]
-    ])('sync trigger: %s is recorded as the options asked for', async (_name, body, expected) => {
-        const req = fakeReq({ body: { syncs: ['sync-a'], ...body } });
-        const event = await runAudit(auditSyncTriggered, req, fakeRes(secretKeyLocals));
-        expect(event?.metadata).toEqual(expected);
     });
 
     it('sync start: one target per sync, the variant inside the id', async () => {

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -95,8 +95,6 @@ import {
     auditPublicApiKeyCreated,
     auditPublicApiKeyDeleted,
     auditPublicConnectionDeleted,
-    auditPublicConnectionMetadataSet,
-    auditPublicConnectionMetadataUpdated,
     auditPublicConnectionUpdated,
     auditPublicEnvironmentCreated,
     auditPublicEnvironmentDeleted,
@@ -109,7 +107,6 @@ import {
     auditPublicWebhookSigningKeyRotated,
     auditSyncPaused,
     auditSyncStarted,
-    auditSyncTriggered,
     auditSyncVariantCreated,
     auditSyncVariantDeleted
 } from './middleware/audit.middleware.js';
@@ -284,25 +281,15 @@ publicAPI.route('/connection/:connectionId').delete(apiAuth, auditPublicConnecti
 // @deprecated
 publicAPI
     .route('/connection/:connectionId/metadata')
-    .post(
-        apiAuth,
-        auditPublicConnectionMetadataSet,
-        withScope('environment:connections:update'),
-        connectionController.setMetadataLegacy.bind(connectionController)
-    );
+    .post(apiAuth, withScope('environment:connections:update'), connectionController.setMetadataLegacy.bind(connectionController));
 // @deprecated
 publicAPI
     .route('/connection/:connectionId/metadata')
-    .patch(
-        apiAuth,
-        auditPublicConnectionMetadataUpdated,
-        withScope('environment:connections:update'),
-        connectionController.updateMetadataLegacy.bind(connectionController)
-    );
+    .patch(apiAuth, withScope('environment:connections:update'), connectionController.updateMetadataLegacy.bind(connectionController));
 // @deprecated
-publicAPI.route('/connection/metadata').post(apiAuth, auditPublicConnectionMetadataSet, withScope('environment:connections:update'), postPublicMetadata);
+publicAPI.route('/connection/metadata').post(apiAuth, withScope('environment:connections:update'), postPublicMetadata);
 // @deprecated
-publicAPI.route('/connection/metadata').patch(apiAuth, auditPublicConnectionMetadataUpdated, withScope('environment:connections:update'), patchPublicMetadata);
+publicAPI.route('/connection/metadata').patch(apiAuth, withScope('environment:connections:update'), patchPublicMetadata);
 // @deprecated
 publicAPI
     .route('/connection')
@@ -312,8 +299,8 @@ publicAPI
 publicAPI.use('/connections', jsonContentTypeMiddleware);
 publicAPI.route('/connections').post(apiAuth, auditConnectionCreated, withScope('environment:connections:create'), postPublicConnection);
 publicAPI.route('/connections').get(apiAuth, withAnyScope('environment:connections:list', 'environment:connections:list_credentials'), getPublicConnections);
-publicAPI.route('/connections/metadata').post(apiAuth, auditPublicConnectionMetadataSet, withScope('environment:connections:update'), postPublicMetadata);
-publicAPI.route('/connections/metadata').patch(apiAuth, auditPublicConnectionMetadataUpdated, withScope('environment:connections:update'), patchPublicMetadata);
+publicAPI.route('/connections/metadata').post(apiAuth, withScope('environment:connections:update'), postPublicMetadata);
+publicAPI.route('/connections/metadata').patch(apiAuth, withScope('environment:connections:update'), patchPublicMetadata);
 publicAPI
     .route('/connections/:connectionId')
     .get(apiAuth, withAnyScope('environment:connections:read', 'environment:connections:read_credentials'), getPublicConnection);
@@ -357,7 +344,7 @@ publicAPI.route('/records/prune').patch(apiAuth, withScope('environment:records:
 
 // Syncs (continued)
 publicAPI.use('/sync', jsonContentTypeMiddleware);
-publicAPI.route('/sync/trigger').post(apiAuth, auditSyncTriggered, withScope('environment:syncs:execute'), postPublicTrigger);
+publicAPI.route('/sync/trigger').post(apiAuth, withScope('environment:syncs:execute'), postPublicTrigger);
 publicAPI.route('/sync/pause').post(apiAuth, auditSyncPaused, withScope('environment:syncs:execute'), postPublicSyncPause);
 publicAPI.route('/sync/start').post(apiAuth, auditSyncStarted, withScope('environment:syncs:execute'), postPublicSyncStart);
 publicAPI.route('/sync/status').get(apiAuth, withScope('environment:syncs:read'), getPublicSyncStatus);

--- a/packages/types/lib/connection/api/metadata.ts
+++ b/packages/types/lib/connection/api/metadata.ts
@@ -11,7 +11,7 @@ export interface MetadataBody {
 type MetadataError = ApiError<'invalid_body'> | ApiError<'unknown_connection'>;
 
 export type SetMetadata = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'metadata_updated', 'environment'>;
+    Audit: { kind: 'no-audit'; reason: 'data-plane operation' };
     Method: 'POST';
     Body: MetadataBody;
     Path: '/connection/metadata';
@@ -20,7 +20,7 @@ export type SetMetadata = ApiEndpoint<{
 }>;
 
 export type UpdateMetadata = ApiEndpoint<{
-    Audit: AuditPolicy<'connection', 'metadata_updated', 'environment'>;
+    Audit: { kind: 'no-audit'; reason: 'data-plane operation' };
     Method: 'PATCH';
     Path: '/connection/metadata';
     Body: MetadataBody;

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -3,7 +3,7 @@ import type { AuditPolicy } from '../audit-trail/event.js';
 import type { ReportedSyncJobStatus } from './index.js';
 
 export type PostPublicTrigger = ApiEndpoint<{
-    Audit: AuditPolicy<'sync', 'triggered', 'environment'>;
+    Audit: { kind: 'no-audit'; reason: 'data-plane operation' };
     Method: 'POST';
     Path: '/sync/trigger';
     Body: {


### PR DESCRIPTION
- Removes the audit events on `POST`/`PATCH` `/connection/metadata`, `/connections/metadata`, the deprecated `/connection/:connectionId/metadata` pair, and `POST /sync/trigger`. These are data-plane calls — our original categorization put them there — and they were audited by mistake. With the heavy accounts enabled in production they were 89% of everything we recorded (`connection.metadata_updated` 80%, `sync.triggered` 9%), against a fleet forecast of ~1M events/month for the control plane.
- Their endpoint types now carry the no-audit opt-out instead of an `AuditPolicy`, so the three now-orphaned middleware specs are a compile error rather than dead code, and re-adding one is too.

## What stays

Both actions keep exactly one producer on the dashboard routes — `connection.metadata_updated` on `POST /api/v1/connections/:connectionId/metadata`, `sync.triggered` on the private sync-command route — so the read vocabulary, the filter selectors and the stored rows are unchanged. The public and private surfaces are now deliberately asymmetric for these two: a customer editing metadata or triggering a sync from the dashboard is recorded, the same thing done by their own code at data-plane volume is not.

The cross-surface parity test loses its two trigger rows for the same reason; pause and start still compare both surfaces.

## Test plan

- [x] `ts-build`, `lint`, `format:check` clean
- [x] 85 audit middleware unit tests pass
- [x] Break-check: re-adding a spec for either endpoint fails to compile (two `TS2344`s), so this cannot silently come back
- [x] Confirmed no integration test asserted an audit event on any of the removed mounts
- [ ] After deploy: `nango.audit.event.recorded` drops to control-plane volume, and `resource_action` in ClickHouse shows no new `connection.metadata_updated` or `sync.triggered` rows from public-API traffic

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

