### PR TITLE
feat(orchestrator): per-environment webhook dispatch rate limit (NAN-6542)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,7 +135,8 @@ GOOGLE_APPLICATION_CREDENTIALS=
 
 # Orchestrator
 ORCHESTRATOR_SERVICE_URL="http://localhost:3008"
-# Max immediate tasks admitted per minute per rate limit key. 0 (the default) disables throttling.
+# Max immediate tasks admitted per minute per rate limit key. 0 (the default) means no global limit.
+# Per-group overrides in group_overrides.rate_limit_per_min apply either way.
 # ORCHESTRATOR_THROTTLED_IMMEDIATE_PER_MIN=3200
 
 # Key to display domain logo in the UI

--- a/.env.example
+++ b/.env.example
@@ -136,7 +136,7 @@ GOOGLE_APPLICATION_CREDENTIALS=
 # Orchestrator
 ORCHESTRATOR_SERVICE_URL="http://localhost:3008"
 # Max immediate tasks admitted per minute per rate limit key. 0 (the default) means no global limit.
-# Per-group overrides in group_overrides.rate_limit_per_min apply either way.
+# Per-group overrides in group_overrides.immediate_rate_limit_per_min apply either way.
 # ORCHESTRATOR_THROTTLED_IMMEDIATE_PER_MIN=3200
 
 # Key to display domain logo in the UI

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -129,7 +129,7 @@ export class DispatchQueueConsumer {
             tags: { 'webhook.dispatch.received': messages.length }
         });
 
-        return void (await tracer.scope().activate(span, async () => {
+        return await tracer.scope().activate(span, async () => {
             try {
                 const entries = await this.filterMessages(messages);
                 if (entries.length === 0) {
@@ -185,7 +185,7 @@ export class DispatchQueueConsumer {
             } finally {
                 span.finish();
             }
-        }));
+        });
     }
 
     private async filterMessages(messages: Message[]): Promise<ParsedEntry[]> {
@@ -264,7 +264,10 @@ export class DispatchQueueConsumer {
             } else if (result.error.name === 'rate_limit_exceeded') {
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'rate_limited', provider });
                 const logCtx = logContextGetter.get({ id: group[0]!.parsed.activityLogId, accountId: group[0]!.parsed.accountId });
-                await logCtx.warn('Webhook execution is delayed: this environment reached its webhook dispatch rate limit');
+                const limitPerMin = getRateLimitPerMin(result.error);
+                await logCtx.warn(
+                    `Webhook execution is delayed: this environment reached its webhook dispatch rate limit${limitPerMin === null ? '' : ` of ${limitPerMin}/min`}`
+                );
             } else if (result.error.name === 'task_cap_exceeded') {
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_DROPPED, count, { reason: 'task_cap', provider, providerConfigKey });
                 await this.deleteGroup(group);
@@ -298,6 +301,14 @@ export class DispatchQueueConsumer {
             report(new Error('webhook dispatch consumer delete failed', { cause: err }));
         }
     }
