### PR TITLE
feat(plans): add the pay-as-you-go plan

### DIFF
--- a/packages/server/lib/controllers/v1/plans/change/postChange.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.ts
@@ -55,6 +55,13 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         return;
     }
 
+    const isUpgrade = plansList.filter((p) => currentDef.nextPlan?.includes(p.code))?.find((p) => p.code === body.orbId);
+    const isDowngrade = currentDef.prevPlan?.includes(body.orbId);
+    if (!isUpgrade && !isDowngrade) {
+        res.status(400).send({ error: { code: 'invalid_body', message: 'team cannot change to this plan' } });
+        return;
+    }
+
     try {
         const sub = (await billing.getSubscription(account.id)).unwrap();
         if (!sub) {
@@ -72,8 +79,6 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         report(err);
         return;
     }
-
-    const isUpgrade = plansList.filter((p) => currentDef.nextPlan?.includes(p.code))?.find((p) => p.code === body.orbId);
 
     // -- Upgrade
     if (isUpgrade) {

--- a/packages/server/lib/utils/spendPlans.ts
+++ b/packages/server/lib/utils/spendPlans.ts
@@ -4,6 +4,7 @@ import type { DBPlan } from '@nangohq/types';
 // anything. An annual contract's own invoice states its whole contract total, not one period's charge.
 // Exhaustive, so a new plan has to be classified rather than inheriting a figure.
 const SPEND_PLANS: Record<DBPlan['name'], boolean> = {
+    'pay-as-you-go': true,
     'starter-v2': true,
     'growth-v2': true,
     'startup-deal': true,

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -5,7 +5,13 @@ export const freePlan: PlanDefinition = {
     title: 'Free',
     description: 'For hobby and testing.',
     prevPlan: null,
-    nextPlan: ['starter-v2', 'growth-v2', 'enterprise'],
+    // TODO: drop 'starter-v2' and 'growth-v2' when pay-as-you-go stops being hidden.
+    // They're sunset and shouldn't be sold to new accounts, but removing them before
+    // the pay-as-you-go card is exposed would leave Free accounts with no self-serve
+    // upgrade at all: their cards fall back to "Contact us" and postChange rejects
+    // the transition. Existing customers are unaffected either way, their moves are
+    // driven by starterV2Plan/growthV2Plan and the downgrade matrix.
+    nextPlan: ['starter-v2', 'growth-v2', 'pay-as-you-go', 'enterprise'],
     canChange: true,
     basePrice: 0,
     flags: {
@@ -152,11 +158,32 @@ export const growthV2Plan: PlanDefinition = {
     flags: growthV1Plan.flags
 };
 
+export const payAsYouGoPlan: PlanDefinition = {
+    code: 'pay-as-you-go',
+    title: 'Pay as you go',
+    description: 'Usage-based pricing with a monthly minimum.',
+    prevPlan: ['free'],
+    nextPlan: ['enterprise'],
+    canChange: true,
+    // TODO: flip the flag once we're ready to roll the plan out.
+    // Not offered in the dashboard yet, the billing page work lands separately.
+    // Flipping this to false is the only switch needed to expose the plan.
+    hidden: true,
+    // TODO: update value and handling of basePrice, as this plan will be charged
+    // fully in-arrears without an actual base price; it'll rather have a minimum
+    // spend.
+    basePrice: 50,
+    flags: {
+        // Starter-level for now, the growth add-on will unlock the growth flags later
+        ...starterV2Plan.flags
+    }
+};
+
 export const enterprisePlan: PlanDefinition = {
     code: 'enterprise',
     title: 'Enterprise',
     description: 'For custom needs.',
-    prevPlan: ['free', 'starter', 'growth'],
+    prevPlan: ['free', 'pay-as-you-go', 'starter', 'growth'],
     nextPlan: null,
     canChange: false,
     cta: 'Contact Us',
@@ -364,6 +391,9 @@ export const plansList: PlanDefinition[] = [
     starterV2Plan,
     growthV2Plan,
 
+    // Usage-based plan, replaces starter-v2/growth-v2
+    payAsYouGoPlan,
+
     // V1 plans
     starterV1Plan,
     growthV1Plan,
@@ -396,6 +426,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
     const downgradeMatrix = {
         free: {
             free: false,
+            'pay-as-you-go': false,
             'starter-v2': false,
             'growth-v2': false,
             starter: false,
@@ -410,6 +441,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         'starter-v2': {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': false,
             'growth-v2': false,
             starter: false,
@@ -424,6 +456,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         'growth-v2': {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': true,
             'growth-v2': false,
             starter: true,
@@ -436,8 +469,25 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
             'free-uncapped': false,
             'startup-deal': false
         },
+        'pay-as-you-go': {
+            // Base flags are starter-level, so this row mirrors 'starter-v2'.
+            free: true,
+            'pay-as-you-go': false,
+            'starter-v2': false,
+            'growth-v2': false,
+            starter: false,
+            growth: false,
+            enterprise: false,
+            'starter-legacy': false,
+            'scale-legacy': false,
+            'growth-legacy': false,
+            'enterprise-cloud-hosted': false,
+            'free-uncapped': false,
+            'startup-deal': false
+        },
         starter: {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': false,
             'growth-v2': false,
             starter: false,
@@ -452,6 +502,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         growth: {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': true,
             'growth-v2': false,
             starter: true,
@@ -466,6 +517,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         enterprise: {
             free: true,
+            'pay-as-you-go': true,
             'starter-v2': true,
             'growth-v2': true,
             starter: true,
@@ -480,6 +532,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         'starter-legacy': {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': false,
             'growth-v2': false,
             starter: false,
@@ -494,6 +547,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         'growth-legacy': {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': true,
             'growth-v2': false,
             starter: true,
@@ -508,6 +562,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         'scale-legacy': {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': true,
             'growth-v2': true,
             starter: true,
@@ -525,6 +580,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
             // the new plan's flags will be adopted and any overrides from the current
             // plan will be dropped.
             free: true,
+            'pay-as-you-go': true,
             'starter-v2': true,
             'growth-v2': true,
             enterprise: true,
@@ -543,6 +599,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
             // the new plan's flags will be adopted and any overrides from the current
             // plan will be dropped.
             free: true,
+            'pay-as-you-go': true,
             'starter-v2': true,
             'growth-v2': true,
             enterprise: true,
@@ -564,6 +621,11 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
             // meaning the new plan's flags will be adopted and any overrides from
             // the current plan will be dropped.
             free: true,
+            // TODO: revisit this once the growth add-on is implemented, as it will
+            // likely interplay with it. We don't want customers coming from startup-
+            // deals to lose the feature set they had enabled while on trial, so this
+            // flag achieves that for now.
+            'pay-as-you-go': false,
             'starter-v2': true,
             'growth-v2': false,
             enterprise: false,

--- a/packages/shared/lib/services/plans/plans.integration.test.ts
+++ b/packages/shared/lib/services/plans/plans.integration.test.ts
@@ -1,3 +1,4 @@
+import ms from 'ms';
 import { beforeAll, describe, expect, it } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
@@ -27,5 +28,45 @@ describe('handlePlanChanged', () => {
         const updated = await getPlan(db.knex, { accountId: account.id });
         expect(updated.unwrap().name).toBe('growth-v2');
         expect(updated.unwrap().orb_subscription_id).toBe('orb_sub_2');
+    });
+
+    it('clears the trial and applies the paid flags when a free account moves to pay-as-you-go', async () => {
+        const { account } = await seedAccountEnvAndUser({
+            plan: { name: 'free', auto_idle: true, trial_start_at: new Date(), trial_end_at: new Date(Date.now() + ms('10days')) }
+        });
+
+        const res = await handlePlanChanged(db.knex, account, { newPlanCode: 'pay-as-you-go', orbSubscriptionId: 'orb_sub_payg' });
+
+        expect(res.unwrap()).toBe(true);
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.name).toBe('pay-as-you-go');
+        expect(updated.orb_subscription_id).toBe('orb_sub_payg');
+        expect(updated.orb_subscribed_at).not.toBeNull();
+        // The trial cron pauses syncs on any plan still flagged auto_idle, so a paid plan has to clear both
+        expect(updated.auto_idle).toBe(false);
+        expect(updated.trial_start_at).toBeNull();
+        expect(updated.trial_end_at).toBeNull();
+        expect(updated.trial_expired).toBeNull();
+        // Uncapped, metered through Orb instead
+        expect(updated.connections_max).toBeNull();
+        expect(updated.records_max).toBeNull();
+        // Growth features stay off until the add-on exists
+        expect(updated.has_rbac).toBe(false);
+        expect(updated.has_otel).toBe(false);
+    });
+
+    it('restarts the trial and resets the flags when pay-as-you-go downgrades to free', async () => {
+        const { account } = await seedAccountEnvAndUser({ plan: { name: 'pay-as-you-go', auto_idle: false, connections_max: null } });
+
+        const res = await handlePlanChanged(db.knex, account, { newPlanCode: 'free', orbSubscriptionId: 'orb_sub_free' });
+
+        expect(res.unwrap()).toBe(true);
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.name).toBe('free');
+        expect(updated.auto_idle).toBe(true);
+        expect(updated.trial_end_at).not.toBeNull();
+        expect(updated.trial_expired).toBe(false);
+        // pg hands back the bigint column as a string
+        expect(Number(updated.connections_max)).toBe(10);
     });
 });

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -370,6 +370,7 @@ export function lambdaKeepWarmProvisionedConcurrencyMultiplier(planName: DBPlan[
         case 'starter':
         case 'starter-legacy':
         case 'starter-v2':
+        case 'pay-as-you-go':
             return 2;
         case 'scale-legacy':
             return 3;

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -10,6 +10,7 @@ describe('mergeFlags', () => {
         expect(getPlanDefinition('free')?.flags.has_rbac).toBe(false);
         expect(getPlanDefinition('starter')?.flags.has_rbac).toBe(false);
         expect(getPlanDefinition('starter-v2')?.flags.has_rbac).toBe(false);
+        expect(getPlanDefinition('pay-as-you-go')?.flags.has_rbac).toBe(false);
         expect(getPlanDefinition('starter-legacy')?.flags.has_rbac).toBe(false);
         expect(getPlanDefinition('scale-legacy')?.flags.has_rbac).toBe(false);
         expect(getPlanDefinition('growth-legacy')?.flags.has_rbac).toBe(false);
@@ -36,6 +37,7 @@ describe('mergeFlags', () => {
 
     describe.each([
         { from: 'starter-v2', to: 'free' },
+        { from: 'pay-as-you-go', to: 'free' },
         { from: 'growth-v2', to: 'starter-v2' },
         { from: 'enterprise-cloud-hosted', to: 'free' },
         { from: 'enterprise-cloud-hosted', to: 'starter-v2' },
@@ -84,7 +86,10 @@ describe('mergeFlags', () => {
         { from: 'starter', to: 'starter-v2' }, // migration
         { from: 'starter-legacy', to: 'starter-v2' }, // migration
         { from: 'starter', to: 'growth-v2' }, // upgrade and migration
-        { from: 'starter-legacy', to: 'growth-v2' } // upgrade and migration
+        { from: 'starter-legacy', to: 'growth-v2' }, // upgrade and migration
+        { from: 'free', to: 'pay-as-you-go' }, // upgrade from free
+        { from: 'starter-v2', to: 'pay-as-you-go' }, // migration off a sunset plan
+        { from: 'growth-v2', to: 'pay-as-you-go' } // migration off a sunset plan
     ] as { from: PlanDefinition['code']; to: PlanDefinition['code'] }[])('when upgrading/migrating from $from to $to', ({ from, to }) => {
         it('should apply new plan defaults if no overrides', () => {
             const currentPlan = makePlan({ code: from, flagOverrides: {} });
@@ -126,6 +131,33 @@ describe('mergeFlags', () => {
                 // can_disable_connect_ui_watermark: new plan more generous default (true)
             });
             expect(newFlags).not.toHaveProperty('has_audit_trail_access');
+        });
+    });
+
+    // pay-as-you-go carries starter-level flags until the growth add-on exists, so migrating a
+    // Growth customer onto it must not be a downgrade — otherwise mergeFlags would reset their
+    // flags to the starter defaults and silently revoke the features they pay for today.
+    it('should keep growth features when migrating a growth-v2 account to pay-as-you-go', () => {
+        const currentPlan = makePlan({
+            code: 'growth-v2',
+            flagOverrides: {
+                has_rbac: true,
+                has_otel: true,
+                can_customize_connect_ui_theme: true,
+                can_override_docs_connect_url: true,
+                api_rate_limit_size: 'xl'
+            }
+        });
+        const newPlanDefinition = getPlanDefinition('pay-as-you-go')!;
+
+        const newFlags = mergeFlags({ currentPlan, newPlanDefinition });
+
+        expect(newFlags).toMatchObject({
+            has_rbac: true,
+            has_otel: true,
+            can_customize_connect_ui_theme: true,
+            can_override_docs_connect_url: true,
+            api_rate_limit_size: 'xl'
         });
     });
 });

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -9,6 +9,7 @@ export interface DBPlan extends Timestamps {
         | 'free'
         | 'free-uncapped'
         | 'startup-deal'
+        | 'pay-as-you-go'
         | 'starter-v2'
         | 'growth-v2'
         | 'enterprise'

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -8,6 +8,7 @@ import type { ApiPlan, DBPlan } from '@nangohq/types';
 // legacy and lose its reset date.
 const PLAN_IS_CURRENT: Record<DBPlan['name'], boolean> = {
     free: true,
+    'pay-as-you-go': true,
     'free-uncapped': true,
     'startup-deal': true,
     enterprise: true,
@@ -27,6 +28,7 @@ const PLAN_IS_CURRENT: Record<DBPlan['name'], boolean> = {
 // `DBPlan['name']`, so a new plan fails to compile until it is classified for both.
 const SHOWS_SUMMARY_STRIP: Record<DBPlan['name'], boolean> = {
     free: true,
+    'pay-as-you-go': true,
     'starter-v2': true,
     'growth-v2': true,
     'startup-deal': true,
@@ -44,6 +46,7 @@ const SHOWS_SUMMARY_STRIP: Record<DBPlan['name'], boolean> = {
 // section. The startup deal included, since its $0.00 is a real answer rather than a gap. The
 // server enforces the same allowlist independently; drift here is a display bug, not a hole.
 const HAS_MONTHLY_SPEND: Record<DBPlan['name'], boolean> = {
+    'pay-as-you-go': true,
     'starter-v2': true,
     'growth-v2': true,
     'startup-deal': true,
@@ -62,6 +65,7 @@ const HAS_MONTHLY_SPEND: Record<DBPlan['name'], boolean> = {
 // invoices to link to — the header's "All invoices" action is pointless on them. Exhaustive over
 // `DBPlan['name']` for the same reason as the maps above.
 const PLAN_IS_BILLED: Record<DBPlan['name'], boolean> = {
+    'pay-as-you-go': true,
     'starter-v2': true,
     'growth-v2': true,
     enterprise: true,
@@ -79,6 +83,7 @@ const PLAN_IS_BILLED: Record<DBPlan['name'], boolean> = {
 // Whether the plan can put a charge on the invoice at all. The startup deal has no base fee and
 // never bills overage, so nothing accrues until it converts.
 const PLAN_ACCRUES_CHARGES: Record<DBPlan['name'], boolean> = {
+    'pay-as-you-go': true,
     'starter-v2': true,
     'growth-v2': true,
     'startup-deal': false,

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -37,8 +37,8 @@ function spendOf(amountInCents: number | null, currency: string | null = 'USD'):
 }
 
 describe('showsSummaryStrip', () => {
-    it('renders for the four current plans', () => {
-        for (const name of ['free', 'starter-v2', 'growth-v2', 'startup-deal'] as const) {
+    it('renders for the current plans', () => {
+        for (const name of ['free', 'pay-as-you-go', 'starter-v2', 'growth-v2', 'startup-deal'] as const) {
             expect(showsSummaryStrip(planOf(name))).toBe(true);
         }
     });
@@ -65,7 +65,7 @@ describe('showsSummaryStrip', () => {
 
 describe('hasMonthlySpend', () => {
     it('leads with spend on the plans billed monthly', () => {
-        for (const name of ['starter-v2', 'growth-v2', 'startup-deal'] as const) {
+        for (const name of ['pay-as-you-go', 'starter-v2', 'growth-v2', 'startup-deal'] as const) {
             expect(hasMonthlySpend(planOf(name))).toBe(true);
         }
     });
@@ -94,7 +94,7 @@ describe('hasMonthlySpend', () => {
 
 describe('planAccruesCharges', () => {
     it('is true for the plans with a base fee and billable overage', () => {
-        for (const name of ['starter-v2', 'growth-v2'] as const) {
+        for (const name of ['pay-as-you-go', 'starter-v2', 'growth-v2'] as const) {
             expect(planAccruesCharges(planOf(name))).toBe(true);
         }
     });
@@ -164,7 +164,16 @@ describe('isLegacyPlan', () => {
     // A bespoke contract isn't the same thing as an old usage model, so Enterprise gets the normal
     // usage view rather than the legacy-plan banner.
     it('does not flag current plans, including the custom-contract ones', () => {
-        for (const name of ['free', 'free-uncapped', 'starter-v2', 'growth-v2', 'startup-deal', 'enterprise', 'enterprise-cloud-hosted'] as const) {
+        for (const name of [
+            'free',
+            'free-uncapped',
+            'pay-as-you-go',
+            'starter-v2',
+            'growth-v2',
+            'startup-deal',
+            'enterprise',
+            'enterprise-cloud-hosted'
+        ] as const) {
             expect(isLegacyPlan(planOf(name))).toBe(false);
         }
     });
@@ -183,6 +192,7 @@ describe('isBilledPlan', () => {
 
     it('includes every paid plan, current and legacy', () => {
         for (const name of [
+            'pay-as-you-go',
             'starter-v2',
             'growth-v2',
             'enterprise',

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -73,7 +73,7 @@ export const LEGACY_USAGE_METRICS: readonly UsageMetric[] = [
 
 export const S26_USAGE_METRICS: readonly UsageMetric[] = ['connections', 'function_duration_seconds', 'data_transfer'];
 
-const PLANS_ON_S26_PRICING: readonly DBPlan['name'][] = ['free', 'free-uncapped'];
+const PLANS_ON_S26_PRICING: readonly DBPlan['name'][] = ['free', 'free-uncapped', 'pay-as-you-go'];
 
 export function billedUsageMetrics(plan: ApiPlan | null | undefined, s26PricingEnabled: boolean): readonly UsageMetric[] {
     if (!plan || !s26PricingEnabled) {

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -100,6 +100,7 @@ describe('billedUsageMetrics', () => {
     const BILLED_ON: Record<ApiPlan['name'], 's26' | 'legacy'> = {
         free: 's26',
         'free-uncapped': 's26',
+        'pay-as-you-go': 's26',
         'startup-deal': 'legacy',
         'starter-v2': 'legacy',
         'growth-v2': 'legacy',


### PR DESCRIPTION
Adds `pay-as-you-go`, usage-metered with a $50 monthly minimum commit, replacing Starter and Growth as the self-serve paid tier. Both stay available for existing customers until they are sunset.

Backend wiring only. A plan's `code` is Orb's `external_plan_id`, so switching an account in the Orb dashboard now lands a correct `plans` row via the `subscription.plan_changed` webhook. The plan is `hidden` until the billing page work lands, so it is not self-serve yet.

Flags are starter-level (`...starterV2Plan.flags`) until the growth add-on exists. Migrating off the growth-tier plans is deliberately not a downgrade: `mergeFlags` resets every flag on a downgrade, which would silently revoke RBAC, OTel and connect-UI customisation from Growth customers moved across.

Also tightens POST /api/v1/plans/change, which treated any target absent from `nextPlan` as a downgrade and scheduled it in Orb without collecting the base fee. It now rejects targets in neither `nextPlan` nor `prevPlan`.

Self-serve upgrades onto the plan still do not work: the upgrade path charges `basePrice` upfront when Orb reports nothing payable now, which is wrong for a plan billed in arrears. See the TODO in definitions.ts.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

