### PR TITLE
fix(orchestrator): count rate limited and duplicate tasks as rejected (NAN-6809)

### DIFF
--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -93,7 +93,7 @@ const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter) =>
         if (rateLimitKey) {
             const rateLimit = await rateLimiter.consume(rateLimitKey, 1);
             if (rateLimit.rejected > 0) {
-                metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, 1, { reason: 'rate_limit' });
+                metrics.increment(metrics.Types.ORCH_TASKS_REJECTED, 1, { reason: 'rate_limit' });
                 res.setHeader('Retry-After', Math.max(1, Math.ceil(rateLimit.retryAfterMs / 1000)));
                 res.status(429).json({
                     error: {

--- a/packages/orchestrator/lib/routes/v1/postImmediate.unit.test.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.unit.test.ts
@@ -4,7 +4,7 @@ import getPort from 'get-port';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { InMemorySlidingWindowRateLimiter } from '@nangohq/kvstore';
-import { Ok } from '@nangohq/utils';
+import { metrics, Ok } from '@nangohq/utils';
 
 import { getServer } from '../../server.js';
 
@@ -54,6 +54,19 @@ describe('immediate routes', () => {
             error: { code: 'rate_limit_exceeded', payload: { retryAfterMs: expect.any(Number) } }
         });
         expect(immediate).toHaveBeenCalledTimes(2);
+    });
+
+    it('counts a rate limited task as rejected, not dropped', async () => {
+        const spy = vi.spyOn(metrics, 'increment').mockImplementation(() => {});
+
+        await post('/v1/immediate', buildTask('metric-1', 'metric-key'));
+        await post('/v1/immediate', buildTask('metric-2', 'metric-key'));
+        const limited = await post('/v1/immediate', buildTask('metric-3', 'metric-key'));
+
+        expect(limited.status).toBe(429);
+        expect(spy).toHaveBeenCalledWith(metrics.Types.ORCH_TASKS_REJECTED, 1, { reason: 'rate_limit' });
+        expect(spy).not.toHaveBeenCalledWith(metrics.Types.ORCH_TASKS_DROPPED, expect.anything(), expect.anything());
+        spy.mockRestore();
     });
 
     it('rejects an empty rate limit key', async () => {

--- a/packages/orchestrator/lib/routes/v1/postImmediate.unit.test.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.unit.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 
 import getPort from 'get-port';
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { InMemorySlidingWindowRateLimiter } from '@nangohq/kvstore';
 import { metrics, Ok } from '@nangohq/utils';
@@ -10,6 +10,7 @@ import { getServer } from '../../server.js';
 
 import type { Scheduler } from '@nangohq/scheduler';
 import type { Server } from 'node:http';
+import type { MockInstance } from 'vitest';
 
 const immediate = vi.fn((props: { name: string }) => Promise.resolve(Ok({ id: `task-${props.name}`, retryKey: `retry-${props.name}` })));
 const immediateBatch = vi.fn((propsList: { name: string }[]) =>
@@ -27,12 +28,19 @@ const baseUrl = `http://localhost:${port}`;
 let api: Server;
 
 describe('immediate routes', () => {
+    let metricsSpy: MockInstance | undefined;
+
     beforeAll(() => {
         api = getServer(scheduler, new EventEmitter(), rateLimiter).listen(port);
     });
 
     beforeEach(() => {
         vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        metricsSpy?.mockRestore();
+        metricsSpy = undefined;
     });
 
     afterAll(async () => {
@@ -57,7 +65,7 @@ describe('immediate routes', () => {
     });
 
     it('counts a rate limited task as rejected, not dropped', async () => {
-        const spy = vi.spyOn(metrics, 'increment').mockImplementation(() => {});
+        const spy = (metricsSpy = vi.spyOn(metrics, 'increment').mockImplementation(() => {}));
 
         await post('/v1/immediate', buildTask('metric-1', 'metric-key'));
         await post('/v1/immediate', buildTask('metric-2', 'metric-key'));
@@ -66,7 +74,6 @@ describe('immediate routes', () => {
         expect(limited.status).toBe(429);
         expect(spy).toHaveBeenCalledWith(metrics.Types.ORCH_TASKS_REJECTED, 1, { reason: 'rate_limit' });
         expect(spy).not.toHaveBeenCalledWith(metrics.Types.ORCH_TASKS_DROPPED, expect.anything(), expect.anything());
-        spy.mockRestore();
     });
 
     it('rejects an empty rate limit key', async () => {

--- a/packages/orchestrator/lib/routes/v1/postImmediateBatch.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediateBatch.ts
@@ -95,7 +95,7 @@ const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter) =>
             })
         );
         if (rateLimitedCount > 0) {
-            metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, rateLimitedCount, { reason: 'rate_limit' });
+            metrics.increment(metrics.Types.ORCH_TASKS_REJECTED, rateLimitedCount, { reason: 'rate_limit' });
         }
 
         const admittedEntries = entries.filter((_, index) => admitted[index]);
@@ -133,7 +133,7 @@ const handler = (scheduler: Scheduler, rateLimiter: SlidingWindowRateLimiter) =>
                 }
             }
             if (duplicateCount > 0) {
-                metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, duplicateCount, { reason: 'duplicate' });
+                metrics.increment(metrics.Types.ORCH_TASKS_REJECTED, duplicateCount, { reason: 'duplicate' });
             }
         }
 

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -96,6 +96,7 @@ export enum Types {
 
     ORCH_TASKS_CREATED = 'nango.orch.tasks.created',
     ORCH_TASKS_DROPPED = 'nango.orch.tasks.dropped',
+    ORCH_TASKS_REJECTED = 'nango.orch.tasks.rejected',
     ORCH_TASKS_STARTED = 'nango.orch.tasks.started',
     ORCH_TASKS_SUCCEEDED = 'nango.orch.tasks.succeeded',
     ORCH_TASKS_FAILED = 'nango.orch.tasks.failed',


### PR DESCRIPTION
NAN-6809

Rate limited and duplicate tasks were counted as `nango.orch.tasks.dropped`, which fires the dropped task alert on normal backpressure. Both now go to a new `nango.orch.tasks.rejected` metric with the same `reason` tag.

`nango.orch.tasks.dropped` is left with `task_cap` only.

The alert in nango-environments needs to be updated to match.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

