### PR TITLE
fix(runner): auth runner start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,8 +195,8 @@ FLAG_SERVE_CONNECT_UI=true
 # and set NANGO_INTERNAL_AUTH_REQUIRED=true. See docs/guides/platform/self-hosting.mdx.
 # Control plane only (server, jobs, orchestrator). Never set on runners.
 # NANGO_INTERNAL_AUTH_TOKEN=<SHARED-BEARER>
-# Jobs only. Used to mint per-task JWTs for putTask/heartbeat and runner dispatch.
-# Never set the jobs master key on runners; jobs injects a derived verify key at node start.
+# Jobs only. Used to mint per-task HMAC JWTs for putTask/heartbeat and to seed the Ed25519
+# runner-dispatch keypair. Never set on runners; jobs injects only the public key at node start.
 # NANGO_INTERNAL_AUTH_SIGNING_KEY=<HMAC-SECRET>
 # Fail closed. Default false. Flip independently on orchestrator, then jobs (runners inherit REQUIRED at node start).
 # NANGO_INTERNAL_AUTH_REQUIRED=false

--- a/.env.example
+++ b/.env.example
@@ -195,7 +195,8 @@ FLAG_SERVE_CONNECT_UI=true
 # and set NANGO_INTERNAL_AUTH_REQUIRED=true. See docs/guides/platform/self-hosting.mdx.
 # Control plane only (server, jobs, orchestrator). Never set on runners.
 # NANGO_INTERNAL_AUTH_TOKEN=<SHARED-BEARER>
-# Jobs only. Used to mint per-task JWTs for putTask/heartbeat. Never set on runners.
+# Jobs only. Used to mint per-task JWTs for putTask/heartbeat and runner dispatch.
+# Never set the jobs master key on runners; jobs injects a derived verify key at node start.
 # NANGO_INTERNAL_AUTH_SIGNING_KEY=<HMAC-SECRET>
-# Fail closed. Default false. Flip independently on orchestrator then jobs after drain.
+# Fail closed. Default false. Flip independently on orchestrator, then jobs (runners inherit REQUIRED at node start).
 # NANGO_INTERNAL_AUTH_REQUIRED=false

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -496,18 +496,19 @@ NANGO_INTERNAL_TLS_CA_FILE=/etc/nango/tls/ca.crt
 
 #### Internal service auth
 
-Orchestrator and jobs HTTP APIs accept an `Authorization: Bearer` credential except `GET /health`, which stays open for probes. Enforcement is off until you set `NANGO_INTERNAL_AUTH_REQUIRED=true`. Shipping the image with no new variables is a no-op.
+Orchestrator, jobs, and runner HTTP APIs accept an `Authorization: Bearer` credential except `GET /health`, which stays open for probes. Enforcement is off until you set `NANGO_INTERNAL_AUTH_REQUIRED=true`. Shipping the image with no new variables is a no-op.
 
-There are two credential kinds:
+There are three credential kinds:
 
 - **Control plane** (server, jobs, orchestrator): a static shared secret. Used for server and jobs calling orchestrator.
-- **Task JWT**: jobs mints an HMAC token at invoke time (`iss: nango-internal`, `aud: jobs`, `task_id`) and passes it in the runner `start` call. The runner presents it on `putTask`/`heartbeat`. The signing key never leaves jobs. A stolen task token can at most forge **that** task. The default lifetime is 25 hours (orchestrator started-to-completed is one day, plus one hour).
+- **Task JWT**: jobs mints an HMAC token at invoke time (`iss: nango-internal`, `aud: jobs`, `task_id`) and passes it in the runner `start` call body. The runner presents it on `putTask`/`heartbeat`. The signing key never leaves jobs. A stolen task token can at most forge **that** task. The default lifetime is 25 hours (orchestrator started-to-completed is one day, plus one hour).
+- **Runner dispatch JWT**: jobs mints a second HMAC token (`aud: runner`, `task_id` or `node_id`) and sends it as `Authorization: Bearer` on `start`, `abort`, and `notifyWhenIdle`. It is signed with a key derived from `NANGO_INTERNAL_AUTH_SIGNING_KEY`, not the jobs master key. Jobs injects that derived key onto the runner at node start. A start call without a valid jobs identity is rejected when `REQUIRED=true`.
 
 | Variable | Where | Purpose |
 | - | - | - |
 | `NANGO_INTERNAL_AUTH_TOKEN` | server, jobs, orchestrator | Static Bearer. Never the runner service. |
-| `NANGO_INTERNAL_AUTH_SIGNING_KEY` | jobs only | HMAC key for task JWTs. |
-| `NANGO_INTERNAL_AUTH_REQUIRED` | orchestrator, jobs | Fail closed. Default `false`. Flip independently. |
+| `NANGO_INTERNAL_AUTH_SIGNING_KEY` | jobs only (master). Runners receive a derived verify key that jobs injects — never the jobs master key. | HMAC key for task JWTs and runner dispatch. |
+| `NANGO_INTERNAL_AUTH_REQUIRED` | orchestrator, jobs, runners | Fail closed. Default `false`. Flip independently on orchestrator, then jobs. Runners inherit `REQUIRED` at node start. |
 
 #### Custom websockets path
 

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -502,12 +502,13 @@ There are three credential kinds:
 
 - **Control plane** (server, jobs, orchestrator): a static shared secret. Used for server and jobs calling orchestrator.
 - **Task JWT**: jobs mints an HMAC token at invoke time (`iss: nango-internal`, `aud: jobs`, `task_id`) and passes it in the runner `start` call body. The runner presents it on `putTask`/`heartbeat`. The signing key never leaves jobs. A stolen task token can at most forge **that** task. The default lifetime is 25 hours (orchestrator started-to-completed is one day, plus one hour).
-- **Runner dispatch JWT**: jobs mints a second HMAC token (`aud: runner`, `task_id` or `node_id`) and sends it as `Authorization: Bearer` on `start`, `abort`, and `notifyWhenIdle`. It is signed with a key derived from `NANGO_INTERNAL_AUTH_SIGNING_KEY`, not the jobs master key. Jobs injects that derived key onto the runner at node start. A start call without a valid jobs identity is rejected when `REQUIRED=true`.
+- **Runner dispatch JWT**: jobs mints an EdDSA token (`aud: runner`, `task_id` or `node_id`) and sends it as `Authorization: Bearer` on `start`, `abort`, and `notifyWhenIdle`. The Ed25519 private key is derived from `NANGO_INTERNAL_AUTH_SIGNING_KEY` and never leaves jobs. Jobs injects only the matching public key onto the runner at node start, so a runner process cannot mint dispatch tokens. A start call without a valid jobs identity is rejected when `REQUIRED=true`.
 
 | Variable | Where | Purpose |
 | - | - | - |
 | `NANGO_INTERNAL_AUTH_TOKEN` | server, jobs, orchestrator | Static Bearer. Never the runner service. |
-| `NANGO_INTERNAL_AUTH_SIGNING_KEY` | jobs only (master). Runners receive a derived verify key that jobs injects — never the jobs master key. | HMAC key for task JWTs and runner dispatch. |
+| `NANGO_INTERNAL_AUTH_SIGNING_KEY` | jobs only. Never set on runners. | HMAC key for task JWTs (`aud: jobs`). Also the seed for the Ed25519 runner-dispatch keypair. |
+| `NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY` | runners (injected by jobs at node start) | Ed25519 public key. Verify-only; cannot mint dispatch tokens. |
 | `NANGO_INTERNAL_AUTH_REQUIRED` | orchestrator, jobs, runners | Fail closed. Default `false`. Flip independently on orchestrator, then jobs. Runners inherit `REQUIRED` at node start. |
 
 #### Custom websockets path

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7166,18 +7166,19 @@ NANGO_INTERNAL_TLS_CA_FILE=/etc/nango/tls/ca.crt
 
 #### Internal service auth
 
-Orchestrator and jobs HTTP APIs accept an `Authorization: Bearer` credential except `GET /health`, which stays open for probes. Enforcement is off until you set `NANGO_INTERNAL_AUTH_REQUIRED=true`. Shipping the image with no new variables is a no-op.
+Orchestrator, jobs, and runner HTTP APIs accept an `Authorization: Bearer` credential except `GET /health`, which stays open for probes. Enforcement is off until you set `NANGO_INTERNAL_AUTH_REQUIRED=true`. Shipping the image with no new variables is a no-op.
 
-There are two credential kinds:
+There are three credential kinds:
 
 - **Control plane** (server, jobs, orchestrator): a static shared secret. Used for server and jobs calling orchestrator.
-- **Task JWT**: jobs mints an HMAC token at invoke time (`iss: nango-internal`, `aud: jobs`, `task_id`) and passes it in the runner `start` call. The runner presents it on `putTask`/`heartbeat`. The signing key never leaves jobs. A stolen task token can at most forge **that** task. The default lifetime is 25 hours (orchestrator started-to-completed is one day, plus one hour).
+- **Task JWT**: jobs mints an HMAC token at invoke time (`iss: nango-internal`, `aud: jobs`, `task_id`) and passes it in the runner `start` call body. The runner presents it on `putTask`/`heartbeat`. The signing key never leaves jobs. A stolen task token can at most forge **that** task. The default lifetime is 25 hours (orchestrator started-to-completed is one day, plus one hour).
+- **Runner dispatch JWT**: jobs mints a second HMAC token (`aud: runner`, `task_id` or `node_id`) and sends it as `Authorization: Bearer` on `start`, `abort`, and `notifyWhenIdle`. It is signed with a key derived from `NANGO_INTERNAL_AUTH_SIGNING_KEY`, not the jobs master key. Jobs injects that derived key onto the runner at node start. A start call without a valid jobs identity is rejected when `REQUIRED=true`.
 
 | Variable | Where | Purpose |
 | - | - | - |
 | `NANGO_INTERNAL_AUTH_TOKEN` | server, jobs, orchestrator | Static Bearer. Never the runner service. |
-| `NANGO_INTERNAL_AUTH_SIGNING_KEY` | jobs only | HMAC key for task JWTs. |
-| `NANGO_INTERNAL_AUTH_REQUIRED` | orchestrator, jobs | Fail closed. Default `false`. Flip independently. |
+| `NANGO_INTERNAL_AUTH_SIGNING_KEY` | jobs only (master). Runners receive a derived verify key that jobs injects — never the jobs master key. | HMAC key for task JWTs and runner dispatch. |
+| `NANGO_INTERNAL_AUTH_REQUIRED` | orchestrator, jobs, runners | Fail closed. Default `false`. Flip independently on orchestrator, then jobs. Runners inherit `REQUIRED` at node start. |
 
 #### Custom websockets path
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7172,12 +7172,13 @@ There are three credential kinds:
 
 - **Control plane** (server, jobs, orchestrator): a static shared secret. Used for server and jobs calling orchestrator.
 - **Task JWT**: jobs mints an HMAC token at invoke time (`iss: nango-internal`, `aud: jobs`, `task_id`) and passes it in the runner `start` call body. The runner presents it on `putTask`/`heartbeat`. The signing key never leaves jobs. A stolen task token can at most forge **that** task. The default lifetime is 25 hours (orchestrator started-to-completed is one day, plus one hour).
-- **Runner dispatch JWT**: jobs mints a second HMAC token (`aud: runner`, `task_id` or `node_id`) and sends it as `Authorization: Bearer` on `start`, `abort`, and `notifyWhenIdle`. It is signed with a key derived from `NANGO_INTERNAL_AUTH_SIGNING_KEY`, not the jobs master key. Jobs injects that derived key onto the runner at node start. A start call without a valid jobs identity is rejected when `REQUIRED=true`.
+- **Runner dispatch JWT**: jobs mints an EdDSA token (`aud: runner`, `task_id` or `node_id`) and sends it as `Authorization: Bearer` on `start`, `abort`, and `notifyWhenIdle`. The Ed25519 private key is derived from `NANGO_INTERNAL_AUTH_SIGNING_KEY` and never leaves jobs. Jobs injects only the matching public key onto the runner at node start, so a runner process cannot mint dispatch tokens. A start call without a valid jobs identity is rejected when `REQUIRED=true`.
 
 | Variable | Where | Purpose |
 | - | - | - |
 | `NANGO_INTERNAL_AUTH_TOKEN` | server, jobs, orchestrator | Static Bearer. Never the runner service. |
-| `NANGO_INTERNAL_AUTH_SIGNING_KEY` | jobs only (master). Runners receive a derived verify key that jobs injects — never the jobs master key. | HMAC key for task JWTs and runner dispatch. |
+| `NANGO_INTERNAL_AUTH_SIGNING_KEY` | jobs only. Never set on runners. | HMAC key for task JWTs (`aud: jobs`). Also the seed for the Ed25519 runner-dispatch keypair. |
+| `NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY` | runners (injected by jobs at node start) | Ed25519 public key. Verify-only; cannot mint dispatch tokens. |
 | `NANGO_INTERNAL_AUTH_REQUIRED` | orchestrator, jobs, runners | Fail closed. Default `false`. Flip independently on orchestrator, then jobs. Runners inherit `REQUIRED` at node start. |
 
 #### Custom websockets path

--- a/packages/internal-auth/lib/constants.ts
+++ b/packages/internal-auth/lib/constants.ts
@@ -2,8 +2,8 @@ export const INTERNAL_SERVICE_TOKEN_ISSUER = 'nango-internal';
 export const INTERNAL_SERVICE_AUDIENCE_ORCHESTRATOR = 'orchestrator';
 export const INTERNAL_SERVICE_AUDIENCE_JOBS = 'jobs';
 export const INTERNAL_SERVICE_AUDIENCE_RUNNER = 'runner';
-/** Info string for HMAC-deriving the runner verify key from the jobs signing key. */
-export const INTERNAL_SERVICE_RUNNER_KEY_INFO = 'nango-internal-runner';
+/** Info string for HKDF-style Ed25519 seed from the jobs HMAC signing key. */
+export const INTERNAL_SERVICE_RUNNER_ED25519_INFO = 'nango-internal-runner-ed25519';
 // Longest runner tasks are scheduled syncs (orchestrator startedToCompleted is 1 day). +1h covers
 // clock skew and a late heartbeat; there is no refresh. Callers pass expiresInSecs to override
 export const INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS = 24 * 3600 + 3600;
@@ -13,7 +13,7 @@ export const INTERNAL_SERVICE_AUTH_LOCALS_KEY = 'internalServiceAuth';
 
 export type InternalServiceTokenOp = 'task' | 'node';
 