+}
+
+function getRateLimitPerMin(err: { payload?: unknown }): number | null {
+    const payload = err.payload;
+    if (!payload || typeof payload !== 'object' || !('limitPerMin' in payload) || typeof payload.limitPerMin !== 'number') {
+        return null;
+    }
+    return payload.limitPerMin;
 }
 
 function getClientErrorResponsePayload(err: { payload?: unknown }): string | null {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -205,7 +205,10 @@ describe('DispatchQueueConsumer', () => {
         const msgs = [buildMessage({ taskName: 'webhook:1' }), buildMessage({ taskName: 'webhook:2' })];
         const h = makeHarness({ messages: msgs });
         h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(
-            Ok([Ok({ taskId: 't1', retryKey: 'r1' }), Err({ name: 'rate_limit_exceeded', message: 'Rate limit exceeded', payload: { retryAfterMs: 1000 } })])
+            Ok([
+                Ok({ taskId: 't1', retryKey: 'r1' }),
+                Err({ name: 'rate_limit_exceeded', message: 'Rate limit exceeded', payload: { retryAfterMs: 1000, limitPerMin: 500 } })
+            ])
         );
 
         await runOnce(h, () => {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -16,6 +16,12 @@ vi.mock('../../env.js', () => ({
     }
 }));
 
+const { logCtxWarn } = vi.hoisted(() => ({ logCtxWarn: vi.fn<(message: string, meta?: unknown) => Promise<void>>(() => Promise.resolve()) }));
+
+vi.mock('@nangohq/logs', () => ({
+    logContextGetter: { get: () => ({ warn: logCtxWarn }) }
+}));
+
 function buildMessage(overrides: Partial<WebhookDispatchMessage> = {}): WebhookDispatchMessage {
     return {
         version: 1,
@@ -130,6 +136,7 @@ async function runOnce(h: Harness, waitFor: () => void | Promise<void>): Promise
 describe('DispatchQueueConsumer', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        logCtxWarn.mockClear();
     });
 
     it('sends all received messages in a single executeWebhookBatch call', async () => {
@@ -218,6 +225,20 @@ describe('DispatchQueueConsumer', () => {
         // The environment is over its cap, so the throttled message is left for redelivery.
         // Only the successful entry is deleted.
         expect(getDeleteCalls(h)).toHaveLength(1);
+        expect(logCtxWarn).toHaveBeenCalledWith('Webhook execution is delayed: this environment reached its webhook dispatch rate limit of 500/min');
+    });
+
+    it('omits the limit from the delay warning when the orchestrator did not report one', async () => {
+        const h = makeHarness({ messages: [buildMessage({ taskName: 'webhook:1' })] });
+        h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(
+            Ok([Err({ name: 'rate_limit_exceeded', message: 'Rate limit exceeded', payload: { retryAfterMs: 1000 } })])
+        );
+
+        await runOnce(h, () => {
+            expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(1);
+        });
+
+        expect(logCtxWarn).toHaveBeenCalledWith('Webhook execution is delayed: this environment reached its webhook dispatch rate limit');
     });
 
     it('does not delete messages whose per-entry result is a generic error', async () => {

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.integration.test.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.integration.test.ts
@@ -133,7 +133,8 @@ describe('RedisSlidingWindowRateLimiter', () => {
             rejected: 0,
             remaining: null,
             estimatedUsage: null,
-            retryAfterMs: 0
+            retryAfterMs: 0,
+            limit: 1
         });
     });
 });

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.ts
@@ -4,8 +4,14 @@ import type { NangoRedisClient } from './redisClient.js';
 
 export interface SlidingWindowRateLimiterOptions {
     keyPrefix: string;
-    limit: number;
+    /** Default limit for every key. null leaves keys unlimited unless consume() passes a limit. */
+    limit: number | null;
     windowMs: number;
+}
+
+export interface SlidingWindowConsumeOptions {
+    /** Limit for this key, replacing the limiter default. undefined keeps the default, null makes the key unlimited. */
+    limit?: number | null | undefined;
 }
 
 export interface SlidingWindowRateLimitResult {
@@ -15,10 +21,12 @@ export interface SlidingWindowRateLimitResult {
     estimatedUsage: number | null;
     /** Approximate delay until the weighted estimate has room for one unit. */
     retryAfterMs: number;
+    /** Limit applied to this call, null when the key is unlimited. */
+    limit: number | null;
 }
 
 export interface SlidingWindowRateLimiter {
-    consume(key: string, units: number): Promise<SlidingWindowRateLimitResult>;
+    consume(key: string, units: number, opts?: SlidingWindowConsumeOptions): Promise<SlidingWindowRateLimitResult>;
     destroy(): Promise<void>;
 }
 
@@ -80,10 +88,9 @@ function validateOptions(options: SlidingWindowRateLimiterOptions): void {
     if (options.keyPrefix.includes('{') || options.keyPrefix.includes('}')) {
         throw new Error('keyPrefix must not contain braces');
     }
-    validatePositiveInteger(options.limit, 'limit');
     validatePositiveInteger(options.windowMs, 'windowMs');
-    if (!Number.isSafeInteger(options.limit * options.windowMs)) {
-        throw new Error('limit multiplied by windowMs must be a safe integer');
+    if (options.limit !== null) {
+        validateLimit(options.limit, options.windowMs);
     }
     if (!Number.isSafeInteger(options.windowMs * 2)) {
         throw new Error('windowMs multiplied by 2 must be a safe integer');
@@ -95,6 +102,29 @@ function validateConsume(key: string, units: number): void {
         throw new Error('key must not be empty');
     }
     validatePositiveInteger(units, 'units');
+}
+
+function validateLimit(limit: number, windowMs: number): void {
+    validatePositiveInteger(limit, 'limit');
+    if (!Number.isSafeInteger(limit * windowMs)) {
+        throw new Error('limit multiplied by windowMs must be a safe integer');
+    }
+}
+
+/**
+ * Pick the limit for a single consume() call and validate it, so a bad override fails loudly
+ * instead of silently letting everything through.
+ */
+function resolveLimit(defaultLimit: number | null, windowMs: number, opts: SlidingWindowConsumeOptions | undefined): number | null {
+    const limit = opts?.limit === undefined ? defaultLimit : opts.limit;
+    if (limit !== null) {
+        validateLimit(limit, windowMs);
+    }
+    return limit;
+}
+
+function unlimited(units: number): SlidingWindowRateLimitResult {
+    return { admitted: units, rejected: 0, remaining: null, estimatedUsage: null, retryAfterMs: 0, limit: null };
 }
 
 function validatePositiveInteger(value: number, name: string): void {
@@ -109,7 +139,8 @@ function result(requested: number, admitted: number, estimatedUsage: number | nu
         rejected: requested - admitted,
         remaining: estimatedUsage === null ? null : Math.max(0, limit - estimatedUsage),
         estimatedUsage,
-        retryAfterMs
+        retryAfterMs,
+        limit
     };
 }
 
@@ -162,30 +193,36 @@ export class InMemorySlidingWindowRateLimiter implements SlidingWindowRateLimite
         this.cleanupTimer.unref();
     }
 
-    public consume(key: string, units: number): Promise<SlidingWindowRateLimitResult> {
+    public consume(key: string, units: number, opts?: SlidingWindowConsumeOptions): Promise<SlidingWindowRateLimitResult> {
+        let limit: number | null;
         try {
             validateConsume(key, units);
+            limit = resolveLimit(this.options.limit, this.options.windowMs, opts);
         } catch (err) {
             return Promise.reject(err);
+        }
+        if (limit === null) {
+            return Promise.resolve(unlimited(units));
         }
 
         const now = Date.now();
         const windowIndex = Math.floor(now / this.options.windowMs);
         const remainingWindowMs = this.options.windowMs - (now - windowIndex * this.options.windowMs);
-        const window = rotateWindow(this.windows.get(key), windowIndex, now + this.options.windowMs * 2);
+        const windowKey = `${limit}:${key}`;
+        const window = rotateWindow(this.windows.get(windowKey), windowIndex, now + this.options.windowMs * 2);
         let estimatedNumerator = window.previous * remainingWindowMs + window.current * this.options.windowMs;
-        const available = Math.max(0, Math.floor((this.options.limit * this.options.windowMs - estimatedNumerator) / this.options.windowMs));
+        const available = Math.max(0, Math.floor((limit * this.options.windowMs - estimatedNumerator) / this.options.windowMs));
         const admitted = Math.min(units, available);
 
         window.current += admitted;
         estimatedNumerator += admitted * this.options.windowMs;
-        this.windows.set(key, window);
+        this.windows.set(windowKey, window);
 
         const estimatedUsage = Math.ceil(estimatedNumerator / this.options.windowMs);
         const retryAfterMs =
             admitted < units
                 ? getRetryAfterMs({
-                      limit: this.options.limit,
+                      limit,
                       windowMs: this.options.windowMs,
                       remainingWindowMs,
                       current: window.current,
@@ -195,7 +232,7 @@ export class InMemorySlidingWindowRateLimiter implements SlidingWindowRateLimite
                 : 0;
 
         metrics.distribution(metrics.Types.KVSTORE_SLIDING_WINDOW_USAGE, estimatedUsage);
-        return Promise.resolve(result(units, admitted, estimatedUsage, this.options.limit, retryAfterMs));
+        return Promise.resolve(result(units, admitted, estimatedUsage, limit, retryAfterMs));
     }
 
     public destroy(): Promise<void> {
@@ -223,18 +260,20 @@ export class RedisSlidingWindowRateLimiter implements SlidingWindowRateLimiter {
         validateOptions(options);
     }
 
-    public async consume(key: string, units: number): Promise<SlidingWindowRateLimitResult> {
+    public async consume(key: string, units: number, opts?: SlidingWindowConsumeOptions): Promise<SlidingWindowRateLimitResult> {
         validateConsume(key, units);
+        const limit = resolveLimit(this.options.limit, this.options.windowMs, opts);
+        if (limit === null) {
+            return unlimited(units);
+        }
 
         let estimatedUsage: number;
         let rateLimitResult: SlidingWindowRateLimitResult;
         try {
             const client = typeof this.client === 'function' ? await this.client() : this.client;
             const response = await client.eval(CONSUME_SLIDING_WINDOW, {
-                keys: [
-                    `${REDIS_KEY_PREFIX}:${this.options.keyPrefix.length}:{${this.options.keyPrefix}}:${this.options.limit}:${this.options.windowMs}:${key}`
-                ],
-                arguments: [String(this.options.limit), String(this.options.windowMs), String(units)]
+                keys: [`${REDIS_KEY_PREFIX}:${this.options.keyPrefix.length}:{${this.options.keyPrefix}}:${limit}:${this.options.windowMs}:${key}`],
+                arguments: [String(limit), String(this.options.windowMs), String(units)]
             });
             if (!Array.isArray(response) || response.length !== 5) {
                 throw new Error('Unexpected Redis sliding window response');
@@ -253,7 +292,7 @@ export class RedisSlidingWindowRateLimiter implements SlidingWindowRateLimiter {
             const retryAfterMs =
                 admitted < units
                     ? getRetryAfterMs({
-                          limit: this.options.limit,
+                          limit,
                           windowMs: this.options.windowMs,
                           remainingWindowMs,
                           current,
@@ -262,11 +301,11 @@ export class RedisSlidingWindowRateLimiter implements SlidingWindowRateLimiter {
                       })
                     : 0;
 
-            rateLimitResult = result(units, admitted, estimatedUsage, this.options.limit, retryAfterMs);
+            rateLimitResult = result(units, admitted, estimatedUsage, limit, retryAfterMs);
         } catch (err) {
             logger.error('Redis sliding window rate limiter failed. Admitting all requested units.', { error: err });
             metrics.increment(metrics.Types.KVSTORE_SLIDING_WINDOW_FAIL_OPEN);
-            return result(units, units, null, this.options.limit);
+            return result(units, units, null, limit);
         }
 
         metrics.distribution(metrics.Types.KVSTORE_SLIDING_WINDOW_USAGE, estimatedUsage);

--- a/packages/kvstore/lib/SlidingWindowRateLimiter.unit.test.ts
+++ b/packages/kvstore/lib/SlidingWindowRateLimiter.unit.test.ts
@@ -22,14 +22,16 @@ describe('InMemorySlidingWindowRateLimiter', () => {
             rejected: 0,
             remaining: 4,
             estimatedUsage: 6,
-            retryAfterMs: 0
+            retryAfterMs: 0,
+            limit: 10
         });
         await expect(limiter.consume('key', 8)).resolves.toEqual({
             admitted: 4,
             rejected: 4,
             remaining: 0,
             estimatedUsage: 10,
-            retryAfterMs: 1100
+            retryAfterMs: 1100,
+            limit: 10
         });
     });
 
@@ -55,7 +57,8 @@ describe('InMemorySlidingWindowRateLimiter', () => {
             rejected: 2,
             remaining: 0,
             estimatedUsage: 4,
-            retryAfterMs: 250
+            retryAfterMs: 250,
+            limit: 4
         });
     });
 
@@ -103,5 +106,55 @@ describe('InMemorySlidingWindowRateLimiter', () => {
         [{ keyPrefix: 'test', limit: 1, windowMs: 4_503_599_627_370_496 }, 'windowMs multiplied by 2 must be a safe integer']
     ])('rejects invalid options', (options, message) => {
         expect(() => new InMemorySlidingWindowRateLimiter(options)).toThrow(message);
+    });
+
+    it('applies a per-call limit instead of the default', async () => {
+        await expect(limiter.consume('key', 3, { limit: 2 })).resolves.toMatchObject({ admitted: 2, rejected: 1, limit: 2 });
+        await expect(limiter.consume('key', 1)).resolves.toMatchObject({ admitted: 1, rejected: 0, limit: 10 });
+    });
+
+    it('counts a key separately per limit, so changing an override starts a fresh window', async () => {
+        await limiter.consume('key', 10, { limit: 10 });
+
+        await expect(limiter.consume('key', 10, { limit: 10 })).resolves.toMatchObject({ admitted: 0 });
+        await expect(limiter.consume('key', 10, { limit: 20 })).resolves.toMatchObject({ admitted: 10 });
+    });
+
+    it('leaves a key unlimited when the per-call limit is null', async () => {
+        await expect(limiter.consume('key', 1000, { limit: null })).resolves.toEqual({
+            admitted: 1000,
+            rejected: 0,
+            remaining: null,
+            estimatedUsage: null,
+            retryAfterMs: 0,
+            limit: null
+        });
+    });
+
+    it.each([
+        [0, 'limit must be a positive safe integer'],
+        [1.5, 'limit must be a positive safe integer']
+    ])('rejects an invalid per-call limit', async (limit, message) => {
+        await expect(limiter.consume('key', 1, { limit })).rejects.toThrow(message);
+    });
+});
+
+describe('InMemorySlidingWindowRateLimiter without a default limit', () => {
+    let limiter: InMemorySlidingWindowRateLimiter;
+
+    beforeEach(() => {
+        limiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: null, windowMs: 1000 });
+    });
+
+    afterEach(async () => {
+        await limiter.destroy();
+    });
+
+    it('admits everything for keys without a per-call limit', async () => {
+        await expect(limiter.consume('key', 1_000_000)).resolves.toMatchObject({ admitted: 1_000_000, rejected: 0, limit: null });
+    });
+
+    it('still enforces a per-call limit', async () => {
+        await expect(limiter.consume('key', 5, { limit: 3 })).resolves.toMatchObject({ admitted: 3, rejected: 2, limit: 3 });
     });
 });

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -8,6 +8,7 @@ import { BackpressureMonitor } from './backpressure-monitor.js';
 import { envs } from './env.js';
 import { TaskEventsHandler } from './events.js';
 import { createImmediateRateLimiter } from './rateLimiter.js';
+import { RateLimitOverrides } from './rateLimitOverrides.js';
 import { buildSchedulerConfig, handleSchedulerEvent } from './scheduler-config.js';
 import { getServer } from './server.js';
 import { logger } from './utils.js';
@@ -83,7 +84,9 @@ try {
     // each processor fetching from a group_key adds a listener for the long-polling dequeue
     eventsHandler.setMaxListeners(Infinity);
 
-    const server = getServer(scheduler, eventsHandler, immediateRateLimiter);
+    const rateLimitOverrides = new RateLimitOverrides({ load: () => scheduler.getRateLimitOverrides() });
+
+    const server = getServer(scheduler, eventsHandler, immediateRateLimiter, rateLimitOverrides);
     const port = envs.NANGO_ORCHESTRATOR_PORT;
     const api = server.listen(port, () => {
         logger.info(`🚀 Orchestrator API ready at http://localhost:${port}`);

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -7,8 +7,8 @@ import { once, report, stringifyError } from '@nangohq/utils';
 import { BackpressureMonitor } from './backpressure-monitor.js';
 import { envs } from './env.js';
 import { TaskEventsHandler } from './events.js';
+import { ImmediateRateLimitOverrides } from './immediateRateLimitOverrides.js';
 import { createImmediateRateLimiter } from './rateLimiter.js';
-import { RateLimitOverrides } from './rateLimitOverrides.js';
 import { buildSchedulerConfig, handleSchedulerEvent } from './scheduler-config.js';
 import { getServer } from './server.js';
 import { logger } from './utils.js';
@@ -84,9 +84,9 @@ try {
     // each processor fetching from a group_key adds a listener for the long-polling dequeue
     eventsHandler.setMaxListeners(Infinity);
 
-    const rateLimitOverrides = new RateLimitOverrides({ load: () => scheduler.getRateLimitOverrides() });
+    const immediateRateLimitOverrides = new ImmediateRateLimitOverrides({ load: () => scheduler.getImmediateRateLimitOverrides() });
 
-    const server = getServer(scheduler, eventsHandler, immediateRateLimiter, rateLimitOverrides);
+    const server = getServer(scheduler, eventsHandler, immediateRateLimiter, immediateRateLimitOverrides);
     const port = envs.NANGO_ORCHESTRATOR_PORT;
     const api = server.listen(port, () => {
         logger.info(`🚀 Orchestrator API ready at http://localhost:${port}`);

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -6,7 +6,7 @@ import { getTestDbClient, Scheduler } from '@nangohq/scheduler';
 import { nanoid } from '@nangohq/utils';
 
 import { TaskEventsHandler } from '../events.js';
-import { RateLimitOverrides } from '../rateLimitOverrides.js';
+import { ImmediateRateLimitOverrides } from '../immediateRateLimitOverrides.js';
 import { getServer } from '../server.js';
 import { OrchestratorClient } from './client.js';
 
@@ -24,8 +24,8 @@ const scheduler = new Scheduler({
 const immediateRateLimiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'orchestrator-client-test', limit: 1_000_000, windowMs: 60_000 });
 
 describe('OrchestratorClient', async () => {
-    const rateLimitOverrides = new RateLimitOverrides({ load: () => scheduler.getRateLimitOverrides() });
-    const server = getServer(scheduler, eventsHandler, immediateRateLimiter, rateLimitOverrides);
+    const immediateRateLimitOverrides = new ImmediateRateLimitOverrides({ load: () => scheduler.getImmediateRateLimitOverrides() });
+    const server = getServer(scheduler, eventsHandler, immediateRateLimiter, immediateRateLimitOverrides);
     const port = await getPort();
     const client = new OrchestratorClient({ baseUrl: `http://localhost:${port}` });
 

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -6,6 +6,7 @@ import { getTestDbClient, Scheduler } from '@nangohq/scheduler';
 import { nanoid } from '@nangohq/utils';
 
 import { TaskEventsHandler } from '../events.js';
+import { RateLimitOverrides } from '../rateLimitOverrides.js';
 import { getServer } from '../server.js';
 import { OrchestratorClient } from './client.js';
 
@@ -23,7 +24,8 @@ const scheduler = new Scheduler({
 const immediateRateLimiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'orchestrator-client-test', limit: 1_000_000, windowMs: 60_000 });
 
 describe('OrchestratorClient', async () => {
-    const server = getServer(scheduler, eventsHandler, immediateRateLimiter);
+    const rateLimitOverrides = new RateLimitOverrides({ load: () => scheduler.getRateLimitOverrides() });
+    const server = getServer(scheduler, eventsHandler, immediateRateLimiter, rateLimitOverrides);
     const port = await getPort();
     const client = new OrchestratorClient({ baseUrl: `http://localhost:${port}` });
 

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -390,7 +390,7 @@ export class OrchestratorClient {
     public async executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn> {
         const res = await this.immediate({
             ...this.buildWebhookSchedulingProps(props),
-            rateLimitKey: String(props.args.connection.environment_id)
+            rateLimitKey: props.group.key
         });
         if (res.isErr()) {
             return Err(res.error);
@@ -412,7 +412,7 @@ export class OrchestratorClient {
             return {
                 ...schedulingProps,
                 ownerKey: schedulingProps.ownerKey ?? '',
-                rateLimitKey: String(props.args.connection.environment_id)
+                rateLimitKey: props.group.key
             };
         });
 

--- a/packages/orchestrator/lib/clients/client.unit.test.ts
+++ b/packages/orchestrator/lib/clients/client.unit.test.ts
@@ -242,7 +242,7 @@ describe('OrchestratorClient executeWebhookBatch', () => {
             expect(res.value[2]!.isOk() && res.value[2].value).toEqual({ taskId: 't3', retryKey: 'r3' });
         }
         const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
-        expect(JSON.parse(request.body as string).tasks[0].rateLimitKey).toBe('1');
+        expect(JSON.parse(request.body as string).tasks[0].rateLimitKey).toBe('webhook:environment:1');
     });
 
     it('returns per-entry rate limit failures with the suggested delay', async () => {
@@ -323,7 +323,7 @@ describe('OrchestratorClient executeWebhook', () => {
         }
         expect(fetchMock).toHaveBeenCalledOnce();
         const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
-        expect(JSON.parse(request.body as string).rateLimitKey).toBe('1');
+        expect(JSON.parse(request.body as string).rateLimitKey).toBe('webhook:environment:1');
     });
 
     it('does not retry transient failures because each attempt consumes capacity', async () => {

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -8,6 +8,7 @@ import { getTestDbClient, Scheduler } from '@nangohq/scheduler';
 import { Err, nanoid, Ok } from '@nangohq/utils';
 
 import { TaskEventsHandler } from '../events.js';
+import { RateLimitOverrides } from '../rateLimitOverrides.js';
 import { getServer } from '../server.js';
 import { OrchestratorClient } from './client.js';
 import { OrchestratorProcessor } from './processor.js';
@@ -28,7 +29,8 @@ const orchestratorClient = new OrchestratorClient({ baseUrl: `http://localhost:$
 const immediateRateLimiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'orchestrator-processor-test', limit: 1_000_000, windowMs: 60_000 });
 
 describe('OrchestratorProcessor', () => {
-    const server = getServer(scheduler, taskEventsHandler, immediateRateLimiter);
+    const rateLimitOverrides = new RateLimitOverrides({ load: () => scheduler.getRateLimitOverrides() });
+    const server = getServer(scheduler, taskEventsHandler, immediateRateLimiter, rateLimitOverrides);
 
     beforeAll(async () => {
         await dbClient.migrate();

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -8,7 +8,7 @@ import { getTestDbClient, Scheduler } from '@nangohq/scheduler';
 import { Err, nanoid, Ok } from '@nangohq/utils';
 
 import { TaskEventsHandler } from '../events.js';
-import { RateLimitOverrides } from '../rateLimitOverrides.js';
+import { ImmediateRateLimitOverrides } from '../immediateRateLimitOverrides.js';
 import { getServer } from '../server.js';
 import { OrchestratorClient } from './client.js';
 import { OrchestratorProcessor } from './processor.js';
@@ -29,8 +29,8 @@ const orchestratorClient = new OrchestratorClient({ baseUrl: `http://localhost:$
 const immediateRateLimiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'orchestrator-processor-test', limit: 1_000_000, windowMs: 60_000 });
 
 describe('OrchestratorProcessor', () => {
-    const rateLimitOverrides = new RateLimitOverrides({ load: () => scheduler.getRateLimitOverrides() });
-    const server = getServer(scheduler, taskEventsHandler, immediateRateLimiter, rateLimitOverrides);
+    const immediateRateLimitOverrides = new ImmediateRateLimitOverrides({ load: () => scheduler.getImmediateRateLimitOverrides() });
+    const server = getServer(scheduler, taskEventsHandler, immediateRateLimiter, immediateRateLimitOverrides);
 
     beforeAll(async () => {
         await dbClient.migrate();

--- a/packages/orchestrator/lib/helpers.test.ts
+++ b/packages/orchestrator/lib/helpers.test.ts
@@ -3,6 +3,7 @@ import { getTestDbClient, Scheduler } from '@nangohq/scheduler';
 
 import { OrchestratorClient } from './clients/client.js';
 import { TaskEventsHandler } from './events.js';
+import { RateLimitOverrides } from './rateLimitOverrides.js';
 import { handleSchedulerEvent } from './scheduler-config.js';
 import { getServer } from './server.js';
 
@@ -33,7 +34,8 @@ export class TestOrchestratorService {
             onError: () => {},
             onEvent: handleSchedulerEvent
         });
-        const server = getServer(this.scheduler, this.eventsHandler, this.immediateRateLimiter);
+        const rateLimitOverrides = new RateLimitOverrides({ load: () => this.scheduler!.getRateLimitOverrides() });
+        const server = getServer(this.scheduler, this.eventsHandler, this.immediateRateLimiter, rateLimitOverrides);
         server.listen(this.port);
     }
 

--- a/packages/orchestrator/lib/helpers.test.ts
+++ b/packages/orchestrator/lib/helpers.test.ts
@@ -3,7 +3,7 @@ import { getTestDbClient, Scheduler } from '@nangohq/scheduler';
 
 import { OrchestratorClient } from './clients/client.js';
 import { TaskEventsHandler } from './events.js';
-import { RateLimitOverrides } from './rateLimitOverrides.js';
+import { ImmediateRateLimitOverrides } from './immediateRateLimitOverrides.js';
 import { handleSchedulerEvent } from './scheduler-config.js';
 import { getServer } from './server.js';
 
@@ -34,8 +34,8 @@ export class TestOrchestratorService {
             onError: () => {},
             onEvent: handleSchedulerEvent
         });
-        const rateLimitOverrides = new RateLimitOverrides({ load: () => this.scheduler!.getRateLimitOverrides() });
-        const server = getServer(this.scheduler, this.eventsHandler, this.immediateRateLimiter, rateLimitOverrides);
+        const immediateRateLimitOverrides = new ImmediateRateLimitOverrides({ load: () => this.scheduler!.getImmediateRateLimitOverrides() });
+        const server = getServer(this.scheduler, this.eventsHandler, this.immediateRateLimiter, immediateRateLimitOverrides);
         server.listen(this.port);
     }
 

--- a/packages/orchestrator/lib/immediateRateLimitOverrides.ts
+++ b/packages/orchestrator/lib/immediateRateLimitOverrides.ts
@@ -7,11 +7,11 @@ import type { Result } from '@nangohq/utils';
 const DEFAULT_REFRESH_INTERVAL_MS = 30_000;
 
 /**
- * Per-group rate limit overrides, cached so admission does not query the database on every request.
- * A rate limit key doubles as the `group_overrides.group_key` its override is read from, which is why
- * webhook dispatch sends its group key as the rate limit key.
+ * Per-group overrides for the immediate task admission rate, cached so admission does not query the
+ * database on every request. A rate limit key doubles as the `group_overrides.group_key` its override
+ * is read from, which is why webhook dispatch sends its group key as the rate limit key.
  */
-export class RateLimitOverrides {
+export class ImmediateRateLimitOverrides {
     private readonly load: () => Promise<Result<Map<string, number>>>;
     private readonly refreshIntervalMs: number;
     private overrides = new Map<string, number>();
@@ -47,12 +47,12 @@ export class RateLimitOverrides {
         try {
             const res = await this.load();
             if (res.isErr()) {
-                logger.error(`Failed to load rate limit overrides: ${stringifyError(res.error)}`);
+                logger.error(`Failed to load immediate rate limit overrides: ${stringifyError(res.error)}`);
                 return;
             }
             this.overrides = res.value;
         } catch (err) {
-            logger.error(`Failed to load rate limit overrides: ${stringifyError(err)}`);
+            logger.error(`Failed to load immediate rate limit overrides: ${stringifyError(err)}`);
         }
     }
 }

--- a/packages/orchestrator/lib/immediateRateLimitOverrides.ts
+++ b/packages/orchestrator/lib/immediateRateLimitOverrides.ts
@@ -42,7 +42,8 @@ export class ImmediateRateLimitOverrides {
     }
 
     private async refresh(): Promise<void> {
-        // Back off on failure too, so a broken query keeps serving the last snapshot instead of hammering the database
+        // Push the deadline out before loading so callers arriving meanwhile read the previous snapshot
+        // rather than queueing behind a database query
         this.nextRefreshAt = Date.now() + this.refreshIntervalMs;
         try {
             const res = await this.load();
@@ -53,6 +54,10 @@ export class ImmediateRateLimitOverrides {
             this.overrides = res.value;
         } catch (err) {
             logger.error(`Failed to load immediate rate limit overrides: ${stringifyError(err)}`);
+        } finally {
+            // Measure the interval from when the attempt finished, so a slow or failing query is not
+            // retried back to back
+            this.nextRefreshAt = Date.now() + this.refreshIntervalMs;
         }
     }
 }

--- a/packages/orchestrator/lib/immediateRateLimitOverrides.unit.test.ts
+++ b/packages/orchestrator/lib/immediateRateLimitOverrides.unit.test.ts
@@ -59,6 +59,45 @@ describe('ImmediateRateLimitOverrides', () => {
         expect(load).toHaveBeenCalledTimes(2);
     });
 
+    it('measures the refresh interval from when the load finished', async () => {
+        const snapshot = () => Promise.resolve(Ok(new Map([['key', 500]])));
+        const load = vi.fn<() => Promise<Result<Map<string, number>>>>().mockImplementationOnce(() => {
+            // a load that outlives the refresh interval
+            vi.advanceTimersByTime(45_000);
+            return snapshot();
+        });
+        load.mockImplementation(snapshot);
+        const overrides = new ImmediateRateLimitOverrides({ load, refreshIntervalMs: 30_000 });
+
+        await expect(overrides.get('key')).resolves.toBe(500);
+
+        await overrides.get('key');
+        expect(load).toHaveBeenCalledOnce();
+
+        vi.advanceTimersByTime(30_000);
+        await overrides.get('key');
+        expect(load).toHaveBeenCalledTimes(2);
+    });
+
+    it('serves the previous snapshot to callers that arrive while a refresh is in flight', async () => {
+        let resolveSecondLoad: (value: Result<Map<string, number>>) => void = () => undefined;
+        const load = vi
+            .fn<() => Promise<Result<Map<string, number>>>>()
+            .mockResolvedValueOnce(Ok(new Map([['key', 500]])))
+            .mockImplementationOnce(() => new Promise((resolve) => (resolveSecondLoad = resolve)));
+        const overrides = new ImmediateRateLimitOverrides({ load, refreshIntervalMs: 30_000 });
+
+        await expect(overrides.get('key')).resolves.toBe(500);
+        vi.advanceTimersByTime(30_000);
+
+        const refreshing = overrides.get('key');
+        await expect(overrides.get('key')).resolves.toBe(500);
+
+        resolveSecondLoad(Ok(new Map([['key', 100]])));
+        await expect(refreshing).resolves.toBe(100);
+        expect(load).toHaveBeenCalledTimes(2);
+    });
+
     it('falls back to the default when the first load fails', async () => {
         const overrides = new ImmediateRateLimitOverrides({ load: () => Promise.reject(new Error('database is down')) });
 

--- a/packages/orchestrator/lib/immediateRateLimitOverrides.unit.test.ts
+++ b/packages/orchestrator/lib/immediateRateLimitOverrides.unit.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import { ImmediateRateLimitOverrides } from './immediateRateLimitOverrides.js';
+
+import type { Result } from '@nangohq/utils';
+
+describe('ImmediateRateLimitOverrides', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns the override for a key and undefined for the rest', async () => {
+        const overrides = new ImmediateRateLimitOverrides({ load: () => Promise.resolve(Ok(new Map([['webhook:environment:1', 500]]))) });
+
+        await expect(overrides.get('webhook:environment:1')).resolves.toBe(500);
+        await expect(overrides.get('webhook:environment:2')).resolves.toBeUndefined();
+    });
+
+    it('loads once per refresh interval, then picks up a change', async () => {
+        let limit = 500;
+        const load = vi.fn(() => Promise.resolve(Ok(new Map([['key', limit]]))));
+        const overrides = new ImmediateRateLimitOverrides({ load, refreshIntervalMs: 30_000 });
+
+        await overrides.get('key');
+        await overrides.get('key');
+        expect(load).toHaveBeenCalledOnce();
+
+        limit = 100;
+        vi.advanceTimersByTime(30_000);
+        await expect(overrides.get('key')).resolves.toBe(100);
+        expect(load).toHaveBeenCalledTimes(2);
+    });
+
+    it('shares a single load between concurrent calls', async () => {
+        const load = vi.fn(() => Promise.resolve(Ok(new Map([['key', 500]]))));
+        const overrides = new ImmediateRateLimitOverrides({ load });
+
+        await Promise.all([overrides.get('key'), overrides.get('key'), overrides.get('key')]);
+
+        expect(load).toHaveBeenCalledOnce();
+    });
+
+    it('keeps serving the last snapshot when loading fails', async () => {
+        const results: Result<Map<string, number>>[] = [Ok(new Map([['key', 500]])), Err(new Error('database is down'))];
+        const load = vi.fn(() => Promise.resolve(results.shift()!));
+        const overrides = new ImmediateRateLimitOverrides({ load, refreshIntervalMs: 30_000 });
+
+        await expect(overrides.get('key')).resolves.toBe(500);
+        vi.advanceTimersByTime(30_000);
+
+        await expect(overrides.get('key')).resolves.toBe(500);
+        expect(load).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to the default when the first load fails', async () => {
+        const overrides = new ImmediateRateLimitOverrides({ load: () => Promise.reject(new Error('database is down')) });
+
+        await expect(overrides.get('key')).resolves.toBeUndefined();
+    });
+});

--- a/packages/orchestrator/lib/rateLimitOverrides.ts
+++ b/packages/orchestrator/lib/rateLimitOverrides.ts
@@ -1,0 +1,58 @@
+import { stringifyError } from '@nangohq/utils';
+
+import { logger } from './utils.js';
+
+import type { Result } from '@nangohq/utils';
+
+const DEFAULT_REFRESH_INTERVAL_MS = 30_000;
+
+/**
+ * Per-group rate limit overrides, cached so admission does not query the database on every request.
+ * A rate limit key doubles as the `group_overrides.group_key` its override is read from, which is why
+ * webhook dispatch sends its group key as the rate limit key.
+ */
+export class RateLimitOverrides {
+    private readonly load: () => Promise<Result<Map<string, number>>>;
+    private readonly refreshIntervalMs: number;
+    private overrides = new Map<string, number>();
+    private nextRefreshAt = 0;
+    private refreshing: Promise<void> | undefined;
+
+    constructor({ load, refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS }: { load: () => Promise<Result<Map<string, number>>>; refreshIntervalMs?: number }) {
+        this.load = load;
+        this.refreshIntervalMs = refreshIntervalMs;
+    }
+
+    /**
+     * Override for a rate limit key, or undefined to fall back to the global default.
+     */
+    public async get(rateLimitKey: string): Promise<number | undefined> {
+        await this.refreshIfStale();
+        return this.overrides.get(rateLimitKey);
+    }
+
+    private async refreshIfStale(): Promise<void> {
+        if (Date.now() < this.nextRefreshAt) {
+            return;
+        }
+        this.refreshing ??= this.refresh().finally(() => {
+            this.refreshing = undefined;
+        });
+        await this.refreshing;
+    }
+
+    private async refresh(): Promise<void> {
+        // Back off on failure too, so a broken query keeps serving the last snapshot instead of hammering the database
+        this.nextRefreshAt = Date.now() + this.refreshIntervalMs;
+        try {
+            const res = await this.load();
+            if (res.isErr()) {
+                logger.error(`Failed to load rate limit overrides: ${stringifyError(res.error)}`);
+                return;
+            }
+            this.overrides = res.value;
+        } catch (err) {
+            logger.error(`Failed to load rate limit overrides: ${stringifyError(err)}`);
+        }
+    }
+}

--- a/packages/orchestrator/lib/rateLimiter.ts
+++ b/packages/orchestrator/lib/rateLimiter.ts
@@ -4,25 +4,21 @@ import { logger } from './utils.js';
 
 import type { SlidingWindowRateLimiter } from '@nangohq/kvstore';
 
-const uncappedRateLimiter: SlidingWindowRateLimiter = {
-    consume: (_key, units) => Promise.resolve({ admitted: units, rejected: 0, remaining: null, estimatedUsage: null, retryAfterMs: 0 }),
-    destroy: () => Promise.resolve()
-};
-
 /**
  * Build the limiter guarding immediate task admission.
- * A limit of 0 disables throttling: every request is admitted and no Redis connection is opened.
+ * A limit of 0 leaves keys unlimited by default. Per-group overrides still apply, and no Redis
+ * connection is opened until a key that has one consumes.
  */
 export function createImmediateRateLimiter(limitPerMin: number): Promise<SlidingWindowRateLimiter> {
-    if (limitPerMin <= 0) {
-        logger.info('Immediate task throttling is disabled (ORCHESTRATOR_THROTTLED_IMMEDIATE_PER_MIN=0)');
-        return Promise.resolve(uncappedRateLimiter);
+    if (limitPerMin > 0) {
+        logger.info(`Immediate task throttling is enabled (${limitPerMin}/min per rate limit key)`);
+    } else {
+        logger.info('Immediate task throttling has no global limit (ORCHESTRATOR_THROTTLED_IMMEDIATE_PER_MIN=0), only per-group overrides apply');
     }
 
-    logger.info(`Immediate task throttling is enabled (${limitPerMin}/min per rate limit key)`);
     return createSlidingWindowRateLimiter({
         keyPrefix: 'orchestrator-throttled-immediate',
-        limit: limitPerMin,
+        limit: limitPerMin > 0 ? limitPerMin : null,
         windowMs: 60_000
     });
 }

--- a/packages/orchestrator/lib/rateLimiter.unit.test.ts
+++ b/packages/orchestrator/lib/rateLimiter.unit.test.ts
@@ -9,8 +9,16 @@ describe('createImmediateRateLimiter', () => {
         const first = await limiter.consume('env-1', 5000);
         const second = await limiter.consume('env-1', 5000);
 
-        expect(first).toStrictEqual({ admitted: 5000, rejected: 0, remaining: null, estimatedUsage: null, retryAfterMs: 0 });
+        expect(first).toStrictEqual({ admitted: 5000, rejected: 0, remaining: null, estimatedUsage: null, retryAfterMs: 0, limit: null });
         expect(second.rejected).toBe(0);
+
+        await limiter.destroy();
+    });
+
+    it('still enforces an override when the limit is 0', async () => {
+        const limiter = await createImmediateRateLimiter(0);
+
+        await expect(limiter.consume('env-1', 5, { limit: 2 })).resolves.toMatchObject({ admitted: 2, rejected: 3, limit: 2 });
 
         await limiter.destroy();
     });

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -5,7 +5,7 @@ import { metrics, validateRequest } from '@nangohq/utils';
 
 import { actionArgsSchema, functionArgsSchema, onEventArgsSchema, syncAbortArgsSchema, syncArgsSchema, webhookArgsSchema } from '../../clients/validate.js';
 
-import type { RateLimitOverrides } from '../../rateLimitOverrides.js';
+import type { ImmediateRateLimitOverrides } from '../../immediateRateLimitOverrides.js';
 import type { TaskType } from '../../types.js';
 import type { SlidingWindowRateLimiter } from '@nangohq/kvstore';
 import type { Scheduler } from '@nangohq/scheduler';
@@ -90,11 +90,11 @@ const validate = validateRequest<PostImmediate>({
     }
 });
 
-const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter, rateLimitOverrides: RateLimitOverrides) => {
+const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter, immediateRateLimitOverrides: ImmediateRateLimitOverrides) => {
     return async (_req: EndpointRequest, res: EndpointResponse<PostImmediate>) => {
         const rateLimitKey = res.locals.parsedBody.rateLimitKey;
         if (rateLimitKey) {
-            const limit = await rateLimitOverrides.get(rateLimitKey);
+            const limit = await immediateRateLimitOverrides.get(rateLimitKey);
             const rateLimit = await rateLimiter.consume(rateLimitKey, 1, { limit });
             if (rateLimit.rejected > 0) {
                 metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, 1, { reason: 'rate_limit', limit: String(rateLimit.limit) });
@@ -146,11 +146,11 @@ export const route: Route<PostImmediate> = { path, method };
 export const routeHandler = (
     scheduler: Scheduler,
     rateLimiter: SlidingWindowRateLimiter,
-    rateLimitOverrides: RateLimitOverrides
+    immediateRateLimitOverrides: ImmediateRateLimitOverrides
 ): RouteHandler<PostImmediate> => {
     return {
         ...route,
         validate,
-        handler: handler(scheduler, rateLimiter, rateLimitOverrides)
+        handler: handler(scheduler, rateLimiter, immediateRateLimitOverrides)
     };
 };

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -5,6 +5,7 @@ import { metrics, validateRequest } from '@nangohq/utils';
 
 import { actionArgsSchema, functionArgsSchema, onEventArgsSchema, syncAbortArgsSchema, syncArgsSchema, webhookArgsSchema } from '../../clients/validate.js';
 
+import type { RateLimitOverrides } from '../../rateLimitOverrides.js';
 import type { TaskType } from '../../types.js';
 import type { SlidingWindowRateLimiter } from '@nangohq/kvstore';
 import type { Scheduler } from '@nangohq/scheduler';
@@ -22,6 +23,8 @@ export interface ImmediateSuccess {
 
 export interface RateLimitPayload {
     retryAfterMs: number;
+    /** Limit that rejected the call, so support can tell which value is in play. */
+    limitPerMin: number | null;
 }
 
 export const immediateTaskSchema = z
@@ -87,19 +90,20 @@ const validate = validateRequest<PostImmediate>({
     }
 });
 
-const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter) => {
+const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter, rateLimitOverrides: RateLimitOverrides) => {
     return async (_req: EndpointRequest, res: EndpointResponse<PostImmediate>) => {
         const rateLimitKey = res.locals.parsedBody.rateLimitKey;
         if (rateLimitKey) {
-            const rateLimit = await rateLimiter.consume(rateLimitKey, 1);
+            const limit = await rateLimitOverrides.get(rateLimitKey);
+            const rateLimit = await rateLimiter.consume(rateLimitKey, 1, { limit });
             if (rateLimit.rejected > 0) {
-                metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, 1, { reason: 'rate_limit' });
+                metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, 1, { reason: 'rate_limit', limit: String(rateLimit.limit) });
                 res.setHeader('Retry-After', Math.max(1, Math.ceil(rateLimit.retryAfterMs / 1000)));
                 res.status(429).json({
                     error: {
                         code: 'rate_limit_exceeded',
                         message: 'Rate limit exceeded',
-                        payload: { retryAfterMs: rateLimit.retryAfterMs }
+                        payload: { retryAfterMs: rateLimit.retryAfterMs, limitPerMin: rateLimit.limit }
                     }
                 });
                 return;
@@ -139,10 +143,14 @@ const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter) =>
 
 export const route: Route<PostImmediate> = { path, method };
 
-export const routeHandler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter): RouteHandler<PostImmediate> => {
+export const routeHandler = (
+    scheduler: Scheduler,
+    rateLimiter: SlidingWindowRateLimiter,
+    rateLimitOverrides: RateLimitOverrides
+): RouteHandler<PostImmediate> => {
     return {
         ...route,
         validate,
-        handler: handler(scheduler, rateLimiter)
+        handler: handler(scheduler, rateLimiter, rateLimitOverrides)
     };
 };

--- a/packages/orchestrator/lib/routes/v1/postImmediate.unit.test.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.unit.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import { InMemorySlidingWindowRateLimiter } from '@nangohq/kvstore';
 import { Ok } from '@nangohq/utils';
 
+import { RateLimitOverrides } from '../../rateLimitOverrides.js';
 import { getServer } from '../../server.js';
 
 import type { Scheduler } from '@nangohq/scheduler';
@@ -22,13 +23,18 @@ const immediateBatch = vi.fn((propsList: { name: string }[]) =>
 );
 const scheduler = { immediate, immediateBatch } as unknown as Scheduler;
 const rateLimiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'immediate-route-test', limit: 2, windowMs: 60_000 });
+const overrides = new Map<string, number>([
+    ['raised-key', 4],
+    ['lowered-key', 1]
+]);
+const rateLimitOverrides = new RateLimitOverrides({ load: () => Promise.resolve(Ok(new Map(overrides))), refreshIntervalMs: 60_000 });
 const port = await getPort();
 const baseUrl = `http://localhost:${port}`;
 let api: Server;
 
 describe('immediate routes', () => {
     beforeAll(() => {
-        api = getServer(scheduler, new EventEmitter(), rateLimiter).listen(port);
+        api = getServer(scheduler, new EventEmitter(), rateLimiter, rateLimitOverrides).listen(port);
     });
 
     beforeEach(() => {
@@ -51,7 +57,7 @@ describe('immediate routes', () => {
         expect(limited.status).toBe(429);
         expect(limited.headers.get('retry-after')).toBeTruthy();
         await expect(limited.json()).resolves.toMatchObject({
-            error: { code: 'rate_limit_exceeded', payload: { retryAfterMs: expect.any(Number) } }
+            error: { code: 'rate_limit_exceeded', payload: { retryAfterMs: expect.any(Number), limitPerMin: 2 } }
         });
         expect(immediate).toHaveBeenCalledTimes(2);
     });
@@ -85,13 +91,40 @@ describe('immediate routes', () => {
                     error: {
                         code: 'rate_limit_exceeded',
                         message: 'Rate limit exceeded',
-                        payload: { retryAfterMs: expect.any(Number) }
+                        payload: { retryAfterMs: expect.any(Number), limitPerMin: 2 }
                     }
                 }
             ]
         });
         expect(immediateBatch).toHaveBeenCalledOnce();
         expect(immediateBatch.mock.calls[0]![0].map((task) => task.name)).toEqual(['a-1', 'unlimited', 'b-1', 'a-2']);
+    });
+
+    it('raises the limit for a key with an override', async () => {
+        const responses = await Promise.all([
+            post('/v1/immediate', buildTask('raised-1', 'raised-key')),
+            post('/v1/immediate', buildTask('raised-2', 'raised-key')),
+            post('/v1/immediate', buildTask('raised-3', 'raised-key')),
+            post('/v1/immediate', buildTask('raised-4', 'raised-key'))
+        ]);
+        const limited = await post('/v1/immediate', buildTask('raised-5', 'raised-key'));
+
+        expect(responses.map((response) => response.status)).toEqual([200, 200, 200, 200]);
+        expect(limited.status).toBe(429);
+        await expect(limited.json()).resolves.toMatchObject({
+            error: { code: 'rate_limit_exceeded', payload: { limitPerMin: 4 } }
+        });
+    });
+
+    it('lowers the limit for a key with an override', async () => {
+        const response = await post('/v1/immediate', buildTask('lowered-1', 'lowered-key'));
+        const limited = await post('/v1/immediate', buildTask('lowered-2', 'lowered-key'));
+
+        expect(response.status).toBe(200);
+        expect(limited.status).toBe(429);
+        await expect(limited.json()).resolves.toMatchObject({
+            error: { code: 'rate_limit_exceeded', payload: { limitPerMin: 1 } }
+        });
     });
 
     it('does not apply the limiter to the existing immediate route', async () => {

--- a/packages/orchestrator/lib/routes/v1/postImmediate.unit.test.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.unit.test.ts
@@ -6,7 +6,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import { InMemorySlidingWindowRateLimiter } from '@nangohq/kvstore';
 import { Ok } from '@nangohq/utils';
 
-import { RateLimitOverrides } from '../../rateLimitOverrides.js';
+import { ImmediateRateLimitOverrides } from '../../immediateRateLimitOverrides.js';
 import { getServer } from '../../server.js';
 
 import type { Scheduler } from '@nangohq/scheduler';
@@ -27,14 +27,14 @@ const overrides = new Map<string, number>([
     ['raised-key', 4],
     ['lowered-key', 1]
 ]);
-const rateLimitOverrides = new RateLimitOverrides({ load: () => Promise.resolve(Ok(new Map(overrides))), refreshIntervalMs: 60_000 });
+const immediateRateLimitOverrides = new ImmediateRateLimitOverrides({ load: () => Promise.resolve(Ok(new Map(overrides))), refreshIntervalMs: 60_000 });
 const port = await getPort();
 const baseUrl = `http://localhost:${port}`;
 let api: Server;
 
 describe('immediate routes', () => {
     beforeAll(() => {
-        api = getServer(scheduler, new EventEmitter(), rateLimiter, rateLimitOverrides).listen(port);
+        api = getServer(scheduler, new EventEmitter(), rateLimiter, immediateRateLimitOverrides).listen(port);
     });
 
     beforeEach(() => {

--- a/packages/orchestrator/lib/routes/v1/postImmediateBatch.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediateBatch.ts
@@ -4,7 +4,7 @@ import { metrics, validateRequest } from '@nangohq/utils';
 
 import { immediateTaskSchema } from './postImmediate.js';
 
-import type { RateLimitOverrides } from '../../rateLimitOverrides.js';
+import type { ImmediateRateLimitOverrides } from '../../immediateRateLimitOverrides.js';
 import type { ImmediateSuccess, RateLimitPayload } from './postImmediate.js';
 import type { SlidingWindowRateLimiter } from '@nangohq/kvstore';
 import type { Scheduler } from '@nangohq/scheduler';
@@ -66,7 +66,7 @@ const validate = validateRequest<PostImmediateBatch>({
     }
 });
 
-const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter, rateLimitOverrides: RateLimitOverrides) => {
+const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter, immediateRateLimitOverrides: ImmediateRateLimitOverrides) => {
     return async (_req: EndpointRequest, res: EndpointResponse<PostImmediateBatch>) => {
         const entries = res.locals.parsedBody.tasks;
         const admitted = entries.map((entry) => !entry.rateLimitKey);
@@ -79,7 +79,7 @@ const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter, ra
         const rateLimitedCounts = new Map<string, number>();
         await Promise.all(
             [...entriesByRateLimitKey.entries()].map(async ([rateLimitKey, entriesForKey]) => {
-                const limit = await rateLimitOverrides.get(rateLimitKey);
+                const limit = await immediateRateLimitOverrides.get(rateLimitKey);
                 const rateLimit = await rateLimiter.consume(rateLimitKey, entriesForKey.length, { limit });
                 for (const { index } of entriesForKey.slice(0, rateLimit.admitted)) {
                     admitted[index] = true;
@@ -155,11 +155,11 @@ export const route: Route<PostImmediateBatch> = { path, method };
 export const routeHandler = (
     scheduler: Scheduler,
     rateLimiter: SlidingWindowRateLimiter,
-    rateLimitOverrides: RateLimitOverrides
+    immediateRateLimitOverrides: ImmediateRateLimitOverrides
 ): RouteHandler<PostImmediateBatch> => {
     return {
         ...route,
         validate,
-        handler: handler(scheduler, rateLimiter, rateLimitOverrides)
+        handler: handler(scheduler, rateLimiter, immediateRateLimitOverrides)
     };
 };

--- a/packages/orchestrator/lib/routes/v1/postImmediateBatch.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediateBatch.ts
@@ -4,6 +4,7 @@ import { metrics, validateRequest } from '@nangohq/utils';
 
 import { immediateTaskSchema } from './postImmediate.js';
 
+import type { RateLimitOverrides } from '../../rateLimitOverrides.js';
 import type { ImmediateSuccess, RateLimitPayload } from './postImmediate.js';
 import type { SlidingWindowRateLimiter } from '@nangohq/kvstore';
 import type { Scheduler } from '@nangohq/scheduler';
@@ -65,7 +66,7 @@ const validate = validateRequest<PostImmediateBatch>({
     }
 });
 
-const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter) => {
+const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter, rateLimitOverrides: RateLimitOverrides) => {
     return async (_req: EndpointRequest, res: EndpointResponse<PostImmediateBatch>) => {
         const entries = res.locals.parsedBody.tasks;
         const admitted = entries.map((entry) => !entry.rateLimitKey);
@@ -75,27 +76,32 @@ const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter) =>
         );
         const resultByName = new Map<string, ImmediateBatchResult>();
 
-        let rateLimitedCount = 0;
+        const rateLimitedCounts = new Map<string, number>();
         await Promise.all(
             [...entriesByRateLimitKey.entries()].map(async ([rateLimitKey, entriesForKey]) => {
-                const rateLimit = await rateLimiter.consume(rateLimitKey, entriesForKey.length);
+                const limit = await rateLimitOverrides.get(rateLimitKey);
+                const rateLimit = await rateLimiter.consume(rateLimitKey, entriesForKey.length, { limit });
                 for (const { index } of entriesForKey.slice(0, rateLimit.admitted)) {
                     admitted[index] = true;
                 }
-                for (const { entry } of entriesForKey.slice(rateLimit.admitted)) {
-                    rateLimitedCount++;
+                const rejected = entriesForKey.slice(rateLimit.admitted);
+                for (const { entry } of rejected) {
                     resultByName.set(entry.name, {
                         error: {
                             code: 'rate_limit_exceeded',
                             message: 'Rate limit exceeded',
-                            payload: { retryAfterMs: rateLimit.retryAfterMs }
+                            payload: { retryAfterMs: rateLimit.retryAfterMs, limitPerMin: rateLimit.limit }
                         }
                     });
                 }
+                if (rejected.length > 0) {
+                    const tag = String(rateLimit.limit);
+                    rateLimitedCounts.set(tag, (rateLimitedCounts.get(tag) ?? 0) + rejected.length);
+                }
             })
         );
-        if (rateLimitedCount > 0) {
-            metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, rateLimitedCount, { reason: 'rate_limit' });
+        for (const [limit, count] of rateLimitedCounts) {
+            metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, count, { reason: 'rate_limit', limit });
         }
 
         const admittedEntries = entries.filter((_, index) => admitted[index]);
@@ -146,10 +152,14 @@ const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter) =>
 
 export const route: Route<PostImmediateBatch> = { path, method };
 
-export const routeHandler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter): RouteHandler<PostImmediateBatch> => {
+export const routeHandler = (
+    scheduler: Scheduler,
+    rateLimiter: SlidingWindowRateLimiter,
+    rateLimitOverrides: RateLimitOverrides
+): RouteHandler<PostImmediateBatch> => {
     return {
         ...route,
         validate,
-        handler: handler(scheduler, rateLimiter)
+        handler: handler(scheduler, rateLimiter, rateLimitOverrides)
     };
 };

--- a/packages/orchestrator/lib/server.ts
+++ b/packages/orchestrator/lib/server.ts
@@ -20,20 +20,26 @@ import { routeHandler as putTaskHandler } from './routes/v1/tasks/putTaskId.js';
 import { routeHandler as getOutputHandler } from './routes/v1/tasks/taskId/getOutput.js';
 import { routeHandler as postHeartbeatHandler } from './routes/v1/tasks/taskId/postHeartbeat.js';
 
+import type { RateLimitOverrides } from './rateLimitOverrides.js';
 import type { SlidingWindowRateLimiter } from '@nangohq/kvstore';
 import type { Scheduler } from '@nangohq/scheduler';
 import type { ApiError } from '@nangohq/types';
 import type { Express, NextFunction, Request, Response } from 'express';
 import type EventEmitter from 'node:events';
 
-export const getServer = (scheduler: Scheduler, eventEmmiter: EventEmitter, immediateRateLimiter: SlidingWindowRateLimiter): Express => {
+export const getServer = (
+    scheduler: Scheduler,
+    eventEmmiter: EventEmitter,
+    immediateRateLimiter: SlidingWindowRateLimiter,
+    rateLimitOverrides: RateLimitOverrides
+): Express => {
     const server = express();
 
     createRoute(server, getHealthHandler);
     server.use(internalServiceAuthMiddleware({ audience: INTERNAL_SERVICE_AUDIENCE_ORCHESTRATOR, envs }));
     server.use(express.json({ limit: serverRequestSizeLimit }));
-    createRoute(server, postImmediateHandler(scheduler, immediateRateLimiter));
-    createRoute(server, postImmediateBatchHandler(scheduler, immediateRateLimiter));
+    createRoute(server, postImmediateHandler(scheduler, immediateRateLimiter, rateLimitOverrides));
+    createRoute(server, postImmediateBatchHandler(scheduler, immediateRateLimiter, rateLimitOverrides));
     createRoute(server, postRecurringHandler(scheduler));
     createRoute(server, postScheduleRunHandler(scheduler));
     createRoute(server, putRecurringHandler(scheduler));

--- a/packages/orchestrator/lib/server.ts
+++ b/packages/orchestrator/lib/server.ts
@@ -20,7 +20,7 @@ import { routeHandler as putTaskHandler } from './routes/v1/tasks/putTaskId.js';
 import { routeHandler as getOutputHandler } from './routes/v1/tasks/taskId/getOutput.js';
 import { routeHandler as postHeartbeatHandler } from './routes/v1/tasks/taskId/postHeartbeat.js';
 
-import type { RateLimitOverrides } from './rateLimitOverrides.js';
+import type { ImmediateRateLimitOverrides } from './immediateRateLimitOverrides.js';
 import type { SlidingWindowRateLimiter } from '@nangohq/kvstore';
 import type { Scheduler } from '@nangohq/scheduler';
 import type { ApiError } from '@nangohq/types';
@@ -31,15 +31,15 @@ export const getServer = (
     scheduler: Scheduler,
     eventEmmiter: EventEmitter,
     immediateRateLimiter: SlidingWindowRateLimiter,
-    rateLimitOverrides: RateLimitOverrides
+    immediateRateLimitOverrides: ImmediateRateLimitOverrides
 ): Express => {
     const server = express();
 
     createRoute(server, getHealthHandler);
     server.use(internalServiceAuthMiddleware({ audience: INTERNAL_SERVICE_AUDIENCE_ORCHESTRATOR, envs }));
     server.use(express.json({ limit: serverRequestSizeLimit }));
-    createRoute(server, postImmediateHandler(scheduler, immediateRateLimiter, rateLimitOverrides));
-    createRoute(server, postImmediateBatchHandler(scheduler, immediateRateLimiter, rateLimitOverrides));
+    createRoute(server, postImmediateHandler(scheduler, immediateRateLimiter, immediateRateLimitOverrides));
+    createRoute(server, postImmediateBatchHandler(scheduler, immediateRateLimiter, immediateRateLimitOverrides));
     createRoute(server, postRecurringHandler(scheduler));
     createRoute(server, postScheduleRunHandler(scheduler));
     createRoute(server, putRecurringHandler(scheduler));

--- a/packages/orchestrator/lib/server.unit.test.ts
+++ b/packages/orchestrator/lib/server.unit.test.ts
@@ -6,7 +6,7 @@ import { InMemorySlidingWindowRateLimiter } from '@nangohq/kvstore';
 import { Ok } from '@nangohq/utils';
 
 import { envs } from './env.js';
-import { RateLimitOverrides } from './rateLimitOverrides.js';
+import { ImmediateRateLimitOverrides } from './immediateRateLimitOverrides.js';
 import { getServer } from './server.js';
 
 import type { Scheduler } from '@nangohq/scheduler';
@@ -22,7 +22,7 @@ function app() {
         {} as Scheduler,
         new EventEmitter(),
         new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: 100, windowMs: 1000 }),
-        new RateLimitOverrides({ load: () => Promise.resolve(Ok(new Map())) })
+        new ImmediateRateLimitOverrides({ load: () => Promise.resolve(Ok(new Map())) })
     );
 }
 

--- a/packages/orchestrator/lib/server.unit.test.ts
+++ b/packages/orchestrator/lib/server.unit.test.ts
@@ -3,8 +3,10 @@ import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { InMemorySlidingWindowRateLimiter } from '@nangohq/kvstore';
+import { Ok } from '@nangohq/utils';
 
 import { envs } from './env.js';
+import { RateLimitOverrides } from './rateLimitOverrides.js';
 import { getServer } from './server.js';
 
 import type { Scheduler } from '@nangohq/scheduler';
@@ -16,7 +18,12 @@ afterEach(() => {
 });
 
 function app() {
-    return getServer({} as Scheduler, new EventEmitter(), new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: 100, windowMs: 1000 }));
+    return getServer(
+        {} as Scheduler,
+        new EventEmitter(),
+        new InMemorySlidingWindowRateLimiter({ keyPrefix: 'test', limit: 100, windowMs: 1000 }),
+        new RateLimitOverrides({ load: () => Promise.resolve(Ok(new Map())) })
+    );
 }
 
 async function listen(server: ReturnType<typeof app>) {

--- a/packages/scheduler/lib/db/migrations/20260827120000_group_overrides_add_immediate_rate_limit.ts
+++ b/packages/scheduler/lib/db/migrations/20260827120000_group_overrides_add_immediate_rate_limit.ts
@@ -5,7 +5,7 @@ import type { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
     await knex.raw(`
         ALTER TABLE ${GROUP_OVERRIDES_TABLE}
-            ADD COLUMN IF NOT EXISTS rate_limit_per_min INT CHECK (rate_limit_per_min > 0)
+            ADD COLUMN IF NOT EXISTS immediate_rate_limit_per_min INT CHECK (immediate_rate_limit_per_min > 0)
     `);
 }
 

--- a/packages/scheduler/lib/db/migrations/20260827120000_group_overrides_add_rate_limit.ts
+++ b/packages/scheduler/lib/db/migrations/20260827120000_group_overrides_add_rate_limit.ts
@@ -1,0 +1,12 @@
+import { GROUP_OVERRIDES_TABLE } from '../../models/groupOverrides.js';
+
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${GROUP_OVERRIDES_TABLE}
+            ADD COLUMN IF NOT EXISTS rate_limit_per_min INT CHECK (rate_limit_per_min > 0)
+    `);
+}
+
+export async function down(): Promise<void> {}

--- a/packages/scheduler/lib/models/groupOverrides.integration.test.ts
+++ b/packages/scheduler/lib/models/groupOverrides.integration.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { nanoid } from '@nangohq/utils';
+
+import { getTestDbClient } from '../db/helpers.test.js';
+import * as groupOverrides from './groupOverrides.js';
+
+describe('groupOverrides', () => {
+    const dbClient = getTestDbClient('scheduler_group_overrides');
+    const db = dbClient.db;
+
+    beforeEach(async () => {
+        await dbClient.migrate();
+    });
+
+    afterEach(async () => {
+        await dbClient.clearDatabase();
+    });
+
+    afterAll(async () => {
+        await dbClient.destroy();
+    });
+
+    it('stores a rate limit override without clearing the other overrides', async () => {
+        const groupKey = nanoid();
+        (await groupOverrides.upsert(db, { groupKey, maxConcurrency: 3, taskCap: 7 })).unwrap();
+        (await groupOverrides.upsert(db, { groupKey, rateLimitPerMin: 500 })).unwrap();
+
+        const overrides = (await groupOverrides.getByGroupKeys(db, [groupKey])).unwrap();
+
+        expect(overrides.get(groupKey)).toEqual({ maxConcurrency: 3, taskCap: 7, rateLimitPerMin: 500 });
+    });
+
+    it('only returns groups that have a rate limit override', async () => {
+        const withRateLimit = nanoid();
+        const withoutRateLimit = nanoid();
+        (await groupOverrides.upsert(db, { groupKey: withRateLimit, rateLimitPerMin: 500 })).unwrap();
+        (await groupOverrides.upsert(db, { groupKey: withoutRateLimit, maxConcurrency: 3 })).unwrap();
+
+        const rateLimits = (await groupOverrides.getRateLimits(db)).unwrap();
+
+        expect([...rateLimits]).toEqual([[withRateLimit, 500]]);
+    });
+
+    it('clears a rate limit override', async () => {
+        const groupKey = nanoid();
+        (await groupOverrides.upsert(db, { groupKey, rateLimitPerMin: 500 })).unwrap();
+        (await groupOverrides.upsert(db, { groupKey, rateLimitPerMin: null })).unwrap();
+
+        expect((await groupOverrides.getRateLimits(db)).unwrap().size).toBe(0);
+    });
+
+    it('rejects a rate limit that is not positive', async () => {
+        const res = await groupOverrides.upsert(db, { groupKey: nanoid(), rateLimitPerMin: 0 });
+
+        expect(res.isErr()).toBe(true);
+    });
+});

--- a/packages/scheduler/lib/models/groupOverrides.integration.test.ts
+++ b/packages/scheduler/lib/models/groupOverrides.integration.test.ts
@@ -24,34 +24,34 @@ describe('groupOverrides', () => {
     it('stores a rate limit override without clearing the other overrides', async () => {
         const groupKey = nanoid();
         (await groupOverrides.upsert(db, { groupKey, maxConcurrency: 3, taskCap: 7 })).unwrap();
-        (await groupOverrides.upsert(db, { groupKey, rateLimitPerMin: 500 })).unwrap();
+        (await groupOverrides.upsert(db, { groupKey, immediateRateLimitPerMin: 500 })).unwrap();
 
         const overrides = (await groupOverrides.getByGroupKeys(db, [groupKey])).unwrap();
 
-        expect(overrides.get(groupKey)).toEqual({ maxConcurrency: 3, taskCap: 7, rateLimitPerMin: 500 });
+        expect(overrides.get(groupKey)).toEqual({ maxConcurrency: 3, taskCap: 7, immediateRateLimitPerMin: 500 });
     });
 
     it('only returns groups that have a rate limit override', async () => {
         const withRateLimit = nanoid();
         const withoutRateLimit = nanoid();
-        (await groupOverrides.upsert(db, { groupKey: withRateLimit, rateLimitPerMin: 500 })).unwrap();
+        (await groupOverrides.upsert(db, { groupKey: withRateLimit, immediateRateLimitPerMin: 500 })).unwrap();
         (await groupOverrides.upsert(db, { groupKey: withoutRateLimit, maxConcurrency: 3 })).unwrap();
 
-        const rateLimits = (await groupOverrides.getRateLimits(db)).unwrap();
+        const rateLimits = (await groupOverrides.getImmediateRateLimits(db)).unwrap();
 
         expect([...rateLimits]).toEqual([[withRateLimit, 500]]);
     });
 
     it('clears a rate limit override', async () => {
         const groupKey = nanoid();
-        (await groupOverrides.upsert(db, { groupKey, rateLimitPerMin: 500 })).unwrap();
-        (await groupOverrides.upsert(db, { groupKey, rateLimitPerMin: null })).unwrap();
+        (await groupOverrides.upsert(db, { groupKey, immediateRateLimitPerMin: 500 })).unwrap();
+        (await groupOverrides.upsert(db, { groupKey, immediateRateLimitPerMin: null })).unwrap();
 
-        expect((await groupOverrides.getRateLimits(db)).unwrap().size).toBe(0);
+        expect((await groupOverrides.getImmediateRateLimits(db)).unwrap().size).toBe(0);
     });
 
     it('rejects a rate limit that is not positive', async () => {
-        const res = await groupOverrides.upsert(db, { groupKey: nanoid(), rateLimitPerMin: 0 });
+        const res = await groupOverrides.upsert(db, { groupKey: nanoid(), immediateRateLimitPerMin: 0 });
 
         expect(res.isErr()).toBe(true);
     });

--- a/packages/scheduler/lib/models/groupOverrides.ts
+++ b/packages/scheduler/lib/models/groupOverrides.ts
@@ -9,6 +9,7 @@ export interface GroupOverride {
     group_key: string;
     max_concurrency: number | null;
     task_cap: number | null;
+    rate_limit_per_min: number | null;
     created_at?: Date;
     updated_at?: Date;
 }
@@ -16,27 +17,36 @@ export interface GroupOverride {
 export interface GroupOverrideValues {
     maxConcurrency: number | null;
     taskCap: number | null;
+    rateLimitPerMin: number | null;
 }
 
 type UpsertParams = { groupKey: string } & (
-    | { maxConcurrency: number | null; taskCap?: number | null }
-    | { maxConcurrency?: number | null; taskCap: number | null }
+    | { maxConcurrency: number | null; taskCap?: number | null; rateLimitPerMin?: number | null }
+    | { maxConcurrency?: number | null; taskCap: number | null; rateLimitPerMin?: number | null }
+    | { maxConcurrency?: number | null; taskCap?: number | null; rateLimitPerMin: number | null }
 );
 
 /**
  * Set one or more overrides for a group. Values omitted from an update are preserved, while null clears an override.
- * Max concurrency is stamped onto tasks when they are created, while the task cap is evaluated on every admission.
+ * Max concurrency is stamped onto tasks when they are created, the task cap is evaluated on every admission,
+ * and the rate limit replaces the global admission rate for the group.
  */
-export async function upsert(db: knex.Knex, { groupKey, maxConcurrency, taskCap }: UpsertParams): Promise<Result<void>> {
+export async function upsert(db: knex.Knex, { groupKey, maxConcurrency, taskCap, rateLimitPerMin }: UpsertParams): Promise<Result<void>> {
     try {
         const update = {
             ...(maxConcurrency !== undefined ? { max_concurrency: maxConcurrency } : {}),
             ...(taskCap !== undefined ? { task_cap: taskCap } : {}),
+            ...(rateLimitPerMin !== undefined ? { rate_limit_per_min: rateLimitPerMin } : {}),
             updated_at: new Date()
         };
         await db
             .from<GroupOverride>(GROUP_OVERRIDES_TABLE)
-            .insert({ group_key: groupKey, max_concurrency: maxConcurrency ?? null, task_cap: taskCap ?? null })
+            .insert({
+                group_key: groupKey,
+                max_concurrency: maxConcurrency ?? null,
+                task_cap: taskCap ?? null,
+                rate_limit_per_min: rateLimitPerMin ?? null
+            })
             .onConflict('group_key')
             .merge(update);
         return Ok(undefined);
@@ -65,9 +75,29 @@ export async function getByGroupKeys(db: knex.Knex, groupKeys: string[]): Promis
         const rows = await db
             .from<GroupOverride>(GROUP_OVERRIDES_TABLE)
             .whereIn('group_key', groupKeys)
-            .select<Pick<GroupOverride, 'group_key' | 'max_concurrency' | 'task_cap'>[]>('group_key', 'max_concurrency', 'task_cap');
-        return Ok(new Map(rows.map((row) => [row.group_key, { maxConcurrency: row.max_concurrency, taskCap: row.task_cap }])));
+            .select<
+                Pick<GroupOverride, 'group_key' | 'max_concurrency' | 'task_cap' | 'rate_limit_per_min'>[]
+            >('group_key', 'max_concurrency', 'task_cap', 'rate_limit_per_min');
+        return Ok(
+            new Map(rows.map((row) => [row.group_key, { maxConcurrency: row.max_concurrency, taskCap: row.task_cap, rateLimitPerMin: row.rate_limit_per_min }]))
+        );
     } catch (err) {
         return Err(new Error(`Error getting group overrides: ${stringifyError(err)}`));
+    }
+}
+
+/**
+ * Fetch every group that has a rate limit override. Callers cache this, so it is a full scan of a
+ * table that only holds rows an operator created by hand.
+ */
+export async function getRateLimits(db: knex.Knex): Promise<Result<Map<string, number>>> {
+    try {
+        const rows = await db
+            .from<GroupOverride>(GROUP_OVERRIDES_TABLE)
+            .whereNotNull('rate_limit_per_min')
+            .select<Pick<GroupOverride, 'group_key' | 'rate_limit_per_min'>[]>('group_key', 'rate_limit_per_min');
+        return Ok(new Map(rows.map((row) => [row.group_key, row.rate_limit_per_min!])));
+    } catch (err) {
+        return Err(new Error(`Error getting group rate limit overrides: ${stringifyError(err)}`));
     }
 }

--- a/packages/scheduler/lib/models/groupOverrides.ts
+++ b/packages/scheduler/lib/models/groupOverrides.ts
@@ -9,7 +9,7 @@ export interface GroupOverride {
     group_key: string;
     max_concurrency: number | null;
     task_cap: number | null;
-    rate_limit_per_min: number | null;
+    immediate_rate_limit_per_min: number | null;
     created_at?: Date;
     updated_at?: Date;
 }
@@ -17,26 +17,26 @@ export interface GroupOverride {
 export interface GroupOverrideValues {
     maxConcurrency: number | null;
     taskCap: number | null;
-    rateLimitPerMin: number | null;
+    immediateRateLimitPerMin: number | null;
 }
 
 type UpsertParams = { groupKey: string } & (
-    | { maxConcurrency: number | null; taskCap?: number | null; rateLimitPerMin?: number | null }
-    | { maxConcurrency?: number | null; taskCap: number | null; rateLimitPerMin?: number | null }
-    | { maxConcurrency?: number | null; taskCap?: number | null; rateLimitPerMin: number | null }
+    | { maxConcurrency: number | null; taskCap?: number | null; immediateRateLimitPerMin?: number | null }
+    | { maxConcurrency?: number | null; taskCap: number | null; immediateRateLimitPerMin?: number | null }
+    | { maxConcurrency?: number | null; taskCap?: number | null; immediateRateLimitPerMin: number | null }
 );
 
 /**
  * Set one or more overrides for a group. Values omitted from an update are preserved, while null clears an override.
  * Max concurrency is stamped onto tasks when they are created, the task cap is evaluated on every admission,
- * and the rate limit replaces the global admission rate for the group.
+ * and the immediate rate limit replaces the global admission rate for the group.
  */
-export async function upsert(db: knex.Knex, { groupKey, maxConcurrency, taskCap, rateLimitPerMin }: UpsertParams): Promise<Result<void>> {
+export async function upsert(db: knex.Knex, { groupKey, maxConcurrency, taskCap, immediateRateLimitPerMin }: UpsertParams): Promise<Result<void>> {
     try {
         const update = {
             ...(maxConcurrency !== undefined ? { max_concurrency: maxConcurrency } : {}),
             ...(taskCap !== undefined ? { task_cap: taskCap } : {}),
-            ...(rateLimitPerMin !== undefined ? { rate_limit_per_min: rateLimitPerMin } : {}),
+            ...(immediateRateLimitPerMin !== undefined ? { immediate_rate_limit_per_min: immediateRateLimitPerMin } : {}),
             updated_at: new Date()
         };
         await db
@@ -45,7 +45,7 @@ export async function upsert(db: knex.Knex, { groupKey, maxConcurrency, taskCap,
                 group_key: groupKey,
                 max_concurrency: maxConcurrency ?? null,
                 task_cap: taskCap ?? null,
-                rate_limit_per_min: rateLimitPerMin ?? null
+                immediate_rate_limit_per_min: immediateRateLimitPerMin ?? null
             })
             .onConflict('group_key')
             .merge(update);
@@ -76,10 +76,15 @@ export async function getByGroupKeys(db: knex.Knex, groupKeys: string[]): Promis
             .from<GroupOverride>(GROUP_OVERRIDES_TABLE)
             .whereIn('group_key', groupKeys)
             .select<
-                Pick<GroupOverride, 'group_key' | 'max_concurrency' | 'task_cap' | 'rate_limit_per_min'>[]
-            >('group_key', 'max_concurrency', 'task_cap', 'rate_limit_per_min');
+                Pick<GroupOverride, 'group_key' | 'max_concurrency' | 'task_cap' | 'immediate_rate_limit_per_min'>[]
+            >('group_key', 'max_concurrency', 'task_cap', 'immediate_rate_limit_per_min');
         return Ok(
-            new Map(rows.map((row) => [row.group_key, { maxConcurrency: row.max_concurrency, taskCap: row.task_cap, rateLimitPerMin: row.rate_limit_per_min }]))
+            new Map(
+                rows.map((row) => [
+                    row.group_key,
+                    { maxConcurrency: row.max_concurrency, taskCap: row.task_cap, immediateRateLimitPerMin: row.immediate_rate_limit_per_min }
+                ])
+            )
         );
     } catch (err) {
         return Err(new Error(`Error getting group overrides: ${stringifyError(err)}`));
@@ -87,16 +92,16 @@ export async function getByGroupKeys(db: knex.Knex, groupKeys: string[]): Promis
 }
 
 /**
- * Fetch every group that has a rate limit override. Callers cache this, so it is a full scan of a
- * table that only holds rows an operator created by hand.
+ * Fetch every group that overrides the immediate admission rate. Callers cache this, so it is a full
+ * scan of a table that only holds rows an operator created by hand.
  */
-export async function getRateLimits(db: knex.Knex): Promise<Result<Map<string, number>>> {
+export async function getImmediateRateLimits(db: knex.Knex): Promise<Result<Map<string, number>>> {
     try {
         const rows = await db
             .from<GroupOverride>(GROUP_OVERRIDES_TABLE)
-            .whereNotNull('rate_limit_per_min')
-            .select<Pick<GroupOverride, 'group_key' | 'rate_limit_per_min'>[]>('group_key', 'rate_limit_per_min');
-        return Ok(new Map(rows.map((row) => [row.group_key, row.rate_limit_per_min!])));
+            .whereNotNull('immediate_rate_limit_per_min')
+            .select<Pick<GroupOverride, 'group_key' | 'immediate_rate_limit_per_min'>[]>('group_key', 'immediate_rate_limit_per_min');
+        return Ok(new Map(rows.map((row) => [row.group_key, row.immediate_rate_limit_per_min!])));
     } catch (err) {
         return Err(new Error(`Error getting group rate limit overrides: ${stringifyError(err)}`));
     }

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -7,6 +7,7 @@ import { CleaningDaemon } from './daemons/cleaning/cleaning.daemon.js';
 import { ExpiringDaemon } from './daemons/expiring/expiring.daemon.js';
 import { SchedulingDaemon } from './daemons/scheduling/scheduling.daemon.js';
 import { ScheduleTaskAlreadyRunningError } from './errors.js';
+import * as groupOverrides from './models/groupOverrides.js';
 import * as schedules from './models/schedules.js';
 import * as tasks from './models/tasks.js';
 import { logger, setLogger } from './utils/logger.js';
@@ -181,6 +182,13 @@ export class Scheduler {
         forUpdate?: boolean;
     }): Promise<Result<Schedule[]>> {
         return schedules.search(this.db, params);
+    }
+
+    /**
+     * Rate limit override per group key, for groups that have one.
+     */
+    public async getRateLimitOverrides(): Promise<Result<Map<string, number>>> {
+        return groupOverrides.getRateLimits(this.db);
     }
 
     public monitoring = {

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -185,10 +185,10 @@ export class Scheduler {
     }
 
     /**
-     * Rate limit override per group key, for groups that have one.
+     * Immediate admission rate limit per group key, for the groups that override it.
      */
-    public async getRateLimitOverrides(): Promise<Result<Map<string, number>>> {
-        return groupOverrides.getRateLimits(this.db);
+    public async getImmediateRateLimitOverrides(): Promise<Result<Map<string, number>>> {
+        return groupOverrides.getImmediateRateLimits(this.db);
     }
 
     public monitoring = {


### PR DESCRIPTION
NAN-6542

Lets us raise or lower the webhook dispatch rate limit for a single environment without a deploy. Adds an optional `immediate_rate_limit_per_min` column on `group_overrides`, alongside the existing concurrency and task cap overrides. Admission uses the override when there is one and `ORCHESTRATOR_THROTTLED_IMMEDIATE_PER_MIN` otherwise.

A global limit of 0 no longer turns the limiter off, it leaves keys unlimited until one has an override. The limit in play is readable from the 429 payload, the dropped-task metric, and the activity log.