### PR TITLE
feat(server): add action trigger management MCP tool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -13027,6 +13027,18 @@ Use the Connections tools to inspect connections in the authenticated Nango envi
 | `connections_list` | List and filter connections.                                                                                                            | `environment:connections:list` or `environment:connections:list_credentials` |
 | `connections_get`  | Get a connection and its current credential state. Credential access and refresh flags require `read_credentials` and may rotate credential material. | `environment:connections:read` or `environment:connections:read_credentials` |
 
+### Actions
+
+Use the Actions tool to trigger an action function synchronously for a connection. Provide the integration ID, connection ID, and action name. The JSON input is optional. The tool returns the action's JSON result in the `data` field.
+
+<Warning>
+    Expect the MCP request to time out within 90 seconds. This does not cancel the action function, which may continue running for up to 15 minutes. After a timeout, the tool cannot return the result or an action ID, and retrying starts another execution. When the action supports it, use input parameters that limit the amount of data processed to keep execution within the MCP timeout.
+</Warning>
+
+| Tool              | Description                                                    | Required API key scope          |
+| ----------------- | -------------------------------------------------------------- | ------------------------------- |
+| `actions_trigger` | Trigger an action function synchronously for a connection.     | `environment:actions:execute`   |
+
 ### Syncs
 
 Use the Sync tool to set one or more syncs to the `started` or `paused` state for an integration in the authenticated Nango environment. You can optionally limit the operation to one connection and select named sync variants.

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -77,6 +77,18 @@ Use the Connections tools to inspect connections in the authenticated Nango envi
 | `connections_list` | List and filter connections.                                                                                                            | `environment:connections:list` or `environment:connections:list_credentials` |
 | `connections_get`  | Get a connection and its current credential state. Credential access and refresh flags require `read_credentials` and may rotate credential material. | `environment:connections:read` or `environment:connections:read_credentials` |
 
+### Actions
+
+Use the Actions tool to trigger an action function synchronously for a connection. Provide the integration ID, connection ID, and action name. The JSON input is optional. The tool returns the action's JSON result in the `data` field.
+
+<Warning>
+    Expect the MCP request to time out within 90 seconds. This does not cancel the action function, which may continue running for up to 15 minutes. After a timeout, the tool cannot return the result or an action ID, and retrying starts another execution. When the action supports it, use input parameters that limit the amount of data processed to keep execution within the MCP timeout.
+</Warning>
+
+| Tool              | Description                                                    | Required API key scope          |
+| ----------------- | -------------------------------------------------------------- | ------------------------------- |
+| `actions_trigger` | Trigger an action function synchronously for a connection.     | `environment:actions:execute`   |
+
 ### Syncs
 
 Use the Sync tool to set one or more syncs to the `started` or `paused` state for an integration in the authenticated Nango environment. You can optionally limit the operation to one connection and select named sync variants.

--- a/packages/server/lib/controllers/mcp/actions/errors.ts
+++ b/packages/server/lib/controllers/mcp/actions/errors.ts
@@ -1,0 +1,27 @@
+import { getLogger } from '@nangohq/utils';
+
+import { InternalMcpError, PublicMcpError } from '../utils.js';
+
+import type { ActionExecutionError } from '../../../services/action.service.js';
+
+const logger = getLogger('Server.MCP.Actions');
+
+export function actionExecutionErrorToMcp(error: ActionExecutionError): Error {
+    const code = error.code;
+    switch (code) {
+        case 'unknown_connection':
+        case 'unknown_provider':
+        case 'unknown_action':
+        case 'disabled_action':
+        case 'action_failed':
+            return new PublicMcpError(error.message);
+        case 'internal_error':
+            logger.error('Failed to trigger action', { err: error });
+            return new InternalMcpError();
+        default: {
+            const exhaustiveCheck: never = code;
+            logger.error('Unexpected ActionExecutionError code while triggering action', { code: exhaustiveCheck });
+            return new InternalMcpError();
+        }
+    }
+}

--- a/packages/server/lib/controllers/mcp/actions/schema.ts
+++ b/packages/server/lib/controllers/mcp/actions/schema.ts
@@ -11,8 +11,8 @@ export const triggerActionArgumentsSchema = z
     })
     .strict();
 
-// Action functions return user-defined JSON objects. MCP structured content requires the
-// top-level value to be an object.
-export const triggerActionOutputSchema = z.looseObject({});
+// Action functions can return any JSON value. MCP structured content requires a top-level
+// object, so keep the action response in a stable data envelope.
+export const triggerActionOutputSchema = z.object({ data: z.json() }).strict();
 
 export type TriggerActionOutput = z.infer<typeof triggerActionOutputSchema>;

