### PR TITLE
fix(audit): guard the pre-validation fields the resolvers read

### DIFF
--- a/packages/server/lib/middleware/audit/apiKey.middleware.ts
+++ b/packages/server/lib/middleware/audit/apiKey.middleware.ts
@@ -9,7 +9,7 @@ export const auditApiKeyCreated = auditable<CreateApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'created', scope: 'environment' }),
     // Never read the secret from the response — only the id and display name identify the key.
     targetFromResponse: (response) => makeTarget('api_key', response.data.id, response.data.display_name),
-    metadata: (req) => omitUndefined({ displayName: req.body.display_name }),
+    metadata: (req) => omitUndefined({ displayName: nonEmptyString(req.body.display_name) }),
     metadataFromResponse: (response) => omitUndefined({ scopes: response.data.scopes })
 });
 
@@ -24,7 +24,7 @@ export const auditPublicApiKeyCreated = auditable<PostPublicApiKey>({
 export const auditAccountApiKeyCreated = auditable<CreateAccountApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'created', scope: 'account' }),
     targetFromResponse: (response) => makeTarget('api_key', response.data.id, response.data.display_name),
-    metadata: (req) => omitUndefined({ displayName: req.body.display_name }),
+    metadata: (req) => omitUndefined({ displayName: nonEmptyString(req.body.display_name) }),
     // Scopes are chosen by the service/controller today and will be request-configurable later —
     // always record what was actually persisted.
     metadataFromResponse: (response) => omitUndefined({ scopes: response.data.scopes })
@@ -35,7 +35,7 @@ export const auditApiKeyUpdated = auditable<PatchApiKey>({
     target: (req, locals) => apiKeyTarget(req.params.keyId, locals),
     metadata: (req) =>
         omitUndefined({
-            displayName: typeof req.body.display_name === 'string' ? req.body.display_name : undefined,
+            displayName: nonEmptyString(req.body.display_name),
             scopes: Array.isArray(req.body.scopes) ? req.body.scopes.filter((s) => typeof s === 'string') : undefined
         })
 });

--- a/packages/server/lib/middleware/audit/billing.middleware.ts
+++ b/packages/server/lib/middleware/audit/billing.middleware.ts
@@ -1,5 +1,5 @@
 import { Audit, auditable } from './auditable.js';
-import { omitUndefined } from './input.js';
+import { nonEmptyString, omitUndefined } from './input.js';
 
 import type {
     DeleteSpendAlert,
@@ -15,7 +15,7 @@ export const auditBillingPlanChanged = auditable<PostPlanChange>({
     policy: Audit.auditable({ resource: 'billing', action: 'plan_changed', scope: 'account' }),
     metadata: (req, locals) =>
         omitUndefined({
-            toPlan: typeof req.body.orbId === 'string' ? req.body.orbId : undefined,
+            toPlan: nonEmptyString(req.body.orbId),
             fromPlan: locals.plan?.name || undefined
         })
 });

--- a/packages/server/lib/middleware/audit/connection.middleware.ts
+++ b/packages/server/lib/middleware/audit/connection.middleware.ts
@@ -95,9 +95,9 @@ function providerConfigKeyMeta(value: unknown): Record<string, unknown> | undefi
     return omitUndefined({ providerConfigKey: nonEmptyString(value) });
 }
 