-export type InternalServiceAuthKind = 'hmac' | 'static';
+export type InternalServiceAuthKind = 'hmac' | 'static' | 'eddsa';
 
 export interface InternalServiceAuth {
     kind: InternalServiceAuthKind;

--- a/packages/internal-auth/lib/constants.ts
+++ b/packages/internal-auth/lib/constants.ts
@@ -1,6 +1,9 @@
 export const INTERNAL_SERVICE_TOKEN_ISSUER = 'nango-internal';
 export const INTERNAL_SERVICE_AUDIENCE_ORCHESTRATOR = 'orchestrator';
 export const INTERNAL_SERVICE_AUDIENCE_JOBS = 'jobs';
+export const INTERNAL_SERVICE_AUDIENCE_RUNNER = 'runner';
+/** Info string for HMAC-deriving the runner verify key from the jobs signing key. */
+export const INTERNAL_SERVICE_RUNNER_KEY_INFO = 'nango-internal-runner';
 // Longest runner tasks are scheduled syncs (orchestrator startedToCompleted is 1 day). +1h covers
 // clock skew and a late heartbeat; there is no refresh. Callers pass expiresInSecs to override
 export const INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS = 24 * 3600 + 3600;

--- a/packages/internal-auth/lib/credential.ts
+++ b/packages/internal-auth/lib/credential.ts
@@ -1,3 +1,7 @@
+import { createHmac } from 'node:crypto';
+
+import { INTERNAL_SERVICE_RUNNER_KEY_INFO } from './constants.js';
+
 export type InternalAuthEnvs = {
     NANGO_INTERNAL_AUTH_REQUIRED: boolean;
     NANGO_INTERNAL_AUTH_TOKEN?: string | undefined;
@@ -7,6 +11,18 @@ export type InternalAuthEnvs = {
 export function trimOrNull(value: string | undefined): string | null {
     const token = value?.trim();
     return token || null;
+}
+
+/**
+ * Deterministic runner verify key. Same jobs signing key always yields the same derived key.
+ * The jobs master key never goes on a runner; this value does.
+ */
+export function deriveRunnerSigningKey(jobsSigningKey: string | null | undefined): string | null {
+    const key = trimOrNull(jobsSigningKey ?? undefined);
+    if (!key) {
+        return null;
+    }
+    return createHmac('sha256', key).update(INTERNAL_SERVICE_RUNNER_KEY_INFO).digest('base64url');
 }
 
 export function getInternalAuthBearerHeaderIfPresent(token: string | null | undefined): Record<string, string> {

--- a/packages/internal-auth/lib/credential.ts
+++ b/packages/internal-auth/lib/credential.ts
@@ -1,28 +1,13 @@
-import { createHmac } from 'node:crypto';
-
-import { INTERNAL_SERVICE_RUNNER_KEY_INFO } from './constants.js';
-
 export type InternalAuthEnvs = {
     NANGO_INTERNAL_AUTH_REQUIRED: boolean;
     NANGO_INTERNAL_AUTH_TOKEN?: string | undefined;
     NANGO_INTERNAL_AUTH_SIGNING_KEY?: string | undefined;
+    NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY?: string | undefined;
 };
 
 export function trimOrNull(value: string | undefined): string | null {
     const token = value?.trim();
     return token || null;
-}
-
-/**
- * Deterministic runner verify key. Same jobs signing key always yields the same derived key.
- * The jobs master key never goes on a runner; this value does.
- */
-export function deriveRunnerSigningKey(jobsSigningKey: string | null | undefined): string | null {
-    const key = trimOrNull(jobsSigningKey ?? undefined);
-    if (!key) {
-        return null;
-    }
-    return createHmac('sha256', key).update(INTERNAL_SERVICE_RUNNER_KEY_INFO).digest('base64url');
 }
 
 export function getInternalAuthBearerHeaderIfPresent(token: string | null | undefined): Record<string, string> {

--- a/packages/internal-auth/lib/credential.unit.test.ts
+++ b/packages/internal-auth/lib/credential.unit.test.ts
@@ -1,34 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_RUNNER } from './constants.js';
-import { deriveRunnerSigningKey, getInternalAuthBearerHeaderIfPresent } from './credential.js';
-import { createInternalServiceToken, verifyInternalServiceToken } from './token.js';
-
-describe('deriveRunnerSigningKey', () => {
-    it('returns null when the jobs signing key is unset', () => {
-        expect(deriveRunnerSigningKey(undefined)).toBeNull();
-        expect(deriveRunnerSigningKey(null)).toBeNull();
-        expect(deriveRunnerSigningKey('')).toBeNull();
-        expect(deriveRunnerSigningKey('   ')).toBeNull();
-    });
-
-    it('is deterministic for the same jobs signing key', () => {
-        expect(deriveRunnerSigningKey('sign')).toBe(deriveRunnerSigningKey('sign'));
-        expect(deriveRunnerSigningKey('sign')).toEqual(expect.any(String));
-        expect(deriveRunnerSigningKey('sign')).not.toBe('sign');
-    });
-
-    it('cannot verify a master-signed jobs JWT', () => {
-        const derived = deriveRunnerSigningKey('sign');
-        const token = createInternalServiceToken({ taskId: 'task-1', expiresInSecs: 120 }, 'sign');
-        expect(token).toEqual(expect.any(String));
-        if (!token || !derived) {
-            return;
-        }
-        expect(verifyInternalServiceToken(token, INTERNAL_SERVICE_AUDIENCE_JOBS, derived)).toMatchObject({ ok: false });
-        expect(verifyInternalServiceToken(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, derived)).toMatchObject({ ok: false });
-    });
-});
+import { getInternalAuthBearerHeaderIfPresent } from './credential.js';
 
 describe('getInternalAuthBearerHeaderIfPresent', () => {
     it('omits the header when there is no token', () => {

--- a/packages/internal-auth/lib/credential.unit.test.ts
+++ b/packages/internal-auth/lib/credential.unit.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it } from 'vitest';
 
-import { getInternalAuthBearerHeaderIfPresent } from './credential.js';
+import { INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_RUNNER } from './constants.js';
+import { deriveRunnerSigningKey, getInternalAuthBearerHeaderIfPresent } from './credential.js';
+import { createInternalServiceToken, verifyInternalServiceToken } from './token.js';
+
+describe('deriveRunnerSigningKey', () => {
+    it('returns null when the jobs signing key is unset', () => {
+        expect(deriveRunnerSigningKey(undefined)).toBeNull();
+        expect(deriveRunnerSigningKey(null)).toBeNull();
+        expect(deriveRunnerSigningKey('')).toBeNull();
+        expect(deriveRunnerSigningKey('   ')).toBeNull();
+    });
+
+    it('is deterministic for the same jobs signing key', () => {
+        expect(deriveRunnerSigningKey('sign')).toBe(deriveRunnerSigningKey('sign'));
+        expect(deriveRunnerSigningKey('sign')).toEqual(expect.any(String));
+        expect(deriveRunnerSigningKey('sign')).not.toBe('sign');
+    });
+
+    it('cannot verify a master-signed jobs JWT', () => {
+        const derived = deriveRunnerSigningKey('sign');
+        const token = createInternalServiceToken({ taskId: 'task-1', expiresInSecs: 120 }, 'sign');
+        expect(token).toEqual(expect.any(String));
+        if (!token || !derived) {
+            return;
+        }
+        expect(verifyInternalServiceToken(token, INTERNAL_SERVICE_AUDIENCE_JOBS, derived)).toMatchObject({ ok: false });
+        expect(verifyInternalServiceToken(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, derived)).toMatchObject({ ok: false });
+    });
+});
 
 describe('getInternalAuthBearerHeaderIfPresent', () => {
     it('omits the header when there is no token', () => {

--- a/packages/internal-auth/lib/ed25519.ts
+++ b/packages/internal-auth/lib/ed25519.ts
@@ -1,0 +1,64 @@
+import { createHmac, createPrivateKey, createPublicKey } from 'node:crypto';
+
+import { INTERNAL_SERVICE_RUNNER_ED25519_INFO } from './constants.js';
+
+import type { KeyObject } from 'node:crypto';
+
+/** PKCS#8 prefix for an Ed25519 private key whose OCTET STRING is the 32-byte seed (RFC 8410). */
+const ED25519_PKCS8_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+/** SPKI prefix for an Ed25519 public key (RFC 8410). */
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+const ED25519_SEED_LEN = 32;
+const ED25519_PUBLIC_LEN = 32;
+
+function trimOrNull(value: string | undefined): string | null {
+    const token = value?.trim();
+    return token || null;
+}
+
+function runnerSeed(jobsSigningKey: string): Buffer {
+    return createHmac('sha256', jobsSigningKey).update(INTERNAL_SERVICE_RUNNER_ED25519_INFO).digest();
+}
+
+export function deriveRunnerEd25519PrivateKey(jobsSigningKey: string | null | undefined): KeyObject | null {
+    const key = trimOrNull(jobsSigningKey ?? undefined);
+    if (!key) {
+        return null;
+    }
+    const seed = runnerSeed(key);
+    if (seed.length !== ED25519_SEED_LEN) {
+        return null;
+    }
+    const pkcs8 = Buffer.concat([ED25519_PKCS8_PREFIX, seed]);
+    return createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
+}
+
+/**
+ * Compact verify-only material for runners: base64url of the 32-byte Ed25519 public key.
+ * Cannot mint tokens. Deterministic from the jobs HMAC signing key.
+ */
+export function exportRunnerPublicKey(jobsSigningKey: string | null | undefined): string | null {
+    const privateKey = deriveRunnerEd25519PrivateKey(jobsSigningKey);
+    if (!privateKey) {
+        return null;
+    }
+    const spki = createPublicKey(privateKey).export({ type: 'spki', format: 'der' });
+    return Buffer.from(spki).subarray(-ED25519_PUBLIC_LEN).toString('base64url');
+}
+
+export function runnerPublicKeyFromEnv(publicKey: string | null | undefined): KeyObject | null {
+    const raw = trimOrNull(publicKey ?? undefined);
+    if (!raw) {
+        return null;
+    }
+    try {
+        const bytes = Buffer.from(raw, 'base64url');
+        if (bytes.length !== ED25519_PUBLIC_LEN) {
+            return null;
+        }
+        const spki = Buffer.concat([ED25519_SPKI_PREFIX, bytes]);
+        return createPublicKey({ key: spki, format: 'der', type: 'spki' });
+    } catch {
+        return null;
+    }
+}

--- a/packages/internal-auth/lib/ed25519.ts
+++ b/packages/internal-auth/lib/ed25519.ts
@@ -9,7 +9,6 @@ import type { KeyObject } from 'node:crypto';
 const ED25519_PKCS8_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
 /** SPKI prefix for an Ed25519 public key (RFC 8410). */
 const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
-const ED25519_SEED_LEN = 32;
 const ED25519_PUBLIC_LEN = 32;
 
 function runnerSeed(jobsSigningKey: string): Buffer {
@@ -22,9 +21,6 @@ export function deriveRunnerEd25519PrivateKey(jobsSigningKey: string | null | un
         return null;
     }
     const seed = runnerSeed(key);
-    if (seed.length !== ED25519_SEED_LEN) {
-        return null;
-    }
     const pkcs8 = Buffer.concat([ED25519_PKCS8_PREFIX, seed]);
     return createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
 }
@@ -39,7 +35,7 @@ export function exportRunnerPublicKey(jobsSigningKey: string | null | undefined)
         return null;
     }
     const spki = createPublicKey(privateKey).export({ type: 'spki', format: 'der' });
-    return Buffer.from(spki).subarray(-ED25519_PUBLIC_LEN).toString('base64url');
+    return Buffer.from(spki).subarray(ED25519_SPKI_PREFIX.length).toString('base64url');
 }
 
 export function runnerPublicKeyFromEnv(publicKey: string | null | undefined): KeyObject | null {

--- a/packages/internal-auth/lib/ed25519.ts
+++ b/packages/internal-auth/lib/ed25519.ts
@@ -1,6 +1,7 @@
 import { createHmac, createPrivateKey, createPublicKey } from 'node:crypto';
 
 import { INTERNAL_SERVICE_RUNNER_ED25519_INFO } from './constants.js';
+import { trimOrNull } from './credential.js';
 
 import type { KeyObject } from 'node:crypto';
 
@@ -10,11 +11,6 @@ const ED25519_PKCS8_PREFIX = Buffer.from('302e020100300506032b657004220420', 'he
 const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
 const ED25519_SEED_LEN = 32;
 const ED25519_PUBLIC_LEN = 32;
-
-function trimOrNull(value: string | undefined): string | null {
-    const token = value?.trim();
-    return token || null;
-}
 
 function runnerSeed(jobsSigningKey: string): Buffer {
     return createHmac('sha256', jobsSigningKey).update(INTERNAL_SERVICE_RUNNER_ED25519_INFO).digest();

--- a/packages/internal-auth/lib/ed25519.unit.test.ts
+++ b/packages/internal-auth/lib/ed25519.unit.test.ts
@@ -45,6 +45,26 @@ describe('createRunnerDispatchToken', () => {
         expect(verifyInternalServiceToken(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, 'sign')).toMatchObject({ ok: false });
     });
 
+    it('rejects a non-canonical base64url signature segment', () => {
+        const token = createRunnerDispatchToken({ taskId: 'task-1', expiresInSecs: 120 }, 'sign');
+        const publicKey = exportRunnerPublicKey('sign');
+        expect(token).toEqual(expect.any(String));
+        expect(publicKey).toEqual(expect.any(String));
+        if (!token || !publicKey) {
+            return;
+        }
+        const [header, payload, signature] = token.split('.');
+        expect(header && payload && signature).toBeTruthy();
+        expect(verifyRunnerDispatchToken(`${header}.${payload}.${signature}!`, INTERNAL_SERVICE_AUDIENCE_RUNNER, publicKey)).toMatchObject({
+            ok: false,
+            reason: 'bad_signature'
+        });
+        expect(verifyRunnerDispatchToken(`${header}.${payload}.${signature}=`, INTERNAL_SERVICE_AUDIENCE_RUNNER, publicKey)).toMatchObject({
+            ok: false,
+            reason: 'bad_signature'
+        });
+    });
+
     it('cannot mint a token the runner accepts using only the public key', () => {
         const publicKey = exportRunnerPublicKey('sign');
         expect(publicKey).toEqual(expect.any(String));

--- a/packages/internal-auth/lib/ed25519.unit.test.ts
+++ b/packages/internal-auth/lib/ed25519.unit.test.ts
@@ -55,11 +55,32 @@ describe('createRunnerDispatchToken', () => {
         }
         const [header, payload, signature] = token.split('.');
         expect(header && payload && signature).toBeTruthy();
+        if (!header || !payload || !signature) {
+            return;
+        }
+
         expect(verifyRunnerDispatchToken(`${header}.${payload}.${signature}!`, INTERNAL_SERVICE_AUDIENCE_RUNNER, publicKey)).toMatchObject({
             ok: false,
             reason: 'bad_signature'
         });
         expect(verifyRunnerDispatchToken(`${header}.${payload}.${signature}=`, INTERNAL_SERVICE_AUDIENCE_RUNNER, publicKey)).toMatchObject({
+            ok: false,
+            reason: 'bad_signature'
+        });
+
+        // Same alphabet, non-zero unused low bits on the last sextet: regex passes, re-encode does not.
+        const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+        const last = signature.at(-1);
+        expect(last).toEqual(expect.any(String));
+        if (!last) {
+            return;
+        }
+        const idx = alphabet.indexOf(last);
+        const mutatedLast = alphabet[(idx & ~3) + ((idx + 1) % 4)];
+        const mutated = `${signature.slice(0, -1)}${mutatedLast}`;
+        expect(mutated).toMatch(/^[A-Za-z0-9_-]+$/);
+        expect(Buffer.from(mutated, 'base64url').toString('base64url')).not.toBe(mutated);
+        expect(verifyRunnerDispatchToken(`${header}.${payload}.${mutated}`, INTERNAL_SERVICE_AUDIENCE_RUNNER, publicKey)).toMatchObject({
             ok: false,
             reason: 'bad_signature'
         });

--- a/packages/internal-auth/lib/ed25519.unit.test.ts
+++ b/packages/internal-auth/lib/ed25519.unit.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_RUNNER } from './constants.js';
+import { exportRunnerPublicKey, runnerPublicKeyFromEnv } from './ed25519.js';
+import { createInternalServiceToken, createRunnerDispatchToken, verifyInternalServiceToken, verifyRunnerDispatchToken } from './token.js';
+
+describe('exportRunnerPublicKey', () => {
+    it('returns null when the jobs signing key is unset', () => {
+        expect(exportRunnerPublicKey(undefined)).toBeNull();
+        expect(exportRunnerPublicKey(null)).toBeNull();
+        expect(exportRunnerPublicKey('')).toBeNull();
+        expect(exportRunnerPublicKey('   ')).toBeNull();
+    });
+
+    it('is deterministic for the same jobs signing key', () => {
+        expect(exportRunnerPublicKey('sign')).toBe(exportRunnerPublicKey('sign'));
+        expect(exportRunnerPublicKey('sign')).toEqual(expect.any(String));
+        expect(exportRunnerPublicKey('sign')).not.toBe('sign');
+        expect(exportRunnerPublicKey('sign')).not.toBe(exportRunnerPublicKey('other'));
+    });
+});
+
+describe('createRunnerDispatchToken', () => {
+    it('returns null when the jobs signing key is unset', () => {
+        expect(createRunnerDispatchToken({ taskId: 'task-1' }, undefined)).toBeNull();
+    });
+
+    it('mints an EdDSA runner-audience token that verifies with the public key', () => {
+        const token = createRunnerDispatchToken({ taskId: 'task-1', expiresInSecs: 120 }, 'sign');
+        const publicKey = exportRunnerPublicKey('sign');
+        expect(token).toEqual(expect.any(String));
+        expect(publicKey).toEqual(expect.any(String));
+        if (!token || !publicKey) {
+            return;
+        }
+        expect(JSON.parse(Buffer.from(token.split('.')[0] ?? '', 'base64url').toString('utf8'))).toMatchObject({ alg: 'EdDSA' });
+        expect(verifyRunnerDispatchToken(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, publicKey)).toMatchObject({
+            ok: true,
+            kind: 'eddsa',
+            op: 'task',
+            taskId: 'task-1',
+            audience: INTERNAL_SERVICE_AUDIENCE_RUNNER
+        });
+        expect(verifyRunnerDispatchToken(token, INTERNAL_SERVICE_AUDIENCE_JOBS, publicKey)).toMatchObject({ ok: false, reason: 'wrong_audience' });
+        expect(verifyInternalServiceToken(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, 'sign')).toMatchObject({ ok: false });
+    });
+
+    it('cannot mint a token the runner accepts using only the public key', () => {
+        const publicKey = exportRunnerPublicKey('sign');
+        expect(publicKey).toEqual(expect.any(String));
+        if (!publicKey) {
+            return;
+        }
+        const forgedFromPublicKeyAsMaster = createRunnerDispatchToken({ taskId: 'victim-task', expiresInSecs: 120 }, publicKey);
+        expect(forgedFromPublicKeyAsMaster).toEqual(expect.any(String));
+        if (!forgedFromPublicKeyAsMaster) {
+            return;
+        }
+        expect(verifyRunnerDispatchToken(forgedFromPublicKeyAsMaster, INTERNAL_SERVICE_AUDIENCE_RUNNER, publicKey)).toMatchObject({
+            ok: false,
+            reason: 'bad_signature'
+        });
+
+        const hmacForged = createInternalServiceToken({ audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, taskId: 'victim-task', expiresInSecs: 120 }, publicKey);
+        expect(hmacForged).toEqual(expect.any(String));
+        if (!hmacForged) {
+            return;
+        }
+        expect(verifyRunnerDispatchToken(hmacForged, INTERNAL_SERVICE_AUDIENCE_RUNNER, publicKey)).toMatchObject({ ok: false });
+    });
+
+    it('cannot construct a private key from runner-held public key material', () => {
+        const publicKey = exportRunnerPublicKey('sign');
+        expect(publicKey).toEqual(expect.any(String));
+        if (!publicKey) {
+            return;
+        }
+        expect(runnerPublicKeyFromEnv(publicKey)?.type).toBe('public');
+        expect(exportRunnerPublicKey(publicKey)).not.toBe(exportRunnerPublicKey('sign'));
+    });
+});

--- a/packages/internal-auth/lib/index.ts
+++ b/packages/internal-auth/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './constants.js';
 export * from './credential.js';
+export * from './ed25519.js';
 export * from './token.js';
 export * from './verify.js';
 export * from './middleware.js';

--- a/packages/internal-auth/lib/middleware.ts
+++ b/packages/internal-auth/lib/middleware.ts
@@ -25,11 +25,15 @@ export function getInternalServiceAuth(res: Response): InternalServiceAuth | und
 }
 
 export function isTaskBoundAuth(auth: InternalServiceAuth | undefined, taskId: string | undefined): boolean {
-    return Boolean(auth?.kind === 'hmac' && auth.op === 'task' && taskId && auth.taskId === taskId);
+    return Boolean(isSignedAuth(auth) && auth?.op === 'task' && taskId && auth.taskId === taskId);
 }
 
 export function isNodeBoundAuth(auth: InternalServiceAuth | undefined, nodeId: string | undefined): boolean {
-    return Boolean(auth?.kind === 'hmac' && auth.op === 'node' && nodeId && auth.nodeId === nodeId);
+    return Boolean(isSignedAuth(auth) && auth?.op === 'node' && nodeId && auth.nodeId === nodeId);
+}
+
+function isSignedAuth(auth: InternalServiceAuth | undefined): boolean {
+    return auth?.kind === 'hmac' || auth?.kind === 'eddsa';
 }
 
 export function internalServiceAuthMiddleware(opts: {
@@ -56,7 +60,8 @@ export function internalServiceAuthMiddleware(opts: {
 
         const auth = verifyInternalServiceCredential(parsed.token, opts.audience, {
             signingKey: opts.envs.NANGO_INTERNAL_AUTH_SIGNING_KEY,
-            staticToken: opts.envs.NANGO_INTERNAL_AUTH_TOKEN
+            staticToken: opts.envs.NANGO_INTERNAL_AUTH_TOKEN,
+            runnerPublicKey: opts.envs.NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY
         });
         if (!auth) {
             unauthorized(res, 'unauthorized', 'Unauthorized');
@@ -72,7 +77,7 @@ function routeParam(req: Request, name: string): string | undefined {
     return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
-/** When REQUIRED, the matched route's `:taskId` must equal the HMAC task JWT. Register on that route. */
+/** When REQUIRED, the matched route's `:taskId` must equal the signed task JWT. Register on that route. */
 export function requireTaskBoundAuth(envs: InternalAuthEnvs): (req: Request, res: Response, next: NextFunction) => void {
     return (req, res, next) => {
         if (!envs.NANGO_INTERNAL_AUTH_REQUIRED) {
@@ -89,7 +94,7 @@ export function requireTaskBoundAuth(envs: InternalAuthEnvs): (req: Request, res
     };
 }
 
-/** When REQUIRED, the matched route's `:nodeId` must equal the HMAC node JWT. Register on that route. */
+/** When REQUIRED, the matched route's `:nodeId` must equal the signed node JWT. Register on that route. */
 export function requireFleetAuth(envs: InternalAuthEnvs): (req: Request, res: Response, next: NextFunction) => void {
     return (req, res, next) => {
         if (!envs.NANGO_INTERNAL_AUTH_REQUIRED) {

--- a/packages/internal-auth/lib/middleware.ts
+++ b/packages/internal-auth/lib/middleware.ts
@@ -24,9 +24,21 @@ export function getInternalServiceAuth(res: Response): InternalServiceAuth | und
     return res.locals[INTERNAL_SERVICE_AUTH_LOCALS_KEY] as InternalServiceAuth | undefined;
 }
 
-export function internalServiceAuthMiddleware(opts: { audience: string; envs: InternalAuthEnvs }): (req: Request, res: Response, next: NextFunction) => void {
+export function isTaskBoundAuth(auth: InternalServiceAuth | undefined, taskId: string | undefined): boolean {
+    return Boolean(auth?.kind === 'hmac' && auth.op === 'task' && taskId && auth.taskId === taskId);
+}
+
+export function isNodeBoundAuth(auth: InternalServiceAuth | undefined, nodeId: string | undefined): boolean {
+    return Boolean(auth?.kind === 'hmac' && auth.op === 'node' && nodeId && auth.nodeId === nodeId);
+}
+
+export function internalServiceAuthMiddleware(opts: {
+    audience: string;
+    envs: InternalAuthEnvs;
+    skip?: (req: Request) => boolean;
+}): (req: Request, res: Response, next: NextFunction) => void {
     return (req, res, next) => {
-        if (!opts.envs.NANGO_INTERNAL_AUTH_REQUIRED) {
+        if (opts.skip?.(req) || !opts.envs.NANGO_INTERNAL_AUTH_REQUIRED) {
             next();
             return;
         }
@@ -69,7 +81,7 @@ export function requireTaskBoundAuth(envs: InternalAuthEnvs): (req: Request, res
         }
         const auth = getInternalServiceAuth(res);
         const taskId = routeParam(req, 'taskId');
-        if (auth?.kind === 'hmac' && auth.op === 'task' && taskId && auth.taskId === taskId) {
+        if (isTaskBoundAuth(auth, taskId)) {
             next();
             return;
         }
@@ -86,7 +98,7 @@ export function requireFleetAuth(envs: InternalAuthEnvs): (req: Request, res: Re
         }
         const auth = getInternalServiceAuth(res);
         const nodeId = routeParam(req, 'nodeId');
-        if (auth?.kind === 'hmac' && auth.op === 'node' && nodeId && auth.nodeId === nodeId) {
+        if (isNodeBoundAuth(auth, nodeId)) {
             next();
             return;
         }

--- a/packages/internal-auth/lib/middleware.unit.test.ts
+++ b/packages/internal-auth/lib/middleware.unit.test.ts
@@ -68,6 +68,7 @@ afterEach(() => {
     envs.NANGO_INTERNAL_AUTH_REQUIRED = false;
     envs.NANGO_INTERNAL_AUTH_TOKEN = undefined;
     envs.NANGO_INTERNAL_AUTH_SIGNING_KEY = undefined;
+    envs.NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY = undefined;
 });
 
 describe('internalServiceAuthMiddleware', () => {

--- a/packages/internal-auth/lib/middleware.unit.test.ts
+++ b/packages/internal-auth/lib/middleware.unit.test.ts
@@ -121,6 +121,22 @@ describe('internalServiceAuthMiddleware', () => {
         }
     });
 
+    it('skips /health when skip matches the path', async () => {
+        envs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const server = express();
+        server.use(internalServiceAuthMiddleware({ audience: INTERNAL_SERVICE_AUDIENCE_ORCHESTRATOR, envs, skip: (req) => req.path === '/health' }));
+        server.get('/health', (_req, res) => {
+            res.json({ status: 'ok' });
+        });
+        const { url, close } = await listen(server);
+        try {
+            const res = await fetch(`${url}/health`);
+            expect(res.status).toBe(200);
+        } finally {
+            await close();
+        }
+    });
+
     it('does not protect /health when mounted after it', async () => {
         envs.NANGO_INTERNAL_AUTH_REQUIRED = true;
         const server = express();

--- a/packages/internal-auth/lib/token.ts
+++ b/packages/internal-auth/lib/token.ts
@@ -1,9 +1,15 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
+import { createHmac, sign, timingSafeEqual, verify } from 'node:crypto';
 
-import { INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS, INTERNAL_SERVICE_TOKEN_ISSUER } from './constants.js';
+import {
+    INTERNAL_SERVICE_AUDIENCE_JOBS,
+    INTERNAL_SERVICE_AUDIENCE_RUNNER,
+    INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS,
+    INTERNAL_SERVICE_TOKEN_ISSUER
+} from './constants.js';
 import { trimOrNull } from './credential.js';
+import { deriveRunnerEd25519PrivateKey, runnerPublicKeyFromEnv } from './ed25519.js';
 
-import type { InternalServiceAuth, InternalServiceTokenOp } from './constants.js';
+import type { InternalServiceAuth, InternalServiceAuthKind, InternalServiceTokenOp } from './constants.js';
 
 type CreateInternalServiceTokenBase = {
     audience?: string;
@@ -27,6 +33,25 @@ function base64UrlDecode(value: string): string {
 export function isJwtShape(token: string): boolean {
     const parts = token.split('.');
     return parts.length === 3 && parts.every((part) => part.length > 0);
+}
+
+export function jwtHeaderAlg(token: string): string | null {
+    if (!isJwtShape(token)) {
+        return null;
+    }
+    const headerPart = token.split('.')[0];
+    if (!headerPart) {
+        return null;
+    }
+    try {
+        const parsed: unknown = JSON.parse(base64UrlDecode(headerPart));
+        if (!parsed || typeof parsed !== 'object' || !('alg' in parsed) || typeof parsed.alg !== 'string') {
+            return null;
+        }
+        return parsed.alg;
+    } catch {
+        return null;
+    }
 }
 
 function signHs256(signingInput: string, key: string): string {
@@ -87,12 +112,80 @@ export function verifyInternalServiceToken(token: string, audience: string, sign
         return { ok: false, reason: 'not_jwt' };
     }
 
+    if (jwtHeaderAlg(token) !== 'HS256') {
+        return { ok: false, reason: 'bad_signature' };
+    }
+
     const signingInput = `${headerPart}.${payloadPart}`;
     const expected = signHs256(signingInput, key);
     if (!signaturesMatch(signature, expected)) {
         return { ok: false, reason: 'bad_signature' };
     }
 
+    return authFromPayload(payloadPart, audience, 'hmac');
+}
+
+/**
+ * Mint an EdDSA JWT for jobs→runner dispatch. Signed with a private key derived from the jobs
+ * HMAC master; runners receive only the matching public key. Returns null when the signing key is unset.
+ */
+export function createRunnerDispatchToken(args: CreateInternalServiceTokenArgs, jobsSigningKey: string | null | undefined): string | null {
+    const privateKey = deriveRunnerEd25519PrivateKey(jobsSigningKey);
+    if (!privateKey) {
+        return null;
+    }
+
+    const iat = args.issuedAt ?? Math.floor(Date.now() / 1000);
+    const exp = iat + (args.expiresInSecs ?? INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS);
+    const header = base64UrlEncode(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' }));
+    const payload = base64UrlEncode(JSON.stringify(tokenPayload({ ...args, audience: INTERNAL_SERVICE_AUDIENCE_RUNNER }, iat, exp)));
+    const signingInput = `${header}.${payload}`;
+    const signature = sign(null, Buffer.from(signingInput), privateKey);
+    return `${signingInput}.${base64UrlEncode(signature)}`;
+}
+
+export function verifyRunnerDispatchToken(token: string, audience: string, runnerPublicKey: string | null | undefined): VerifyInternalServiceTokenResult {
+    if (!isJwtShape(token)) {
+        return { ok: false, reason: 'not_jwt' };
+    }
+
+    const publicKey = runnerPublicKeyFromEnv(runnerPublicKey);
+    if (!publicKey) {
+        return { ok: false, reason: 'no_signing_key' };
+    }
+
+    const [headerPart, payloadPart, signature] = token.split('.');
+    if (!headerPart || !payloadPart || !signature) {
+        return { ok: false, reason: 'not_jwt' };
+    }
+
+    if (jwtHeaderAlg(token) !== 'EdDSA') {
+        return { ok: false, reason: 'bad_signature' };
+    }
+
+    let signatureBytes: Buffer;
+    try {
+        signatureBytes = Buffer.from(signature, 'base64url');
+    } catch {
+        return { ok: false, reason: 'bad_signature' };
+    }
+    if (signatureBytes.length === 0) {
+        return { ok: false, reason: 'bad_signature' };
+    }
+
+    const signingInput = `${headerPart}.${payloadPart}`;
+    try {
+        if (!verify(null, Buffer.from(signingInput), publicKey, signatureBytes)) {
+            return { ok: false, reason: 'bad_signature' };
+        }
+    } catch {
+        return { ok: false, reason: 'bad_signature' };
+    }
+
+    return authFromPayload(payloadPart, audience, 'eddsa');
+}
+
+function authFromPayload(payloadPart: string, audience: string, kind: InternalServiceAuthKind): VerifyInternalServiceTokenResult {
     let payload: { iss?: unknown; aud?: unknown; op?: unknown; task_id?: unknown; node_id?: unknown; exp?: unknown };
     try {
         const parsed: unknown = JSON.parse(base64UrlDecode(payloadPart));
@@ -127,7 +220,7 @@ export function verifyInternalServiceToken(token: string, audience: string, sign
         }
         return {
             ok: true,
-            kind: 'hmac',
+            kind,
             subject: INTERNAL_SERVICE_TOKEN_ISSUER,
             audience,
             op,
@@ -140,7 +233,7 @@ export function verifyInternalServiceToken(token: string, audience: string, sign
     }
     return {
         ok: true,
-        kind: 'hmac',
+        kind,
         subject: INTERNAL_SERVICE_TOKEN_ISSUER,
         audience,
         op,

--- a/packages/internal-auth/lib/token.ts
+++ b/packages/internal-auth/lib/token.ts
@@ -30,6 +30,20 @@ function base64UrlDecode(value: string): string {
     return Buffer.from(value, 'base64url').toString('utf8');
 }
 
+/** JWT base64url (RFC 7515): A-Za-z0-9_- only, no padding. Node's decoder silently drops other chars. */
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+
+function decodeBase64UrlStrict(value: string): Buffer | null {
+    if (!BASE64URL_RE.test(value)) {
+        return null;
+    }
+    const decoded = Buffer.from(value, 'base64url');
+    if (decoded.length === 0 || decoded.toString('base64url') !== value) {
+        return null;
+    }
+    return decoded;
+}
+
 export function isJwtShape(token: string): boolean {
     const parts = token.split('.');
     return parts.length === 3 && parts.every((part) => part.length > 0);
@@ -163,13 +177,8 @@ export function verifyRunnerDispatchToken(token: string, audience: string, runne
         return { ok: false, reason: 'bad_signature' };
     }
 
-    let signatureBytes: Buffer;
-    try {
-        signatureBytes = Buffer.from(signature, 'base64url');
-    } catch {
-        return { ok: false, reason: 'bad_signature' };
-    }
-    if (signatureBytes.length === 0) {
+    const signatureBytes = decodeBase64UrlStrict(signature);
+    if (!signatureBytes) {
         return { ok: false, reason: 'bad_signature' };
     }
 

--- a/packages/internal-auth/lib/token.unit.test.ts
+++ b/packages/internal-auth/lib/token.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_TOKEN_ISSUER } from './constants.js';
+import { INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_RUNNER, INTERNAL_SERVICE_TOKEN_ISSUER } from './constants.js';
 import { createInternalServiceToken, isJwtShape, verifyInternalServiceToken } from './token.js';
 
 const signingKey = 'test-signing-key';
@@ -34,6 +34,19 @@ describe('createInternalServiceToken', () => {
 });
 
 describe('verifyInternalServiceToken', () => {
+    it('accepts a runner-audience task token minted with the same key', () => {
+        const token = createInternalServiceToken({ taskId: 'task-1', audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, expiresInSecs: 120 }, signingKey);
+        const result = verifyInternalServiceToken(token!, INTERNAL_SERVICE_AUDIENCE_RUNNER, signingKey);
+        expect(result).toMatchObject({
+            ok: true,
+            kind: 'hmac',
+            audience: INTERNAL_SERVICE_AUDIENCE_RUNNER,
+            op: 'task',
+            taskId: 'task-1'
+        });
+        expect(verifyInternalServiceToken(token!, INTERNAL_SERVICE_AUDIENCE_JOBS, signingKey)).toEqual({ ok: false, reason: 'wrong_audience' });
+    });
+
     it('accepts a task token minted with the same key and audience', () => {
         const token = createInternalServiceToken({ taskId: 'task-1', expiresInSecs: 120 }, signingKey);
         const result = verifyInternalServiceToken(token!, INTERNAL_SERVICE_AUDIENCE_JOBS, signingKey);

--- a/packages/internal-auth/lib/verify.ts
+++ b/packages/internal-auth/lib/verify.ts
@@ -1,15 +1,21 @@
 import { stringTimingSafeEqual } from '@nangohq/utils';
 
 import { trimOrNull } from './credential.js';
-import { verifyInternalServiceToken } from './token.js';
+import { jwtHeaderAlg, verifyInternalServiceToken, verifyRunnerDispatchToken } from './token.js';
 
 import type { InternalServiceAuth } from './constants.js';
 
 export function verifyInternalServiceCredential(
     token: string,
     audience: string,
-    creds: { signingKey?: string | undefined; staticToken?: string | undefined }
+    creds: { signingKey?: string | undefined; staticToken?: string | undefined; runnerPublicKey?: string | undefined }
 ): InternalServiceAuth | null {
+    const alg = jwtHeaderAlg(token);
+    if (alg === 'EdDSA') {
+        const eddsa = verifyRunnerDispatchToken(token, audience, creds.runnerPublicKey);
+        return eddsa.ok ? eddsa : null;
+    }
+
     const hmac = verifyInternalServiceToken(token, audience, creds.signingKey);
     if (hmac.ok) {
         return hmac;

--- a/packages/internal-auth/lib/verify.unit.test.ts
+++ b/packages/internal-auth/lib/verify.unit.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_ORCHESTRATOR } from './constants.js';
-import { createInternalServiceToken } from './token.js';
+import { INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_ORCHESTRATOR, INTERNAL_SERVICE_AUDIENCE_RUNNER } from './constants.js';
+import { exportRunnerPublicKey } from './ed25519.js';
+import { createInternalServiceToken, createRunnerDispatchToken } from './token.js';
 import { verifyInternalServiceCredential } from './verify.js';
 
 const signingKey = 'test-signing-key';
@@ -61,5 +62,25 @@ describe('verifyInternalServiceCredential', () => {
         }
         const auth = verifyInternalServiceCredential(token, INTERNAL_SERVICE_AUDIENCE_JOBS, { signingKey });
         expect(auth).toBeNull();
+    });
+
+    it('accepts an EdDSA runner dispatch token with the public key and rejects HMAC minting with that public key', () => {
+        const token = createRunnerDispatchToken({ taskId: 'task-1', expiresInSecs: 120 }, signingKey);
+        const runnerPublicKey = exportRunnerPublicKey(signingKey);
+        expect(token).toEqual(expect.any(String));
+        expect(runnerPublicKey).toEqual(expect.any(String));
+        if (!token || !runnerPublicKey) {
+            return;
+        }
+        const auth = verifyInternalServiceCredential(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, { runnerPublicKey });
+        expect(auth).toMatchObject({ kind: 'eddsa', op: 'task', taskId: 'task-1', audience: INTERNAL_SERVICE_AUDIENCE_RUNNER });
+        expect(verifyInternalServiceCredential(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, { signingKey })).toBeNull();
+
+        const hmac = createInternalServiceToken({ audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, taskId: 'task-1', expiresInSecs: 120 }, runnerPublicKey);
+        expect(hmac).toEqual(expect.any(String));
+        if (!hmac) {
+            return;
+        }
+        expect(verifyInternalServiceCredential(hmac, INTERNAL_SERVICE_AUDIENCE_RUNNER, { runnerPublicKey })).toBeNull();
     });
 });

--- a/packages/jobs/lib/execution/operations/abort.ts
+++ b/packages/jobs/lib/execution/operations/abort.ts
@@ -4,6 +4,7 @@ import { accountService, secretService } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
 import { orchestratorClient } from '../../clients.js';
+import { mintRunnerDispatchToken } from '../../internal-auth.js';
 import { logger } from '../../logger.js';
 import { getRunners } from '../../runner/runner.js';
 import { setTaskSuccess } from './state.js';
@@ -46,7 +47,8 @@ export async function abortTaskWithId({ taskId, teamId, environmentId }: { taskI
             logger.error('Error setting abort flag for task, continuing to broadcast to runners', { err: abortFlag.error, taskId });
         }
         // Broadcast abort to all runners as a task might still be running on a different active runner during/after rollouts (e.g. deploying a new runner version).
-        const runners = await getRunners(teamId);
+        const token = mintRunnerDispatchToken({ taskId });
+        const runners = await getRunners(teamId, { token });
         if (runners.isErr()) {
             return Err(runners.error);
         }

--- a/packages/jobs/lib/execution/operations/abort.unit.test.ts
+++ b/packages/jobs/lib/execution/operations/abort.unit.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as shared from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
+import { mintRunnerDispatchToken } from '../../internal-auth.js';
 import { logger } from '../../logger.js';
 import { getRunners } from '../../runner/runner.js';
 import { abortTask, abortTaskWithId } from './abort.js';
@@ -34,6 +35,10 @@ vi.mock('./state.js', () => ({
     setTaskSuccess: mockSetTaskSuccess
 }));
 
+vi.mock('../../internal-auth.js', () => ({
+    mintRunnerDispatchToken: vi.fn(() => null)
+}));
+
 vi.mock('../../runner/runner.js', () => ({
     getRunners: vi.fn()
 }));
@@ -53,6 +58,7 @@ describe('abortTaskWithId', () => {
         mockPutTaskAbort.mockResolvedValue(Ok(undefined));
         mockSetTaskSuccess.mockResolvedValue(Ok({} as never));
         mockOrchestratorFailed.mockResolvedValue(Ok({} as never));
+        vi.mocked(mintRunnerDispatchToken).mockReturnValue(null);
     });
 
     afterEach(() => {
@@ -71,8 +77,22 @@ describe('abortTaskWithId', () => {
 
         expect(result.isOk()).toBe(true);
         expect(mockPutTaskAbort).toHaveBeenCalledWith({ environmentId: 1, taskId: 'task-1' });
+        expect(getRunners).toHaveBeenCalledWith(42, { token: null });
         expect(abortA).toHaveBeenCalledWith({ taskId: 'task-1' });
         expect(abortB).toHaveBeenCalledWith({ taskId: 'task-1' });
+    });
+
+    it('passes a minted runner-audience token to getRunners', async () => {
+        vi.mocked(mintRunnerDispatchToken).mockReturnValue('runner.jwt');
+        const abortA = vi.fn().mockResolvedValue(true);
+
+        (getRunners as unknown as { mockResolvedValue: (value: any) => void }).mockResolvedValue(Ok([{ client: { abort: { mutate: abortA } } }] as any[]));
+
+        const result = await abortTaskWithId({ taskId: 'task-token', teamId: 42, environmentId: 1 });
+
+        expect(result.isOk()).toBe(true);
+        expect(mintRunnerDispatchToken).toHaveBeenCalledWith({ taskId: 'task-token' });
+        expect(getRunners).toHaveBeenCalledWith(42, { token: 'runner.jwt' });
     });
 
     it('succeeds with a single runner that confirms abort', async () => {
@@ -136,6 +156,7 @@ describe('abortTask', () => {
         mockPutTaskAbort.mockResolvedValue(Ok(undefined));
         mockSetTaskSuccess.mockResolvedValue(Ok({} as never));
         mockOrchestratorFailed.mockResolvedValue(Ok({} as never));
+        vi.mocked(mintRunnerDispatchToken).mockReturnValue(null);
     });
 
     afterEach(() => {

--- a/packages/jobs/lib/internal-auth.ts
+++ b/packages/jobs/lib/internal-auth.ts
@@ -1,7 +1,7 @@
 import {
     createInternalServiceToken,
-    deriveRunnerSigningKey,
-    INTERNAL_SERVICE_AUDIENCE_RUNNER,
+    createRunnerDispatchToken,
+    exportRunnerPublicKey,
     INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS,
     INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS
 } from '@nangohq/internal-auth';
@@ -24,23 +24,20 @@ export function mintTaskAuthToken(taskId: string, nangoProps: Pick<NangoProps, '
 }
 
 /**
- * Mint a runner-audience HMAC JWT for jobs→runner dispatch. Signed with the derived runner key so
- * the jobs master key never leaves jobs. Returns null when the signing key is unset.
+ * Mint a runner-audience EdDSA JWT for jobs→runner dispatch. Signed with a private key that never
+ * leaves jobs. Returns null when the signing key is unset.
  */
 export function mintRunnerDispatchToken(args: { taskId: string; nangoProps?: Pick<NangoProps, 'lifecycle'> } | { nodeId: string }): string | null {
-    const derived = deriveRunnerSigningKey(envs.NANGO_INTERNAL_AUTH_SIGNING_KEY);
     if ('nodeId' in args) {
-        return createInternalServiceToken({ audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, op: 'node', nodeId: args.nodeId }, derived);
+        return createRunnerDispatchToken({ op: 'node', nodeId: args.nodeId }, envs.NANGO_INTERNAL_AUTH_SIGNING_KEY);
     }
-    return createInternalServiceToken(
-        { audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, taskId: args.taskId, expiresInSecs: taskExpiresInSecs(args.nangoProps) },
-        derived
-    );
+    return createRunnerDispatchToken({ taskId: args.taskId, expiresInSecs: taskExpiresInSecs(args.nangoProps) }, envs.NANGO_INTERNAL_AUTH_SIGNING_KEY);
 }
 
 /**
  * Env injected onto a runner process. Empty when the signing key is unset so node start stays a
- * no-op. Never includes TOKEN or the jobs master SIGNING_KEY.
+ * no-op. Never includes TOKEN, the jobs master SIGNING_KEY, or any minting material — only the
+ * Ed25519 public key (verify-only) and a jobs-audience node JWT.
  */
 export function mintRunnerAuthEnv(nodeId: number): Record<string, string> {
     const token = createInternalServiceToken(
@@ -51,13 +48,13 @@ export function mintRunnerAuthEnv(nodeId: number): Record<string, string> {
         },
         envs.NANGO_INTERNAL_AUTH_SIGNING_KEY
     );
-    const derived = deriveRunnerSigningKey(envs.NANGO_INTERNAL_AUTH_SIGNING_KEY);
-    if (!token || !derived) {
+    const publicKey = exportRunnerPublicKey(envs.NANGO_INTERNAL_AUTH_SIGNING_KEY);
+    if (!token || !publicKey) {
         return {};
     }
     return {
         NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN: token,
-        NANGO_INTERNAL_AUTH_SIGNING_KEY: derived,
+        NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY: publicKey,
         NANGO_INTERNAL_AUTH_REQUIRED: envs.NANGO_INTERNAL_AUTH_REQUIRED ? 'true' : 'false'
     };
 }

--- a/packages/jobs/lib/internal-auth.ts
+++ b/packages/jobs/lib/internal-auth.ts
@@ -1,22 +1,46 @@
-import { createInternalServiceToken, INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS, INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS } from '@nangohq/internal-auth';
+import {
+    createInternalServiceToken,
+    deriveRunnerSigningKey,
+    INTERNAL_SERVICE_AUDIENCE_RUNNER,
+    INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS,
+    INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS
+} from '@nangohq/internal-auth';
 
 import { envs } from './env.js';
 
 import type { NangoProps } from '@nangohq/types';
+
+function taskExpiresInSecs(nangoProps?: Pick<NangoProps, 'lifecycle'>): number {
+    const killAfterMs = nangoProps?.lifecycle?.killAfterMs;
+    return killAfterMs !== undefined ? Math.max(60, Math.ceil(killAfterMs / 1000) + 60) : INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS;
+}
 
 /**
  * Mint a task-bound HMAC JWT for putTask/heartbeat. Returns null when the signing key is unset so
  * invoke stays a no-op until infra is in place.
  */
 export function mintTaskAuthToken(taskId: string, nangoProps: Pick<NangoProps, 'lifecycle'>): string | null {
-    const killAfterMs = nangoProps.lifecycle?.killAfterMs;
-    const expiresInSecs = killAfterMs !== undefined ? Math.max(60, Math.ceil(killAfterMs / 1000) + 60) : INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS;
-    return createInternalServiceToken({ taskId, expiresInSecs }, envs.NANGO_INTERNAL_AUTH_SIGNING_KEY);
+    return createInternalServiceToken({ taskId, expiresInSecs: taskExpiresInSecs(nangoProps) }, envs.NANGO_INTERNAL_AUTH_SIGNING_KEY);
 }
 
 /**
- * Node-bound JWT for the runner process (register and idle). Empty when the signing key is unset so
- * node start stays a no-op. Never includes TOKEN or SIGNING_KEY.
+ * Mint a runner-audience HMAC JWT for jobs→runner dispatch. Signed with the derived runner key so
+ * the jobs master key never leaves jobs. Returns null when the signing key is unset.
+ */
+export function mintRunnerDispatchToken(args: { taskId: string; nangoProps?: Pick<NangoProps, 'lifecycle'> } | { nodeId: string }): string | null {
+    const derived = deriveRunnerSigningKey(envs.NANGO_INTERNAL_AUTH_SIGNING_KEY);
+    if ('nodeId' in args) {
+        return createInternalServiceToken({ audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, op: 'node', nodeId: args.nodeId }, derived);
+    }
+    return createInternalServiceToken(
+        { audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, taskId: args.taskId, expiresInSecs: taskExpiresInSecs(args.nangoProps) },
+        derived
+    );
+}
+
+/**
+ * Env injected onto a runner process. Empty when the signing key is unset so node start stays a
+ * no-op. Never includes TOKEN or the jobs master SIGNING_KEY.
  */
 export function mintRunnerAuthEnv(nodeId: number): Record<string, string> {
     const token = createInternalServiceToken(
@@ -27,8 +51,13 @@ export function mintRunnerAuthEnv(nodeId: number): Record<string, string> {
         },
         envs.NANGO_INTERNAL_AUTH_SIGNING_KEY
     );
-    if (!token) {
+    const derived = deriveRunnerSigningKey(envs.NANGO_INTERNAL_AUTH_SIGNING_KEY);
+    if (!token || !derived) {
         return {};
     }
-    return { NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN: token };
+    return {
+        NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN: token,
+        NANGO_INTERNAL_AUTH_SIGNING_KEY: derived,
+        NANGO_INTERNAL_AUTH_REQUIRED: envs.NANGO_INTERNAL_AUTH_REQUIRED ? 'true' : 'false'
+    };
 }

--- a/packages/jobs/lib/internal-auth.unit.test.ts
+++ b/packages/jobs/lib/internal-auth.unit.test.ts
@@ -1,12 +1,19 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS, INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS, verifyInternalServiceToken } from '@nangohq/internal-auth';
+import {
+    deriveRunnerSigningKey,
+    INTERNAL_SERVICE_AUDIENCE_RUNNER,
+    INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS,
+    INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS,
+    verifyInternalServiceToken
+} from '@nangohq/internal-auth';
 
-import { mintRunnerAuthEnv, mintTaskAuthToken } from './internal-auth.js';
+import { mintRunnerAuthEnv, mintRunnerDispatchToken, mintTaskAuthToken } from './internal-auth.js';
 
 const { mockEnvs } = vi.hoisted(() => ({
     mockEnvs: {
-        NANGO_INTERNAL_AUTH_SIGNING_KEY: undefined as string | undefined
+        NANGO_INTERNAL_AUTH_SIGNING_KEY: undefined as string | undefined,
+        NANGO_INTERNAL_AUTH_REQUIRED: false
     }
 }));
 
@@ -16,6 +23,7 @@ vi.mock('./env.js', () => ({
 
 afterEach(() => {
     mockEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = undefined;
+    mockEnvs.NANGO_INTERNAL_AUTH_REQUIRED = false;
 });
 
 describe('mintTaskAuthToken', () => {
@@ -63,19 +71,49 @@ describe('mintTaskAuthToken', () => {
     });
 });
 
+describe('mintRunnerDispatchToken', () => {
+    it('returns null when the signing key is unset', () => {
+        expect(mintRunnerDispatchToken({ taskId: 'task-1' })).toBeNull();
+    });
+
+    it('mints a runner-audience task token with the derived key', () => {
+        mockEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = 'sign';
+        const token = mintRunnerDispatchToken({ taskId: 'task-1' });
+        expect(token).toBeTruthy();
+        if (!token) {
+            return;
+        }
+        const derived = deriveRunnerSigningKey('sign');
+        expect(verifyInternalServiceToken(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, derived)).toMatchObject({
+            kind: 'hmac',
+            op: 'task',
+            taskId: 'task-1',
+            audience: INTERNAL_SERVICE_AUDIENCE_RUNNER
+        });
+        expect(verifyInternalServiceToken(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, 'sign')).toMatchObject({ ok: false });
+        expect(verifyInternalServiceToken(token, 'jobs', derived)).toMatchObject({ ok: false });
+    });
+});
+
 describe('mintRunnerAuthEnv', () => {
     it('returns nothing when the signing key is unset', () => {
         expect(mintRunnerAuthEnv(7)).toEqual({});
     });
 
-    it('mints a node-bound token when the signing key is set', () => {
+    it('mints a node-bound token and injects the derived verify key when the signing key is set', () => {
         mockEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = 'sign';
+        mockEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
         const issuedAt = Math.floor(Date.now() / 1000);
         const env = mintRunnerAuthEnv(7);
-        expect(Object.keys(env)).toEqual(['NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN']);
+        const derived = deriveRunnerSigningKey('sign');
+        expect(env['NANGO_INTERNAL_AUTH_SIGNING_KEY']).toBe(derived);
+        expect(env['NANGO_INTERNAL_AUTH_SIGNING_KEY']).not.toBe('sign');
+        expect(env['NANGO_INTERNAL_AUTH_REQUIRED']).toBe('true');
+        expect(env).not.toHaveProperty('NANGO_INTERNAL_AUTH_TOKEN');
 
         const auth = verifyInternalServiceToken(env['NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN']!, 'jobs', 'sign');
         expect(auth).toMatchObject({ kind: 'hmac', op: 'node', nodeId: '7', audience: 'jobs' });
+        expect(verifyInternalServiceToken(env['NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN']!, 'jobs', derived)).toMatchObject({ ok: false });
 
         const payload = JSON.parse(Buffer.from(env['NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN']!.split('.')[1] ?? '', 'base64url').toString('utf8')) as {
             exp: number;

--- a/packages/jobs/lib/internal-auth.unit.test.ts
+++ b/packages/jobs/lib/internal-auth.unit.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
-    deriveRunnerSigningKey,
+    exportRunnerPublicKey,
     INTERNAL_SERVICE_AUDIENCE_RUNNER,
     INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS,
     INTERNAL_SERVICE_TOKEN_DEFAULT_EXPIRES_SECS,
-    verifyInternalServiceToken
+    verifyInternalServiceToken,
+    verifyRunnerDispatchToken
 } from '@nangohq/internal-auth';
 
 import { mintRunnerAuthEnv, mintRunnerDispatchToken, mintTaskAuthToken } from './internal-auth.js';
@@ -76,22 +77,23 @@ describe('mintRunnerDispatchToken', () => {
         expect(mintRunnerDispatchToken({ taskId: 'task-1' })).toBeNull();
     });
 
-    it('mints a runner-audience task token with the derived key', () => {
+    it('mints a runner-audience EdDSA token that verifies with the public key, not the jobs master', () => {
         mockEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = 'sign';
         const token = mintRunnerDispatchToken({ taskId: 'task-1' });
+        const publicKey = exportRunnerPublicKey('sign');
         expect(token).toBeTruthy();
-        if (!token) {
+        expect(publicKey).toBeTruthy();
+        if (!token || !publicKey) {
             return;
         }
-        const derived = deriveRunnerSigningKey('sign');
-        expect(verifyInternalServiceToken(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, derived)).toMatchObject({
-            kind: 'hmac',
+        expect(verifyRunnerDispatchToken(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, publicKey)).toMatchObject({
+            kind: 'eddsa',
             op: 'task',
             taskId: 'task-1',
             audience: INTERNAL_SERVICE_AUDIENCE_RUNNER
         });
         expect(verifyInternalServiceToken(token, INTERNAL_SERVICE_AUDIENCE_RUNNER, 'sign')).toMatchObject({ ok: false });
-        expect(verifyInternalServiceToken(token, 'jobs', derived)).toMatchObject({ ok: false });
+        expect(verifyRunnerDispatchToken(token, 'jobs', publicKey)).toMatchObject({ ok: false });
     });
 });
 
@@ -100,20 +102,19 @@ describe('mintRunnerAuthEnv', () => {
         expect(mintRunnerAuthEnv(7)).toEqual({});
     });
 
-    it('mints a node-bound token and injects the derived verify key when the signing key is set', () => {
+    it('injects a node-bound jobs JWT and the Ed25519 public key, never a minting secret', () => {
         mockEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = 'sign';
         mockEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
         const issuedAt = Math.floor(Date.now() / 1000);
         const env = mintRunnerAuthEnv(7);
-        const derived = deriveRunnerSigningKey('sign');
-        expect(env['NANGO_INTERNAL_AUTH_SIGNING_KEY']).toBe(derived);
-        expect(env['NANGO_INTERNAL_AUTH_SIGNING_KEY']).not.toBe('sign');
-        expect(env['NANGO_INTERNAL_AUTH_REQUIRED']).toBe('true');
+        const publicKey = exportRunnerPublicKey('sign');
+        expect(env['NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY']).toBe(publicKey);
+        expect(env).not.toHaveProperty('NANGO_INTERNAL_AUTH_SIGNING_KEY');
         expect(env).not.toHaveProperty('NANGO_INTERNAL_AUTH_TOKEN');
+        expect(env['NANGO_INTERNAL_AUTH_REQUIRED']).toBe('true');
 
         const auth = verifyInternalServiceToken(env['NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN']!, 'jobs', 'sign');
         expect(auth).toMatchObject({ kind: 'hmac', op: 'node', nodeId: '7', audience: 'jobs' });
-        expect(verifyInternalServiceToken(env['NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN']!, 'jobs', derived)).toMatchObject({ ok: false });
 
         const payload = JSON.parse(Buffer.from(env['NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN']!.split('.')[1] ?? '', 'base64url').toString('utf8')) as {
             exp: number;

--- a/packages/jobs/lib/runner/fleet.runner.ts
+++ b/packages/jobs/lib/runner/fleet.runner.ts
@@ -9,8 +9,9 @@ export class FleetRunner implements Runner {
     public runnerType: RunnerType = RunnerType.Fleet;
     constructor(
         public readonly id: string,
-        public readonly url: string
+        public readonly url: string,
+        token?: string | null
     ) {
-        this.client = getRunnerClient(this.url, runnerHttpOpts);
+        this.client = getRunnerClient(this.url, runnerHttpOpts, { token });
     }
 }

--- a/packages/jobs/lib/runner/kubernetes.unit.test.ts
+++ b/packages/jobs/lib/runner/kubernetes.unit.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS, verifyInternalServiceToken } from '@nangohq/internal-auth';
+import { deriveRunnerSigningKey, INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS, verifyInternalServiceToken } from '@nangohq/internal-auth';
 
 import { getAuthSecretName, getRunnerAuthEnvVars, getTlsEnvVars, getTlsSecretName, kubernetesNodeProvider } from './kubernetes.js';
 
@@ -30,7 +30,8 @@ const { getInternalTlsEnvMock, k8sMock, mockEnvs, defaultRunnerEnvs } = vi.hoist
         RUNNER_REQUEST_CPU_MULTIPLIER: 1.4,
         RUNNER_REQUEST_MEMORY_MULTIPLIER: 1.4,
         NANGO_INTERNAL_AUTH_SIGNING_KEY: undefined as string | undefined,
-        NANGO_INTERNAL_AUTH_TOKEN: undefined as string | undefined
+        NANGO_INTERNAL_AUTH_TOKEN: undefined as string | undefined,
+        NANGO_INTERNAL_AUTH_REQUIRED: false
     };
     return {
         getInternalTlsEnvMock: vi.fn<() => Record<string, string>>(() => ({})),
@@ -581,8 +582,11 @@ describe('runner internal auth env', () => {
         const nodeExp = JSON.parse(Buffer.from(nodeToken.split('.')[1] ?? '', 'base64url').toString('utf8')) as { exp: number };
         expect(nodeExp.exp).toBeGreaterThanOrEqual(issuedAt + INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS);
         expect(nodeExp.exp).toBeLessThan(issuedAt + INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS + 5);
+        const derived = deriveRunnerSigningKey('sign');
         expect(secret.stringData).not.toHaveProperty('NANGO_INTERNAL_AUTH_TOKEN');
-        expect(secret.stringData).not.toHaveProperty('NANGO_INTERNAL_AUTH_SIGNING_KEY');
+        expect(secret.stringData.NANGO_INTERNAL_AUTH_SIGNING_KEY).toBe(derived);
+        expect(secret.stringData.NANGO_INTERNAL_AUTH_SIGNING_KEY).not.toBe('sign');
+        expect(secret.stringData.NANGO_INTERNAL_AUTH_REQUIRED).toBe('false');
 
         const deployment = k8sMock.calls.find((call) => call.method === 'createNamespacedDeployment')?.body;
         const spec = deployment.spec.template.spec;
@@ -593,9 +597,17 @@ describe('runner internal auth env', () => {
             name: 'NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN',
             valueFrom: { secretKeyRef: { name: authSecretName, key: 'NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN' } }
         });
+        expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_SIGNING_KEY')).toEqual({
+            name: 'NANGO_INTERNAL_AUTH_SIGNING_KEY',
+            valueFrom: { secretKeyRef: { name: authSecretName, key: 'NANGO_INTERNAL_AUTH_SIGNING_KEY' } }
+        });
+        expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_REQUIRED')).toEqual({
+            name: 'NANGO_INTERNAL_AUTH_REQUIRED',
+            valueFrom: { secretKeyRef: { name: authSecretName, key: 'NANGO_INTERNAL_AUTH_REQUIRED' } }
+        });
         expect(JSON.stringify(deployment)).not.toMatch(/eyJ/);
         expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_TOKEN')).toBeUndefined();
-        expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_SIGNING_KEY')).toBeUndefined();
+        expect(JSON.stringify(spec.containers[0].env)).not.toContain('sign');
     });
 
     it('stores fleet JWTs in a separate secret from TLS assets', async () => {

--- a/packages/jobs/lib/runner/kubernetes.unit.test.ts
+++ b/packages/jobs/lib/runner/kubernetes.unit.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { deriveRunnerSigningKey, INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS, verifyInternalServiceToken } from '@nangohq/internal-auth';
+import { exportRunnerPublicKey, INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS, verifyInternalServiceToken } from '@nangohq/internal-auth';
 
 import { getAuthSecretName, getRunnerAuthEnvVars, getTlsEnvVars, getTlsSecretName, kubernetesNodeProvider } from './kubernetes.js';
 
@@ -559,6 +559,7 @@ describe('runner internal auth env', () => {
         expect(spec.containers[0].volumeMounts).toBeUndefined();
         expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_TOKEN')).toBeUndefined();
         expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_SIGNING_KEY')).toBeUndefined();
+        expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY')).toBeUndefined();
         expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN')).toBeUndefined();
     });
 
@@ -582,10 +583,9 @@ describe('runner internal auth env', () => {
         const nodeExp = JSON.parse(Buffer.from(nodeToken.split('.')[1] ?? '', 'base64url').toString('utf8')) as { exp: number };
         expect(nodeExp.exp).toBeGreaterThanOrEqual(issuedAt + INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS);
         expect(nodeExp.exp).toBeLessThan(issuedAt + INTERNAL_SERVICE_NODE_TOKEN_EXPIRES_SECS + 5);
-        const derived = deriveRunnerSigningKey('sign');
         expect(secret.stringData).not.toHaveProperty('NANGO_INTERNAL_AUTH_TOKEN');
-        expect(secret.stringData.NANGO_INTERNAL_AUTH_SIGNING_KEY).toBe(derived);
-        expect(secret.stringData.NANGO_INTERNAL_AUTH_SIGNING_KEY).not.toBe('sign');
+        expect(secret.stringData).not.toHaveProperty('NANGO_INTERNAL_AUTH_SIGNING_KEY');
+        expect(secret.stringData.NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY).toBe(exportRunnerPublicKey('sign'));
         expect(secret.stringData.NANGO_INTERNAL_AUTH_REQUIRED).toBe('false');
 
         const deployment = k8sMock.calls.find((call) => call.method === 'createNamespacedDeployment')?.body;
@@ -597,10 +597,11 @@ describe('runner internal auth env', () => {
             name: 'NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN',
             valueFrom: { secretKeyRef: { name: authSecretName, key: 'NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN' } }
         });
-        expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_SIGNING_KEY')).toEqual({
-            name: 'NANGO_INTERNAL_AUTH_SIGNING_KEY',
-            valueFrom: { secretKeyRef: { name: authSecretName, key: 'NANGO_INTERNAL_AUTH_SIGNING_KEY' } }
+        expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY')).toEqual({
+            name: 'NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY',
+            valueFrom: { secretKeyRef: { name: authSecretName, key: 'NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY' } }
         });
+        expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_SIGNING_KEY')).toBeUndefined();
         expect(spec.containers[0].env.find((env: { name: string }) => env.name === 'NANGO_INTERNAL_AUTH_REQUIRED')).toEqual({
             name: 'NANGO_INTERNAL_AUTH_REQUIRED',
             valueFrom: { secretKeyRef: { name: authSecretName, key: 'NANGO_INTERNAL_AUTH_REQUIRED' } }

--- a/packages/jobs/lib/runner/local.unit.test.ts
+++ b/packages/jobs/lib/runner/local.unit.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { deriveRunnerSigningKey } from '@nangohq/internal-auth';
+import { exportRunnerPublicKey } from '@nangohq/internal-auth';
 
 import { envForRunnerProcess } from './local.js';
 
@@ -34,7 +34,7 @@ afterEach(() => {
 });
 
 describe('envForRunnerProcess', () => {
-    it('strips control-plane secrets and injects fleet tokens plus the derived verify key', () => {
+    it('strips control-plane secrets and injects fleet tokens plus the Ed25519 public key', () => {
         mockEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = 'sign';
         mockEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
         const env = envForRunnerProcess(7, {
@@ -43,8 +43,8 @@ describe('envForRunnerProcess', () => {
             NANGO_INTERNAL_AUTH_SIGNING_KEY: 'sign'
         });
         expect(env['NANGO_INTERNAL_AUTH_TOKEN']).toBeUndefined();
-        expect(env['NANGO_INTERNAL_AUTH_SIGNING_KEY']).toBe(deriveRunnerSigningKey('sign'));
-        expect(env['NANGO_INTERNAL_AUTH_SIGNING_KEY']).not.toBe('sign');
+        expect(env['NANGO_INTERNAL_AUTH_SIGNING_KEY']).toBeUndefined();
+        expect(env['NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY']).toBe(exportRunnerPublicKey('sign'));
         expect(env['NANGO_INTERNAL_AUTH_REQUIRED']).toBe('true');
         expect(env['PATH']).toBe('/usr/bin');
         expect(env['NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN']).toBeTruthy();

--- a/packages/jobs/lib/runner/local.unit.test.ts
+++ b/packages/jobs/lib/runner/local.unit.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { deriveRunnerSigningKey } from '@nangohq/internal-auth';
+
 import { envForRunnerProcess } from './local.js';
 
 const { mockEnvs } = vi.hoisted(() => ({
     mockEnvs: {
         PROVIDERS_RELOAD_INTERVAL: 60_000,
-        NANGO_INTERNAL_AUTH_SIGNING_KEY: undefined as string | undefined
+        NANGO_INTERNAL_AUTH_SIGNING_KEY: undefined as string | undefined,
+        NANGO_INTERNAL_AUTH_REQUIRED: false
     }
 }));
 
@@ -27,18 +30,22 @@ vi.mock('./runner.js', () => ({
 
 afterEach(() => {
     mockEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = undefined;
+    mockEnvs.NANGO_INTERNAL_AUTH_REQUIRED = false;
 });
 
 describe('envForRunnerProcess', () => {
-    it('strips control-plane secrets and injects fleet tokens', () => {
+    it('strips control-plane secrets and injects fleet tokens plus the derived verify key', () => {
         mockEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = 'sign';
+        mockEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
         const env = envForRunnerProcess(7, {
             PATH: '/usr/bin',
             NANGO_INTERNAL_AUTH_TOKEN: 'shared',
             NANGO_INTERNAL_AUTH_SIGNING_KEY: 'sign'
         });
         expect(env['NANGO_INTERNAL_AUTH_TOKEN']).toBeUndefined();
-        expect(env['NANGO_INTERNAL_AUTH_SIGNING_KEY']).toBeUndefined();
+        expect(env['NANGO_INTERNAL_AUTH_SIGNING_KEY']).toBe(deriveRunnerSigningKey('sign'));
+        expect(env['NANGO_INTERNAL_AUTH_SIGNING_KEY']).not.toBe('sign');
+        expect(env['NANGO_INTERNAL_AUTH_REQUIRED']).toBe('true');
         expect(env['PATH']).toBe('/usr/bin');
         expect(env['NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN']).toBeTruthy();
         expect(env['NANGO_INTERNAL_AUTH_REGISTER_TOKEN']).toBeUndefined();

--- a/packages/jobs/lib/runner/remote.runner.ts
+++ b/packages/jobs/lib/runner/remote.runner.ts
@@ -9,12 +9,13 @@ export class RemoteRunner implements Runner {
     public runnerType: RunnerType = RunnerType.Remote;
     constructor(
         public readonly id: string,
-        public readonly url: string
+        public readonly url: string,
+        token?: string | null
     ) {
-        this.client = getRunnerClient(this.url, runnerHttpOpts);
+        this.client = getRunnerClient(this.url, runnerHttpOpts, { token });
     }
 
-    static async getOrStart(runnerId: string): Promise<RemoteRunner> {
-        return Promise.resolve(new RemoteRunner(runnerId, process.env['RUNNER_SERVICE_URL'] || 'http://nango-runner'));
+    static async getOrStart(runnerId: string, token?: string | null): Promise<RemoteRunner> {
+        return Promise.resolve(new RemoteRunner(runnerId, process.env['RUNNER_SERVICE_URL'] || 'http://nango-runner', token));
     }
 }

--- a/packages/jobs/lib/runner/remote.runner.ts
+++ b/packages/jobs/lib/runner/remote.runner.ts
@@ -1,5 +1,6 @@
 import { getRunnerClient } from '@nangohq/nango-runner';
 
+import { envs } from '../env.js';
 import { runnerHttpOpts, RunnerType } from './runner.js';
 
 import type { Runner } from './runner.js';
@@ -16,6 +17,6 @@ export class RemoteRunner implements Runner {
     }
 
     static async getOrStart(runnerId: string, token?: string | null): Promise<RemoteRunner> {
-        return Promise.resolve(new RemoteRunner(runnerId, process.env['RUNNER_SERVICE_URL'] || 'http://nango-runner', token));
+        return Promise.resolve(new RemoteRunner(runnerId, envs.RUNNER_SERVICE_URL || 'http://nango-runner', token));
     }
 }

--- a/packages/jobs/lib/runner/runner.ts
+++ b/packages/jobs/lib/runner/runner.ts
@@ -1,6 +1,8 @@
+import { getInternalAuthBearerHeaderIfPresent } from '@nangohq/internal-auth';
 import { env, Err, isProd, Ok, retryWithBackoff, withInternalTls } from '@nangohq/utils';
 
 import { envs } from '../env.js';
+import { mintRunnerDispatchToken } from '../internal-auth.js';
 import { getDefaultFleet } from '../runtime/runtimes.js';
 import { FleetRunner } from './fleet.runner.js';
 import { RemoteRunner } from './remote.runner.js';
@@ -38,21 +40,23 @@ function getRunnerIdForTeam(teamId: number): string {
     return isProd ? getRunnerId(`${teamId}`) : getRunnerId('default');
 }
 
-export async function getRunner(teamId: number): Promise<Result<Runner>> {
+type RunnerAuthOpts = { token?: string | null | undefined };
+
+export async function getRunner(teamId: number, auth?: RunnerAuthOpts): Promise<Result<Runner>> {
     try {
         const runnerId = getRunnerIdForTeam(teamId);
-        const runner = await getOrStartRunner(runnerId).catch(() => getOrStartRunner(getRunnerId('default')));
+        const runner = await getOrStartRunner(runnerId, auth?.token).catch(() => getOrStartRunner(getRunnerId('default'), auth?.token));
         return Ok(runner);
     } catch (err) {
         return Err(new Error(`Failed to get runner for team ${teamId}`, { cause: err }));
     }
 }
 
-export async function getRunners(teamId: number): Promise<Result<Runner[]>> {
+export async function getRunners(teamId: number, auth?: RunnerAuthOpts): Promise<Result<Runner[]>> {
     try {
         const runnerId = getRunnerIdForTeam(teamId);
         if (envs.RUNNER_TYPE === 'REMOTE') {
-            const runner = await getOrStartRunner(runnerId).catch(() => getOrStartRunner(getRunnerId('default')));
+            const runner = await getOrStartRunner(runnerId, auth?.token).catch(() => getOrStartRunner(getRunnerId('default'), auth?.token));
             return Ok([runner]);
         }
 
@@ -65,12 +69,12 @@ export async function getRunners(teamId: number): Promise<Result<Runner[]>> {
             return Err(nodes.error);
         }
 
-        const runners = nodes.value.filter((node) => node.url).map((node) => new FleetRunner(runnerId, node.url as string));
+        const runners = nodes.value.filter((node) => node.url).map((node) => new FleetRunner(runnerId, node.url as string, auth?.token));
         if (runners.length > 0) {
             return Ok(runners);
         }
 
-        const runner = await getOrStartRunner(runnerId).catch(() => getOrStartRunner(getRunnerId('default')));
+        const runner = await getOrStartRunner(runnerId, auth?.token).catch(() => getOrStartRunner(getRunnerId('default'), auth?.token));
         return Ok([runner]);
     } catch (err) {
         return Err(new Error(`Failed to get runners for team ${teamId}`, { cause: err }));
@@ -89,7 +93,15 @@ export async function idle(nodeId: number): Promise<Result<void>> {
 export async function notifyOnIdle(node: Node): Promise<Result<void>> {
     const res = await retryWithBackoff(
         async () => {
-            return await fetch(`${node.url}/notifyWhenIdle`, withInternalTls({ method: 'POST', body: JSON.stringify({ nodeId: node.id }) }));
+            const token = mintRunnerDispatchToken({ nodeId: String(node.id) });
+            return await fetch(
+                `${node.url}/notifyWhenIdle`,
+                withInternalTls({
+                    method: 'POST',
+                    body: JSON.stringify({ nodeId: node.id }),
+                    headers: getInternalAuthBearerHeaderIfPresent(token)
+                })
+            );
         },
         {
             numOfAttempts: 5
@@ -101,9 +113,9 @@ export async function notifyOnIdle(node: Node): Promise<Result<void>> {
     return Ok(undefined);
 }
 
-async function getOrStartRunner(runnerId: string): Promise<Runner> {
+async function getOrStartRunner(runnerId: string, token?: string | null): Promise<Runner> {
     if (envs.RUNNER_TYPE === 'REMOTE') {
-        return RemoteRunner.getOrStart(runnerId);
+        return RemoteRunner.getOrStart(runnerId, token);
     }
     const runnersFleet = getDefaultFleet();
     const getNode = await runnersFleet.getRunningNode(runnerId);
@@ -114,5 +126,5 @@ async function getOrStartRunner(runnerId: string): Promise<Runner> {
     if (!node.url) {
         throw new Error(`Node url is missing for runner '${runnerId}'`);
     }
-    return new FleetRunner(runnerId, node.url);
+    return new FleetRunner(runnerId, node.url, token);
 }

--- a/packages/jobs/lib/runtime/runner.adapter.ts
+++ b/packages/jobs/lib/runtime/runner.adapter.ts
@@ -1,6 +1,6 @@
 import { Err, getLogger, Ok } from '@nangohq/utils';
 
-import { mintTaskAuthToken } from '../internal-auth.js';
+import { mintRunnerDispatchToken, mintTaskAuthToken } from '../internal-auth.js';
 import { getRunner, getRunners } from '../runner/runner.js';
 
 import type { RuntimeAdapter } from './adapter.js';
@@ -12,7 +12,8 @@ const logger = getLogger('RunnerRuntimeAdapter');
 export class RunnerRuntimeAdapter implements RuntimeAdapter {
     async cancel(params: { taskId: string; nangoProps: NangoProps }): Promise<Result<boolean>> {
         try {
-            const runners = await getRunners(params.nangoProps.team.id);
+            const token = mintRunnerDispatchToken({ taskId: params.taskId, nangoProps: params.nangoProps });
+            const runners = await getRunners(params.nangoProps.team.id, { token });
             if (runners.isErr()) {
                 return Err(runners.error);
             }
@@ -28,7 +29,8 @@ export class RunnerRuntimeAdapter implements RuntimeAdapter {
     }
 
     async invoke(params: { taskId: string; nangoProps: NangoProps; code: string; codeParams: object }): Promise<Result<boolean>> {
-        const runner = await getRunner(params.nangoProps.team.id);
+        const token = mintRunnerDispatchToken({ taskId: params.taskId, nangoProps: params.nangoProps });
+        const runner = await getRunner(params.nangoProps.team.id, { token });
         if (runner.isErr()) {
             return Err(runner.error);
         }

--- a/packages/jobs/lib/runtime/runner.adapter.unit.test.ts
+++ b/packages/jobs/lib/runtime/runner.adapter.unit.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { deriveRunnerSigningKey, INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_RUNNER, verifyInternalServiceToken } from '@nangohq/internal-auth';
+import {
+    exportRunnerPublicKey,
+    INTERNAL_SERVICE_AUDIENCE_JOBS,
+    INTERNAL_SERVICE_AUDIENCE_RUNNER,
+    verifyInternalServiceToken,
+    verifyRunnerDispatchToken
+} from '@nangohq/internal-auth';
 import { Ok } from '@nangohq/utils';
 
 import { RunnerRuntimeAdapter } from './runner.adapter.js';
@@ -140,7 +146,7 @@ describe('RunnerRuntimeAdapter internal auth', () => {
         });
         expect(getRunnerMock).toHaveBeenCalledWith(1, expect.objectContaining({ token: expect.stringMatching(/^eyJ/) }));
         const dispatchToken = getRunnerMock.mock.calls[0]?.[1]?.token as string;
-        expect(verifyInternalServiceToken(dispatchToken, INTERNAL_SERVICE_AUDIENCE_RUNNER, deriveRunnerSigningKey('sign'))).toMatchObject({
+        expect(verifyRunnerDispatchToken(dispatchToken, INTERNAL_SERVICE_AUDIENCE_RUNNER, exportRunnerPublicKey('sign'))).toMatchObject({
             op: 'task',
             taskId: 'task-1',
             audience: INTERNAL_SERVICE_AUDIENCE_RUNNER
@@ -156,7 +162,7 @@ describe('RunnerRuntimeAdapter internal auth', () => {
         expect(result.isOk()).toBe(true);
         expect(getRunnersMock).toHaveBeenCalledWith(1, expect.objectContaining({ token: expect.stringMatching(/^eyJ/) }));
         const dispatchToken = getRunnersMock.mock.calls[0]?.[1]?.token as string;
-        expect(verifyInternalServiceToken(dispatchToken, INTERNAL_SERVICE_AUDIENCE_RUNNER, deriveRunnerSigningKey('sign'))).toMatchObject({
+        expect(verifyRunnerDispatchToken(dispatchToken, INTERNAL_SERVICE_AUDIENCE_RUNNER, exportRunnerPublicKey('sign'))).toMatchObject({
             op: 'task',
             taskId: 'task-1'
         });

--- a/packages/jobs/lib/runtime/runner.adapter.unit.test.ts
+++ b/packages/jobs/lib/runtime/runner.adapter.unit.test.ts
@@ -1,15 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { deriveRunnerSigningKey, INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_RUNNER, verifyInternalServiceToken } from '@nangohq/internal-auth';
 import { Ok } from '@nangohq/utils';
 
 import { RunnerRuntimeAdapter } from './runner.adapter.js';
 
 import type { NangoProps } from '@nangohq/types';
 
-const { getRunnerMock, mockEnvs } = vi.hoisted(() => ({
+const { getRunnerMock, getRunnersMock, mockEnvs } = vi.hoisted(() => ({
     getRunnerMock: vi.fn(),
+    getRunnersMock: vi.fn(),
     mockEnvs: {
-        NANGO_INTERNAL_AUTH_SIGNING_KEY: undefined as string | undefined
+        NANGO_INTERNAL_AUTH_SIGNING_KEY: undefined as string | undefined,
+        NANGO_INTERNAL_AUTH_REQUIRED: false
     }
 }));
 
@@ -19,7 +22,7 @@ vi.mock('../env.js', () => ({
 
 vi.mock('../runner/runner.js', () => ({
     getRunner: getRunnerMock,
-    getRunners: vi.fn()
+    getRunners: getRunnersMock
 }));
 
 vi.mock('@nangohq/utils', async (importOriginal) => {
@@ -128,6 +131,34 @@ describe('RunnerRuntimeAdapter internal auth', () => {
         const adapter = new RunnerRuntimeAdapter();
         const result = await adapter.invoke({ taskId: 'task-1', nangoProps: minimalNangoProps(), code: 'code', codeParams: {} });
         expect(result.isOk()).toBe(true);
-        expect(startMutate.mock.calls[0]?.[0].internalAuthToken).toEqual(expect.stringMatching(/^eyJ/));
+        const internalAuthToken = startMutate.mock.calls[0]?.[0].internalAuthToken as string;
+        expect(internalAuthToken).toEqual(expect.stringMatching(/^eyJ/));
+        expect(verifyInternalServiceToken(internalAuthToken, INTERNAL_SERVICE_AUDIENCE_JOBS, 'sign')).toMatchObject({
+            op: 'task',
+            taskId: 'task-1',
+            audience: INTERNAL_SERVICE_AUDIENCE_JOBS
+        });
+        expect(getRunnerMock).toHaveBeenCalledWith(1, expect.objectContaining({ token: expect.stringMatching(/^eyJ/) }));
+        const dispatchToken = getRunnerMock.mock.calls[0]?.[1]?.token as string;
+        expect(verifyInternalServiceToken(dispatchToken, INTERNAL_SERVICE_AUDIENCE_RUNNER, deriveRunnerSigningKey('sign'))).toMatchObject({
+            op: 'task',
+            taskId: 'task-1',
+            audience: INTERNAL_SERVICE_AUDIENCE_RUNNER
+        });
+    });
+
+    it('passes a runner-audience token to getRunners on cancel when the signing key is set', async () => {
+        mockEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = 'sign';
+        const abortMutate = vi.fn().mockResolvedValue(true);
+        getRunnersMock.mockResolvedValue(Ok([{ client: { abort: { mutate: abortMutate } } }]));
+        const adapter = new RunnerRuntimeAdapter();
+        const result = await adapter.cancel({ taskId: 'task-1', nangoProps: minimalNangoProps() });
+        expect(result.isOk()).toBe(true);
+        expect(getRunnersMock).toHaveBeenCalledWith(1, expect.objectContaining({ token: expect.stringMatching(/^eyJ/) }));
+        const dispatchToken = getRunnersMock.mock.calls[0]?.[1]?.token as string;
+        expect(verifyInternalServiceToken(dispatchToken, INTERNAL_SERVICE_AUDIENCE_RUNNER, deriveRunnerSigningKey('sign'))).toMatchObject({
+            op: 'task',
+            taskId: 'task-1'
+        });
     });
 });

--- a/packages/runner/lib/client.ts
+++ b/packages/runner/lib/client.ts
@@ -2,6 +2,7 @@ import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import superjson from 'superjson';
 import { Agent, fetch } from 'undici';
 
+import { getInternalAuthBearerHeaderIfPresent } from '@nangohq/internal-auth';
 import { getInternalTlsOptions } from '@nangohq/utils';
 
 import type { AppRouter } from './server.js';
@@ -15,6 +16,10 @@ interface RunnerHttpOpts {
     connectTimeoutMs: number;
     responseTimeoutMs: number;
 }
+
+export type RunnerClientAuth = {
+    token?: string | null | undefined;
+};
 
 // A new client is built for every task, so the agent has to outlive it or no connection is ever
 // reused and every call pays a fresh handshake.
@@ -36,13 +41,14 @@ function getAgent(httpOpts: RunnerHttpOpts): Agent {
     return agent;
 }
 
-export function getRunnerClient(url: string, httpOpts: RunnerHttpOpts): ProxyAppRouter {
+export function getRunnerClient(url: string, httpOpts: RunnerHttpOpts, auth?: RunnerClientAuth): ProxyAppRouter {
     const dispatcher = getAgent(httpOpts);
     return createTRPCProxyClient<AppRouter>({
         transformer: superjson,
         links: [
             httpBatchLink({
                 url,
+                headers: getInternalAuthBearerHeaderIfPresent(auth?.token),
                 // @ts-expect-error type discrepancy between undici and node and trpc
                 fetch(url: string, options?: RequestInit) {
                     return fetch(url, {

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -214,7 +214,18 @@ function isHealthPath(req: Request): boolean {
 export function getServer(authEnvs: InternalAuthEnvs = envs): express.Express {
     const app = express();
     app.use(timeout('24h'));
-    app.use(internalServiceAuthMiddleware({ audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, envs: authEnvs, skip: isHealthPath }));
+    // Verify-only: never pass a minting secret. Leftover SIGNING_KEY / TOKEN on the process
+    // must not authenticate runner dispatch.
+    app.use(
+        internalServiceAuthMiddleware({
+            audience: INTERNAL_SERVICE_AUDIENCE_RUNNER,
+            envs: {
+                NANGO_INTERNAL_AUTH_REQUIRED: authEnvs.NANGO_INTERNAL_AUTH_REQUIRED,
+                NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY: authEnvs.NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY
+            },
+            skip: isHealthPath
+        })
+    );
     app.use(
         '/',
         trpcExpress.createExpressMiddleware({

--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -1,28 +1,70 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { initTRPC } from '@trpc/server';
+import { initTRPC, TRPCError } from '@trpc/server';
 import * as trpcExpress from '@trpc/server/adapters/express';
 import timeout from 'connect-timeout';
 import express from 'express';
 import superjson from 'superjson';
 
+import {
+    getInternalServiceAuth,
+    INTERNAL_SERVICE_AUDIENCE_RUNNER,
+    internalServiceAuthMiddleware,
+    isNodeBoundAuth,
+    isTaskBoundAuth
+} from '@nangohq/internal-auth';
+
 import { abort } from './abort.js';
 import { jobsClient } from './clients/jobs.js';
 import { PersistClient } from './clients/persist.js';
-import { abortCheckIntervalMs, heartbeatIntervalMs } from './env.js';
+import { abortCheckIntervalMs, envs, heartbeatIntervalMs } from './env.js';
 import { exec } from './exec.js';
 import { logger } from './logger.js';
 import { HttpLocks } from './sdk/locks.js';
 import { abortControllers, distributedCoordination, usage } from './state.js';
 
+import type { InternalAuthEnvs, InternalServiceAuth } from '@nangohq/internal-auth';
 import type { NangoProps } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
 
-export const t = initTRPC.create({
+type RunnerContext = {
+    auth: InternalServiceAuth | undefined;
+    required: boolean;
+};
+
+export const t = initTRPC.context<RunnerContext>().create({
     transformer: superjson
 });
 
 const router = t.router;
 const publicProcedure = t.procedure;
+
+function taskIdFromRawInput(rawInput: unknown): string | undefined {
+    if (!rawInput || typeof rawInput !== 'object') {
+        return undefined;
+    }
+    const taskId = (rawInput as { taskId?: unknown }).taskId;
+    return typeof taskId === 'string' && taskId.length > 0 ? taskId : undefined;
+}
+
+const taskBoundProcedure = t.procedure.use(({ ctx, rawInput, next }) => {
+    if (!ctx.required) {
+        return next();
+    }
+    if (isTaskBoundAuth(ctx.auth, taskIdFromRawInput(rawInput))) {
+        return next();
+    }
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Unauthorized' });
+});
+
+const nodeBoundProcedure = t.procedure.use(({ ctx, next }) => {
+    if (!ctx.required) {
+        return next();
+    }
+    if (isNodeBoundAuth(ctx.auth, String(envs.RUNNER_NODE_ID))) {
+        return next();
+    }
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Unauthorized' });
+});
 
 interface StartParams {
     taskId: string;
@@ -48,7 +90,7 @@ function healthProcedure() {
 }
 
 function startProcedure() {
-    return publicProcedure
+    return taskBoundProcedure
         .input((input) => input as StartParams)
         .mutation(async (arg): Promise<boolean> => {
             const startTime = Date.now();
@@ -149,7 +191,7 @@ function startProcedure() {
 }
 
 function abortProcedure() {
-    return publicProcedure
+    return taskBoundProcedure
         .input((input) => input as { taskId: string })
         .mutation(({ input }) => {
             logger.info('Received cancel', { input });
@@ -158,23 +200,36 @@ function abortProcedure() {
 }
 
 function notifyWhenIdleProcedure() {
-    return publicProcedure.mutation(() => {
+    return nodeBoundProcedure.mutation(() => {
         logger.info('Received notifyWhenIdle');
         usage.resetIdleMaxDurationMs();
         return true;
     });
 }
 
-export const server = express();
-server.use(timeout('24h'));
-server.use(
-    '/',
-    trpcExpress.createExpressMiddleware({
-        router: appRouter,
-        createContext: () => ({})
-    })
-);
-server.use(haltOnTimedout);
+function isHealthPath(req: Request): boolean {
+    return req.path === '/health' || req.path === '/health/';
+}
+
+export function getServer(authEnvs: InternalAuthEnvs = envs): express.Express {
+    const app = express();
+    app.use(timeout('24h'));
+    app.use(internalServiceAuthMiddleware({ audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, envs: authEnvs, skip: isHealthPath }));
+    app.use(
+        '/',
+        trpcExpress.createExpressMiddleware({
+            router: appRouter,
+            createContext: ({ res }): RunnerContext => ({
+                auth: getInternalServiceAuth(res),
+                required: authEnvs.NANGO_INTERNAL_AUTH_REQUIRED
+            })
+        })
+    );
+    app.use(haltOnTimedout);
+    return app;
+}
+
+export const server = getServer();
 
 function haltOnTimedout(req: Request, _res: Response, next: NextFunction) {
     if (!req.timedout) next();

--- a/packages/runner/lib/server.unit.test.ts
+++ b/packages/runner/lib/server.unit.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createInternalServiceToken, deriveRunnerSigningKey, INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_RUNNER } from '@nangohq/internal-auth';
+
+import { getRunnerClient } from './client.js';
+import { getServer } from './server.js';
+
+import type { InternalAuthEnvs } from '@nangohq/internal-auth';
+import type { DBSyncConfig, NangoProps } from '@nangohq/types';
+
+const derivedKey = deriveRunnerSigningKey('sign')!;
+
+const authEnvs: InternalAuthEnvs = {
+    NANGO_INTERNAL_AUTH_REQUIRED: false,
+    NANGO_INTERNAL_AUTH_SIGNING_KEY: derivedKey
+};
+
+const httpOpts = {
+    headersTimeoutMs: 3_000,
+    connectTimeoutMs: 2_000,
+    responseTimeoutMs: 5_000
+};
+
+const nangoProps = {
+    scriptType: 'sync',
+    host: 'http://localhost:3003',
+    connectionId: 'connection-id',
+    environmentId: 1,
+    providerConfigKey: 'provider-config-key',
+    provider: 'provider',
+    activityLogId: '1',
+    secretKey: 'secret-key',
+    environmentName: 'dev',
+    nangoConnectionId: 1,
+    syncId: 'sync-id',
+    syncJobId: 1,
+    lastSyncDate: new Date(),
+    attributes: {},
+    track_deletes: false,
+    syncConfig: {} as DBSyncConfig,
+    debug: false,
+    startedAt: new Date(),
+    runnerFlags: {} as NangoProps['runnerFlags'],
+    endUser: null,
+    team: { id: 1, name: 'team' },
+    heartbeatTimeoutSecs: 30,
+    logger: { level: 'off' }
+} as NangoProps;
+
+afterEach(() => {
+    authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = false;
+});
+
+async function listen() {
+    const app = getServer(authEnvs);
+    return await new Promise<{ url: string; close: () => Promise<void> }>((resolve) => {
+        const httpServer = app.listen(0, '127.0.0.1', () => {
+            const address = httpServer.address();
+            const port = typeof address === 'object' && address ? address.port : 0;
+            resolve({
+                url: `http://127.0.0.1:${port}`,
+                close: () =>
+                    new Promise((r) => {
+                        httpServer.close(() => r());
+                    })
+            });
+        });
+    });
+}
+
+function runnerTaskToken(taskId: string): string {
+    return createInternalServiceToken({ audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, taskId, expiresInSecs: 120 }, derivedKey)!;
+}
+
+function runnerNodeToken(nodeId: string): string {
+    return createInternalServiceToken({ audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, op: 'node', nodeId, expiresInSecs: 120 }, derivedKey)!;
+}
+
+describe('runner internal service auth', () => {
+    it('serves /health without a credential when REQUIRED is true', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const { url, close } = await listen();
+        try {
+            const res = await fetch(`${url}/health`);
+            expect(res.status).toBe(200);
+            expect(await res.json()).toMatchObject({ result: { data: { json: { status: 'ok' } } } });
+        } finally {
+            await close();
+        }
+    });
+
+    it('returns 401 on start without a credential when REQUIRED is true', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const { url, close } = await listen();
+        try {
+            const res = await fetch(`${url}/start`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
+            expect(res.status).toBe(401);
+            expect(await res.json()).toMatchObject({ error: { code: 'missing_auth_header' } });
+        } finally {
+            await close();
+        }
+    });
+
+    it('returns 401 on abort without a credential when REQUIRED is true', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const { url, close } = await listen();
+        try {
+            const res = await fetch(`${url}/abort`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
+            expect(res.status).toBe(401);
+            expect(await res.json()).toMatchObject({ error: { code: 'missing_auth_header' } });
+        } finally {
+            await close();
+        }
+    });
+
+    it('returns 401 on notifyWhenIdle without a credential when REQUIRED is true', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const { url, close } = await listen();
+        try {
+            const res = await fetch(`${url}/notifyWhenIdle`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
+            expect(res.status).toBe(401);
+            expect(await res.json()).toMatchObject({ error: { code: 'missing_auth_header' } });
+        } finally {
+            await close();
+        }
+    });
+
+    it('returns 401 for a jobs-audience JWT on start when REQUIRED is true', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const jobsToken = createInternalServiceToken({ taskId: 'task-1', audience: INTERNAL_SERVICE_AUDIENCE_JOBS, expiresInSecs: 120 }, derivedKey);
+        const { url, close } = await listen();
+        try {
+            const res = await fetch(`${url}/start`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', Authorization: `Bearer ${jobsToken}` },
+                body: '{}'
+            });
+            expect(res.status).toBe(401);
+            expect(await res.json()).toMatchObject({ error: { code: 'unauthorized' } });
+        } finally {
+            await close();
+        }
+    });
+
+    it('returns 401 for garbage on start when REQUIRED is true', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const { url, close } = await listen();
+        try {
+            const res = await fetch(`${url}/start`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', Authorization: 'Bearer not-a-jwt' },
+                body: '{}'
+            });
+            expect(res.status).toBe(401);
+        } finally {
+            await close();
+        }
+    });
+
+    it('accepts start with a matching runner-audience task JWT when REQUIRED is true', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const { url, close } = await listen();
+        try {
+            const client = getRunnerClient(url, httpOpts, { token: runnerTaskToken('task-id') });
+            await expect(client.start.mutate({ taskId: 'task-id', nangoProps, code: `exports.default = async () => [1]` })).resolves.toEqual(true);
+        } finally {
+            await close();
+        }
+    });
+
+    it('rejects start when the task JWT is bound to a different task', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const { url, close } = await listen();
+        try {
+            const client = getRunnerClient(url, httpOpts, { token: runnerTaskToken('other-task') });
+            await expect(client.start.mutate({ taskId: 'task-id', nangoProps, code: `exports.default = async () => [1]` })).rejects.toThrow();
+        } finally {
+            await close();
+        }
+    });
+
+    it('accepts notifyWhenIdle with a matching runner-audience node JWT when REQUIRED is true', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const { url, close } = await listen();
+        try {
+            const client = getRunnerClient(url, httpOpts, { token: runnerNodeToken('1') });
+            await expect(client.notifyWhenIdle.mutate()).resolves.toEqual(true);
+        } finally {
+            await close();
+        }
+    });
+});

--- a/packages/runner/lib/server.unit.test.ts
+++ b/packages/runner/lib/server.unit.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { createInternalServiceToken, deriveRunnerSigningKey, INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_RUNNER } from '@nangohq/internal-auth';
+import { createInternalServiceToken, createRunnerDispatchToken, exportRunnerPublicKey, INTERNAL_SERVICE_AUDIENCE_JOBS } from '@nangohq/internal-auth';
 
 import { getRunnerClient } from './client.js';
 import { envs } from './env.js';
@@ -8,11 +8,12 @@ import { getServer } from './server.js';
 
 import type { InternalAuthEnvs } from '@nangohq/internal-auth';
 
-const derivedKey = deriveRunnerSigningKey('sign')!;
+const jobsSigningKey = 'sign';
+const runnerPublicKey = exportRunnerPublicKey(jobsSigningKey)!;
 
 const authEnvs: InternalAuthEnvs = {
     NANGO_INTERNAL_AUTH_REQUIRED: false,
-    NANGO_INTERNAL_AUTH_SIGNING_KEY: derivedKey
+    NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY: runnerPublicKey
 };
 
 const httpOpts = {
@@ -23,6 +24,7 @@ const httpOpts = {
 
 afterEach(() => {
     authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = false;
+    authEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = undefined;
 });
 
 async function listen() {
@@ -43,11 +45,11 @@ async function listen() {
 }
 
 function runnerTaskToken(taskId: string): string {
-    return createInternalServiceToken({ audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, taskId, expiresInSecs: 120 }, derivedKey)!;
+    return createRunnerDispatchToken({ taskId, expiresInSecs: 120 }, jobsSigningKey)!;
 }
 
 function runnerNodeToken(nodeId: string): string {
-    return createInternalServiceToken({ audience: INTERNAL_SERVICE_AUDIENCE_RUNNER, op: 'node', nodeId, expiresInSecs: 120 }, derivedKey)!;
+    return createRunnerDispatchToken({ op: 'node', nodeId, expiresInSecs: 120 }, jobsSigningKey)!;
 }
 
 describe('runner internal service auth', () => {
@@ -101,7 +103,7 @@ describe('runner internal service auth', () => {
 
     it('returns 401 for a jobs-audience JWT on start when REQUIRED is true', async () => {
         authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
-        const jobsToken = createInternalServiceToken({ taskId: 'task-1', audience: INTERNAL_SERVICE_AUDIENCE_JOBS, expiresInSecs: 120 }, derivedKey);
+        const jobsToken = createInternalServiceToken({ taskId: 'task-1', audience: INTERNAL_SERVICE_AUDIENCE_JOBS, expiresInSecs: 120 }, jobsSigningKey);
         const { url, close } = await listen();
         try {
             const res = await fetch(`${url}/start`, {
@@ -111,6 +113,39 @@ describe('runner internal service auth', () => {
             });
             expect(res.status).toBe(401);
             expect(await res.json()).toMatchObject({ error: { code: 'unauthorized' } });
+        } finally {
+            await close();
+        }
+    });
+
+    it('returns 401 for an HMAC runner-audience JWT minted from runner-held public key material', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        const forged = createInternalServiceToken({ audience: 'runner', taskId: 'task-id', expiresInSecs: 120 }, runnerPublicKey);
+        const { url, close } = await listen();
+        try {
+            const res = await fetch(`${url}/start`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', Authorization: `Bearer ${forged}` },
+                body: JSON.stringify({ taskId: 'task-id' })
+            });
+            expect(res.status).toBe(401);
+        } finally {
+            await close();
+        }
+    });
+
+    it('returns 401 for an HMAC runner-audience JWT even if a leftover signing key is present', async () => {
+        authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
+        authEnvs.NANGO_INTERNAL_AUTH_SIGNING_KEY = jobsSigningKey;
+        const hmac = createInternalServiceToken({ audience: 'runner', taskId: 'task-id', expiresInSecs: 120 }, jobsSigningKey);
+        const { url, close } = await listen();
+        try {
+            const res = await fetch(`${url}/start`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', Authorization: `Bearer ${hmac}` },
+                body: JSON.stringify({ taskId: 'task-id' })
+            });
+            expect(res.status).toBe(401);
         } finally {
             await close();
         }

--- a/packages/runner/lib/server.unit.test.ts
+++ b/packages/runner/lib/server.unit.test.ts
@@ -3,10 +3,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createInternalServiceToken, deriveRunnerSigningKey, INTERNAL_SERVICE_AUDIENCE_JOBS, INTERNAL_SERVICE_AUDIENCE_RUNNER } from '@nangohq/internal-auth';
 
 import { getRunnerClient } from './client.js';
+import { envs } from './env.js';
 import { getServer } from './server.js';
 
 import type { InternalAuthEnvs } from '@nangohq/internal-auth';
-import type { DBSyncConfig, NangoProps } from '@nangohq/types';
 
 const derivedKey = deriveRunnerSigningKey('sign')!;
 
@@ -20,32 +20,6 @@ const httpOpts = {
     connectTimeoutMs: 2_000,
     responseTimeoutMs: 5_000
 };
-
-const nangoProps = {
-    scriptType: 'sync',
-    host: 'http://localhost:3003',
-    connectionId: 'connection-id',
-    environmentId: 1,
-    providerConfigKey: 'provider-config-key',
-    provider: 'provider',
-    activityLogId: '1',
-    secretKey: 'secret-key',
-    environmentName: 'dev',
-    nangoConnectionId: 1,
-    syncId: 'sync-id',
-    syncJobId: 1,
-    lastSyncDate: new Date(),
-    attributes: {},
-    track_deletes: false,
-    syncConfig: {} as DBSyncConfig,
-    debug: false,
-    startedAt: new Date(),
-    runnerFlags: {} as NangoProps['runnerFlags'],
-    endUser: null,
-    team: { id: 1, name: 'team' },
-    heartbeatTimeoutSecs: 30,
-    logger: { level: 'off' }
-} as NangoProps;
 
 afterEach(() => {
     authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = false;
@@ -157,23 +131,24 @@ describe('runner internal service auth', () => {
         }
     });
 
-    it('accepts start with a matching runner-audience task JWT when REQUIRED is true', async () => {
+    it('accepts a task-bound mutation with a matching runner-audience JWT when REQUIRED is true', async () => {
         authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
         const { url, close } = await listen();
         try {
             const client = getRunnerClient(url, httpOpts, { token: runnerTaskToken('task-id') });
-            await expect(client.start.mutate({ taskId: 'task-id', nangoProps, code: `exports.default = async () => [1]` })).resolves.toEqual(true);
+            // abort shares start's task-bound procedure and does not exec() or call jobs
+            await expect(client.abort.mutate({ taskId: 'task-id' })).resolves.toBe(false);
         } finally {
             await close();
         }
     });
 
-    it('rejects start when the task JWT is bound to a different task', async () => {
+    it('rejects a task-bound mutation when the JWT is bound to a different task', async () => {
         authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
         const { url, close } = await listen();
         try {
             const client = getRunnerClient(url, httpOpts, { token: runnerTaskToken('other-task') });
-            await expect(client.start.mutate({ taskId: 'task-id', nangoProps, code: `exports.default = async () => [1]` })).rejects.toThrow();
+            await expect(client.abort.mutate({ taskId: 'task-id' })).rejects.toThrow();
         } finally {
             await close();
         }
@@ -183,7 +158,7 @@ describe('runner internal service auth', () => {
         authEnvs.NANGO_INTERNAL_AUTH_REQUIRED = true;
         const { url, close } = await listen();
         try {
-            const client = getRunnerClient(url, httpOpts, { token: runnerNodeToken('1') });
+            const client = getRunnerClient(url, httpOpts, { token: runnerNodeToken(String(envs.RUNNER_NODE_ID)) });
             await expect(client.notifyWhenIdle.mutate()).resolves.toEqual(true);
         } finally {
             await close();

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -741,6 +741,7 @@ const ENVS_SHAPE = z.object({
     NANGO_INTERNAL_AUTH_TOKEN: z.string().optional(),
     NANGO_INTERNAL_AUTH_SIGNING_KEY: z.string().optional(),
     NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN: z.string().optional(),
+    NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY: z.string().optional(),
     NANGO_INTERNAL_AUTH_REQUIRED: z
         .stringbool({ truthy: ['true'], falsy: ['false'] })
         .optional()

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -37,6 +37,7 @@ describe('parse', () => {
         expect(res.NANGO_INTERNAL_AUTH_SIGNING_KEY).toBeUndefined();
         expect(res).not.toHaveProperty('NANGO_INTERNAL_AUTH_TOKEN_FILE');
         expect(res.NANGO_INTERNAL_AUTH_RUNNER_NODE_TOKEN).toBeUndefined();
+        expect(res.NANGO_INTERNAL_AUTH_RUNNER_PUBLIC_KEY).toBeUndefined();
         expect(res).not.toHaveProperty('NANGO_INTERNAL_AUTH_RUNNER_SERVICE_ACCOUNT');
         expect(res).not.toHaveProperty('NANGO_INTERNAL_AUTH_AUDIENCE');
     });


### PR DESCRIPTION
## Summary

- Require a jobs identity on runner `start` / `abort` / `notifyWhenIdle` when `NANGO_INTERNAL_AUTH_REQUIRED=true`. Jobs mints an EdDSA JWT (`aud: runner`); runners verify with a public key only.
- Jobs never puts a minting secret on the runner. At node start it injects the Ed25519 public key, a jobs-audience node JWT, and a snapshot of `REQUIRED`. `/health` stays open.
- Default is a no-op. Existing runners keep accepting dispatch (fail-open). Enforcement starts on pods created after jobs has a signing key and `REQUIRED=true`.