--- a/packages/server/lib/controllers/mcp/actions/schema.ts
+++ b/packages/server/lib/controllers/mcp/actions/schema.ts
@@ -1,0 +1,18 @@
+import * as z from 'zod/v4';
+
+import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../../helpers/validation.js';
+
+export const triggerActionArgumentsSchema = z
+    .object({
+        action_name: syncNameSchema,
+        input: z.json(),
+        integration_id: providerConfigKeySchema,
+        connection_id: connectionIdSchema
+    })
+    .strict();
+
+// Action functions return user-defined JSON objects. MCP structured content requires the
+// top-level value to be an object.
+export const triggerActionOutputSchema = z.looseObject({});
+
+export type TriggerActionOutput = z.infer<typeof triggerActionOutputSchema>;

--- a/packages/server/lib/controllers/mcp/actions/schema.ts
+++ b/packages/server/lib/controllers/mcp/actions/schema.ts
@@ -5,7 +5,7 @@ import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../
 export const triggerActionArgumentsSchema = z
     .object({
         action_name: syncNameSchema,
-        input: z.json(),
+        input: z.json().optional(),
         integration_id: providerConfigKeySchema,
         connection_id: connectionIdSchema
     })

--- a/packages/server/lib/controllers/mcp/actions/trigger.ts
+++ b/packages/server/lib/controllers/mcp/actions/trigger.ts
@@ -1,18 +1,22 @@
 import tracer from 'dd-trace';
 
-import { Err, Ok } from '@nangohq/utils';
+import { Err, getLogger, Ok } from '@nangohq/utils';
 
 import { executeAction } from '../../../services/action.service.js';
 import { defineManagementMcpTool } from '../managementTool.js';
+import { InternalMcpError } from '../utils.js';
 import { actionExecutionErrorToMcp } from './errors.js';
 import { triggerActionArgumentsSchema, triggerActionOutputSchema } from './schema.js';
 
+import type { ManagementMcpTool } from '../managementTool.js';
 import type { TriggerActionOutput } from './schema.js';
 
-export const triggerActionTool = defineManagementMcpTool<typeof triggerActionArgumentsSchema, TriggerActionOutput>({
+const logger = getLogger('Server.MCP.Actions');
+
+export const triggerActionTool: ManagementMcpTool<TriggerActionOutput> = defineManagementMcpTool<typeof triggerActionArgumentsSchema, TriggerActionOutput>({
     name: 'actions_trigger',
     description:
-        'Trigger an action synchronously for a connection and return its result. Expect the MCP request to time out within 90 seconds, but this does not cancel the action, which may continue running for up to 15 minutes. If the request times out, this tool cannot return the result or an action ID; retrying will execute the action again.',
+        'Trigger an action synchronously for a connection and return its result in the data field. Expect the MCP request to time out within 90 seconds, but this does not cancel the action, which may continue running for up to 15 minutes. If the request times out, this tool cannot return the result or an action ID; retrying will execute the action again.',
     inputSchema: triggerActionArgumentsSchema,
     outputSchema: triggerActionOutputSchema,
     requiredScopes: { every: ['environment:actions:execute'] },
@@ -41,8 +45,13 @@ export const triggerActionTool = defineManagementMcpTool<typeof triggerActionArg
                 return Err<TriggerActionOutput>(actionExecutionErrorToMcp(execution.result.error));
             }
 
-            const response = 'data' in execution.result.value ? execution.result.value.data : execution.result.value;
-            return Ok(response as TriggerActionOutput);
+            const output = triggerActionOutputSchema.safeParse(execution.result.value);
+            if (!output.success) {
+                logger.error('Action returned a response incompatible with Management MCP structured content', { issues: output.error.issues });
+                return Err<TriggerActionOutput>(new InternalMcpError());
+            }
+
+            return Ok(output.data);
         });
     }
 });

--- a/packages/server/lib/controllers/mcp/actions/trigger.ts
+++ b/packages/server/lib/controllers/mcp/actions/trigger.ts
@@ -47,7 +47,9 @@ export const triggerActionTool: ManagementMcpTool<TriggerActionOutput> = defineM
 
             const output = triggerActionOutputSchema.safeParse(execution.result.value);
             if (!output.success) {
-                logger.error('Action returned a response incompatible with Management MCP structured content', { issues: output.error.issues });
+                logger.error('Orchestrator returned an invalid synchronous action response; expected a top-level data field containing a JSON value', {
+                    issues: output.error.issues
+                });
                 return Err<TriggerActionOutput>(new InternalMcpError());
             }
 