-function connectionUpdatedMeta(providerConfigKey: string | undefined, fields: string[] | undefined): Record<string, unknown> | undefined {
+function connectionUpdatedMeta(providerConfigKey: unknown, fields: string[] | undefined): Record<string, unknown> | undefined {
     return omitUndefined({
-        providerConfigKey: providerConfigKey && providerConfigKey.length > 0 ? providerConfigKey : undefined,
+        providerConfigKey: nonEmptyString(providerConfigKey),
         changedFields: fields
     });
 }

--- a/packages/server/lib/middleware/audit/environment.middleware.ts
+++ b/packages/server/lib/middleware/audit/environment.middleware.ts
@@ -18,13 +18,13 @@ import type {
 export const auditEnvironmentCreated = auditable<PostEnvironment>({
     policy: Audit.auditable({ resource: 'environment', action: 'created', scope: 'account' }),
     targetFromResponse: (response) => makeTarget('environment', response.data.id, response.data.name),
-    metadata: (req) => omitUndefined({ name: req.body.name })
+    metadata: (req) => omitUndefined({ name: nonEmptyString(req.body.name) })
 });
 
 export const auditPublicEnvironmentCreated = auditable<PostPublicEnvironment>({
     policy: Audit.auditable({ resource: 'environment', action: 'created', scope: 'account' }),
     targetFromResponse: (response) => makeTarget('environment', response.data.id, response.data.name),
-    metadata: (req) => omitUndefined({ name: req.body.name })
+    metadata: (req) => omitUndefined({ name: nonEmptyString(req.body.name) })
 });
 
 export const auditEnvironmentUpdated = auditable<PatchEnvironment>({
@@ -46,8 +46,8 @@ export const auditEnvironmentVariablesChanged = auditable<PostEnvironmentVariabl
             return undefined;
         }
         const variableNames = variables
-            .map((v) => (v && typeof v === 'object' ? (v as Record<string, unknown>)['name'] : undefined))
-            .filter((n): n is string => typeof n === 'string');
+            .map((v) => (v && typeof v === 'object' ? nonEmptyString((v as Record<string, unknown>)['name']) : undefined))
+            .filter((n): n is string => n !== undefined);
         return omitUndefined({ variableCount: variables.length, variableNames: variableNames.length > 0 ? variableNames : undefined });
     }
 });

--- a/packages/server/lib/middleware/audit/environment.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/environment.middleware.unit.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { flags } from '@nangohq/utils';
 
-import { auditEnvironmentUpdated, auditEnvironmentVariablesChanged, auditEnvironmentWebhookUrlsChanged } from './environment.middleware.js';
+import {
+    auditEnvironmentCreated,
+    auditEnvironmentUpdated,
+    auditEnvironmentVariablesChanged,
+    auditEnvironmentWebhookUrlsChanged
+} from './environment.middleware.js';
 import { fakeReq, fakeRes, installAuditMockDefaults, locals, recordMock, resetAuditMocks, runAudit } from './testing.js';
 
 vi.mock('../../audit.js', async (importOriginal) => (await import('./testing.js')).auditModuleMock(importOriginal as never));
