### PR TITLE
feat(plans): add upgrade path from free to PAYG

### DIFF
--- a/packages/billing/lib/clients/noop/client.ts
+++ b/packages/billing/lib/clients/noop/client.ts
@@ -106,7 +106,10 @@ export class NoopBillingClient implements BillingClient {
         return Promise.resolve(Ok(undefined));
     }
 
-    applyPendingChanges(_opts: { pendingChangeId: string; paymentExternalId: string; amountCollected: string }): Promise<Result<BillingSubscription>> {
+    applyPendingChanges(_opts: {
+        pendingChangeId: string;
+        payment?: { externalId: string; amountCollected: string } | undefined;
+    }): Promise<Result<BillingSubscription>> {
         return Promise.resolve(Ok({ id: 'local-sub', planExternalId: 'free' }));
     }
 

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -468,15 +468,28 @@ export class OrbClient implements BillingClient {
         }
     }
 
-    async applyPendingChanges(opts: { pendingChangeId: string; amountCollected: string; paymentExternalId: string }): Promise<Result<BillingSubscription>> {
+    async applyPendingChanges(opts: {
+        pendingChangeId: string;
+        payment?: { externalId: string; amountCollected: string } | undefined;
+    }): Promise<Result<BillingSubscription>> {
         try {
-            const res = await this.orbSDK.subscriptionChanges.apply(opts.pendingChangeId, {
-                description: 'Initial payment on subscription',
-                mark_as_paid: true,
-                previously_collected_amount: opts.amountCollected,
-                payment_external_id: opts.paymentExternalId,
-                payment_notes: `Stripe collected: $${opts.amountCollected}`
-            });
+            const res = await this.orbSDK.subscriptionChanges.apply(
+                opts.pendingChangeId,
+                opts.payment
+                    ? {
+                          description: 'Initial payment on subscription',
+                          mark_as_paid: true,
+                          previously_collected_amount: opts.payment.amountCollected,
+                          payment_external_id: opts.payment.externalId,
+                          payment_notes: `Stripe collected: $${opts.payment.amountCollected}`
+                      }
+                    : {
+                          // Nothing was collected up front, so there is no payment to record and no
+                          // invoice to mark as paid. This happens when the plan bills fully in-arrears:
+                          // Orb invoices the period at its end as usual, but with zero charges.
+                          description: 'Plan change with no upfront payment'
+                      }
+            );
 
             if (!res.subscription) {
                 return Err(new Error('failed_to_apply_pending_changes', { cause: 'no subscription' }));

--- a/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 
 import { billing } from '@nangohq/billing';
 import db from '@nangohq/database';
-import { productTracking, seeders, updatePlan } from '@nangohq/shared';
+import { getPlan, productTracking, seeders, updatePlan } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
 import { isError, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../utils/tests.js';
@@ -23,6 +23,10 @@ vi.mock('@nangohq/billing', async () => {
     };
 });
 
+async function setupPlan(data: Parameters<typeof updatePlan>[1]): Promise<void> {
+    (await updatePlan(db.knex, data)).unwrap();
+}
+
 const route = '/api/v1/plans/change';
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -31,6 +35,7 @@ let getSubscriptionSpy: any;
 let upgradeSpy: any;
 let downgradeSpy: any;
 let cancelPendingChangesSpy: any;
+let applyPendingChangesSpy: any;
 let productTrackingSpy: any;
 
 describe(`POST ${route}`, () => {
@@ -42,6 +47,7 @@ describe(`POST ${route}`, () => {
         upgradeSpy = vi.spyOn(billing, 'upgrade');
         downgradeSpy = vi.spyOn(billing, 'downgrade');
         cancelPendingChangesSpy = vi.spyOn(billing.client, 'cancelPendingChanges');
+        applyPendingChangesSpy = vi.spyOn(billing.client, 'applyPendingChanges');
         productTrackingSpy = vi.spyOn(productTracking, 'track');
     });
 
@@ -56,6 +62,7 @@ describe(`POST ${route}`, () => {
         upgradeSpy.mockResolvedValue(Ok({ pendingChangeId: 'pending_123', amountInCents: 5000 }));
         downgradeSpy.mockResolvedValue(Ok(undefined));
         cancelPendingChangesSpy.mockResolvedValue(Ok(undefined));
+        applyPendingChangesSpy.mockResolvedValue(Ok({ id: 'sub_123', planExternalId: 'pay-as-you-go' }));
         productTrackingSpy.mockImplementation(() => {
             // no-op
         });
@@ -152,7 +159,7 @@ describe(`POST ${route}`, () => {
         it('should reject if team has no orb subscription', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
             // Ensure orb_subscription_id is null
-            await updatePlan(db.knex, { id: plan.id, orb_subscription_id: null });
+            await setupPlan({ id: plan.id, orb_subscription_id: null });
 
             const res = await api.fetch(route, {
                 method: 'POST',
@@ -172,7 +179,7 @@ describe(`POST ${route}`, () => {
         it('should reject if plan cannot change', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
             // Set plan to enterprise which has canChange: false
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 name: 'enterprise',
                 orb_subscription_id: 'sub_123'
@@ -196,7 +203,7 @@ describe(`POST ${route}`, () => {
         it('should reject if already on target plan', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
             // Ensure plan has subscription
-            await updatePlan(db.knex, { id: plan.id, orb_subscription_id: 'sub_123' });
+            await setupPlan({ id: plan.id, orb_subscription_id: 'sub_123' });
 
             const res = await api.fetch(route, {
                 method: 'POST',
@@ -217,7 +224,7 @@ describe(`POST ${route}`, () => {
     describe('Subscription Validation', () => {
         it('should reject if subscription not found in Orb', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, { id: plan.id, orb_subscription_id: 'sub_123' });
+            await setupPlan({ id: plan.id, orb_subscription_id: 'sub_123' });
 
             getSubscriptionSpy.mockResolvedValue(Ok(null));
 
@@ -238,7 +245,7 @@ describe(`POST ${route}`, () => {
 
         it('should handle pending changes', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 orb_subscription_id: 'sub_123',
                 stripe_customer_id: 'cus_123',
@@ -272,7 +279,7 @@ describe(`POST ${route}`, () => {
     describe('Upgrade Flow', () => {
         it('should reject upgrade without Stripe linkage', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 orb_subscription_id: 'sub_123',
                 stripe_customer_id: null,
@@ -303,7 +310,7 @@ describe(`POST ${route}`, () => {
 
         it('should create payment intent for upgrade', async () => {
             const { account, plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 orb_subscription_id: 'sub_123',
                 stripe_customer_id: 'cus_123',
@@ -342,7 +349,7 @@ describe(`POST ${route}`, () => {
 
         it('should return payment intent when not auto-confirmed', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 orb_subscription_id: 'sub_123',
                 stripe_customer_id: 'cus_123',
@@ -377,7 +384,7 @@ describe(`POST ${route}`, () => {
 
         it('should return success when payment auto-confirmed', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 orb_subscription_id: 'sub_123',
                 stripe_customer_id: 'cus_123',
@@ -407,9 +414,44 @@ describe(`POST ${route}`, () => {
             expect(res.json.data).toStrictEqual({ success: true });
         });
 
-        it('should cancel pending change on upgrade error', async () => {
+        it('should apply the pending change without a payment when nothing is payable now', async () => {
+            // A plan billed fully in arrears has no base fee to charge when the change is applied, so Orb
+            // reports nothing payable now. Stripe should not be involved.
+            const { account, plan, apiKey } = await seeders.seedAccountEnvAndUser();
+            await setupPlan({
+                id: plan.id,
+                orb_subscription_id: 'sub_123',
+                stripe_customer_id: 'cus_123',
+                stripe_payment_id: 'pm_123'
+            });
+
+            getSubscriptionSpy.mockResolvedValue(Ok({ id: 'sub_123', planExternalId: 'free' } satisfies BillingSubscription));
+            upgradeSpy.mockResolvedValue(Ok({ pendingChangeId: 'pending_123', amountInCents: null }));
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                token: apiKey.secret,
+                body: { orbId: 'pay-as-you-go' }
+            });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+            expect(res.json.data).toStrictEqual({ success: true });
+
+            // No card charged, and Orb told there was nothing collected
+            expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+            expect(applyPendingChangesSpy).toHaveBeenCalledWith({ pendingChangeId: 'pending_123' });
+
+            // The plan is switched inline rather than waiting on a webhook that will never fire
+            const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+            expect(updated.name).toBe('pay-as-you-go');
+            expect(updated.orb_subscription_id).toBe('sub_123');
+        });
+
+        it('should leave the pending change alone on upgrade error', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 orb_subscription_id: 'sub_123',
                 stripe_customer_id: 'cus_123',
@@ -433,7 +475,8 @@ describe(`POST ${route}`, () => {
                 body: { orbId: 'starter-v2' }
             });
 
-            expect(cancelPendingChangesSpy).toHaveBeenCalledWith({ pendingChangeId: 'pending_123' });
+            // Left for Orb's `expiration_time` and the next attempt's cleanup rather than compensated here
+            expect(cancelPendingChangesSpy).not.toHaveBeenCalled();
             isError(res.json);
             expect(res.res.status).toBe(500);
             expect(res.json.error.code).toBe('server_error');
@@ -441,7 +484,7 @@ describe(`POST ${route}`, () => {
 
         it('should handle upgrade billing service errors', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 orb_subscription_id: 'sub_123',
                 stripe_customer_id: 'cus_123',
@@ -472,7 +515,7 @@ describe(`POST ${route}`, () => {
     describe('Downgrade Flow', () => {
         it('should allow downgrade to free without Stripe', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 name: 'starter-v2',
                 orb_subscription_id: 'sub_123',
@@ -502,7 +545,7 @@ describe(`POST ${route}`, () => {
 
         it('should require Stripe for paid plan downgrade', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 name: 'growth-v2',
                 orb_subscription_id: 'sub_123',
@@ -534,7 +577,7 @@ describe(`POST ${route}`, () => {
 
         it('should reject if already scheduled for downgrade', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 name: 'starter-v2',
                 orb_subscription_id: 'sub_123',
@@ -565,7 +608,7 @@ describe(`POST ${route}`, () => {
 
         it('should successfully downgrade', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 name: 'starter-v2',
                 orb_subscription_id: 'sub_123'
@@ -593,7 +636,7 @@ describe(`POST ${route}`, () => {
 
         it('should handle downgrade billing service errors', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 name: 'starter-v2',
                 orb_subscription_id: 'sub_123'
@@ -623,7 +666,7 @@ describe(`POST ${route}`, () => {
     describe('Error Handling', () => {
         it('should handle billing service errors gracefully', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 orb_subscription_id: 'sub_123'
             });
@@ -644,7 +687,7 @@ describe(`POST ${route}`, () => {
 
         it('should handle Stripe API errors', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await updatePlan(db.knex, {
+            await setupPlan({
                 id: plan.id,
                 orb_subscription_id: 'sub_123',
                 stripe_customer_id: 'cus_123',
@@ -671,7 +714,8 @@ describe(`POST ${route}`, () => {
             isError(res.json);
             expect(res.res.status).toBe(500);
             expect(res.json.error.code).toBe('server_error');
-            expect(cancelPendingChangesSpy).toHaveBeenCalledWith({ pendingChangeId: 'pending_123' });
+            // Left for Orb's `expiration_time` and the next attempt's cleanup rather than compensated here
+            expect(cancelPendingChangesSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/server/lib/controllers/v1/plans/change/postChange.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.ts
@@ -1,14 +1,38 @@
 import { z } from 'zod';
 
-import { billing, getStripe } from '@nangohq/billing';
-import { plansList, productTracking } from '@nangohq/shared';
-import { getLogger, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { billing } from '@nangohq/billing';
+import { plansList } from '@nangohq/shared';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { downgradePlan, upgradePlan } from '../../../../services/planChange.service.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
+import type { PlanChangeError } from '../../../../services/planChange.service.js';
+import type { RequestLocals } from '../../../../utils/express.js';
 import type { PostPlanChange } from '@nangohq/types';
+import type { Response } from 'express';
 
-const logger = getLogger('orb');
+type PlanChangeResponse = Response<PostPlanChange['Reply'], RequestLocals>;
+
+function sendPlanChangeError(res: PlanChangeResponse, error: PlanChangeError): void {
+    switch (error.code) {
+        case 'not_linked_to_stripe':
+            res.status(400).send({ error: { code: 'invalid_body', message: 'team is not linked to stripe' } });
+            return;
+        case 'already_scheduled':
+            res.status(400).send({ error: { code: 'invalid_body', message: 'team is already scheduled to be downgraded' } });
+            return;
+        case 'upgrade_failed':
+        case 'downgrade_failed':
+            // Already reported with its cause by the service, which has the context to describe it
+            res.status(500).send({ error: { code: 'server_error' } });
+            return;
+        default:
+            ((exhaustiveCheck: never) => {
+                throw new Error(`Unhandled plan change error code: ${exhaustiveCheck}`);
+            })(error.code);
+    }
+}
 
 const orbIds = plansList.map((p) => p.code).filter(Boolean) as string[];
 const validation = z
@@ -69,8 +93,7 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
             return;
         }
 
-        // if there is a pending change we can't change the plan
-        // so we need to cancel it first
+        // We can't change the plan if there's a pending change; need to cancel it first.
         if (sub?.pendingChangeId) {
             (await billing.client.cancelPendingChanges({ pendingChangeId: sub.pendingChangeId })).unwrap();
         }
@@ -80,93 +103,26 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         return;
     }
 
-    // -- Upgrade
+    const context = { team: account, plan, subscriptionId: plan.orb_subscription_id, newPlanCode: body.orbId };
+
     if (isUpgrade) {
-        if (!plan.stripe_payment_id || !plan.stripe_customer_id) {
-            res.status(400).send({ error: { code: 'invalid_body', message: 'team is not linked to stripe' } });
+        const upgraded = await upgradePlan(context);
+        if (upgraded.isErr()) {
+            sendPlanChangeError(res, upgraded.error);
             return;
         }
 
-        let hasPending: string | undefined;
-        try {
-            logger.info(`Upgrading ${account.id} to ${body.orbId}`);
-
-            // Schedule an upgrade
-            const resUpgrade = await billing.upgrade({ subscriptionId: plan.orb_subscription_id, planExternalId: body.orbId });
-            if (resUpgrade.isErr()) {
-                report(resUpgrade.error);
-                res.status(500).send({ error: { code: 'server_error' } });
-                return;
-            }
-            hasPending = resUpgrade.value.pendingChangeId;
-
-            const stripe = getStripe();
-
-            logger.info(`Asking for base fee ${resUpgrade.value.amountInCents} for ${account.id}`);
-
-            // Create a payment intent to confirm the card
-            const paymentIntent = await stripe.paymentIntents.create({
-                metadata: { accountUuid: account.uuid },
-                amount: resUpgrade.value.amountInCents ? Math.round(resUpgrade.value.amountInCents) : newPlan.basePrice! * 100,
-                currency: 'usd',
-                customer: plan.stripe_customer_id,
-                payment_method: plan.stripe_payment_id
-            });
-
-            // The payment will be confirmed by the webhook
-            if (paymentIntent.status !== 'succeeded') {
-                res.status(200).send({ data: { paymentIntent } });
-                return;
-            }
-
-            // Payment is auto confirmed
-            // Never made it happen but it's a possibilty
-            res.status(200).send({ data: { success: true } });
-        } catch (err) {
-            if (hasPending) {
-                logger.info(`Error: cancelling pending change ${hasPending} for ${account.id}`);
-                const resCancel = await billing.client.cancelPendingChanges({ pendingChangeId: hasPending });
-                if (resCancel.isErr()) {
-                    report(resCancel.error);
-                    res.status(500).send({ error: { code: 'server_error' } });
-                    return;
-                }
-            }
-            report(err);
-        }
-
-        res.status(500).send({ error: { code: 'server_error' } });
-        return;
-    } else {
-        if (newPlan.code === plan.orb_future_plan) {
-            res.status(400).send({ error: { code: 'invalid_body', message: 'team is already scheduled to be downgraded' } });
-            return;
-        }
-
-        // -- Downgrade
-        if (newPlan.code !== 'free' && (!plan.stripe_payment_id || !plan.stripe_customer_id)) {
-            res.status(400).send({ error: { code: 'invalid_body', message: 'team is not linked to stripe' } });
-            return;
-        }
-
-        logger.info(`Downgrading ${account.id} to ${body.orbId}`);
-
-        const resDowngrade = await billing.downgrade({ subscriptionId: plan.orb_subscription_id, planExternalId: body.orbId });
-        if (resDowngrade.isErr()) {
-            report(resDowngrade.error);
-            res.status(500).send({ error: { code: 'server_error' } });
-            return;
-        }
-
-        res.status(200).send({
-            data: { success: true }
-        });
-
-        productTracking.track({
-            name: 'account:billing:downgraded',
-            team: account,
-            eventProperties: { previousPlan: plan.name, newPlan: body.orbId, orbCustomerId: plan.orb_customer_id }
-        });
+        // A pending intent still needs the client to confirm the card; without one, the change is done
+        const { paymentIntent } = upgraded.value;
+        res.status(200).send({ data: paymentIntent ? { paymentIntent } : { success: true } });
         return;
     }
+
+    const downgraded = await downgradePlan(context);
+    if (downgraded.isErr()) {
+        sendPlanChangeError(res, downgraded.error);
+        return;
+    }
+
+    res.status(200).send({ data: { success: true } });
 });

--- a/packages/server/lib/controllers/v1/plans/change/postChange.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.ts
@@ -55,6 +55,13 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         return;
     }
 
+    const isUpgrade = plansList.filter((p) => currentDef.nextPlan?.includes(p.code))?.find((p) => p.code === body.orbId);
+    const isDowngrade = currentDef.prevPlan?.includes(body.orbId);
+    if (!isUpgrade && !isDowngrade) {
+        res.status(400).send({ error: { code: 'invalid_body', message: 'team cannot change to this plan' } });
+        return;
+    }
+
     try {
         const sub = (await billing.getSubscription(account.id)).unwrap();
         if (!sub) {
@@ -72,8 +79,6 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         report(err);
         return;
     }
-
-    const isUpgrade = plansList.filter((p) => currentDef.nextPlan?.includes(p.code))?.find((p) => p.code === body.orbId);
 
     // -- Upgrade
     if (isUpgrade) {

--- a/packages/server/lib/controllers/v1/stripe/postWebhooks.ts
+++ b/packages/server/lib/controllers/v1/stripe/postWebhooks.ts
@@ -1,10 +1,10 @@
 import { billing, getStripe } from '@nangohq/billing';
 import db from '@nangohq/database';
-import { accountService, getPlan, handlePlanChanged, updatePlan } from '@nangohq/shared';
+import { accountService, getPlan, updatePlan } from '@nangohq/shared';
 import { Err, getLogger, Ok, report } from '@nangohq/utils';
 
 import { envs } from '../../../env.js';
-import { clearSpendAlertOnPlanChange } from '../../../services/spendAlertNotification.service.js';
+import { applyPendingPlanChange } from '../../../services/planChange.service.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
 import type { PostStripeWebhooks, Result } from '@nangohq/types';
@@ -169,40 +169,17 @@ async function handleWebhook(event: Stripe.Event, stripe: Stripe): Promise<Resul
                 return Err("team doesn't not have a subscription or pending changes");
             }
 
-            // Finally, we apply the pending change to confirm the card and the plan
-            const resApply = await billing.client.applyPendingChanges({
-                pendingChangeId: sub.pendingChangeId,
-                paymentExternalId: data.id,
-                amountCollected: (data.amount / 100).toFixed(2)
-            });
-            if (resApply.isErr()) {
-                return Err(resApply.error);
-            }
-
-            // This operation is also done in orb/postWebhooks
-            // But their webhook system is so slow that we need to duplicate the logic here
             const team = await accountService.getAccountById(db.knex, plan.account_id);
             if (!team) {
                 return Err('Failed to find team');
             }
 
-            const planExternalId = resApply.value.planExternalId;
-
-            const changed = await handlePlanChanged(db.knex, team, {
-                newPlanCode: planExternalId,
-                orbSubscriptionId: resApply.value.id
+            // Finally, we apply the pending change to confirm the card and the plan
+            return await applyPendingPlanChange({
+                team,
+                pendingChangeId: sub.pendingChangeId,
+                payment: { externalId: data.id, amountCollected: (data.amount / 100).toFixed(2) }
             });
-
-            if (changed.isErr()) {
-                return Err(changed.error);
-            }
-            logger.info(`Plan updated for account ${team.id} to ${planExternalId}`);
-
-            if (changed.value) {
-                await clearSpendAlertOnPlanChange({ accountId: team.id, subscriptionId: resApply.value.id });
-            }
-
-            return Ok(undefined);
         }
 
         // payment intent from upgrade has not been successful

--- a/packages/server/lib/services/planChange.service.ts
+++ b/packages/server/lib/services/planChange.service.ts
@@ -1,0 +1,156 @@
+import { billing, getStripe } from '@nangohq/billing';
+import db from '@nangohq/database';
+import { handlePlanChanged, productTracking } from '@nangohq/shared';
+import { Err, getLogger, Ok, report } from '@nangohq/utils';
+
+import { clearSpendAlertOnPlanChange } from './spendAlertNotification.service.js';
+
+import type { DBPlan, DBTeam, Result } from '@nangohq/types';
+import type Stripe from 'stripe';
+
+const logger = getLogger('Server.PlanChange');
+
+export type PlanChangeErrorCode = 'not_linked_to_stripe' | 'already_scheduled' | 'upgrade_failed' | 'downgrade_failed';
+
+export class PlanChangeError extends Error {
+    constructor(
+        public readonly code: PlanChangeErrorCode,
+        options?: { cause?: unknown }
+    ) {
+        super(code, options);
+    }
+}
+
+export interface PlanChangeContext {
+    team: DBTeam;
+    plan: DBPlan;
+    subscriptionId: string;
+    /** Orb external plan id. */
+    newPlanCode: string;
+}
+
+export interface PlanUpgradeResult {
+    paymentIntent?: Stripe.PaymentIntent | undefined;
+}
+
+/**
+ * Applies a pending Orb subscription change and persists the resulting plan in the database.
+ *
+ * @param payment - What Stripe collected up front, recorded against the change so Orb doesn't try to
+ * collect it again. Omit it for a plan billed fully in arrears: there is no base fee to charge when
+ * the change is applied, only usage invoiced at the end of the period. Omitting it also leaves the
+ * change unmarked as paid, so Orb invoices the period itself.
+ */
+export async function applyPendingPlanChange({
+    team,
+    pendingChangeId,
+    payment
+}: {
+    team: DBTeam;
+    pendingChangeId: string;
+    payment?: { externalId: string; amountCollected: string } | undefined;
+}): Promise<Result<void>> {
+    const resApply = await billing.client.applyPendingChanges({ pendingChangeId, payment });
+    if (resApply.isErr()) {
+        return Err(new Error('failed_to_apply_pending_change', { cause: resApply.error }));
+    }
+
+    const subscription = resApply.value;
+
+    const resChanged = await handlePlanChanged(db.knex, team, {
+        newPlanCode: subscription.planExternalId,
+        orbSubscriptionId: subscription.id
+    });
+    if (resChanged.isErr()) {
+        return Err(new Error('failed_to_sync_applied_plan_change', { cause: resChanged.error }));
+    }
+
+    const planChanged = resChanged.value;
+
+    if (planChanged) {
+        logger.info(`Plan updated for account ${team.id} to ${resApply.value.planExternalId}`);
+        await clearSpendAlertOnPlanChange({ accountId: team.id, subscriptionId: resApply.value.id });
+    }
+
+    return Ok(undefined);
+}
+
+/**
+ * Schedules an upgrade in Orb and settles it, either by collecting the base fee or, when there is
+ * nothing payable now, by applying the change immediately.
+ */
+export async function upgradePlan({ team, plan, subscriptionId, newPlanCode }: PlanChangeContext): Promise<Result<PlanUpgradeResult, PlanChangeError>> {
+    if (!plan.stripe_payment_id || !plan.stripe_customer_id) {
+        return Err(new PlanChangeError('not_linked_to_stripe'));
+    }
+
+    try {
+        logger.info(`Upgrading ${team.id} to ${newPlanCode}`);
+
+        const resUpgrade = await billing.upgrade({ subscriptionId, planExternalId: newPlanCode });
+        if (resUpgrade.isErr()) {
+            report(resUpgrade.error);
+            return Err(new PlanChangeError('upgrade_failed', { cause: resUpgrade.error }));
+        }
+        const pendingChangeId = resUpgrade.value.pendingChangeId;
+
+        if (!resUpgrade.value.amountInCents) {
+            // Orb reported no pending payments found, so apply the pending change inline rather than
+            // asynchronously (via Stripe's webhook).
+            logger.info(`Nothing to collect upfront, applying ${pendingChangeId} for ${team.id}`);
+
+            const applied = await applyPendingPlanChange({ team, pendingChangeId });
+            if (applied.isErr()) {
+                report(applied.error);
+                return Err(new PlanChangeError('upgrade_failed', { cause: applied.error }));
+            }
+
+            return Ok({});
+        }
+
+        const stripe = getStripe();
+
+        logger.info(`Asking for base fee ${resUpgrade.value.amountInCents} for ${team.id}`);
+
+        // Create a payment intent to confirm the card
+        const paymentIntent = await stripe.paymentIntents.create({
+            metadata: { accountUuid: team.uuid },
+            amount: Math.round(resUpgrade.value.amountInCents),
+            currency: 'usd',
+            customer: plan.stripe_customer_id,
+            payment_method: plan.stripe_payment_id
+        });
+
+        return Ok(paymentIntent.status === 'succeeded' ? {} : { paymentIntent });
+    } catch (err) {
+        report(err);
+        return Err(new PlanChangeError('upgrade_failed', { cause: err }));
+    }
+}
+
+/** Schedules a downgrade in Orb, which takes effect at the end of the current term. */
+export async function downgradePlan({ team, plan, subscriptionId, newPlanCode }: PlanChangeContext): Promise<Result<void, PlanChangeError>> {
+    if (newPlanCode === plan.orb_future_plan) {
+        return Err(new PlanChangeError('already_scheduled'));
+    }
+
+    if (newPlanCode !== 'free' && (!plan.stripe_payment_id || !plan.stripe_customer_id)) {
+        return Err(new PlanChangeError('not_linked_to_stripe'));
+    }
+
+    logger.info(`Downgrading ${team.id} to ${newPlanCode}`);
+
+    const resDowngrade = await billing.downgrade({ subscriptionId, planExternalId: newPlanCode });
+    if (resDowngrade.isErr()) {
+        report(resDowngrade.error);
+        return Err(new PlanChangeError('downgrade_failed', { cause: resDowngrade.error }));
+    }
+
+    productTracking.track({
+        name: 'account:billing:downgraded',
+        team,
+        eventProperties: { previousPlan: plan.name, newPlan: newPlanCode, orbCustomerId: plan.orb_customer_id }
+    });
+
+    return Ok(undefined);
+}

--- a/packages/server/lib/utils/spendPlans.ts
+++ b/packages/server/lib/utils/spendPlans.ts
@@ -4,6 +4,7 @@ import type { DBPlan } from '@nangohq/types';
 // anything. An annual contract's own invoice states its whole contract total, not one period's charge.
 // Exhaustive, so a new plan has to be classified rather than inheriting a figure.
 const SPEND_PLANS: Record<DBPlan['name'], boolean> = {
+    'pay-as-you-go': true,
     'starter-v2': true,
     'growth-v2': true,
     'startup-deal': true,

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -169,9 +169,11 @@ export const payAsYouGoPlan: PlanDefinition = {
     // Not offered in the dashboard yet, the billing page work lands separately.
     // Flipping this to false is the only switch needed to expose the plan.
     hidden: true,
-    // TODO: update value and handling of basePrice, as this plan will be charged
-    // fully in-arrears without an actual base price; it'll rather have a minimum
-    // spend.
+    // TODO: this plan has no base fee — it bills fully in arrears against a monthly minimum — so
+    // basePrice is display-only here and nothing charges against it. It can't just be dropped: the
+    // billing page labels it a "base fee" on the plan card and interpolates it unguarded into the
+    // upgrade confirm dialog, which would render "undefined". 50 is at least the right number until
+    // the frontend can express a minimum. Revisit with the billing page work.
     basePrice: 50,
     flags: {
         // Starter-level for now, the growth add-on will unlock the growth flags later

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -5,7 +5,13 @@ export const freePlan: PlanDefinition = {
     title: 'Free',
     description: 'For hobby and testing.',
     prevPlan: null,
-    nextPlan: ['starter-v2', 'growth-v2', 'enterprise'],
+    // TODO: drop 'starter-v2' and 'growth-v2' when pay-as-you-go stops being hidden.
+    // They're sunset and shouldn't be sold to new accounts, but removing them before
+    // the pay-as-you-go card is exposed would leave Free accounts with no self-serve
+    // upgrade at all: their cards fall back to "Contact us" and postChange rejects
+    // the transition. Existing customers are unaffected either way, their moves are
+    // driven by starterV2Plan/growthV2Plan and the downgrade matrix.
+    nextPlan: ['starter-v2', 'growth-v2', 'pay-as-you-go', 'enterprise'],
     canChange: true,
     basePrice: 0,
     flags: {
@@ -152,11 +158,32 @@ export const growthV2Plan: PlanDefinition = {
     flags: growthV1Plan.flags
 };
 
+export const payAsYouGoPlan: PlanDefinition = {
+    code: 'pay-as-you-go',
+    title: 'Pay as you go',
+    description: 'Usage-based pricing with a monthly minimum.',
+    prevPlan: ['free'],
+    nextPlan: ['enterprise'],
+    canChange: true,
+    // TODO: flip the flag once we're ready to roll the plan out.
+    // Not offered in the dashboard yet, the billing page work lands separately.
+    // Flipping this to false is the only switch needed to expose the plan.
+    hidden: true,
+    // TODO: update value and handling of basePrice, as this plan will be charged
+    // fully in-arrears without an actual base price; it'll rather have a minimum
+    // spend.
+    basePrice: 50,
+    flags: {
+        // Starter-level for now, the growth add-on will unlock the growth flags later
+        ...starterV2Plan.flags
+    }
+};
+
 export const enterprisePlan: PlanDefinition = {
     code: 'enterprise',
     title: 'Enterprise',
     description: 'For custom needs.',
-    prevPlan: ['free', 'starter', 'growth'],
+    prevPlan: ['free', 'pay-as-you-go', 'starter', 'growth'],
     nextPlan: null,
     canChange: false,
     cta: 'Contact Us',
@@ -364,6 +391,9 @@ export const plansList: PlanDefinition[] = [
     starterV2Plan,
     growthV2Plan,
 
+    // Usage-based plan, replaces starter-v2/growth-v2
+    payAsYouGoPlan,
+
     // V1 plans
     starterV1Plan,
     growthV1Plan,
@@ -396,6 +426,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
     const downgradeMatrix = {
         free: {
             free: false,
+            'pay-as-you-go': false,
             'starter-v2': false,
             'growth-v2': false,
             starter: false,
@@ -410,6 +441,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         'starter-v2': {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': false,
             'growth-v2': false,
             starter: false,
@@ -424,6 +456,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         'growth-v2': {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': true,
             'growth-v2': false,
             starter: true,
@@ -436,8 +469,25 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
             'free-uncapped': false,
             'startup-deal': false
         },
+        'pay-as-you-go': {
+            // Base flags are starter-level, so this row mirrors 'starter-v2'.
+            free: true,
+            'pay-as-you-go': false,
+            'starter-v2': false,
+            'growth-v2': false,
+            starter: false,
+            growth: false,
+            enterprise: false,
+            'starter-legacy': false,
+            'scale-legacy': false,
+            'growth-legacy': false,
+            'enterprise-cloud-hosted': false,
+            'free-uncapped': false,
+            'startup-deal': false
+        },
         starter: {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': false,
             'growth-v2': false,
             starter: false,
@@ -452,6 +502,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         growth: {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': true,
             'growth-v2': false,
             starter: true,
@@ -466,6 +517,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         enterprise: {
             free: true,
+            'pay-as-you-go': true,
             'starter-v2': true,
             'growth-v2': true,
             starter: true,
@@ -480,6 +532,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         'starter-legacy': {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': false,
             'growth-v2': false,
             starter: false,
@@ -494,6 +547,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         'growth-legacy': {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': true,
             'growth-v2': false,
             starter: true,
@@ -508,6 +562,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
         },
         'scale-legacy': {
             free: true,
+            'pay-as-you-go': false,
             'starter-v2': true,
             'growth-v2': true,
             starter: true,
@@ -525,6 +580,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
             // the new plan's flags will be adopted and any overrides from the current
             // plan will be dropped.
             free: true,
+            'pay-as-you-go': true,
             'starter-v2': true,
             'growth-v2': true,
             enterprise: true,
@@ -543,6 +599,7 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
             // the new plan's flags will be adopted and any overrides from the current
             // plan will be dropped.
             free: true,
+            'pay-as-you-go': true,
             'starter-v2': true,
             'growth-v2': true,
             enterprise: true,
@@ -564,6 +621,11 @@ export function isPotentialDowngrade({ from, to }: { from: PlanDefinition['code'
             // meaning the new plan's flags will be adopted and any overrides from
             // the current plan will be dropped.
             free: true,
+            // TODO: revisit this once the growth add-on is implemented, as it will
+            // likely interplay with it. We don't want customers coming from startup-
+            // deals to lose the feature set they had enabled while on trial, so this
+            // flag achieves that for now.
+            'pay-as-you-go': false,
             'starter-v2': true,
             'growth-v2': false,
             enterprise: false,

--- a/packages/shared/lib/services/plans/plans.integration.test.ts
+++ b/packages/shared/lib/services/plans/plans.integration.test.ts
@@ -1,3 +1,4 @@
+import ms from 'ms';
 import { beforeAll, describe, expect, it } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
@@ -27,5 +28,45 @@ describe('handlePlanChanged', () => {
         const updated = await getPlan(db.knex, { accountId: account.id });
         expect(updated.unwrap().name).toBe('growth-v2');
         expect(updated.unwrap().orb_subscription_id).toBe('orb_sub_2');
+    });
+
+    it('clears the trial and applies the paid flags when a free account moves to pay-as-you-go', async () => {
+        const { account } = await seedAccountEnvAndUser({
+            plan: { name: 'free', auto_idle: true, trial_start_at: new Date(), trial_end_at: new Date(Date.now() + ms('10days')) }
+        });
+
+        const res = await handlePlanChanged(db.knex, account, { newPlanCode: 'pay-as-you-go', orbSubscriptionId: 'orb_sub_payg' });
+
+        expect(res.unwrap()).toBe(true);
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.name).toBe('pay-as-you-go');
+        expect(updated.orb_subscription_id).toBe('orb_sub_payg');
+        expect(updated.orb_subscribed_at).not.toBeNull();
+        // The trial cron pauses syncs on any plan still flagged auto_idle, so a paid plan has to clear both
+        expect(updated.auto_idle).toBe(false);
+        expect(updated.trial_start_at).toBeNull();
+        expect(updated.trial_end_at).toBeNull();
+        expect(updated.trial_expired).toBeNull();
+        // Uncapped, metered through Orb instead
+        expect(updated.connections_max).toBeNull();
+        expect(updated.records_max).toBeNull();
+        // Growth features stay off until the add-on exists
+        expect(updated.has_rbac).toBe(false);
+        expect(updated.has_otel).toBe(false);
+    });
+
+    it('restarts the trial and resets the flags when pay-as-you-go downgrades to free', async () => {
+        const { account } = await seedAccountEnvAndUser({ plan: { name: 'pay-as-you-go', auto_idle: false, connections_max: null } });
+
+        const res = await handlePlanChanged(db.knex, account, { newPlanCode: 'free', orbSubscriptionId: 'orb_sub_free' });
+
+        expect(res.unwrap()).toBe(true);
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.name).toBe('free');
+        expect(updated.auto_idle).toBe(true);
+        expect(updated.trial_end_at).not.toBeNull();
+        expect(updated.trial_expired).toBe(false);
+        // pg hands back the bigint column as a string
+        expect(Number(updated.connections_max)).toBe(10);
     });
 });

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -370,6 +370,7 @@ export function lambdaKeepWarmProvisionedConcurrencyMultiplier(planName: DBPlan[
         case 'starter':
         case 'starter-legacy':
         case 'starter-v2':
+        case 'pay-as-you-go':
             return 2;
         case 'scale-legacy':
             return 3;

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -10,6 +10,7 @@ describe('mergeFlags', () => {
         expect(getPlanDefinition('free')?.flags.has_rbac).toBe(false);
         expect(getPlanDefinition('starter')?.flags.has_rbac).toBe(false);
         expect(getPlanDefinition('starter-v2')?.flags.has_rbac).toBe(false);
+        expect(getPlanDefinition('pay-as-you-go')?.flags.has_rbac).toBe(false);
         expect(getPlanDefinition('starter-legacy')?.flags.has_rbac).toBe(false);
         expect(getPlanDefinition('scale-legacy')?.flags.has_rbac).toBe(false);
         expect(getPlanDefinition('growth-legacy')?.flags.has_rbac).toBe(false);
@@ -36,6 +37,7 @@ describe('mergeFlags', () => {
 
     describe.each([
         { from: 'starter-v2', to: 'free' },
+        { from: 'pay-as-you-go', to: 'free' },
         { from: 'growth-v2', to: 'starter-v2' },
         { from: 'enterprise-cloud-hosted', to: 'free' },
         { from: 'enterprise-cloud-hosted', to: 'starter-v2' },
@@ -84,7 +86,10 @@ describe('mergeFlags', () => {
         { from: 'starter', to: 'starter-v2' }, // migration
         { from: 'starter-legacy', to: 'starter-v2' }, // migration
         { from: 'starter', to: 'growth-v2' }, // upgrade and migration
-        { from: 'starter-legacy', to: 'growth-v2' } // upgrade and migration
+        { from: 'starter-legacy', to: 'growth-v2' }, // upgrade and migration
+        { from: 'free', to: 'pay-as-you-go' }, // upgrade from free
+        { from: 'starter-v2', to: 'pay-as-you-go' }, // migration off a sunset plan
+        { from: 'growth-v2', to: 'pay-as-you-go' } // migration off a sunset plan
     ] as { from: PlanDefinition['code']; to: PlanDefinition['code'] }[])('when upgrading/migrating from $from to $to', ({ from, to }) => {
         it('should apply new plan defaults if no overrides', () => {
             const currentPlan = makePlan({ code: from, flagOverrides: {} });
@@ -126,6 +131,33 @@ describe('mergeFlags', () => {
                 // can_disable_connect_ui_watermark: new plan more generous default (true)
             });
             expect(newFlags).not.toHaveProperty('has_audit_trail_access');
+        });
+    });
+
+    // pay-as-you-go carries starter-level flags until the growth add-on exists, so migrating a
+    // Growth customer onto it must not be a downgrade — otherwise mergeFlags would reset their
+    // flags to the starter defaults and silently revoke the features they pay for today.
+    it('should keep growth features when migrating a growth-v2 account to pay-as-you-go', () => {
+        const currentPlan = makePlan({
+            code: 'growth-v2',
+            flagOverrides: {
+                has_rbac: true,
+                has_otel: true,
+                can_customize_connect_ui_theme: true,
+                can_override_docs_connect_url: true,
+                api_rate_limit_size: 'xl'
+            }
+        });
+        const newPlanDefinition = getPlanDefinition('pay-as-you-go')!;
+
+        const newFlags = mergeFlags({ currentPlan, newPlanDefinition });
+
+        expect(newFlags).toMatchObject({
+            has_rbac: true,
+            has_otel: true,
+            can_customize_connect_ui_theme: true,
+            can_override_docs_connect_url: true,
+            api_rate_limit_size: 'xl'
         });
     });
 });

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -22,16 +22,18 @@ export interface BillingClient {
     applyPendingChanges: (opts: {
         pendingChangeId: string;
         /**
-         * Stripe PaymentIntent ID, used to cross-reference the payment in Orb.
+         * Payment collected up front.
+         *
+         * Omitted for a plan billed fully in arrears, where nothing is collected when the change is applied.
          */
-        paymentExternalId: string;
-        /**
-         * Amount collected via Stripe in dollars (e.g. "25.00"). Orb uses this
-         * to credit the customer the difference vs. the actual invoice amount,
-         * so overcharges (e.g. when falling back to the base fee) are corrected
-         * automatically. No credit is issued if the amounts match exactly.
-         */
-        amountCollected: string;
+        payment?:
+            | {
+                  /** The external payment ID; for Stripe, it's the PaymentIntent ID. */
+                  externalId: string;
+                  /** Amount collected in dollars. */
+                  amountCollected: string;
+              }
+            | undefined;
     }) => Promise<Result<BillingSubscription>>;
     cancelPendingChanges: (opts: { pendingChangeId: string }) => Promise<Result<void>>;
     verifyWebhookSignature(body: string, headers: Record<string, unknown>, secret: string): Result<true>;

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -9,6 +9,7 @@ export interface DBPlan extends Timestamps {
         | 'free'
         | 'free-uncapped'
         | 'startup-deal'
+        | 'pay-as-you-go'
         | 'starter-v2'
         | 'growth-v2'
         | 'enterprise'

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -8,6 +8,7 @@ import type { ApiPlan, DBPlan } from '@nangohq/types';
 // legacy and lose its reset date.
 const PLAN_IS_CURRENT: Record<DBPlan['name'], boolean> = {
     free: true,
+    'pay-as-you-go': true,
     'free-uncapped': true,
     'startup-deal': true,
     enterprise: true,
@@ -27,6 +28,7 @@ const PLAN_IS_CURRENT: Record<DBPlan['name'], boolean> = {
 // `DBPlan['name']`, so a new plan fails to compile until it is classified for both.
 const SHOWS_SUMMARY_STRIP: Record<DBPlan['name'], boolean> = {
     free: true,
+    'pay-as-you-go': true,
     'starter-v2': true,
     'growth-v2': true,
     'startup-deal': true,
@@ -44,6 +46,7 @@ const SHOWS_SUMMARY_STRIP: Record<DBPlan['name'], boolean> = {
 // section. The startup deal included, since its $0.00 is a real answer rather than a gap. The
 // server enforces the same allowlist independently; drift here is a display bug, not a hole.
 const HAS_MONTHLY_SPEND: Record<DBPlan['name'], boolean> = {
+    'pay-as-you-go': true,
     'starter-v2': true,
     'growth-v2': true,
     'startup-deal': true,
@@ -62,6 +65,7 @@ const HAS_MONTHLY_SPEND: Record<DBPlan['name'], boolean> = {
 // invoices to link to — the header's "All invoices" action is pointless on them. Exhaustive over
 // `DBPlan['name']` for the same reason as the maps above.
 const PLAN_IS_BILLED: Record<DBPlan['name'], boolean> = {
+    'pay-as-you-go': true,
     'starter-v2': true,
     'growth-v2': true,
     enterprise: true,
@@ -79,6 +83,7 @@ const PLAN_IS_BILLED: Record<DBPlan['name'], boolean> = {
 // Whether the plan can put a charge on the invoice at all. The startup deal has no base fee and
 // never bills overage, so nothing accrues until it converts.
 const PLAN_ACCRUES_CHARGES: Record<DBPlan['name'], boolean> = {
+    'pay-as-you-go': true,
     'starter-v2': true,
     'growth-v2': true,
     'startup-deal': false,

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -37,8 +37,8 @@ function spendOf(amountInCents: number | null, currency: string | null = 'USD'):
 }
 
 describe('showsSummaryStrip', () => {
-    it('renders for the four current plans', () => {
-        for (const name of ['free', 'starter-v2', 'growth-v2', 'startup-deal'] as const) {
+    it('renders for the current plans', () => {
+        for (const name of ['free', 'pay-as-you-go', 'starter-v2', 'growth-v2', 'startup-deal'] as const) {
             expect(showsSummaryStrip(planOf(name))).toBe(true);
         }
     });
@@ -65,7 +65,7 @@ describe('showsSummaryStrip', () => {
 
 describe('hasMonthlySpend', () => {
     it('leads with spend on the plans billed monthly', () => {
-        for (const name of ['starter-v2', 'growth-v2', 'startup-deal'] as const) {
+        for (const name of ['pay-as-you-go', 'starter-v2', 'growth-v2', 'startup-deal'] as const) {
             expect(hasMonthlySpend(planOf(name))).toBe(true);
         }
     });
@@ -94,7 +94,7 @@ describe('hasMonthlySpend', () => {
 
 describe('planAccruesCharges', () => {
     it('is true for the plans with a base fee and billable overage', () => {
-        for (const name of ['starter-v2', 'growth-v2'] as const) {
+        for (const name of ['pay-as-you-go', 'starter-v2', 'growth-v2'] as const) {
             expect(planAccruesCharges(planOf(name))).toBe(true);
         }
     });
@@ -164,7 +164,16 @@ describe('isLegacyPlan', () => {
     // A bespoke contract isn't the same thing as an old usage model, so Enterprise gets the normal
     // usage view rather than the legacy-plan banner.
     it('does not flag current plans, including the custom-contract ones', () => {
-        for (const name of ['free', 'free-uncapped', 'starter-v2', 'growth-v2', 'startup-deal', 'enterprise', 'enterprise-cloud-hosted'] as const) {
+        for (const name of [
+            'free',
+            'free-uncapped',
+            'pay-as-you-go',
+            'starter-v2',
+            'growth-v2',
+            'startup-deal',
+            'enterprise',
+            'enterprise-cloud-hosted'
+        ] as const) {
             expect(isLegacyPlan(planOf(name))).toBe(false);
         }
     });
@@ -183,6 +192,7 @@ describe('isBilledPlan', () => {
 
     it('includes every paid plan, current and legacy', () => {
         for (const name of [
+            'pay-as-you-go',
             'starter-v2',
             'growth-v2',
             'enterprise',

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -73,7 +73,7 @@ export const LEGACY_USAGE_METRICS: readonly UsageMetric[] = [
 
 export const S26_USAGE_METRICS: readonly UsageMetric[] = ['connections', 'function_duration_seconds', 'data_transfer'];
 
-const PLANS_ON_S26_PRICING: readonly DBPlan['name'][] = ['free', 'free-uncapped'];
+const PLANS_ON_S26_PRICING: readonly DBPlan['name'][] = ['free', 'free-uncapped', 'pay-as-you-go'];
 
 export function billedUsageMetrics(plan: ApiPlan | null | undefined, s26PricingEnabled: boolean): readonly UsageMetric[] {
     if (!plan || !s26PricingEnabled) {

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -100,6 +100,7 @@ describe('billedUsageMetrics', () => {
     const BILLED_ON: Record<ApiPlan['name'], 's26' | 'legacy'> = {
         free: 's26',
         'free-uncapped': 's26',
+        'pay-as-you-go': 's26',
         'startup-deal': 'legacy',
         'starter-v2': 'legacy',
         'growth-v2': 'legacy',


### PR DESCRIPTION
Pay-as-you-go bills fully in arrears, so Orb reports nothing payable when the change is scheduled. The upgrade path charged `basePrice` as an upfront PaymentIntent, and the pending change was only ever applied from Stripe's `payment_intent.succeeded` — with no payment there was no webhook, so the change never applied.

When Orb reports nothing payable now, the pending change is applied inline instead. Gated on Orb's own answer rather than a per-plan flag, so it cannot drift from the Orb configuration, and it covers a $0 prorated upgrade on any plan. `applyPendingChanges` now takes its payment fields as optional; omitted, the change is left unmarked as paid and Orb invoices the period itself.

Extracts planChange.service.ts. The apply → sync → clear-spend-alert sequence was already duplicated in the Stripe webhook, which now shares it. Upgrade and downgrade move there too, returning a typed PlanChangeError the controller maps to status codes, leaving the handler to validation and dispatch.

Drops the compensating cancel on failure. The next attempt clears any leftover before scheduling a new one and Orb permits only one pending change per subscription, so it cannot accumulate — and cancelling is wrong whenever Orb committed the change and only our follow-up failed.

Also removes the dead `basePrice` fallback, which produced NaN for plans without one, and a missing return that could double-send a response.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