--- a/packages/server/lib/controllers/mcp/actions/trigger.ts
+++ b/packages/server/lib/controllers/mcp/actions/trigger.ts
@@ -1,0 +1,48 @@
+import tracer from 'dd-trace';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import { executeAction } from '../../../services/action.service.js';
+import { defineManagementMcpTool } from '../managementTool.js';
+import { actionExecutionErrorToMcp } from './errors.js';
+import { triggerActionArgumentsSchema, triggerActionOutputSchema } from './schema.js';
+
+import type { TriggerActionOutput } from './schema.js';
+
+export const triggerActionTool = defineManagementMcpTool<typeof triggerActionArgumentsSchema, TriggerActionOutput>({
+    name: 'actions_trigger',
+    description:
+        'Trigger an action synchronously for a connection and return its result. Expect the MCP request to time out within 90 seconds, but this does not cancel the action, which may continue running for up to 15 minutes. If the request times out, this tool cannot return the result or an action ID; retrying will execute the action again.',
+    inputSchema: triggerActionArgumentsSchema,
+    outputSchema: triggerActionOutputSchema,
+    requiredScopes: { every: ['environment:actions:execute'] },
+    audit: { kind: 'no-audit', reason: 'non-auditable' },
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true
+    },
+    async handler({ args, account, environment }) {
+        return await tracer.trace('server.mcp.triggerAction', async (span) => {
+            const execution = await executeAction({
+                account,
+                environment,
+                connectionId: args.connection_id,
+                providerConfigKey: args.integration_id,
+                actionName: args.action_name,
+                input: args.input,
+                isAsync: false,
+                retryMax: 0,
+                span
+            });
+
+            if (execution.result.isErr()) {
+                return Err<TriggerActionOutput>(actionExecutionErrorToMcp(execution.result.error));
+            }
+
+            const response = 'data' in execution.result.value ? execution.result.value.data : execution.result.value;
+            return Ok(response as TriggerActionOutput);
+        });
+    }
+});

