### PR TITLE
feat(authz): namespace decides the where, and drop the top-level wildcard

### DIFF
--- a/packages/authz/lib/authorize.ts
+++ b/packages/authz/lib/authorize.ts
@@ -24,7 +24,7 @@ export interface Principal {
 /** Whether any granted selector covers `required`. */
 export function scopeMatches(granted: readonly ScopeSelector[], required: Scope): boolean {
     for (const scope of granted) {
-        if (scope === required || scope === '*') {
+        if (scope === required) {
             return true;
         }
         if (scope.endsWith(':*') && required.startsWith(scope.slice(0, -1))) {

--- a/packages/authz/lib/authorize.unit.test.ts
+++ b/packages/authz/lib/authorize.unit.test.ts
@@ -19,8 +19,6 @@ function principal(grants: Grant[]): Principal {
 
 describe('whereContains', () => {
     it.each([
-        ['*', prodEnv, true],
-        ['*', account, true],
         ['account', account, true],
         ['account', prodEnv, false],
         ['env:*', prodEnv, true],
@@ -35,8 +33,8 @@ describe('whereContains', () => {
         expect(whereContains(where, target)).toBe(expected);
     });
 
-    it('nests: env:5 ⊆ env:production ⊆ env:* ⊆ *', () => {
-        for (const where of ['env:5', 'env:production', 'env:*', '*'] as const) {
+    it('nests: env:5 ⊆ env:production ⊆ env:*', () => {
+        for (const where of ['env:5', 'env:production', 'env:*'] as const) {
             expect(whereContains(where, prodEnv)).toBe(true);
         }
     });
@@ -48,9 +46,14 @@ describe('scopeMatches', () => {
         expect(scopeMatches(['environment:connections:read'], 'environment:connections:delete')).toBe(false);
     });
 
-    it('bare * matches anything, including non-issuable scopes — roles are not customer credentials', () => {
-        expect(scopeMatches(['*'], 'environment:settings:read_secret')).toBe(true);
-        expect(scopeMatches(['*'], 'account:billing:payment_methods:create')).toBe(true);
+    it('a namespace wildcard reaches non-issuable scopes — roles are not customer credentials', () => {
+        expect(scopeMatches(['environment:*'], 'environment:settings:read_secret')).toBe(true);
+        expect(scopeMatches(['account:*'], 'account:billing:payment_methods:create')).toBe(true);
+    });
+
+    it('a namespace wildcard does not cross into the other namespace', () => {
+        expect(scopeMatches(['environment:*'], 'account:billing:payment_methods:create')).toBe(false);
+        expect(scopeMatches(['account:*'], 'environment:connections:read')).toBe(false);
     });
 
     it('a prefix wildcard matches issuable scopes under it', () => {
@@ -112,7 +115,7 @@ describe('authorize', () => {
     it('grants are additive — any match allows', () => {
         const p = principal([
             { can: ['environment:connections:read'], where: ['env:production'] },
-            { can: ['*'], where: ['env:non-production'] }
+            { can: ['environment:*'], where: ['env:non-production'] }
         ]);
         expect(authorize(p, 'environment:connections:delete', prodEnv)).toBe(false);
         expect(authorize(p, 'environment:connections:delete', devEnv)).toBe(true);
@@ -140,7 +143,6 @@ describe('isIssuableWhere', () => {
         expect(isIssuableWhere('env:production')).toBe(false);
         expect(isIssuableWhere('env:non-production')).toBe(false);
         expect(isIssuableWhere('env:*')).toBe(false);
-        expect(isIssuableWhere('*')).toBe(false);
     });
 });
 
@@ -193,7 +195,7 @@ describe('issuedPrincipal', () => {
     });
 
     it.each(PRIVATE_SCOPES)('no wildcard a key may hold reaches private scope %s', (scope) => {
-        const widest = issued(['*', 'environment:*', 'account:*'], ['env:5', 'account']);
+        const widest = issued(['environment:*', 'account:*'], ['env:5', 'account']);
         expect(authorize(widest, scope, prodEnv)).toBe(false);
         expect(authorize(widest, scope, account)).toBe(false);
     });

--- a/packages/authz/lib/roles.ts
+++ b/packages/authz/lib/roles.ts
@@ -5,10 +5,13 @@ import type { Role } from '@nangohq/types';
  * Roles as grant sets.
  */
 export const ROLES: Record<Role, Grant[]> = {
-    administrator: [{ can: ['*'], where: ['*'] }],
+    administrator: [
+        { can: ['environment:*'], where: ['env:*'] },
+        { can: ['account:*'], where: ['account'] }
+    ],
 
     production_support: [
-        { can: ['*'], where: ['env:non-production'] },
+        { can: ['environment:*'], where: ['env:non-production'] },
         {
             can: [
                 'environment:integrations:list',
@@ -19,7 +22,7 @@ export const ROLES: Record<Role, Grant[]> = {
                 'environment:functions:read',
                 'environment:logs:read',
                 'environment:settings:read',
-                'account:environments:api_keys:list',
+                'environment:api_keys:list',
                 'environment:syncs:execute' // the playground
             ],
             where: ['env:production']
@@ -27,5 +30,5 @@ export const ROLES: Record<Role, Grant[]> = {
         { can: ['account:audit_trail:read'], where: ['account'] }
     ],
 
-    development_full_access: [{ can: ['*'], where: ['env:non-production'] }]
+    development_full_access: [{ can: ['environment:*'], where: ['env:non-production'] }]
 };

--- a/packages/authz/lib/scopes.ts
+++ b/packages/authz/lib/scopes.ts
@@ -65,7 +65,7 @@ true satisfies [Exclude<ConcreteApiKeyScope, (typeof PUBLIC_ENVIRONMENT_SCOPES)[
  */
 export const PUBLIC_ACCOUNT_SCOPES = [
     // Environments
-    'account:environments:create',
+    'account:environments:create', // any environment
     'account:environments:delete',
     'account:environments:set_production',
     'account:environments:api_keys:create',
@@ -75,10 +75,11 @@ export const PUBLIC_ACCOUNT_SCOPES = [
 true satisfies [Exclude<ConcreteAccountApiKeyScope, (typeof PUBLIC_ACCOUNT_SCOPES)[number]>] extends [never] ? true : never;
 
 /**
- * Scopes with no public endpoint.
+ * Scopes that can't be issued to API keys. These only apply to roles.
  * When adding a public endpoint that requires one of these, move the scope to the public list. The time of moving is also
  * a good moment to reconsider its name.
  * Wildcards in API keys (eg. `*`, `environment:*`) don't expand to these. When moved to the public list, wildcard keys will start covering it.
+ * Some scopes only make sense in roles (therefore in this list), like `environment:api_keys:read_secret` (environment keys shouldn't be able to read an environment keys secrets)
  */
 export const PRIVATE_SCOPES = [
     // ── account namespace ──
@@ -93,23 +94,26 @@ export const PRIVATE_SCOPES = [
     'account:billing:payment_methods:delete',
     'account:plan:update',
     'account:audit_trail:read',
-
-    // Keys bound to the account
     'account:api_keys:list',
-    'account:api_keys:create',
-    'account:api_keys:delete',
 
-    // Keys bound to an environment
-    'account:environments:api_keys:list',
-    'account:environments:api_keys:update',
-    'account:environments:api_keys:read_secret',
     // ── environment namespace ──
+    'environment:api_keys:list',
+    'environment:api_keys:update',
     'environment:settings:read',
     'environment:settings:update',
-    // Hands over a credential stronger than the caller's; do not promote either of these
-    'environment:settings:read_secret',
     'environment:variables:update',
-    'environment:webhooks:update'
+    'environment:webhooks:update',
+
+    // ── Don't promote ──
+    // Issuing account keys from an account key is self-perpetuating.
+    'account:api_keys:create',
+    'account:api_keys:delete',
+    // `environment:*` is the default on every key, so this would hand environment destruction to all of them.
+    // The account-level equivalent is `account:environments:delete`.
+    'environment:delete',
+    // Hand back a credential stronger than the caller's, so whoever holds one could widen themselves.
+    'environment:api_keys:read_secret',
+    'environment:settings:read_secret'
 ] as const;
 
 export type PrivateScope = (typeof PRIVATE_SCOPES)[number];
@@ -120,10 +124,11 @@ export type IssuableScope = (typeof PUBLIC_ENVIRONMENT_SCOPES)[number] | (typeof
 /** One concrete scope, the kind a route requires. */
 export type Scope = IssuableScope | PrivateScope;
 
-/** A pattern matching many scopes. */
-export type ScopeWildcard = '*' | WildcardsFor<'environment'> | WildcardsFor<'account'>;
+/** A pattern matching many scopes in one namespace. There is no cross-namespace wildcard: the
+ * namespace decides the `where`, so a grant spanning both could not name a single target. */
+export type ScopeWildcard = WildcardsFor<'environment'> | WildcardsFor<'account'>;
 
-/** One scope, or a pattern matching many. Bare `*` is role-only; no public scope is `*`. */
+/** One scope, or a pattern matching many. */
 export type ScopeSelector = Scope | ScopeWildcard;
 
 /** The concrete scopes a credential ends up holding, once wildcards are expanded. */
@@ -141,7 +146,7 @@ export function isIssuable(scope: Scope): scope is IssuableScope {
  */
 export function expandIssuable(granted: readonly ScopeSelector[]): IssuableScope[] {
     return ISSUABLE_SCOPES.filter((scope) =>
-        granted.some((selector) => selector === scope || selector === '*' || (selector.endsWith(':*') && scope.startsWith(selector.slice(0, -1))))
+        granted.some((selector) => selector === scope || (selector.endsWith(':*') && scope.startsWith(selector.slice(0, -1))))
     );
 }
 

--- a/packages/authz/lib/scopes.ts
+++ b/packages/authz/lib/scopes.ts
@@ -78,7 +78,7 @@ true satisfies [Exclude<ConcreteAccountApiKeyScope, (typeof PUBLIC_ACCOUNT_SCOPE
  * Scopes that can't be issued to API keys. These only apply to roles.
  * When adding a public endpoint that requires one of these, move the scope to the public list. The time of moving is also
  * a good moment to reconsider its name.
- * Wildcards in API keys (eg. `*`, `environment:*`) don't expand to these. When moved to the public list, wildcard keys will start covering it.
+ * Wildcards in API keys (eg. `environment:*`, `account:*`) don't expand to these. When moved to the public list, wildcard keys will start covering it.
  * Some scopes only make sense in roles (therefore in this list), like `environment:api_keys:read_secret` (environment keys shouldn't be able to read an environment keys secrets)
  */
 export const PRIVATE_SCOPES = [
@@ -124,8 +124,7 @@ export type IssuableScope = (typeof PUBLIC_ENVIRONMENT_SCOPES)[number] | (typeof
 /** One concrete scope, the kind a route requires. */
 export type Scope = IssuableScope | PrivateScope;
 
-/** A pattern matching many scopes in one namespace. There is no cross-namespace wildcard: the
- * namespace decides the `where`, so a grant spanning both could not name a single target. */
+/** A pattern matching many scopes in one namespace */
 export type ScopeWildcard = WildcardsFor<'environment'> | WildcardsFor<'account'>;
 
 /** One scope, or a pattern matching many. */
@@ -141,8 +140,7 @@ export function isIssuable(scope: Scope): scope is IssuableScope {
 }
 
 /**
- * The concrete issuable scopes matching `granted`. Roles are exempt — their grants are not issued to
- * anyone and may name private scopes.
+ * The concrete issuable scopes matching `granted`
  */
 export function expandIssuable(granted: readonly ScopeSelector[]): IssuableScope[] {
     return ISSUABLE_SCOPES.filter((scope) =>

--- a/packages/authz/lib/scopes.unit.test.ts
+++ b/packages/authz/lib/scopes.unit.test.ts
@@ -36,7 +36,6 @@ describe('isEnvironmentScopeSelector', () => {
         ['environment:settings:*', false],
         ['environment:nope:*', false],
         ['environment:conn*', false],
-        ['*', false],
         ['account:*', false]
     ])('%s -> %s', (value, expected) => {
         expect(isEnvironmentScopeSelector(value)).toBe(expected);
@@ -67,7 +66,6 @@ describe('isAccountScopeSelector', () => {
         ['account:team:*', false],
         ['account:billing:*', false],
         ['account:nope:*', false],
-        ['*', false],
         ['environment:*', false]
     ])('%s -> %s', (value, expected) => {
         expect(isAccountScopeSelector(value)).toBe(expected);

--- a/packages/authz/lib/scopes.unit.test.ts
+++ b/packages/authz/lib/scopes.unit.test.ts
@@ -12,7 +12,7 @@ import {
 
 import type { ScopeSelector } from './scopes.js';
 
-const JUNK = [null, undefined, 42, true, '', 'environment', 'environment:', 'account:', {}, ['environment:*']];
+const JUNK = [null, undefined, 42, true, '', '*', 'environment', 'environment:', 'account:', {}, ['environment:*']];
 
 describe('isEnvironmentScopeSelector', () => {
     it.each(PUBLIC_ENVIRONMENT_SCOPES)('accepts %s', (scope) => {

--- a/packages/authz/lib/where.ts
+++ b/packages/authz/lib/where.ts
@@ -1,6 +1,6 @@
 import type { DBEnvironment } from '@nangohq/types';
 
-export type WhereSelector = '*' | 'account' | 'env:*' | 'env:production' | 'env:non-production' | `env:${number}`;
+export type WhereSelector = 'account' | 'env:*' | 'env:production' | 'env:non-production' | `env:${number}`;
 
 export type Target = { type: 'account'; accountId: number } | { type: 'environment'; accountId: number; environment: { id: number; is_production: boolean } };
 
@@ -14,9 +14,6 @@ export function environmentTarget(environment: Pick<DBEnvironment, 'id' | 'accou
 }
 
 export function whereContains(where: WhereSelector, target: Target): boolean {
-    if (where === '*') {
-        return true;
-    }
     if (target.type === 'account') {
         return where === 'account';
     }
@@ -39,5 +36,5 @@ export function whereContains(where: WhereSelector, target: Target): boolean {
  * Multi-environment selectors expand when new environments are created, or the environment's `is_production` is changed.
  */
 export function isIssuableWhere(where: WhereSelector): boolean {
-    return where !== '*' && where !== 'env:*' && where !== 'env:production' && where !== 'env:non-production';
+    return where !== 'env:*' && where !== 'env:production' && where !== 'env:non-production';
 }

--- a/packages/server/lib/authz/legacyScopes.ts
+++ b/packages/server/lib/authz/legacyScopes.ts
@@ -51,9 +51,9 @@ export const LEGACY_SCOPES: Partial<Record<Scope, [Resource, Action, Plane]>> = 
     'environment:syncs:execute': ['sync_command', 'update', 'environment'],
     'environment:settings:read': ['environment', 'read', 'environment'],
     'environment:settings:update': ['environment', 'update', 'environment'],
-    'account:environments:delete': ['environment', 'delete', 'environment'],
-    'account:environments:api_keys:list': ['environment_key', 'read', 'environment'],
-    'account:environments:api_keys:update': ['environment_key', 'update', 'environment'],
+    'environment:delete': ['environment', 'delete', 'environment'],
+    'environment:api_keys:list': ['environment_key', 'read', 'environment'],
+    'environment:api_keys:update': ['environment_key', 'update', 'environment'],
     'environment:settings:read_secret': ['secret_key', 'read', 'environment'],
     'environment:variables:update': ['environment_variable', 'update', 'environment'],
     'environment:webhooks:update': ['webhook', 'update', 'environment']

--- a/packages/server/lib/authz/legacyScopes.ts
+++ b/packages/server/lib/authz/legacyScopes.ts
@@ -7,66 +7,66 @@ export type Plane = 'account' | 'environment';
  * Scope -> the legacy permission it replaces, and the plane it is evaluated on. The deny map has no
  * opinion on anything absent here.
  *
- * The plane is explicit because it cannot be derived: `account:environments:create` is account-plane
- * while `account:environments:delete` is environment-plane, and both use the same legacy resource.
+ * The plane is not stored here: it follows from the permission's tier, and equivalently from the
+ * scope's namespace.
  *
  * Deleted together with ROLE_DENY_MAP once the private API authorizes through `authorize()`.
  */
-export const LEGACY_SCOPES: Partial<Record<Scope, [Resource, Action, Plane]>> = {
+export const LEGACY_SCOPES: Partial<Record<Scope, [Resource, Action]>> = {
     // account plane
-    'account:team:update': ['team', 'update', 'account'],
-    'account:team:users:update': ['team_member', 'update', 'account'],
-    'account:team:users:delete': ['team_member', 'delete', 'account'],
-    'account:invites:create': ['invite', 'create', 'account'],
-    'account:invites:delete': ['invite', 'delete', 'account'],
-    'account:connect_ui:update': ['connect_ui_settings', 'update', 'account'],
-    'account:billing:payment_methods:list': ['billing', '*', 'account'],
-    'account:billing:payment_methods:create': ['billing', '*', 'account'],
-    'account:billing:payment_methods:delete': ['billing', '*', 'account'],
-    'account:plan:update': ['plan', 'update', 'account'],
-    'account:audit_trail:read': ['audit_trail', 'read', 'account'],
-    'account:api_keys:create': ['account_key', '*', 'account'],
-    'account:api_keys:list': ['account_key', '*', 'account'],
-    'account:api_keys:delete': ['account_key', '*', 'account'],
-    'account:environments:create': ['environment', 'create', 'account'],
-    'account:environments:set_production': ['environment_production_flag', 'update', 'account'],
+    'account:team:update': ['team', 'update'],
+    'account:team:users:update': ['team_member', 'update'],
+    'account:team:users:delete': ['team_member', 'delete'],
+    'account:invites:create': ['invite', 'create'],
+    'account:invites:delete': ['invite', 'delete'],
+    'account:connect_ui:update': ['connect_ui_settings', 'update'],
+    'account:billing:payment_methods:list': ['billing', '*'],
+    'account:billing:payment_methods:create': ['billing', '*'],
+    'account:billing:payment_methods:delete': ['billing', '*'],
+    'account:plan:update': ['plan', 'update'],
+    'account:audit_trail:read': ['audit_trail', 'read'],
+    'account:api_keys:create': ['account_key', '*'],
+    'account:api_keys:list': ['account_key', '*'],
+    'account:api_keys:delete': ['account_key', '*'],
+    'account:environments:create': ['environment', 'create'],
+    'account:environments:set_production': ['environment_production_flag', 'update'],
     // environment plane. `:list` and `:read` both map to the legacy `read` — the private grammar has
     // no list action, so one permission guards the collection and the item alike.
-    'environment:integrations:list': ['integration', 'read', 'environment'],
-    'environment:integrations:read': ['integration', 'read', 'environment'],
-    'environment:integrations:update': ['integration', 'update', 'environment'],
-    'environment:integrations:delete': ['integration', 'delete', 'environment'],
-    'environment:connections:list': ['connection', 'read', 'environment'],
-    'environment:connections:read': ['connection', 'read', 'environment'],
-    'environment:connections:update': ['connection', 'update', 'environment'],
-    'environment:connections:delete': ['connection', 'delete', 'environment'],
-    'environment:connections:read_credentials': ['connection_credential', 'read', 'environment'],
-    'environment:functions:list': ['flow', 'read', 'environment'],
-    'environment:functions:read': ['flow', 'read', 'environment'],
-    'environment:functions:delete': ['flow', 'delete', 'environment'],
+    'environment:integrations:list': ['integration', 'read'],
+    'environment:integrations:read': ['integration', 'read'],
+    'environment:integrations:update': ['integration', 'update'],
+    'environment:integrations:delete': ['integration', 'delete'],
+    'environment:connections:list': ['connection', 'read'],
+    'environment:connections:read': ['connection', 'read'],
+    'environment:connections:update': ['connection', 'update'],
+    'environment:connections:delete': ['connection', 'delete'],
+    'environment:connections:read_credentials': ['connection_credential', 'read'],
+    'environment:functions:list': ['flow', 'read'],
+    'environment:functions:read': ['flow', 'read'],
+    'environment:functions:delete': ['flow', 'delete'],
     // `canWriteProdFlows` guards deploy/upgrade and enable/disable/frequency alike.
-    'environment:deploy': ['flow', 'update', 'environment'],
-    'environment:syncs:update': ['flow', 'update', 'environment'],
-    'environment:logs:read': ['log', 'read', 'environment'],
-    'environment:syncs:execute': ['sync_command', 'update', 'environment'],
-    'environment:settings:read': ['environment', 'read', 'environment'],
-    'environment:settings:update': ['environment', 'update', 'environment'],
-    'environment:delete': ['environment', 'delete', 'environment'],
-    'environment:api_keys:list': ['environment_key', 'read', 'environment'],
-    'environment:api_keys:update': ['environment_key', 'update', 'environment'],
-    'environment:settings:read_secret': ['secret_key', 'read', 'environment'],
-    'environment:variables:update': ['environment_variable', 'update', 'environment'],
-    'environment:webhooks:update': ['webhook', 'update', 'environment']
+    'environment:deploy': ['flow', 'update'],
+    'environment:syncs:update': ['flow', 'update'],
+    'environment:logs:read': ['log', 'read'],
+    'environment:syncs:execute': ['sync_command', 'update'],
+    'environment:settings:read': ['environment', 'read'],
+    'environment:settings:update': ['environment', 'update'],
+    'environment:delete': ['environment', 'delete'],
+    'environment:api_keys:list': ['environment_key', 'read'],
+    'environment:api_keys:update': ['environment_key', 'update'],
+    'environment:settings:read_secret': ['secret_key', 'read'],
+    'environment:variables:update': ['environment_variable', 'update'],
+    'environment:webhooks:update': ['webhook', 'update']
 };
 
 const planeForTier = (tier: RbacTier): Plane => (tier === 'global' ? 'account' : 'environment');
 
 /** Keyed with `|` so it cannot be misread as a scope: `webhook|update|environment` is not `environment:webhooks:update`. */
-const permissionKey = (resource: Resource, action: Action, plane: Plane): string => `${resource}|${action}|${plane}`;
+const permissionKey = (resource: Resource, action: Action): string => `${resource}|${action}`;
 
 const byPermission = new Map<string, Scope[]>();
-for (const [scope, [resource, action, plane]] of Object.entries(LEGACY_SCOPES) as [Scope, [Resource, Action, Plane]][]) {
-    const key = permissionKey(resource, action, plane);
+for (const [scope, [resource, action]] of Object.entries(LEGACY_SCOPES) as [Scope, [Resource, Action]][]) {
+    const key = permissionKey(resource, action);
     byPermission.set(key, [...(byPermission.get(key) ?? []), scope]);
 }
 
@@ -76,7 +76,7 @@ for (const [scope, [resource, action, plane]] of Object.entries(LEGACY_SCOPES) a
  * `{integration, read}` guards both the collection and the item.
  */
 export function scopesForPermission(permission: Permission): Scope[] {
-    return byPermission.get(permissionKey(permission.resource, permission.action, planeForTier(permission.scope))) ?? [];
+    return byPermission.get(permissionKey(permission.resource, permission.action)) ?? [];
 }
 
 export function planeForPermission(permission: Permission): Plane {

--- a/packages/server/lib/authz/legacyScopes.unit.test.ts
+++ b/packages/server/lib/authz/legacyScopes.unit.test.ts
@@ -4,18 +4,20 @@ import { permissions } from '@nangohq/authz';
 
 import { LEGACY_SCOPES, planeForPermission, scopesForPermission } from './legacyScopes.js';
 
-import type { Plane } from './legacyScopes.js';
 import type { Scope } from '@nangohq/authz';
 import type { Action, Permission, Scope as RbacTier, Resource } from '@nangohq/types';
 
-const entries = Object.entries(LEGACY_SCOPES) as [Scope, [Resource, Action, Plane]][];
-const tierFor = (plane: Plane): RbacTier => (plane === 'account' ? 'global' : 'production');
+const entries = Object.entries(LEGACY_SCOPES) as [Scope, [Resource, Action]][];
+const TIERS: RbacTier[] = ['global', 'production', 'non-production'];
 
 describe('scopesForPermission', () => {
-    it.each(entries)('%s resolves back from the permission it replaces', (scope, [resource, action, plane]) => {
-        const permission: Permission = { resource, action, scope: tierFor(plane) };
-        expect(scopesForPermission(permission)).toContain(scope);
-        expect(planeForPermission(permission)).toBe(plane);
+    // The plane comes from the permission's tier, never from this table, so a scope must resolve the
+    // same way whichever tier it is asked about.
+    it.each(entries)('%s resolves back from the permission it replaces, on any tier', (scope, [resource, action]) => {
+        for (const tier of TIERS) {
+            const permission: Permission = { resource, action, scope: tier };
+            expect(scopesForPermission(permission), tier).toContain(scope);
+        }
     });
 
     it('returns every scope sharing a permission, since the legacy grammar has no list action', () => {
@@ -30,14 +32,14 @@ describe('scopesForPermission', () => {
      * key format but not the mapping's content. These do the latter.
      */
     it.each([
-        ['environment:webhooks:update', 'webhook', 'update', 'environment'],
-        ['environment:logs:read', 'log', 'read', 'environment'],
-        ['account:team:update', 'team', 'update', 'account'],
-        ['account:environments:create', 'environment', 'create', 'account'],
-        ['environment:delete', 'environment', 'delete', 'environment'],
-        ['environment:deploy', 'flow', 'update', 'environment']
-    ])('%s replaces %s/%s on the %s plane', (scope, resource, action, plane) => {
-        expect(LEGACY_SCOPES[scope as Scope]).toEqual([resource, action, plane]);
+        ['environment:webhooks:update', 'webhook', 'update'],
+        ['environment:logs:read', 'log', 'read'],
+        ['account:team:update', 'team', 'update'],
+        ['account:environments:create', 'environment', 'create'],
+        ['environment:delete', 'environment', 'delete'],
+        ['environment:deploy', 'flow', 'update']
+    ])('%s replaces %s/%s', (scope, resource, action) => {
+        expect(LEGACY_SCOPES[scope as Scope]).toEqual([resource, action]);
     });
 
     /** Anything missing here is a permission shadow evaluation can never compare, on every request. */

--- a/packages/server/lib/authz/legacyScopes.unit.test.ts
+++ b/packages/server/lib/authz/legacyScopes.unit.test.ts
@@ -34,7 +34,7 @@ describe('scopesForPermission', () => {
         ['environment:logs:read', 'log', 'read', 'environment'],
         ['account:team:update', 'team', 'update', 'account'],
         ['account:environments:create', 'environment', 'create', 'account'],
-        ['account:environments:delete', 'environment', 'delete', 'environment'],
+        ['environment:delete', 'environment', 'delete', 'environment'],
         ['environment:deploy', 'flow', 'update', 'environment']
     ])('%s replaces %s/%s on the %s plane', (scope, resource, action, plane) => {
         expect(LEGACY_SCOPES[scope as Scope]).toEqual([resource, action, plane]);

--- a/packages/server/lib/authz/principal.ts
+++ b/packages/server/lib/authz/principal.ts
@@ -6,7 +6,10 @@ import type { Grant, Principal, PrincipalSubject, ScopeSelector, WhereSelector }
 import type { ApiKeyPrincipal } from '@nangohq/types';
 
 /** What a caller reaches when RBAC does not apply: the flag is off, or the plan has no RBAC. */
-const UNRESTRICTED: Grant[] = [{ can: ['*'], where: ['*'] }];
+const UNRESTRICTED: Grant[] = [
+    { can: ['environment:*'], where: ['env:*'] },
+    { can: ['account:*'], where: ['account'] }
+];
 
 function rbacApplies(locals: Partial<RequestLocals>): boolean {
     if (!flags.hasAuthRoles) {

--- a/packages/server/lib/authz/roles.equivalence.unit.test.ts
+++ b/packages/server/lib/authz/roles.equivalence.unit.test.ts
@@ -42,9 +42,12 @@ function principalFor(role: Role): Principal {
     return { subject: { type: 'user', id: '1' }, accountId: 1, grants: ROLES[role] };
 }
 
+// A scope is only ever evaluated on its own plane, and the namespace is what says which.
+const planeOf = (scope: Scope): Plane => (scope.startsWith('account:') ? 'account' : 'environment');
+
 // A scope is only ever evaluated on its own plane; the other combinations do not occur.
 const cases = (Object.keys(LEGACY_SCOPES) as Scope[]).flatMap((scope) =>
-    ROLE_LIST.flatMap((role) => TIERS.filter((t) => t.plane === LEGACY_SCOPES[scope]![2]).map(({ tier, target }) => ({ scope, role, tier, target })))
+    ROLE_LIST.flatMap((role) => TIERS.filter((t) => t.plane === planeOf(scope)).map(({ tier, target }) => ({ scope, role, tier, target })))
 );
 
 describe('role grants match the legacy deny map', () => {


### PR DESCRIPTION
A few tweaks while we're still in shadow-mode.

This wasn't set in stone before, but I'm setting it in stone now: 
- `account:*` can only use `account` where.
- `environment:` uses `env:?` where. 

There were `account:` scopes using `env:?` wheres. This PR changes them.
I'm also removing the top-level wildcard (`*`), because it spans the 2 namespaces and wheres don't make that much sense in them. I don't feel strongly about this, but as always, it's better to ship less than more. Restricting this now to be safe.