@@ -21,6 +26,12 @@ describe('environment audit middleware (unit)', () => {
         const event = await runAudit(auditEnvironmentUpdated, fakeReq({ body: { name: '', hmac_enabled: true } }), fakeRes(locals));
         expect(event).toMatchObject({ resource: 'environment', action: 'updated', accountId: 42, environment: { id: 9, display: 'dev' } });
         expect(event?.metadata).toEqual({ changedFields: ['name', 'hmac_enabled'] });
+    });
+
+    it('environment create: an empty name is omitted rather than recorded', async () => {
+        const event = await runAudit(auditEnvironmentCreated, fakeReq({ body: { name: '' } }), fakeRes(locals));
+        expect(event).toMatchObject({ resource: 'environment', action: 'created', accountId: 42 });
+        expect(event?.metadata).toBeUndefined();
     });
 
     it('environment update: echoes the name but never a credential in the same body', async () => {

--- a/packages/server/lib/middleware/audit/lookups.ts
+++ b/packages/server/lib/middleware/audit/lookups.ts
@@ -78,10 +78,10 @@ export function apiKeyTarget(value: unknown, locals: Partial<RequestLocals>): Pr
 
 export function accountApiKeyTarget(value: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
     return dbTarget('api_key', value, async (id) => {
-        const numericId = Number(id);
-        // Audit runs before controller param validation; skip the DB lookup for non-numeric
-        // keyIds so malformed deletes return 400 without an audit display-resolution warning.
-        if (Number.isNaN(numericId) || !locals.account) {
+        const numericId = positiveInt(id);
+        // Audit runs before controller param validation; skip the DB lookup for malformed
+        // keyIds so bad deletes return 400 without an audit display-resolution warning.
+        if (numericId === undefined || !locals.account) {
             return undefined;
         }
         const result = await customerKeyService.getAccountApiKeyDisplayName(db.knex, numericId, locals.account.id);

--- a/packages/server/lib/middleware/audit/member.middleware.ts
+++ b/packages/server/lib/middleware/audit/member.middleware.ts
@@ -3,7 +3,7 @@ import { accountService, getInvitation, userService } from '@nangohq/shared';
 
 import { makeAuditTarget as makeTarget, toAuditId as toId } from '../../audit.js';
 import { Audit, auditable, resolveDisplay } from './auditable.js';
-import { omitUndefined } from './input.js';
+import { nonEmptyString, omitUndefined } from './input.js';
 import { memberTarget } from './lookups.js';
 
 import type { AuditTarget } from '@nangohq/audit';
@@ -17,7 +17,7 @@ export const auditMemberInvited = auditable<PostInvite>({
         Array.isArray(req.body.emails)
             ? req.body.emails.map((email) => makeTarget('member', email, email)).filter((t): t is AuditTarget => Boolean(t))
             : undefined,
-    metadata: (req) => (req.body.role ? { role: req.body.role } : undefined)
+    metadata: (req) => omitUndefined({ role: nonEmptyString(req.body.role) })
 });
 
 // Accept/decline run under webAuth, so the acting user IS the invited member — the actor is resolved
@@ -55,7 +55,7 @@ export const auditMemberRoleChanged = auditable<PatchTeamUser>({
             });
         }
         return omitUndefined({
-            toRole: typeof role === 'string' ? role : undefined,
+            toRole: nonEmptyString(role),
             fromRole: fromRole ? fromRole : undefined
         });
     }

--- a/packages/server/lib/middleware/audit/member.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/member.middleware.unit.test.ts
@@ -47,6 +47,13 @@ describe('member audit middleware (unit)', () => {
         });
     });
 
+    it('member invited: a non-string role is omitted rather than recorded', async () => {
+        const req = fakeReq({ body: { emails: ['alice@example.com'], role: { admin: true } } });
+        const event = await runAudit(auditMemberInvited, req, fakeRes(locals));
+        expect(event).toMatchObject({ resource: 'member', action: 'invited', accountId: 42, environment: null });
+        expect(event?.metadata).toBeUndefined();
+    });
+
     it('invite revoked: the revoked email is the target, account-scoped', async () => {
         const req = fakeReq({ body: { email: 'revoke-me@example.com' } });
         const event = await runAudit(auditMemberInviteRevoked, req, fakeRes(locals));

--- a/packages/server/lib/middleware/audit/team.middleware.ts
+++ b/packages/server/lib/middleware/audit/team.middleware.ts
@@ -1,13 +1,11 @@
 import { makeAuditTarget as makeTarget } from '../../audit.js';
 import { Audit, auditable } from './auditable.js';
+import { nonEmptyString, omitUndefined } from './input.js';
 
 import type { PutTeam } from '@nangohq/types';
 
 export const auditTeamUpdated = auditable<PutTeam>({
     policy: Audit.auditable({ resource: 'team', action: 'updated', scope: 'account' }),
     target: (_req, locals) => makeTarget('team', locals.account?.id, locals.account?.name),
-    metadata: (req) => {
-        const name = req.body.name;
-        return typeof name === 'string' ? { name } : undefined;
-    }
+    metadata: (req) => omitUndefined({ name: nonEmptyString(req.body.name) })
 });


### PR DESCRIPTION
- **Ten audit resolvers that read raw request fields now go through `nonEmptyString`.** These resolvers run before the controller validates, so the endpoint's declared type doesn't hold there: a rejected request could record `name: ''`, or a non-string `role`, as event metadata. Covers the environment create emitters and variable names, both api-key display names, the member invite role and role change, the billing plan id, the team name, and the connection provider config key.

- **The account api-key target lookup uses `positiveInt` instead of `Number.isNaN`.** `-1`, `1.5` and `Infinity` all passed the old check, so a malformed delete issued a database query and an enrichment warning for a request the controller was about to reject with a 400.

All of these were raised by cubic on [#7271](https://github.com/NangoHQ/nango/pull/7271) and all predate it — I checked each flagged line against `origin/master` and every one is byte-identical there. They are split out here because #7271 is organisational and these change behaviour.

## Test plan

- [x] `ts-build`, `lint`, `format:check` clean
- [x] 1,089 server unit tests
- [x] Two new cases pin the behaviour and were break-checked: an empty environment name and a non-string invite role are both omitted, and each goes red when its guard is reverted
- [ ] After deploy: no change expected on well-formed requests; rejected requests should stop carrying stray metadata

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

