### PR TITLE
feat(kms): add support for gcp kms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3715,6 +3715,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@google-cloud/kms": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-5.7.0.tgz",
+            "integrity": "sha512-bxsauk8eUHfFEY9kLIbEfjHYhT0/7K+gDAsSzoR1ob7WK2vO0PuXYqn0kIFxTC38+0wYXp5qYfZL1+xSPBxfnw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "google-gax": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@google-cloud/paginator": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.0.0.tgz",
@@ -3758,7 +3770,6 @@
             "version": "1.14.4",
             "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
             "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/proto-loader": "^0.8.0",
@@ -3772,7 +3783,6 @@
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
             "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "lodash.camelcase": "^4.3.0",
@@ -4545,7 +4555,6 @@
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
             "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -6853,33 +6862,28 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
             "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/base64": {
             "version": "1.1.2",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
             "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
             "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
             "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.1"
@@ -6887,24 +6891,20 @@
         },
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
             "version": "1.1.2",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/pool": {
             "version": "1.1.0",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
             "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@radix-ui/number": {
@@ -18750,7 +18750,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dev": true,
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.1",
@@ -22379,17 +22378,78 @@
             }
         },
         "node_modules/gaxios": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
-            "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+            "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "extend": "^3.0.2",
                 "https-proxy-agent": "^7.0.1",
-                "node-fetch": "^3.3.2"
+                "node-fetch": "^3.3.2",
+                "rimraf": "^5.0.1"
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/gaxios/node_modules/brace-expansion": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/gaxios/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/gaxios/node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/gaxios/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/gaxios/node_modules/node-fetch": {
@@ -22410,14 +22470,29 @@
                 "url": "https://opencollective.com/node-fetch"
             }
         },
+        "node_modules/gaxios/node_modules/rimraf": {
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+            "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^10.3.7"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/gcp-metadata": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-            "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.4.tgz",
+            "integrity": "sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "gaxios": "^7.0.0",
-                "google-logging-utils": "^1.0.0",
+                "gaxios": "7.1.3",
+                "google-logging-utils": "1.1.3",
                 "json-bigint": "^1.0.0"
             },
             "engines": {
@@ -22860,15 +22935,15 @@
             }
         },
         "node_modules/google-auth-library": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.1.0.tgz",
-            "integrity": "sha512-GspVjZj1RbyRWpQ9FbAXMKjFGzZwDKnUHi66JJ+tcjcu5/xYAP1pdlWotCuIkMwjfVsxxDvsGZXGLzRt72D0sQ==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+            "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
                 "gaxios": "^7.0.0",
-                "gcp-metadata": "^7.0.0",
+                "gcp-metadata": "^8.0.0",
                 "google-logging-utils": "^1.0.0",
                 "gtoken": "^8.0.0",
                 "jws": "^4.0.0"
@@ -22877,10 +22952,143 @@
                 "node": ">=18"
             }
         },
