### PR TITLE
docs: fix retry and backoff behavior in webhook retries & debugging

### DIFF
--- a/docs/guides/platform/webhooks-from-nango.mdx
+++ b/docs/guides/platform/webhooks-from-nango.mdx
@@ -399,7 +399,13 @@ Forwarded external webhooks use the same webhook URLs, signing, retries, and log
 
 ## Webhook retries & debugging
 
-Nango retries each webhook with non-2xx responses 2 times with exponential backoff (starting delay: 100ms, time multiple: 2, view details in the [code](https://github.com/NangoHQ/nango/blob/master/packages/webhooks/lib/utils.ts)).
+Nango retries a failed webhook 2 times, with exponential backoff: it waits 3 seconds before the first retry and 6 seconds before the second (view details in the [code](https://github.com/NangoHQ/nango/blob/master/packages/utils/lib/retry.ts)).
+
+A delivery is retried when it fails with a 5xx response, or with a network error (`ECONNRESET`, `ETIMEDOUT`, `ECONNABORTED`, `ECONNREFUSED`, `EHOSTUNREACH`, `EAI_AGAIN`, `UND_ERR_SOCKET`). A 4xx response is treated as final and is not retried (view the retry logic in the [code](https://github.com/NangoHQ/nango/blob/master/packages/webhooks/lib/utils.ts)). Redirects are followed, up to 5 hops.
+
+<Note>
+  `429` is a 4xx, so Nango does not back off and retry when your endpoint rate-limits it — the delivery gets one attempt. If your webhook handler may be rate-limited, accept the request with a 2xx and queue the work on your side rather than returning `429`.
+</Note>
 
 Webhooks time out after 20 seconds.
 


### PR DESCRIPTION
Hi this PR fixes :  [7266](https://github.com/NangoHQ/nango/issues/7266)

Corrects two inaccuracies in the "Webhook retries & debugging" section of the webhooks-from-nango guide, verified against master (packages/webhooks/lib/utils.ts, packages/utils/lib/retry.ts, packages/egress/lib/policy.ts):

The doc said Nango retries "non-2xx" responses with a 100ms starting delay. In practice only 5xx responses and a fixed list of network errors are retried; any 4xx is treated as final and never retried. The 100ms/timeMultiple:2 figures matched the pre-#3662 implementation (retryWithBackoff / exponential-backoff defaults) and no longer apply.

- The actual backoff is 3s then 6s (Math.min(3000 * 2 ** attempt, maxDelay) in packages/utils/lib/retry.ts), and the doc's code link pointed at packages/webhooks/lib/utils.ts, which has the retry predicate but not the delay calculation.

Also documents that redirects are followed up to 5 hops (outbound policy default), and adds a note that 429 responses get one attempt with no retry, since that's the case most likely to surprise readers of the old wording.

Fixes #7266




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

