### PR TITLE
fix(server): datadog tag and record every authorization comparison

### DIFF
--- a/packages/server/lib/authz/middleware.ts
+++ b/packages/server/lib/authz/middleware.ts
@@ -1,5 +1,4 @@
 import { resolve } from './resolve.js';
-import { recordRoleDivergence } from './shadow.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { Permission, Scope } from '@nangohq/types';
@@ -15,10 +14,7 @@ export function can(permission: Permission | ScopedPermission): RequestHandler {
         const perm: Permission =
             'scopedBy' in permission ? { action: permission.action, resource: permission.resource, scope: permission.scopedBy(locals) } : permission;
 
-        const allowed = await resolve(locals, perm);
-        recordRoleDivergence({ locals, permission: perm, legacy: allowed });
-
-        if (!allowed) {
+        if (!(await resolve(locals, perm))) {
             res.status(403).json({ error: { code: 'forbidden', message: 'You do not have permission to perform this action' } });
             return;
         }

--- a/packages/server/lib/authz/resolve.shadow.unit.test.ts
+++ b/packages/server/lib/authz/resolve.shadow.unit.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { flags, metrics } from '@nangohq/utils';
+
+import { canReadProdSecret, resolve } from './resolve.js';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { DBEnvironment, DBPlan, DBTeam, DBUser } from '@nangohq/types';
+import type { MockInstance } from 'vitest';
+
+const account = { id: 1 } as DBTeam;
+const environment = { id: 5, account_id: 1, is_production: true } as DBEnvironment;
+const plan = { has_rbac: true } as DBPlan;
+const user = { id: 7, role: 'administrator', email: 'a@b.c' } as DBUser;
+const locals: Partial<RequestLocals> = { account, plan, environment, user };
+
+describe('checks made inside handlers are compared too', () => {
+    const originalFlag = flags.hasAuthRoles;
+    let increment: MockInstance<typeof metrics.increment>;
+    beforeEach(() => {
+        flags.hasAuthRoles = true;
+        increment = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+        flags.hasAuthRoles = originalFlag;
+        increment.mockRestore();
+    });
+
+    const comparisons = () =>
+        increment.mock.calls.filter(([type]) => type === metrics.Types.AUTHZ_ROLE_COMPARISON).map(([, , tags]) => tags as Record<string, string>);
+
+    it('records a comparison for a permission checked outside a route guard', async () => {
+        await resolve(locals, { resource: 'connection_credential', action: 'read', scope: 'production' });
+        expect(comparisons()).toEqual([{ resource: 'connection_credential', action: 'read', tier: 'production', result: 'agree' }]);
+    });
+
+    it('records the secret-key check that only ever runs in a handler', async () => {
+        await canReadProdSecret(locals, environment);
+        expect(comparisons().map((t) => `${t['resource']}/${t['action']}`)).toEqual(['secret_key/read']);
+    });
+
+    it('records nothing extra for a non-production secret read, which never consults the role', async () => {
+        await canReadProdSecret(locals, { is_production: false } as DBEnvironment);
+        expect(comparisons()).toEqual([]);
+    });
+
+    it('records exactly once per check', async () => {
+        await resolve(locals, { resource: 'log', action: 'read', scope: 'production' });
+        expect(comparisons()).toHaveLength(1);
+    });
+});

--- a/packages/server/lib/authz/resolve.ts
+++ b/packages/server/lib/authz/resolve.ts
@@ -2,7 +2,9 @@ import { permissions } from '@nangohq/authz';
 import { flagHasPlan, flags } from '@nangohq/utils';
 
 import { evaluator } from './evaluator.js';
+import { recordRoleDivergence } from './shadow.js';
 
+import type { RequestLocals } from '../utils/express.js';
 import type { AllowedPermissions, Permission, Role } from '@nangohq/types';
 
 /**
@@ -10,7 +12,13 @@ import type { AllowedPermissions, Permission, Role } from '@nangohq/types';
  * Returns true (allowed) when the feature flag is off, no session user exists (API key auth),
  * or the account's plan doesn't have RBAC enabled.
  */
-export async function resolve(locals: { user?: { role: Role }; plan?: { has_rbac: boolean } | null }, permission: Permission): Promise<boolean> {
+export async function resolve(locals: Partial<RequestLocals>, permission: Permission): Promise<boolean> {
+    const allowed = await evaluate(locals, permission);
+    recordRoleDivergence({ locals, permission, legacy: allowed });
+    return allowed;
+}
+
+async function evaluate(locals: Partial<RequestLocals>, permission: Permission): Promise<boolean> {
     if (!flags.hasAuthRoles) return true;
     if (flagHasPlan && (!locals.plan || !locals.plan.has_rbac)) return true;
     const user = locals.user;
@@ -22,10 +30,7 @@ export async function resolve(locals: { user?: { role: Role }; plan?: { has_rbac
  * Check if the current user can read production secrets for the given environment.
  * Non-production environments always allow reading secrets.
  */
-export async function canReadProdSecret(
-    locals: { user?: { role: Role }; plan?: { has_rbac: boolean } | null },
-    environment: { is_production: boolean }
-): Promise<boolean> {
+export async function canReadProdSecret(locals: Partial<RequestLocals>, environment: { is_production: boolean }): Promise<boolean> {
     return !environment.is_production || (await resolve(locals, permissions.canReadProdSecretKey));
 }
 

--- a/packages/server/lib/authz/shadow.ts
+++ b/packages/server/lib/authz/shadow.ts
@@ -74,7 +74,8 @@ export function recordScopeDivergence({
     requiredScopes: readonly CustomerKeyScope[];
     legacy: boolean;
 }): void {
-    const tags = { scope: requiredScopes.join('|') };
+    // `|` and `,` are dogstatsd field separators; a tag value containing either truncates the tag list.
+    const tags = { scope: requiredScopes.join('/') };
 
     const principal = principalFor(locals);
     // Each scope carries its own plane, so a mixed any-of set gets a target per scope.

--- a/packages/server/lib/authz/shadow.unit.test.ts
+++ b/packages/server/lib/authz/shadow.unit.test.ts
@@ -41,6 +41,17 @@ describe('recordScopeDivergence', () => {
         expect(divergences()).toHaveLength(1);
     });
 
+    it('tags an any-of set with no dogstatsd field separator in the value', () => {
+        recordScopeDivergence({
+            locals: localsFor(['environment:*']),
+            requiredScopes: ['environment:connections:read', 'environment:connections:read_credentials'],
+            legacy: true
+        });
+        const tags = increment.mock.calls.map(([, , t]) => t as { scope: string; result: string });
+        expect(tags.every((t) => !/[|,#]/.test(t.scope))).toBe(true);
+        expect(tags.map((t) => t.result)).toEqual(['agree']);
+    });
+
     it('gives each scope in a mixed-plane any-of set its own target', () => {
         const mixed: CustomerKeyScope[] = ['environment:connections:read', 'account:environments:create'];
 


### PR DESCRIPTION
Datadog was truncating the tag on `|`, so I'm changing it to `/`.
Moved `recordRoleDivergece` into `resolve` to catch the in-handler calls to `resolve`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