+        "node_modules/google-gax": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.8.tgz",
+            "integrity": "sha512-M4vpZcXQIC1gqIVGQ7eaU3jXQA6zecStyTXu514TYfThlgSurYJOxHZo9fzU6hAgwPWvuEynAVHWyaIk80VeEA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.12.6",
+                "@grpc/proto-loader": "^0.8.0",
+                "duplexify": "^4.1.3",
+                "google-auth-library": "10.5.0",
+                "google-logging-utils": "1.1.3",
+                "node-fetch": "^3.3.2",
+                "object-hash": "^3.0.0",
+                "proto3-json-serializer": "3.0.4",
+                "protobufjs": "^7.5.4",
+                "retry-request": "^8.0.2",
+                "rimraf": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/google-gax/node_modules/@grpc/proto-loader": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+            "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lodash.camelcase": "^4.3.0",
+                "long": "^5.0.0",
+                "protobufjs": "^7.5.5",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/google-gax/node_modules/brace-expansion": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/google-gax/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/google-gax/node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/google-gax/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/google-gax/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "license": "MIT",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
+        },
+        "node_modules/google-gax/node_modules/rimraf": {
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+            "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^10.3.7"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/google-logging-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
-            "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
@@ -24854,7 +25062,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.includes": {
@@ -25071,7 +25278,6 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
             "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/loose-envify": {
@@ -25834,6 +26040,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-hash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/object-inspect": {
@@ -27140,11 +27355,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/proto3-json-serializer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+            "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "protobufjs": "^7.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/protobufjs": {
             "version": "7.6.5",
             "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
             "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -32340,7 +32566,6 @@
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
             "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -32358,7 +32583,6 @@
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "dev": true,
             "engines": {
                 "node": ">=12"
             }
@@ -35031,6 +35255,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@aws-crypto/client-node": "5.0.0",
+                "@google-cloud/kms": "5.7.0",
                 "@nangohq/utils": "file:../utils"
             },
             "devDependencies": {

--- a/packages/kms/lib/envelope.ts
+++ b/packages/kms/lib/envelope.ts
@@ -1,5 +1,7 @@
 import { buildClient, CommitmentPolicy, KmsKeyringNode } from '@aws-crypto/client-node';
 
+import { GcpKmsKeyringNode } from './gcp_kms_keyring.js';
+
 import type { EncryptionContext, KeyringNode } from '@aws-crypto/client-node';
 
 const DEK_BYTE_LENGTH = 32;
@@ -12,6 +14,7 @@ export type UnwrapDekOptions = {
     expectedContext: EncryptionContext; // the exact encryption context the envelope must have been wrapped with
 } & (
     | { kmsKeyArn: string } // The KMS key ARN to use for unwrapping the DEK
+    | { gcpKmsKeyName: string } // GCP Cloud KMS crypto key resource name
     | { keyring: KeyringNode } // injectable for tests (e.g. RawAesKeyringNode)
 );
 
@@ -20,7 +23,12 @@ export type UnwrapDekOptions = {
  * Fails fast on a tampered envelope, mismatched encryption context, or wrong key length.
  */
 export async function unwrapDek(opts: UnwrapDekOptions): Promise<string> {
-    const keyring = 'keyring' in opts ? opts.keyring : new KmsKeyringNode({ keyIds: [opts.kmsKeyArn] });
+    const keyring =
+        'keyring' in opts
+            ? opts.keyring
+            : 'gcpKmsKeyName' in opts
+              ? new GcpKmsKeyringNode(opts.gcpKmsKeyName)
+              : new KmsKeyringNode({ keyIds: [opts.kmsKeyArn] });
     const { plaintext: unwrapped, messageHeader } = await decrypt(keyring, Buffer.from(opts.wrapped, 'base64'));
     assertEncryptionContext(messageHeader.encryptionContext, opts.expectedContext);
     assertDekLength(unwrapped);

--- a/packages/kms/lib/envelope.ts
+++ b/packages/kms/lib/envelope.ts
@@ -36,27 +36,40 @@ export function assertDekLength(dek: Uint8Array): void {
     }
 }
 
+export type WrappingKey = { kmsKeyArn: string } | { gcpKmsKeyName: string };
+
+/**
+ * Exactly one wrapping-key identifier. Used by unwrapDek and DekRegistry.
+ * Exclusive-union types are still assignable at runtime if a caller passes both
+ * (excess-property checks only apply to object literals).
+ */
+export function resolveWrappingKey(kmsKeyArn: string | undefined, gcpKmsKeyName: string | undefined, errors: { both: string; neither: string }): WrappingKey {
+    if (kmsKeyArn && gcpKmsKeyName) {
+        throw new Error(errors.both);
+    }
+    if (kmsKeyArn) {
+        return { kmsKeyArn };
+    }
+    if (gcpKmsKeyName) {
+        return { gcpKmsKeyName };
+    }
+    throw new Error(errors.neither);
+}
+
+const UNWRAP_ONE_SOURCE = 'unwrapDek requires exactly one of kmsKeyArn, gcpKmsKeyName, or keyring';
+
 function resolveKeyring(opts: UnwrapDekOptions): KeyringNode {
-    // Exclusive-union members are still assignable at runtime if a caller passes both
-    // identifiers (excess-property checks only apply to object literals). Count defined
-    // wrapping sources so we never silently prefer GCP over AWS.
     const kmsKeyArn = 'kmsKeyArn' in opts ? opts.kmsKeyArn : undefined;
     const gcpKmsKeyName = 'gcpKmsKeyName' in opts ? opts.gcpKmsKeyName : undefined;
     const injectable = 'keyring' in opts ? opts.keyring : undefined;
-    const defined = [kmsKeyArn, gcpKmsKeyName, injectable].filter((value) => value !== undefined);
-    if (defined.length !== 1) {
-        throw new Error('unwrapDek requires exactly one of kmsKeyArn, gcpKmsKeyName, or keyring');
-    }
     if (injectable) {
+        if (kmsKeyArn !== undefined || gcpKmsKeyName !== undefined) {
+            throw new Error(UNWRAP_ONE_SOURCE);
+        }
         return injectable;
     }
-    if (gcpKmsKeyName) {
-        return new GcpKmsKeyringNode(gcpKmsKeyName);
-    }
-    if (!kmsKeyArn) {
-        throw new Error('unwrapDek requires exactly one of kmsKeyArn, gcpKmsKeyName, or keyring');
-    }
-    return new KmsKeyringNode({ keyIds: [kmsKeyArn] });
+    const wrappingKey = resolveWrappingKey(kmsKeyArn, gcpKmsKeyName, { both: UNWRAP_ONE_SOURCE, neither: UNWRAP_ONE_SOURCE });
+    return 'gcpKmsKeyName' in wrappingKey ? new GcpKmsKeyringNode(wrappingKey.gcpKmsKeyName) : new KmsKeyringNode({ keyIds: [wrappingKey.kmsKeyArn] });
 }
 
 function assertEncryptionContext(context: Readonly<Record<string, string>>, expected: EncryptionContext): void {

--- a/packages/kms/lib/envelope.ts
+++ b/packages/kms/lib/envelope.ts
@@ -13,9 +13,9 @@ export type UnwrapDekOptions = {
     wrapped: string; // base64 AWS Encryption SDK envelope
     expectedContext: EncryptionContext; // the exact encryption context the envelope must have been wrapped with
 } & (
-    | { kmsKeyArn: string } // The KMS key ARN to use for unwrapping the DEK
-    | { gcpKmsKeyName: string } // GCP Cloud KMS crypto key resource name
-    | { keyring: KeyringNode } // injectable for tests (e.g. RawAesKeyringNode)
+    | { kmsKeyArn: string; gcpKmsKeyName?: never; keyring?: never }
+    | { gcpKmsKeyName: string; kmsKeyArn?: never; keyring?: never }
+    | { keyring: KeyringNode; kmsKeyArn?: never; gcpKmsKeyName?: never }
 );
 
 /**
@@ -23,12 +23,7 @@ export type UnwrapDekOptions = {
  * Fails fast on a tampered envelope, mismatched encryption context, or wrong key length.
  */
 export async function unwrapDek(opts: UnwrapDekOptions): Promise<string> {
-    const keyring =
-        'keyring' in opts
-            ? opts.keyring
-            : 'gcpKmsKeyName' in opts
-              ? new GcpKmsKeyringNode(opts.gcpKmsKeyName)
-              : new KmsKeyringNode({ keyIds: [opts.kmsKeyArn] });
+    const keyring = resolveKeyring(opts);
     const { plaintext: unwrapped, messageHeader } = await decrypt(keyring, Buffer.from(opts.wrapped, 'base64'));
     assertEncryptionContext(messageHeader.encryptionContext, opts.expectedContext);
     assertDekLength(unwrapped);
@@ -39,6 +34,29 @@ export function assertDekLength(dek: Uint8Array): void {
     if (dek.byteLength !== DEK_BYTE_LENGTH) {
         throw new Error(`Encryption key must be ${DEK_BYTE_LENGTH} bytes, got ${dek.byteLength}`);
     }
+}
+
+function resolveKeyring(opts: UnwrapDekOptions): KeyringNode {
+    // Exclusive-union members are still assignable at runtime if a caller passes both
+    // identifiers (excess-property checks only apply to object literals). Count defined
+    // wrapping sources so we never silently prefer GCP over AWS.
+    const kmsKeyArn = 'kmsKeyArn' in opts ? opts.kmsKeyArn : undefined;
+    const gcpKmsKeyName = 'gcpKmsKeyName' in opts ? opts.gcpKmsKeyName : undefined;
+    const injectable = 'keyring' in opts ? opts.keyring : undefined;
+    const defined = [kmsKeyArn, gcpKmsKeyName, injectable].filter((value) => value !== undefined);
+    if (defined.length !== 1) {
+        throw new Error('unwrapDek requires exactly one of kmsKeyArn, gcpKmsKeyName, or keyring');
+    }
+    if (injectable) {
+        return injectable;
+    }
+    if (gcpKmsKeyName) {
+        return new GcpKmsKeyringNode(gcpKmsKeyName);
+    }
+    if (!kmsKeyArn) {
+        throw new Error('unwrapDek requires exactly one of kmsKeyArn, gcpKmsKeyName, or keyring');
+    }
+    return new KmsKeyringNode({ keyIds: [kmsKeyArn] });
 }
 
 function assertEncryptionContext(context: Readonly<Record<string, string>>, expected: EncryptionContext): void {

--- a/packages/kms/lib/envelope.unit.test.ts
+++ b/packages/kms/lib/envelope.unit.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 import { unwrapDek } from './envelope.js';
 
+import type { UnwrapDekOptions } from './envelope.js';
 import type { EncryptionContext, KeyringNode } from '@aws-crypto/client-node';
 
 const { encrypt } = buildClient(CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT);
@@ -50,5 +51,12 @@ describe('unwrapDek', () => {
         const tampered = Buffer.from(await wrap(keyring, Buffer.from(testDek, 'base64')), 'base64');
         tampered[tampered.byteLength - 1] = tampered[tampered.byteLength - 1]! ^ 0xff;
         await expect(unwrapDek({ wrapped: tampered.toString('base64'), keyring, expectedContext })).rejects.toThrow();
+    });
+
+    it('should throw when more than one wrapping-key option is provided', async () => {
+        const keyring = testKeyring();
+        const wrapped = await wrap(keyring, Buffer.from(testDek, 'base64'));
+        const bothProviders = { wrapped, expectedContext, kmsKeyArn: 'arn:aws:kms:test', gcpKmsKeyName: 'projects/test/cryptoKeys/dek' };
+        await expect(unwrapDek(bothProviders as unknown as UnwrapDekOptions)).rejects.toThrow(/exactly one of kmsKeyArn, gcpKmsKeyName, or keyring/);
     });
 });

--- a/packages/kms/lib/gcp_kms_keyring.ts
+++ b/packages/kms/lib/gcp_kms_keyring.ts
@@ -1,0 +1,101 @@
+import crypto from 'node:crypto';
+
+import { EncryptedDataKey, immutableClass, KeyringNode, KeyringTraceFlag, readOnlyProperty, unwrapDataKey } from '@aws-crypto/client-node';
+import { KeyManagementServiceClient } from '@google-cloud/kms';
+
+import type { KeyringTrace, NodeDecryptionMaterial, NodeEncryptionMaterial } from '@aws-crypto/client-node';
+
+export const GCP_KMS_PROVIDER_ID = 'gcp-kms';
+
+export type GcpKmsClient = {
+    encrypt(request: {
+        name: string;
+        plaintext: Uint8Array;
+        additionalAuthenticatedData: Uint8Array;
+    }): Promise<[{ ciphertext?: Uint8Array | string | null | undefined }, ...unknown[]]>;
+    decrypt(request: {
+        name: string;
+        ciphertext: Uint8Array;
+        additionalAuthenticatedData: Uint8Array;
+    }): Promise<[{ plaintext?: Uint8Array | string | null | undefined }, ...unknown[]]>;
+};
+
+/**
+ * Wraps and unwraps an AWS Encryption SDK data key via GCP Cloud KMS Encrypt/Decrypt.
+ * GCP has no GenerateDataKey; on encrypt we generate the data key locally then wrap it.
+ */
+export class GcpKmsKeyringNode extends KeyringNode {
+    declare public readonly keyName: string;
+    declare readonly client: GcpKmsClient;
+
+    constructor(keyName: string, client: GcpKmsClient = new KeyManagementServiceClient()) {
+        super();
+        readOnlyProperty(this, 'keyName', keyName);
+        readOnlyProperty(this, 'client', client);
+    }
+
+    override async _onEncrypt(material: NodeEncryptionMaterial): Promise<NodeEncryptionMaterial> {
+        if (!material.hasUnencryptedDataKey) {
+            material.setUnencryptedDataKey(new Uint8Array(crypto.randomBytes(material.suite.keyLengthBytes)), {
+                keyNamespace: GCP_KMS_PROVIDER_ID,
+                keyName: this.keyName,
+                flags: KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY
+            });
+        }
+
+        const plaintext = unwrapDataKey(material.getUnencryptedDataKey());
+        const [{ ciphertext }] = await this.client.encrypt({
+            name: this.keyName,
+            plaintext,
+            additionalAuthenticatedData: serializeAad(material.encryptionContext)
+        });
+
+        material.addEncryptedDataKey(
+            new EncryptedDataKey({
+                providerId: GCP_KMS_PROVIDER_ID,
+                providerInfo: this.keyName,
+                encryptedDataKey: asBytes(ciphertext, 'ciphertext')
+            }),
+            KeyringTraceFlag.WRAPPING_KEY_ENCRYPTED_DATA_KEY | KeyringTraceFlag.WRAPPING_KEY_SIGNED_ENC_CTX
+        );
+        return material;
+    }
+
+    override async _onDecrypt(material: NodeDecryptionMaterial, encryptedDataKeys: EncryptedDataKey[]): Promise<NodeDecryptionMaterial> {
+        const edk = encryptedDataKeys.find((candidate) => candidate.providerId === GCP_KMS_PROVIDER_ID && candidate.providerInfo === this.keyName);
+        if (!edk) {
+            return material;
+        }
+
+        const [{ plaintext }] = await this.client.decrypt({
+            name: this.keyName,
+            ciphertext: edk.encryptedDataKey,
+            additionalAuthenticatedData: serializeAad(material.encryptionContext)
+        });
+
+        const trace: KeyringTrace = {
+            keyNamespace: GCP_KMS_PROVIDER_ID,
+            keyName: this.keyName,
+            flags: KeyringTraceFlag.WRAPPING_KEY_DECRYPTED_DATA_KEY | KeyringTraceFlag.WRAPPING_KEY_VERIFIED_ENC_CTX
+        };
+        material.setUnencryptedDataKey(asBytes(plaintext, 'plaintext'), trace);
+        return material;
+    }
+}
+immutableClass(GcpKmsKeyringNode);
+
+function asBytes(value: Uint8Array | string | null | undefined, label: string): Uint8Array {
+    if (value == null || value.length === 0) {
+        throw new Error(`GCP KMS did not return a ${label}`);
+    }
+    // The Encryption SDK requires an isolated ArrayBuffer (byteOffset 0). GCP/Node may return pooled Buffers.
+    return new Uint8Array(typeof value === 'string' ? Buffer.from(value, 'base64') : value);
+}
+
+/**
+ * Bound into every GCP-wrapped DEK as Cloud KMS additionalAuthenticatedData.
+ * Changing this serialization makes every previously wrapped DEK unreadable via GCP KMS.
+ */
+function serializeAad(context: Readonly<Record<string, string>>): Uint8Array {
+    return Buffer.from(JSON.stringify(context, Object.keys(context).sort()));
+}

--- a/packages/kms/lib/gcp_kms_keyring.unit.test.ts
+++ b/packages/kms/lib/gcp_kms_keyring.unit.test.ts
@@ -1,0 +1,120 @@
+import crypto from 'node:crypto';
+
+import { AlgorithmSuiteIdentifier, buildClient, CommitmentPolicy, EncryptedDataKey, NodeAlgorithmSuite, NodeDecryptionMaterial } from '@aws-crypto/client-node';
+import { describe, expect, it } from 'vitest';
+
+import { unwrapDek } from './envelope.js';
+import { GCP_KMS_PROVIDER_ID, GcpKmsKeyringNode } from './gcp_kms_keyring.js';
+
+import type { GcpKmsClient } from './gcp_kms_keyring.js';
+import type { EncryptionContext, KeyringNode } from '@aws-crypto/client-node';
+
+const { encrypt } = buildClient(CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT);
+
+const expectedContext = { purpose: 'global_dek', app: 'nango' };
+const testDek = crypto.randomBytes(32).toString('base64');
+const testKeyName = 'projects/test/locations/global/keyRings/nango/cryptoKeys/dek';
+
+function canonicalAad(context: Readonly<Record<string, string>>): Buffer {
+    return Buffer.from(JSON.stringify(context, Object.keys(context).sort()));
+}
+
+function stubClient(onEncrypt?: (aad: Uint8Array) => void): GcpKmsClient {
+    const store = new Map<string, { plaintext: Buffer; aad: Buffer }>();
+    let seq = 0;
+    return {
+        encrypt(request) {
+            onEncrypt?.(request.additionalAuthenticatedData);
+            const ciphertext = Buffer.from(`gcp-cipher-${seq++}`);
+            store.set(ciphertext.toString('hex'), {
+                plaintext: Buffer.from(request.plaintext),
+                aad: Buffer.from(request.additionalAuthenticatedData)
+            });
+            return Promise.resolve([{ ciphertext }]);
+        },
+        decrypt(request) {
+            const stored = store.get(Buffer.from(request.ciphertext).toString('hex'));
+            if (!stored) {
+                throw new Error('unknown ciphertext');
+            }
+            if (!stored.aad.equals(Buffer.from(request.additionalAuthenticatedData))) {
+                throw new Error('AAD mismatch');
+            }
+            return Promise.resolve([{ plaintext: stored.plaintext }]);
+        }
+    };
+}
+
+function testKeyring(client: GcpKmsClient = stubClient(), keyName = testKeyName): GcpKmsKeyringNode {
+    return new GcpKmsKeyringNode(keyName, client);
+}
+
+async function wrap(keyring: KeyringNode, dek: Uint8Array, encryptionContext: EncryptionContext = expectedContext): Promise<string> {
+    const { result } = await encrypt(keyring, dek, { encryptionContext });
+    return result.toString('base64');
+}
+
+describe('GcpKmsKeyringNode', () => {
+    it('should round-trip wrap and unwrap byte-for-byte', async () => {
+        const client = stubClient();
+        const keyring = testKeyring(client);
+        const wrapped = await wrap(keyring, Buffer.from(testDek, 'base64'));
+        await expect(unwrapDek({ wrapped, keyring, expectedContext })).resolves.toBe(testDek);
+    });
+
+    it('should bind the canonical AAD serialization into the GCP encrypt call', async () => {
+        const seen: Uint8Array[] = [];
+        const keyring = testKeyring(stubClient((aad) => seen.push(aad)));
+        await wrap(keyring, Buffer.from(testDek, 'base64'));
+        expect(seen).toHaveLength(1);
+        const aad = seen[0];
+        if (aad === undefined) {
+            throw new Error('expected AAD to be captured');
+        }
+        const parsed = JSON.parse(Buffer.from(aad).toString()) as Record<string, string>;
+        expect(parsed['purpose']).toBe('global_dek');
+        expect(parsed['app']).toBe('nango');
+        // The Encryption SDK may add its own context keys; the wire format is still sorted-key JSON.
+        expect(Buffer.from(aad).equals(canonicalAad(parsed))).toBe(true);
+    });
+
+    it('should throw when the wrapped key was bound to a different encryption context', async () => {
+        const keyring = testKeyring();
+        const wrapped = await wrap(keyring, Buffer.from(testDek, 'base64'), { purpose: 'something_else', app: 'nango' });
+        await expect(unwrapDek({ wrapped, keyring, expectedContext })).rejects.toThrow(/Encryption context mismatch/);
+    });
+
+    it('should ignore an EDK with a different providerId rather than throwing', async () => {
+        const keyring = testKeyring();
+        const material = new NodeDecryptionMaterial(
+            new NodeAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA512_COMMIT_KEY_ECDSA_P384),
+            expectedContext
+        );
+        const result = await keyring._onDecrypt(material, [
+            new EncryptedDataKey({
+                providerId: 'aws-kms',
+                providerInfo: testKeyName,
+                encryptedDataKey: crypto.randomBytes(32)
+            })
+        ]);
+        expect(result).toBe(material);
+        expect(result.hasUnencryptedDataKey).toBe(false);
+    });
+
+    it('should ignore an EDK with a different providerInfo rather than throwing', async () => {
+        const keyring = testKeyring();
+        const material = new NodeDecryptionMaterial(
+            new NodeAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA512_COMMIT_KEY_ECDSA_P384),
+            expectedContext
+        );
+        const result = await keyring._onDecrypt(material, [
+            new EncryptedDataKey({
+                providerId: GCP_KMS_PROVIDER_ID,
+                providerInfo: 'projects/other/locations/global/keyRings/nango/cryptoKeys/other',
+                encryptedDataKey: crypto.randomBytes(32)
+            })
+        ]);
+        expect(result).toBe(material);
+        expect(result.hasUnencryptedDataKey).toBe(false);
+    });
+});

--- a/packages/kms/lib/registry.ts
+++ b/packages/kms/lib/registry.ts
@@ -92,18 +92,8 @@ async function resolveFromEnvs({
     // Fallback to the plaintext key (dev/self hosted) or '' (encryption disabled) when neither is set.
     // Unwrap failures are fatal: we must not silently start up with the wrong key.
     if (wrapped) {
-        if (kmsKeyArn && gcpKmsKeyName) {
-            throw new Error('NANGO_KMS_KEY_ARN and NANGO_GCP_KMS_KEY_NAME are mutually exclusive: set only one');
-        }
-        if (gcpKmsKeyName) {
-            const dek = await unwrapDek({ wrapped, gcpKmsKeyName, expectedContext: GLOBAL_DEK_CONTEXT });
-            logger.info('Loaded encryption key (source=wrapped)');
-            return dek;
-        }
-        if (!kmsKeyArn) {
-            throw new Error('one of NANGO_KMS_KEY_ARN or NANGO_GCP_KMS_KEY_NAME is required when NANGO_ENCRYPTION_KEY_WRAPPED is set');
-        }
-        const dek = await unwrapDek({ wrapped, kmsKeyArn, expectedContext: GLOBAL_DEK_CONTEXT });
+        const wrappingKey = resolveWrappingKey(kmsKeyArn, gcpKmsKeyName);
+        const dek = await unwrapDek({ wrapped, expectedContext: GLOBAL_DEK_CONTEXT, ...wrappingKey });
         logger.info('Loaded encryption key (source=wrapped)');
         return dek;
     }
@@ -115,4 +105,17 @@ async function resolveFromEnvs({
     }
 
     return '';
+}
+
+function resolveWrappingKey(kmsKeyArn: string | undefined, gcpKmsKeyName: string | undefined): { kmsKeyArn: string } | { gcpKmsKeyName: string } {
+    if (kmsKeyArn && gcpKmsKeyName) {
+        throw new Error('NANGO_KMS_KEY_ARN and NANGO_GCP_KMS_KEY_NAME are mutually exclusive: set only one');
+    }
+    if (kmsKeyArn) {
+        return { kmsKeyArn };
+    }
+    if (gcpKmsKeyName) {
+        return { gcpKmsKeyName };
+    }
+    throw new Error('one of NANGO_KMS_KEY_ARN or NANGO_GCP_KMS_KEY_NAME is required when NANGO_ENCRYPTION_KEY_WRAPPED is set');
 }

--- a/packages/kms/lib/registry.ts
+++ b/packages/kms/lib/registry.ts
@@ -22,6 +22,7 @@ export interface DekEnvs {
     NANGO_ENCRYPTION_KEY?: string | undefined;
     NANGO_ENCRYPTION_KEY_WRAPPED?: string | undefined;
     NANGO_KMS_KEY_ARN?: string | undefined;
+    NANGO_GCP_KMS_KEY_NAME?: string | undefined;
 }
 
 export class DekRegistry {
@@ -49,15 +50,20 @@ export class DekRegistry {
 const resolved = new Map<string, Promise<string>>();
 
 function resolveDek(envs: DekEnvs): Promise<string> {
-    const { NANGO_ENCRYPTION_KEY: plaintext, NANGO_ENCRYPTION_KEY_WRAPPED: wrapped, NANGO_KMS_KEY_ARN: kmsKeyArn } = envs;
+    const {
+        NANGO_ENCRYPTION_KEY: plaintext,
+        NANGO_ENCRYPTION_KEY_WRAPPED: wrapped,
+        NANGO_KMS_KEY_ARN: kmsKeyArn,
+        NANGO_GCP_KMS_KEY_NAME: gcpKmsKeyName
+    } = envs;
 
-    const cacheKey = JSON.stringify([plaintext, wrapped, kmsKeyArn]);
+    const cacheKey = JSON.stringify([plaintext, wrapped, kmsKeyArn, gcpKmsKeyName]);
     const cached = resolved.get(cacheKey);
     if (cached !== undefined) {
         return cached;
     }
 
-    const promise = resolveFromEnvs({ plaintext, wrapped, kmsKeyArn }).catch((err: unknown) => {
+    const promise = resolveFromEnvs({ plaintext, wrapped, kmsKeyArn, gcpKmsKeyName }).catch((err: unknown) => {
         // Don't cache failures: a transient KMS error must not poison every future caller.
         resolved.delete(cacheKey);
         throw err;
@@ -69,11 +75,13 @@ function resolveDek(envs: DekEnvs): Promise<string> {
 async function resolveFromEnvs({
     plaintext,
     wrapped,
-    kmsKeyArn
+    kmsKeyArn,
+    gcpKmsKeyName
 }: {
     plaintext?: string | undefined;
     wrapped?: string | undefined;
     kmsKeyArn?: string | undefined;
+    gcpKmsKeyName?: string | undefined;
 }): Promise<string> {
     // Wrapped and plaintext keys are mutually exclusive: fail fast rather than silently picking one.
     if (wrapped && plaintext) {
@@ -84,8 +92,16 @@ async function resolveFromEnvs({
     // Fallback to the plaintext key (dev/self hosted) or '' (encryption disabled) when neither is set.
     // Unwrap failures are fatal: we must not silently start up with the wrong key.
     if (wrapped) {
+        if (kmsKeyArn && gcpKmsKeyName) {
+            throw new Error('NANGO_KMS_KEY_ARN and NANGO_GCP_KMS_KEY_NAME are mutually exclusive: set only one');
+        }
+        if (gcpKmsKeyName) {
+            const dek = await unwrapDek({ wrapped, gcpKmsKeyName, expectedContext: GLOBAL_DEK_CONTEXT });
+            logger.info('Loaded encryption key (source=wrapped)');
+            return dek;
+        }
         if (!kmsKeyArn) {
-            throw new Error('NANGO_KMS_KEY_ARN is required when NANGO_ENCRYPTION_KEY_WRAPPED is set');
+            throw new Error('one of NANGO_KMS_KEY_ARN or NANGO_GCP_KMS_KEY_NAME is required when NANGO_ENCRYPTION_KEY_WRAPPED is set');
         }
         const dek = await unwrapDek({ wrapped, kmsKeyArn, expectedContext: GLOBAL_DEK_CONTEXT });
         logger.info('Loaded encryption key (source=wrapped)');

--- a/packages/kms/lib/registry.ts
+++ b/packages/kms/lib/registry.ts
@@ -5,7 +5,7 @@
  */
 import { getLogger } from '@nangohq/utils';
 
-import { assertDekLength, unwrapDek } from './envelope.js';
+import { assertDekLength, resolveWrappingKey, unwrapDek } from './envelope.js';
 
 const logger = getLogger('kms');
 
@@ -92,7 +92,10 @@ async function resolveFromEnvs({
     // Fallback to the plaintext key (dev/self hosted) or '' (encryption disabled) when neither is set.
     // Unwrap failures are fatal: we must not silently start up with the wrong key.
     if (wrapped) {
-        const wrappingKey = resolveWrappingKey(kmsKeyArn, gcpKmsKeyName);
+        const wrappingKey = resolveWrappingKey(kmsKeyArn, gcpKmsKeyName, {
+            both: 'NANGO_KMS_KEY_ARN and NANGO_GCP_KMS_KEY_NAME are mutually exclusive: set only one',
+            neither: 'one of NANGO_KMS_KEY_ARN or NANGO_GCP_KMS_KEY_NAME is required when NANGO_ENCRYPTION_KEY_WRAPPED is set'
+        });
         const dek = await unwrapDek({ wrapped, expectedContext: GLOBAL_DEK_CONTEXT, ...wrappingKey });
         logger.info('Loaded encryption key (source=wrapped)');
         return dek;
@@ -105,17 +108,4 @@ async function resolveFromEnvs({
     }
 
     return '';
-}
-
-function resolveWrappingKey(kmsKeyArn: string | undefined, gcpKmsKeyName: string | undefined): { kmsKeyArn: string } | { gcpKmsKeyName: string } {
-    if (kmsKeyArn && gcpKmsKeyName) {
-        throw new Error('NANGO_KMS_KEY_ARN and NANGO_GCP_KMS_KEY_NAME are mutually exclusive: set only one');
-    }
-    if (kmsKeyArn) {
-        return { kmsKeyArn };
-    }
-    if (gcpKmsKeyName) {
-        return { gcpKmsKeyName };
-    }
-    throw new Error('one of NANGO_KMS_KEY_ARN or NANGO_GCP_KMS_KEY_NAME is required when NANGO_ENCRYPTION_KEY_WRAPPED is set');
 }

--- a/packages/kms/lib/registry.unit.test.ts
+++ b/packages/kms/lib/registry.unit.test.ts
@@ -8,12 +8,15 @@ const testDek = crypto.randomBytes(32).toString('base64');
 
 // The wrapped key is unwrapped through KMS, which unit tests can't reach.
 // Here we stub unwrapDek to assert the registry's resolution priority.
-const { unwrappedDek } = vi.hoisted(() => ({ unwrappedDek: 'unwrapped-from-kms' }));
+const { unwrappedDek, unwrapDekMock } = vi.hoisted(() => {
+    const unwrappedDek = 'unwrapped-from-kms';
+    return { unwrappedDek, unwrapDekMock: vi.fn(() => Promise.resolve(unwrappedDek)) };
+});
 
 vi.mock('./envelope.js', async (importActual) => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     const actual = await importActual<typeof import('./envelope.js')>();
-    return { ...actual, unwrapDek: () => Promise.resolve(unwrappedDek) };
+    return { ...actual, unwrapDek: unwrapDekMock };
 });
 
 describe('DekRegistry.create', () => {
@@ -50,7 +53,34 @@ describe('DekRegistry.create', () => {
         ).rejects.toThrow(/mutually exclusive/);
     });
 
-    it('should throw when the wrapped key is set without a KMS key ARN', async () => {
-        await expect(DekRegistry.create({ NANGO_ENCRYPTION_KEY_WRAPPED: 'no-arn' })).rejects.toThrow(/NANGO_KMS_KEY_ARN is required/);
+    it('should throw when the wrapped key is set without a wrapping-key identifier', async () => {
+        await expect(DekRegistry.create({ NANGO_ENCRYPTION_KEY_WRAPPED: 'no-arn' })).rejects.toThrow(
+            /one of NANGO_KMS_KEY_ARN or NANGO_GCP_KMS_KEY_NAME is required/
+        );
+    });
+
+    it('should resolve from the wrapped key via GCP KMS', async () => {
+        unwrapDekMock.mockClear();
+        const gcpKmsKeyName = 'projects/test/locations/global/keyRings/nango/cryptoKeys/dek';
+        const registry = await DekRegistry.create({
+            NANGO_ENCRYPTION_KEY_WRAPPED: 'wrapped-gcp',
+            NANGO_GCP_KMS_KEY_NAME: gcpKmsKeyName
+        });
+        expect(registry.get()).toBe(unwrappedDek);
+        expect(unwrapDekMock).toHaveBeenCalledWith({
+            wrapped: 'wrapped-gcp',
+            gcpKmsKeyName,
+            expectedContext: { purpose: 'global_dek', app: 'nango' }
+        });
+    });
+
+    it('should throw when both AWS and GCP wrapping-key identifiers are set', async () => {
+        await expect(
+            DekRegistry.create({
+                NANGO_ENCRYPTION_KEY_WRAPPED: 'wrapped-both-kms',
+                NANGO_KMS_KEY_ARN: 'arn:aws:kms:test',
+                NANGO_GCP_KMS_KEY_NAME: 'projects/test/locations/global/keyRings/nango/cryptoKeys/dek'
+            })
+        ).rejects.toThrow(/NANGO_KMS_KEY_ARN and NANGO_GCP_KMS_KEY_NAME are mutually exclusive/);
     });
 });

--- a/packages/kms/package.json
+++ b/packages/kms/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@aws-crypto/client-node": "5.0.0",
+        "@google-cloud/kms": "5.7.0",
         "@nangohq/utils": "file:../utils"
     },
     "devDependencies": {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -656,6 +656,7 @@ const ENVS_SHAPE = z.object({
     // KMS-wrapped alternative to NANGO_ENCRYPTION_KEY (mutually exclusive, enforced at DEK load).
     NANGO_ENCRYPTION_KEY_WRAPPED: z.string().optional(),
     NANGO_KMS_KEY_ARN: z.string().optional(),
+    NANGO_GCP_KMS_KEY_NAME: z.string().optional(), // GCP-KMS alternative wrapping-key identifier
     NANGO_DB_SCHEMA: z.string().optional().default('nango'),
     NANGO_DB_ADDITIONAL_SCHEMAS: z.string().optional(),
     NANGO_DB_APPLICATION_NAME: z.string().optional().default('[unknown]'),

--- a/scripts/wrap-dek/package.json
+++ b/scripts/wrap-dek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "wrap-dek",
     "version": "1.0.0",
-    "description": "Wrap/unwrap the Nango global DEK with an AWS KMS master key (AWS Encryption SDK envelope)",
+    "description": "Wrap/unwrap the Nango global DEK with an AWS KMS or GCP Cloud KMS master key (AWS Encryption SDK envelope)",
     "type": "module",
     "private": true,
     "dependencies": {

--- a/scripts/wrap-dek/wrap-dek.ts
+++ b/scripts/wrap-dek/wrap-dek.ts
@@ -24,8 +24,6 @@ import { parseArgs } from 'node:util';
 
 import { buildClient, CommitmentPolicy, KmsKeyringNode } from '@aws-crypto/client-node';
 
-import { GcpKmsKeyringNode } from '../../packages/kms/lib/gcp_kms_keyring.js';
-
 import type { KeyringNode } from '@aws-crypto/client-node';
 
 const USAGE = 'Usage: echo -n "$DEK_B64" | tsx wrap-dek.ts (--key-arn <kms-key-arn> | --gcp-key-name <resource>) [--decrypt] [--context key=value ...]';
@@ -49,7 +47,7 @@ if (keyArn && gcpKeyName) {
     process.exit(1);
 }
 
-const keyring = resolveKeyring(keyArn, gcpKeyName, values.decrypt);
+const keyring = await resolveKeyring(keyArn, gcpKeyName, values.decrypt);
 const wrappingKey = gcpKeyName ?? keyArn;
 
 const encryptionContext: Record<string, string> = {};
@@ -90,8 +88,10 @@ if (values.decrypt) {
     writeOut(result.toString('base64'));
 }
 
-function resolveKeyring(keyArn: string | undefined, gcpKeyName: string | undefined, decrypt: boolean | undefined): KeyringNode {
+async function resolveKeyring(keyArn: string | undefined, gcpKeyName: string | undefined, decrypt: boolean | undefined): Promise<KeyringNode> {
     if (gcpKeyName) {
+        // Loaded only for --gcp-key-name so a standalone wrap-dek install (AWS-only deps) still runs --key-arn.
+        const { GcpKmsKeyringNode } = await import('../../packages/kms/lib/gcp_kms_keyring.js');
         return new GcpKmsKeyringNode(gcpKeyName);
     }
     if (!keyArn) {

--- a/scripts/wrap-dek/wrap-dek.ts
+++ b/scripts/wrap-dek/wrap-dek.ts
@@ -1,11 +1,20 @@
 /**
- * Wrap (default) or unwrap (--decrypt) the Nango global DEK with an AWS KMS master key, using the AWS Encryption SDK
+ * Wrap (default) or unwrap (--decrypt) the Nango global DEK with a KMS master key, using the AWS Encryption SDK.
+ *
+ * Supports AWS KMS (--key-arn) or GCP Cloud KMS (--gcp-key-name). Pass exactly one.
  *
  * The DEK is read from stdin so it never lands on disk or in shell history.
  *
- * Wrap:   echo -n "$NANGO_ENCRYPTION_KEY" | npx tsx wrap-dek.ts --key-arn <kms-key-arn> --context purpose=global_dek --context app=nango > dek-wrapped.b64
- * Verify: cat dek-wrapped.b64 | npm run unwrap -- --key-arn <kms-key-arn> --context key1=value1 --context key2=value2 ... | base64 -d
- *          (output must match $NANGO_ENCRYPTION_KEY byte-for-byte)
+ * AWS wrap:    echo -n "$NANGO_ENCRYPTION_KEY" | npx tsx wrap-dek.ts --key-arn <kms-key-arn> --context purpose=global_dek --context app=nango > dek-wrapped.b64
+ * GCP wrap:    echo -n "$NANGO_ENCRYPTION_KEY" | npx tsx wrap-dek.ts --gcp-key-name <resource> --context purpose=global_dek --context app=nango > dek-wrapped.b64
+ * AWS verify:  cat dek-wrapped.b64 | npx tsx wrap-dek.ts --decrypt --key-arn <kms-key-arn> --context purpose=global_dek --context app=nango | base64 -d
+ * GCP verify:  cat dek-wrapped.b64 | npx tsx wrap-dek.ts --decrypt --gcp-key-name <resource> --context purpose=global_dek --context app=nango | base64 -d
+ *               (output must match $NANGO_ENCRYPTION_KEY byte-for-byte)
+ *
+ * --gcp-key-name is a Cloud KMS crypto key resource:
+ *   projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
+ * GCP calls use Application Default Credentials on the host (workload identity or a service
+ * account) with roles/cloudkms.cryptoKeyEncrypterDecrypter scoped to that key.
  *
  * --context is optional and repeatable; pairs are bound to the envelope on wrap and
  * verified against the envelope header on --decrypt.
@@ -15,9 +24,16 @@ import { parseArgs } from 'node:util';
 
 import { buildClient, CommitmentPolicy, KmsKeyringNode } from '@aws-crypto/client-node';
 
+import { GcpKmsKeyringNode } from '../../packages/kms/lib/gcp_kms_keyring.js';
+
+import type { KeyringNode } from '@aws-crypto/client-node';
+
+const USAGE = 'Usage: echo -n "$DEK_B64" | tsx wrap-dek.ts (--key-arn <kms-key-arn> | --gcp-key-name <resource>) [--decrypt] [--context key=value ...]';
+
 const { values } = parseArgs({
     options: {
         'key-arn': { type: 'string' },
+        'gcp-key-name': { type: 'string' },
         decrypt: { type: 'boolean', default: false },
         // Repeatable key=value pairs, e.g. --context purpose=dek --context app=nango.
         // Bound to the envelope on wrap; verified against the envelope header on --decrypt.
@@ -26,11 +42,15 @@ const { values } = parseArgs({
 });
 
 const keyArn = values['key-arn'];
-if (!keyArn) {
-    console.error('Missing KMS key ARN. Pass --key-arn <arn>');
-    console.error('Usage: echo -n "$DEK_B64" | tsx wrap-dek.ts --key-arn <kms-key-arn> [--decrypt] [--context key=value ...]');
+const gcpKeyName = values['gcp-key-name'];
+if (keyArn && gcpKeyName) {
+    console.error('--key-arn and --gcp-key-name are mutually exclusive: pass only one');
+    console.error(USAGE);
     process.exit(1);
 }
+
+const keyring = resolveKeyring(keyArn, gcpKeyName, values.decrypt);
+const wrappingKey = gcpKeyName ?? keyArn;
 
 const encryptionContext: Record<string, string> = {};
 for (const pair of values.context ?? []) {
@@ -52,7 +72,7 @@ if (!input) {
 const { encrypt, decrypt } = buildClient(CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT);
 
 if (values.decrypt) {
-    const { plaintext, messageHeader } = await decrypt(new KmsKeyringNode({ keyIds: [keyArn] }), Buffer.from(input, 'base64'));
+    const { plaintext, messageHeader } = await decrypt(keyring, Buffer.from(input, 'base64'));
     for (const [key, value] of Object.entries(encryptionContext)) {
         if (messageHeader.encryptionContext[key] !== value) {
             throw new Error(`Encryption context mismatch: expected ${key}=${value}, got ${String(messageHeader.encryptionContext[key])}`);
@@ -65,9 +85,21 @@ if (values.decrypt) {
     if (dek.byteLength !== 32) {
         throw new Error(`DEK must be the base64 of exactly 32 bytes, got ${dek.byteLength} bytes`);
     }
-    const { result } = await encrypt(new KmsKeyringNode({ generatorKeyId: keyArn }), dek, { encryptionContext });
-    console.error(`Wrapped ${dek.byteLength}-byte DEK with ${keyArn} (${result.byteLength}-byte envelope)`);
+    const { result } = await encrypt(keyring, dek, { encryptionContext });
+    console.error(`Wrapped ${dek.byteLength}-byte DEK with ${wrappingKey} (${result.byteLength}-byte envelope)`);
     writeOut(result.toString('base64'));
+}
+
+function resolveKeyring(keyArn: string | undefined, gcpKeyName: string | undefined, decrypt: boolean | undefined): KeyringNode {
+    if (gcpKeyName) {
+        return new GcpKmsKeyringNode(gcpKeyName);
+    }
+    if (!keyArn) {
+        console.error('Missing wrapping key. Pass --key-arn <arn> or --gcp-key-name <resource>');
+        console.error(USAGE);
+        process.exit(1);
+    }
+    return decrypt ? new KmsKeyringNode({ keyIds: [keyArn] }) : new KmsKeyringNode({ generatorKeyId: keyArn });
 }
 
 // Trailing newline on a TTY so the shell prompt doesn't overwrite the output;


### PR DESCRIPTION
## Summary

- Adds GCP Cloud KMS as an alternative to AWS KMS for unwrapping Nango’s global DEK. Deployments pick a provider via env vars; this is not a migration and the AWS path is unchanged.
- Wrapped DEKs now require exactly one of `NANGO_KMS_KEY_ARN` or `NANGO_GCP_KMS_KEY_NAME`. `scripts/wrap-dek` gains `--gcp-key-name` as the counterpart to `--key-arn`.
- GCP KMS calls use Application Default Credentials on the host (workload identity / service account) with `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the specific key.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