--- a/packages/server/lib/controllers/mcp/actions/trigger.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/actions/trigger.unit.test.ts
@@ -30,7 +30,7 @@ describe('triggerActionTool', () => {
 
         expect(result.isOk()).toBe(true);
         if (result.isOk()) {
-            expect(result.value).toStrictEqual(response);
+            expect(result.value).toStrictEqual({ data: response });
         }
         expect(executeSpy).toHaveBeenCalledOnce();
         expect(executeSpy.mock.calls[0]?.[0]).toMatchObject({
@@ -44,6 +44,28 @@ describe('triggerActionTool', () => {
             retryMax: 0
         });
         expect(executeSpy.mock.calls[0]?.[0].span).toBeDefined();
+    });
+
+    it('wraps a string action response in the data field', async () => {
+        vi.spyOn(actionService, 'executeAction').mockResolvedValue({ logCtx: undefined, result: Ok({ data: 'created' }) });
+
+        const result = await triggerActionTool.handler(validArguments, context);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({ data: 'created' });
+        }
+    });
+
+    it('rejects action responses that are not JSON values', async () => {
+        vi.spyOn(actionService, 'executeAction').mockResolvedValue({ logCtx: undefined, result: Ok({ data: undefined }) });
+
+        const result = await triggerActionTool.handler(validArguments, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(InternalMcpError);
+        }
     });
 
     it.each([

--- a/packages/server/lib/controllers/mcp/actions/trigger.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/actions/trigger.unit.test.ts
@@ -57,6 +57,22 @@ describe('triggerActionTool', () => {
         }
     });
 
+    it('allows actions to be triggered without input', async () => {
+        const executeSpy = vi.spyOn(actionService, 'executeAction').mockResolvedValue({ logCtx: undefined, result: Ok({ data: null }) });
+
+        const result = await triggerActionTool.handler(
+            {
+                action_name: 'refresh-cache',
+                integration_id: 'github',
+                connection_id: 'connection-id'
+            },
+            context
+        );
+
+        expect(result.isOk()).toBe(true);
+        expect(executeSpy.mock.calls[0]?.[0]).toMatchObject({ input: undefined });
+    });
+
     it('rejects action responses that are not JSON values', async () => {
         vi.spyOn(actionService, 'executeAction').mockResolvedValue({ logCtx: undefined, result: Ok({ data: undefined }) });
 
@@ -70,7 +86,6 @@ describe('triggerActionTool', () => {
 
     it.each([
         { name: 'missing action name', args: { input: {}, integration_id: 'github', connection_id: 'connection-id' } },
-        { name: 'missing input', args: { action_name: 'create-issue', integration_id: 'github', connection_id: 'connection-id' } },
         { name: 'missing integration ID', args: { action_name: 'create-issue', input: {}, connection_id: 'connection-id' } },
         { name: 'missing connection ID', args: { action_name: 'create-issue', input: {}, integration_id: 'github' } },
         {

--- a/packages/server/lib/controllers/mcp/actions/trigger.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/actions/trigger.unit.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import * as actionService from '../../../services/action.service.js';
+import { ActionExecutionError } from '../../../services/action.service.js';
+import { InternalMcpError, PublicMcpError } from '../utils.js';
+import { triggerActionTool } from './trigger.js';
+
+import type { ManagementMcpContext } from '../managementTool.js';
+
+describe('triggerActionTool', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the synchronous action response exactly', async () => {
+        const response = { issue_id: 'issue-123', created: true };
+        const executeSpy = vi.spyOn(actionService, 'executeAction').mockResolvedValue({ logCtx: undefined, result: Ok({ data: response }) });
+
+        const result = await triggerActionTool.handler(
+            {
+                action_name: 'create-issue',
+                input: { title: 'MCP support' },
+                integration_id: 'github',
+                connection_id: 'connection-id'
+            },
+            context
+        );
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual(response);
+        }
+        expect(executeSpy).toHaveBeenCalledOnce();
+        expect(executeSpy.mock.calls[0]?.[0]).toMatchObject({
+            account: context.account,
+            environment: context.environment,
+            connectionId: 'connection-id',
+            providerConfigKey: 'github',
+            actionName: 'create-issue',
+            input: { title: 'MCP support' },
+            isAsync: false,
+            retryMax: 0
+        });
+        expect(executeSpy.mock.calls[0]?.[0].span).toBeDefined();
+    });
+
+    it.each([
+        { name: 'missing action name', args: { input: {}, integration_id: 'github', connection_id: 'connection-id' } },
+        { name: 'missing input', args: { action_name: 'create-issue', integration_id: 'github', connection_id: 'connection-id' } },
+        { name: 'missing integration ID', args: { action_name: 'create-issue', input: {}, connection_id: 'connection-id' } },
+        { name: 'missing connection ID', args: { action_name: 'create-issue', input: {}, integration_id: 'github' } },
+        {
+            name: 'asynchronous execution',
+            args: { action_name: 'create-issue', input: {}, integration_id: 'github', connection_id: 'connection-id', async: true }
+        },
+        {
+            name: 'maximum retries',
+            args: { action_name: 'create-issue', input: {}, integration_id: 'github', connection_id: 'connection-id', max_retries: 1 }
+        }
+    ])('rejects $name before executing the action', async ({ args }) => {
+        const executeSpy = vi.spyOn(actionService, 'executeAction');
+
+        const result = await triggerActionTool.handler(args, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toContain('Invalid actions_trigger arguments:');
+        }
+        expect(executeSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns expected action execution errors as public MCP errors', async () => {
+        vi.spyOn(actionService, 'executeAction').mockResolvedValue({
+            logCtx: undefined,
+            result: Err(new ActionExecutionError({ code: 'unknown_action', message: 'Action not found' }))
+        });
+
+        const result = await triggerActionTool.handler(validArguments, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toBe('Action not found');
+        }
+    });
+
+    it('maps internal action execution failures to internal MCP errors', async () => {
+        vi.spyOn(actionService, 'executeAction').mockResolvedValue({
+            logCtx: undefined,
+            result: Err(new ActionExecutionError({ code: 'internal_error', message: 'sensitive action failure' }))
+        });
+
+        const result = await triggerActionTool.handler(validArguments, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(InternalMcpError);
+            expect(result.error.message).toBe('Internal error');
+        }
+    });
+});
+
+const validArguments = {
+    action_name: 'create-issue',
+    input: { title: 'MCP support' },
+    integration_id: 'github',
+    connection_id: 'connection-id'
+};
+
+const context = {
+    account: { id: 1 },
+    environment: { id: 42 },
+    plan: null,
+    grantedScopes: ['environment:actions:execute']
+} as ManagementMcpContext;

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -9,6 +9,7 @@ import { getGlobalWebhookReceiveUrl, ProxyRequest, remoteFileService, seeders, s
 import { Ok } from '@nangohq/utils';
 
 import { audit } from '../../audit.js';
+import * as actionService from '../../services/action.service.js';
 import { authenticateUser, runServer } from '../../utils/tests.js';
 import { withoutDocsTools } from './testUtils.js';
 
@@ -173,6 +174,7 @@ describe('POST /mcp management server', () => {
             'connections_list',
             'connections_get',
             'syncs_set_state',
+            'actions_trigger',
             'proxy_request',
             'functions_list',
             'deploy_function',
@@ -206,6 +208,7 @@ describe('POST /mcp management server', () => {
             'connections_list',
             'connections_get',
             'syncs_set_state',
+            'actions_trigger',
             'proxy_request',
             'functions_list',
             'deploy_function',
@@ -231,6 +234,50 @@ describe('POST /mcp management server', () => {
                 content: [{ type: 'text', text: `MCP error -32602: Tool ${toolName} disabled` }],
                 isError: true
             });
+        }
+    });
+
+    it('triggers an action for the authenticated environment', async () => {
+        const { secret, env, account } = await createKeyWithScopes(['environment:actions:execute']);
+        const response = { issue_id: 'issue-123', created: true };
+        const executeActionSpy = vi.spyOn(actionService, 'executeAction').mockResolvedValue({ logCtx: undefined, result: Ok({ data: response }) });
+
+        try {
+            const res = await mcpPost({
+                token: secret,
+                body: {
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/call',
+                    params: {
+                        name: 'actions_trigger',
+                        arguments: {
+                            action_name: 'create-issue',
+                            input: { title: 'MCP support' },
+                            integration_id: 'github',
+                            connection_id: 'connection-id'
+                        }
+                    }
+                }
+            });
+
+            expect(res.status).toBe(200);
+            expect(parseToolText(res)).toStrictEqual(response);
+            expect(res.json.result.structuredContent).toStrictEqual(response);
+            expect(executeActionSpy).toHaveBeenCalledOnce();
+            expect(executeActionSpy.mock.calls[0]?.[0]).toMatchObject({
+                account,
+                environment: env,
+                connectionId: 'connection-id',
+                providerConfigKey: 'github',
+                actionName: 'create-issue',
+                input: { title: 'MCP support' },
+                isAsync: false,
+                retryMax: 0
+            });
+            expect(executeActionSpy.mock.calls[0]?.[0].span).toBeDefined();
+        } finally {
+            executeActionSpy.mockRestore();
         }
     });
 

--- a/packages/server/lib/controllers/mcp/management.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/management.integration.test.ts
@@ -262,8 +262,8 @@ describe('POST /mcp management server', () => {
             });
 
             expect(res.status).toBe(200);
-            expect(parseToolText(res)).toStrictEqual(response);
-            expect(res.json.result.structuredContent).toStrictEqual(response);
+            expect(parseToolText(res)).toStrictEqual({ data: response });
+            expect(res.json.result.structuredContent).toStrictEqual({ data: response });
             expect(executeActionSpy).toHaveBeenCalledOnce();
             expect(executeActionSpy.mock.calls[0]?.[0]).toMatchObject({
                 account,

--- a/packages/server/lib/controllers/mcp/managementServer.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.ts
@@ -5,6 +5,7 @@ import * as z from 'zod/v4';
 
 import { getLogger, hasApiKeyScope } from '@nangohq/utils';
 
+import { triggerActionTool } from './actions/trigger.js';
 import { recordManagementMcpAudit } from './audit.js';
 import { getConnectionsTool } from './connections/get.js';
 import { listConnectionsTool } from './connections/list.js';
@@ -47,6 +48,7 @@ const managementMcpTools: ManagementMcpTool[] = [
     listConnectionsTool,
     getConnectionsTool,
     setSyncsStateTool,
+    triggerActionTool,
     proxyRequestTool,
     listFunctionsTool,
     deployFunctionTool,

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -410,7 +410,7 @@ describe('createManagementMcpServer', () => {
                 description: expect.stringContaining('time out within 90 seconds'),
                 inputSchema: {
                     type: 'object',
-                    required: ['action_name', 'input', 'integration_id', 'connection_id'],
+                    required: ['action_name', 'integration_id', 'connection_id'],
                     additionalProperties: false
                 },
                 outputSchema: { type: 'object', required: ['data'], additionalProperties: false },

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -6,6 +6,7 @@ import { envs as logsEnvs } from '@nangohq/logs';
 import { Err, flags, Ok } from '@nangohq/utils';
 
 import { audit } from '../../audit.js';
+import { triggerActionTool } from './actions/trigger.js';
 import { getConnectionsTool } from './connections/get.js';
 import { listConnectionsTool } from './connections/list.js';
 import { createConnectSessionTool } from './connectSessions/create.js';
@@ -72,6 +73,10 @@ describe('createManagementMcpServer', () => {
                 {
                     name: 'syncs_set_state',
                     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false }
+                },
+                {
+                    name: 'actions_trigger',
+                    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
                 },
                 {
                     name: 'proxy_request',
@@ -389,6 +394,73 @@ describe('createManagementMcpServer', () => {
 
             expect(withoutDocsTools(result.tools).map((tool) => tool.name)).toStrictEqual(['connections_list', 'connections_get']);
         } finally {
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('exposes and authorizes non-idempotent action triggering', async () => {
+        const authorized = await createTestClient(['environment:actions:execute']);
+        try {
+            const result = await authorized.client.listTools();
+            const scopedTools = withoutDocsTools(result.tools);
+            expect(scopedTools).toHaveLength(1);
+            expect(scopedTools[0]).toMatchObject({
+                name: 'actions_trigger',
+                description: expect.stringContaining('time out within 90 seconds'),
+                inputSchema: {
+                    type: 'object',
+                    required: ['action_name', 'input', 'integration_id', 'connection_id'],
+                    additionalProperties: false
+                },
+                outputSchema: { type: 'object' },
+                annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
+            });
+            expect(scopedTools[0]?.inputSchema.properties).not.toHaveProperty('async');
+            expect(scopedTools[0]?.inputSchema.properties).not.toHaveProperty('max_retries');
+        } finally {
+            await authorized.client.close();
+            await authorized.server.close();
+        }
+
+        const handlerSpy = vi.spyOn(triggerActionTool, 'handler');
+        const unauthorized = await createTestClient(['environment:mcp']);
+        try {
+            const result = await unauthorized.client.callTool({
+                name: 'actions_trigger',
+                arguments: { action_name: 'create-issue', input: {}, integration_id: 'github', connection_id: 'connection-id' }
+            });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: 'MCP error -32602: Tool actions_trigger disabled' }],
+                isError: true
+            });
+            expect(handlerSpy).not.toHaveBeenCalled();
+        } finally {
+            handlerSpy.mockRestore();
+            await unauthorized.client.close();
+            await unauthorized.server.close();
+        }
+    });
+
+    it('returns action responses as JSON text and structured content', async () => {
+        const response = { issue_id: 'issue-123', created: true };
+        const handlerSpy = vi.spyOn(triggerActionTool, 'handler').mockResolvedValueOnce(Ok(response));
+        const { client, server } = await createTestClient(['environment:actions:execute']);
+
+        try {
+            const result = await client.callTool({
+                name: 'actions_trigger',
+                arguments: { action_name: 'create-issue', input: {}, integration_id: 'github', connection_id: 'connection-id' }
+            });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],
+                structuredContent: response
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
             await client.close();
             await server.close();
         }

--- a/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementServer.unit.test.ts
@@ -413,7 +413,7 @@ describe('createManagementMcpServer', () => {
                     required: ['action_name', 'input', 'integration_id', 'connection_id'],
                     additionalProperties: false
                 },
-                outputSchema: { type: 'object' },
+                outputSchema: { type: 'object', required: ['data'], additionalProperties: false },
                 annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
             });
             expect(scopedTools[0]?.inputSchema.properties).not.toHaveProperty('async');
@@ -444,7 +444,7 @@ describe('createManagementMcpServer', () => {
     });
 
     it('returns action responses as JSON text and structured content', async () => {
-        const response = { issue_id: 'issue-123', created: true };
+        const response = { data: 'created' };
         const handlerSpy = vi.spyOn(triggerActionTool, 'handler').mockResolvedValueOnce(Ok(response));
         const { client, server } = await createTestClient(['environment:actions:execute']);
 


### PR DESCRIPTION
Adds actions_trigger to the Management MCP server for synchronous action execution. Async is not supported yet.

NAN-6326: https://linear.app/nango/issue/NAN-6326/mcp-tool-actions-trigger-sync-only

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

