### PR TITLE
feat(plans): add the growth add-on for pay-as-you-go

### DIFF
--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -17,7 +17,9 @@ import type {
     BillingUpcomingInvoice,
     BillingUsageMetrics,
     DBTeam,
-    GetBillingUsageOpts
+    GetBillingUsageOpts,
+    PlanChangeRequest,
+    PlanUpgradeRequest
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
@@ -88,7 +90,7 @@ export class Billing {
         return await this.client.createSubscription(team, planExternalId);
     }
 
-    async getSubscription(accountId: number): Promise<Result<BillingSubscription | null>> {
+    async getSubscription(accountId: number): Promise<Result<BillingSubscription>> {
         return await this.client.getSubscription(accountId);
     }
 
@@ -120,12 +122,16 @@ export class Billing {
         return await this.client.getUsage(subscriptionId, opts);
     }
 
-    async upgrade(opts: { subscriptionId: string; planExternalId: string }): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
+    async upgrade(opts: PlanUpgradeRequest): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
         return await this.client.upgrade(opts);
     }
 
-    async downgrade(opts: { subscriptionId: string; planExternalId: string }): Promise<Result<void>> {
+    async downgrade(opts: PlanChangeRequest): Promise<Result<void>> {
         return await this.client.downgrade(opts);
+    }
+
+    async endGrowthAddon(opts: { subscriptionId: string; priceIntervalId: string }): Promise<Result<{ growthFeaturesEndsAt: Date | null }>> {
+        return await this.client.endGrowthAddon(opts);
     }
 
     async getPlanById(planId: string): Promise<Result<BillingPlan>> {

--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -18,8 +18,7 @@ import type {
     BillingUsageMetrics,
     DBTeam,
     GetBillingUsageOpts,
-    PlanChangeRequest,
-    PlanUpgradeRequest
+    PlanChangeRequest
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
@@ -122,12 +121,16 @@ export class Billing {
         return await this.client.getUsage(subscriptionId, opts);
     }
 
-    async upgrade(opts: PlanUpgradeRequest): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
+    async upgrade(opts: PlanChangeRequest): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
         return await this.client.upgrade(opts);
     }
 
     async downgrade(opts: PlanChangeRequest): Promise<Result<void>> {
         return await this.client.downgrade(opts);
+    }
+
+    async startGrowthAddon(opts: { subscriptionId: string }): Promise<Result<{ priceIntervalId: string | null }>> {
+        return await this.client.startGrowthAddon(opts);
     }
 
     async endGrowthAddon(opts: { subscriptionId: string; priceIntervalId: string }): Promise<Result<{ growthFeaturesEndsAt: Date | null }>> {

--- a/packages/billing/lib/clients/noop/client.ts
+++ b/packages/billing/lib/clients/noop/client.ts
@@ -13,7 +13,9 @@ import type {
     BillingUpcomingInvoice,
     BillingUsageMetrics,
     DBTeam,
-    GetBillingUsageOpts
+    GetBillingUsageOpts,
+    PlanChangeRequest,
+    PlanUpgradeRequest
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
@@ -62,8 +64,16 @@ export class NoopBillingClient implements BillingClient {
         return Promise.resolve(Ok(stubCustomer(accountId, invoicingDetails)));
     }
 
-    getSubscription(accountId: number): Promise<Result<BillingSubscription | null>> {
-        return Promise.resolve(Ok({ id: `local-sub-${accountId}`, planExternalId: 'free' }));
+    getSubscription(accountId: number): Promise<Result<BillingSubscription>> {
+        return Promise.resolve(
+            Ok({
+                id: `local-sub-${accountId}`,
+                planExternalId: 'free',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
+            })
+        );
     }
 
     getOverdueInvoices(_accountId: number): Promise<Result<BillingOverdueInvoices>> {
@@ -91,18 +101,20 @@ export class NoopBillingClient implements BillingClient {
     }
 
     createSubscription(team: DBTeam, planExternalId: string): Promise<Result<BillingSubscription>> {
-        return Promise.resolve(Ok({ id: `local-sub-${team.id}`, planExternalId }));
+        return Promise.resolve(
+            Ok({ id: `local-sub-${team.id}`, planExternalId, hasGrowthFeatures: false, growthFeaturesEndsAt: null, growthFeaturesPriceIntervalId: null })
+        );
     }
 
     getUsage(_subscriptionId: string, _opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetrics>> {
         return Promise.resolve(Ok({}));
     }
 
-    upgrade(_opts: { subscriptionId: string; planExternalId: string }): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
+    upgrade(_opts: PlanUpgradeRequest): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
         return Promise.resolve(Ok({ pendingChangeId: 'local-pending-change', amountInCents: null }));
     }
 
-    downgrade(_opts: { subscriptionId: string; planExternalId: string }): Promise<Result<void>> {
+    downgrade(_opts: PlanChangeRequest): Promise<Result<void>> {
         return Promise.resolve(Ok(undefined));
     }
 
@@ -110,7 +122,13 @@ export class NoopBillingClient implements BillingClient {
         pendingChangeId: string;
         payment?: { externalId: string; amountCollected: string } | undefined;
     }): Promise<Result<BillingSubscription>> {
-        return Promise.resolve(Ok({ id: 'local-sub', planExternalId: 'free' }));
+        return Promise.resolve(
+            Ok({ id: 'local-sub', planExternalId: 'free', hasGrowthFeatures: false, growthFeaturesEndsAt: null, growthFeaturesPriceIntervalId: null })
+        );
+    }
+
+    endGrowthAddon(_opts: { subscriptionId: string; priceIntervalId: string }): Promise<Result<{ growthFeaturesEndsAt: Date | null }>> {
+        return Promise.resolve(Ok({ growthFeaturesEndsAt: null }));
     }
 
     cancelPendingChanges(_opts: { pendingChangeId: string }): Promise<Result<void>> {

--- a/packages/billing/lib/clients/noop/client.ts
+++ b/packages/billing/lib/clients/noop/client.ts
@@ -14,8 +14,7 @@ import type {
     BillingUsageMetrics,
     DBTeam,
     GetBillingUsageOpts,
-    PlanChangeRequest,
-    PlanUpgradeRequest
+    PlanChangeRequest
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
@@ -110,7 +109,7 @@ export class NoopBillingClient implements BillingClient {
         return Promise.resolve(Ok({}));
     }
 
-    upgrade(_opts: PlanUpgradeRequest): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
+    upgrade(_opts: PlanChangeRequest): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
         return Promise.resolve(Ok({ pendingChangeId: 'local-pending-change', amountInCents: null }));
     }
 
@@ -125,6 +124,10 @@ export class NoopBillingClient implements BillingClient {
         return Promise.resolve(
             Ok({ id: 'local-sub', planExternalId: 'free', hasGrowthFeatures: false, growthFeaturesEndsAt: null, growthFeaturesPriceIntervalId: null })
         );
+    }
+
+    startGrowthAddon(_opts: { subscriptionId: string }): Promise<Result<{ priceIntervalId: string | null }>> {
+        return Promise.resolve(Ok({ priceIntervalId: 'local-price-interval' }));
     }
 
     endGrowthAddon(_opts: { subscriptionId: string; priceIntervalId: string }): Promise<Result<{ growthFeaturesEndsAt: Date | null }>> {

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -1,6 +1,6 @@
 import { uuidv7 } from 'uuidv7';
 
-import { Err, Ok } from '@nangohq/utils';
+import { Err, Ok, report } from '@nangohq/utils';
 
 import { envs } from '../../envs.js';
 import { putOrbCustomerSchema } from './types.js';
@@ -12,6 +12,7 @@ import type {
     BillingInvoicingDetails,
     BillingPeriodCosts,
     BillingSpendAlert,
+    BillingSubscription,
     BillingUpcomingInvoice,
     Result,
     UsageMetric
@@ -243,6 +244,49 @@ export function toOrbPutCustomerPayload(invoicingDetails: BillingInvoicingDetail
     }
 
     return Ok(payload);
+}
+
+/**
+ * Parses Orb's `price_intervals` for the presence of the growth add-on price and its active interval.
+ *
+ * An interval that hasn't started or has already finished gets ignored.
+ */
+export function growthAddonStateFromOrb(
+    priceIntervals: { id?: string; start_date?: string | null; end_date: string | null; price?: { external_price_id?: string | null } | null }[],
+    referenceDate: Date = new Date()
+): Pick<BillingSubscription, 'hasGrowthFeatures' | 'growthFeaturesEndsAt' | 'growthFeaturesPriceIntervalId'> {
+    for (const interval of priceIntervals) {
+        if (interval.price?.external_price_id !== envs.ORB_GROWTH_ADDON_PRICE_ID) {
+            continue;
+        }
+
+        const startsAt = parseOrbDate(interval.start_date, { field: 'start_date', priceIntervalId: interval.id });
+        if (startsAt && startsAt > referenceDate) {
+            continue;
+        }
+
+        const endsAt = parseOrbDate(interval.end_date, { field: 'end_date', priceIntervalId: interval.id });
+        if (endsAt && endsAt <= referenceDate) {
+            continue;
+        }
+
+        return { hasGrowthFeatures: true, growthFeaturesEndsAt: endsAt, growthFeaturesPriceIntervalId: interval.id ?? null };
+    }
+
+    return { hasGrowthFeatures: false, growthFeaturesEndsAt: null, growthFeaturesPriceIntervalId: null };
+}
+
+function parseOrbDate(value: string | null | undefined, context: { field: 'start_date' | 'end_date'; priceIntervalId: string | undefined }): Date | null {
+    if (!value) {
+        return null;
+    }
+    const parsed = new Date(value);
+    // Defensive check: we should never receive an invalid date from Orb.
+    if (Number.isNaN(parsed.getTime())) {
+        report(new Error('orb_unparseable_price_interval_date'), { ...context, value });
+        return null;
+    }
+    return parsed;
 }
 
 export function fromOrbCustomer(orbCustomer: Orb.Customer): BillingCustomer {

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -3,6 +3,7 @@ import { uuidv7 } from 'uuidv7';
 import { Err, Ok, report } from '@nangohq/utils';
 
 import { envs } from '../../envs.js';
+import { growthAddonPriceId } from './catalogue.js';
 import { putOrbCustomerSchema } from './types.js';
 
 import type {
@@ -256,7 +257,7 @@ export function growthAddonStateFromOrb(
     referenceDate: Date = new Date()
 ): Pick<BillingSubscription, 'hasGrowthFeatures' | 'growthFeaturesEndsAt' | 'growthFeaturesPriceIntervalId'> {
     for (const interval of priceIntervals) {
-        if (interval.price?.external_price_id !== envs.ORB_GROWTH_ADDON_PRICE_ID) {
+        if (interval.price?.external_price_id !== growthAddonPriceId) {
             continue;
         }
 

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -7,6 +7,7 @@ import {
     fromOrbCustomer,
     fromOrbPeriodCosts,
     fromOrbUpcomingInvoice,
+    growthAddonStateFromOrb,
     orbAmountToCents,
     orbMetricToUsageMetric,
     toOrbEvent,
@@ -722,5 +723,92 @@ describe('fromOrbPeriodCosts', () => {
         const costs = { data: [bucket([usagePrice(RECORDS_PROD, '0.004')])] };
 
         expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 0 });
+    });
+});
+
+describe('growthAddonStateFromOrb', () => {
+    const NOW = new Date('2026-09-01T00:00:00Z');
+    const addon = (endDate: string | null) => ({ id: 'pi_growth', end_date: endDate, price: { external_price_id: envs.ORB_GROWTH_ADDON_PRICE_ID } });
+    const otherPrice = { end_date: null, price: { external_price_id: 'payg-connections' } };
+
+    it('reports the add-on absent when the subscription only carries other prices', () => {
+        expect(growthAddonStateFromOrb([otherPrice], NOW)).toEqual({
+            hasGrowthFeatures: false,
+            growthFeaturesEndsAt: null,
+            growthFeaturesPriceIntervalId: null
+        });
+    });
+
+    it('reports it active and open-ended when it has no end date', () => {
+        expect(growthAddonStateFromOrb([otherPrice, addon(null)], NOW)).toEqual({
+            hasGrowthFeatures: true,
+            growthFeaturesEndsAt: null,
+            growthFeaturesPriceIntervalId: 'pi_growth'
+        });
+    });
+
+    it('reports it active with the date when removal is scheduled', () => {
+        const state = growthAddonStateFromOrb([addon('2026-10-01T00:00:00Z')], NOW);
+        expect(state).toEqual({
+            hasGrowthFeatures: true,
+            growthFeaturesEndsAt: new Date('2026-10-01T00:00:00Z'),
+            growthFeaturesPriceIntervalId: 'pi_growth'
+        });
+    });
+
+    it('reports it absent once the end date has passed', () => {
+        expect(growthAddonStateFromOrb([addon('2026-08-01T00:00:00Z')], NOW)).toEqual({
+            hasGrowthFeatures: false,
+            growthFeaturesEndsAt: null,
+            growthFeaturesPriceIntervalId: null
+        });
+    });
+
+    it('reports it active with no end date when the end date is unparseable', () => {
+        expect(growthAddonStateFromOrb([addon('not-a-date')], NOW)).toEqual({
+            hasGrowthFeatures: true,
+            growthFeaturesEndsAt: null,
+            growthFeaturesPriceIntervalId: 'pi_growth'
+        });
+    });
+
+    it('reports it active when the start date is unparseable', () => {
+        const started = { id: 'pi_growth', start_date: 'not-a-date', end_date: null, price: { external_price_id: envs.ORB_GROWTH_ADDON_PRICE_ID } };
+        expect(growthAddonStateFromOrb([started], NOW)).toEqual({
+            hasGrowthFeatures: true,
+            growthFeaturesEndsAt: null,
+            growthFeaturesPriceIntervalId: 'pi_growth'
+        });
+    });
+
+    it('reports it absent while the interval has not started yet', () => {
+        const notYetStarted = {
+            id: 'pi_growth',
+            start_date: '2026-10-01T00:00:00Z',
+            end_date: null,
+            price: { external_price_id: envs.ORB_GROWTH_ADDON_PRICE_ID }
+        };
+        expect(growthAddonStateFromOrb([notYetStarted], NOW)).toEqual({
+            hasGrowthFeatures: false,
+            growthFeaturesEndsAt: null,
+            growthFeaturesPriceIntervalId: null
+        });
+    });
+
+    it('reports it active once the interval has started', () => {
+        const started = { id: 'pi_growth', start_date: '2026-08-01T00:00:00Z', end_date: null, price: { external_price_id: envs.ORB_GROWTH_ADDON_PRICE_ID } };
+        expect(growthAddonStateFromOrb([started], NOW)).toEqual({
+            hasGrowthFeatures: true,
+            growthFeaturesEndsAt: null,
+            growthFeaturesPriceIntervalId: 'pi_growth'
+        });
+    });
+
+    it('does not mistake a price with no external id for the add-on', () => {
+        expect(growthAddonStateFromOrb([{ end_date: null, price: { external_price_id: null } }], NOW)).toEqual({
+            hasGrowthFeatures: false,
+            growthFeaturesEndsAt: null,
+            growthFeaturesPriceIntervalId: null
+        });
     });
 });

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -13,6 +13,7 @@ import {
     toOrbEvent,
     toOrbPutCustomerPayload
 } from './adapters.js';
+import { growthAddonPriceId } from './catalogue.js';
 
 import type { BillingEvent, BillingInvoicingDetails } from '@nangohq/types';
 import type Orb from 'orb-billing';
@@ -728,7 +729,7 @@ describe('fromOrbPeriodCosts', () => {
 
 describe('growthAddonStateFromOrb', () => {
     const NOW = new Date('2026-09-01T00:00:00Z');
-    const addon = (endDate: string | null) => ({ id: 'pi_growth', end_date: endDate, price: { external_price_id: envs.ORB_GROWTH_ADDON_PRICE_ID } });
+    const addon = (endDate: string | null) => ({ id: 'pi_growth', end_date: endDate, price: { external_price_id: growthAddonPriceId } });
     const otherPrice = { end_date: null, price: { external_price_id: 'payg-connections' } };
 
     it('reports the add-on absent when the subscription only carries other prices', () => {
@@ -773,7 +774,7 @@ describe('growthAddonStateFromOrb', () => {
     });
 
     it('reports it active when the start date is unparseable', () => {
-        const started = { id: 'pi_growth', start_date: 'not-a-date', end_date: null, price: { external_price_id: envs.ORB_GROWTH_ADDON_PRICE_ID } };
+        const started = { id: 'pi_growth', start_date: 'not-a-date', end_date: null, price: { external_price_id: growthAddonPriceId } };
         expect(growthAddonStateFromOrb([started], NOW)).toEqual({
             hasGrowthFeatures: true,
             growthFeaturesEndsAt: null,
@@ -786,7 +787,7 @@ describe('growthAddonStateFromOrb', () => {
             id: 'pi_growth',
             start_date: '2026-10-01T00:00:00Z',
             end_date: null,
-            price: { external_price_id: envs.ORB_GROWTH_ADDON_PRICE_ID }
+            price: { external_price_id: growthAddonPriceId }
         };
         expect(growthAddonStateFromOrb([notYetStarted], NOW)).toEqual({
             hasGrowthFeatures: false,
@@ -796,7 +797,7 @@ describe('growthAddonStateFromOrb', () => {
     });
 
     it('reports it active once the interval has started', () => {
-        const started = { id: 'pi_growth', start_date: '2026-08-01T00:00:00Z', end_date: null, price: { external_price_id: envs.ORB_GROWTH_ADDON_PRICE_ID } };
+        const started = { id: 'pi_growth', start_date: '2026-08-01T00:00:00Z', end_date: null, price: { external_price_id: growthAddonPriceId } };
         expect(growthAddonStateFromOrb([started], NOW)).toEqual({
             hasGrowthFeatures: true,
             growthFeaturesEndsAt: null,

--- a/packages/billing/lib/clients/orb/catalogue.ts
+++ b/packages/billing/lib/clients/orb/catalogue.ts
@@ -1,0 +1,2 @@
+/** `external_price_id` of the growth add-on price, as registered in Orb. */
+export const growthAddonPriceId = 'growth-add-on';

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -13,6 +13,7 @@ import {
     toOrbEvent,
     toOrbPutCustomerPayload
 } from './adapters.js';
+import { growthAddonPriceId } from './catalogue.js';
 
 import type {
     BillingClient,
@@ -464,7 +465,7 @@ export class OrbClient implements BillingClient {
     async startGrowthAddon(opts: { subscriptionId: string }): Promise<Result<{ priceIntervalId: string | null }>> {
         try {
             const subscription = await this.orbSDK.subscriptions.priceIntervals(opts.subscriptionId, {
-                add: [{ external_price_id: envs.ORB_GROWTH_ADDON_PRICE_ID, start_date: new Date().toISOString() }]
+                add: [{ external_price_id: growthAddonPriceId, start_date: new Date().toISOString() }]
             });
 
             return Ok({ priceIntervalId: growthAddonStateFromOrb(subscription.price_intervals).growthFeaturesPriceIntervalId });

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -28,7 +28,6 @@ import type {
     DBTeam,
     GetBillingUsageOpts,
     PlanChangeRequest,
-    PlanUpgradeRequest,
     Result
 } from '@nangohq/types';
 
@@ -418,7 +417,7 @@ export class OrbClient implements BillingClient {
         }
     }
 
-    async upgrade(opts: PlanUpgradeRequest): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
+    async upgrade(opts: PlanChangeRequest): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
         try {
             // We schedule the upgrade but we don't apply it yet
             // We apply it when the first payment is made to confirm the card
@@ -427,8 +426,7 @@ export class OrbClient implements BillingClient {
                 {
                     change_option: 'immediate', // It will be immediate after first payment
                     auto_collection: true,
-                    external_plan_id: opts.planExternalId,
-                    ...toOrbAddPrices(opts)
+                    external_plan_id: opts.planExternalId
                 },
                 { headers: { 'Create-Pending-Subscription-Change': 'true' } }
             );
@@ -456,6 +454,22 @@ export class OrbClient implements BillingClient {
             });
         } catch (err) {
             return Err(new Error('failed_to_upgrade_customer', { cause: err }));
+        }
+    }
+
+    /**
+     * Attaches the growth add-on price to the subscription, billing from now:
+     * the customer pays for it from the moment they turn it on, prorated by Orb.
+     */
+    async startGrowthAddon(opts: { subscriptionId: string }): Promise<Result<{ priceIntervalId: string | null }>> {
+        try {
+            const subscription = await this.orbSDK.subscriptions.priceIntervals(opts.subscriptionId, {
+                add: [{ external_price_id: envs.ORB_GROWTH_ADDON_PRICE_ID, start_date: new Date().toISOString() }]
+            });
+
+            return Ok({ priceIntervalId: growthAddonStateFromOrb(subscription.price_intervals).growthFeaturesPriceIntervalId });
+        } catch (err) {
+            return Err(new Error('failed_to_start_growth_addon', { cause: err }));
         }
     }
 
@@ -554,11 +568,6 @@ export class OrbClient implements BillingClient {
             return Err(new Error('failed_to_get_plan_by_id', { cause: err }));
         }
     }
-}
-
-function toOrbAddPrices(opts: PlanUpgradeRequest) {
-    // Orb rejects an empty array, so the key is omitted entirely when there is nothing to add
-    return opts.addPriceExternalIds?.length ? { add_prices: opts.addPriceExternalIds.map((id) => ({ external_price_id: id })) } : {};
 }
 
 function isOrbNotFoundError(err: unknown): err is InstanceType<typeof Orb.NotFoundError> {

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -8,6 +8,7 @@ import {
     fromOrbCustomer,
     fromOrbPeriodCosts,
     fromOrbUpcomingInvoice,
+    growthAddonStateFromOrb,
     orbMetricToUsageMetric,
     toOrbEvent,
     toOrbPutCustomerPayload
@@ -26,6 +27,8 @@ import type {
     BillingUsageMetrics,
     DBTeam,
     GetBillingUsageOpts,
+    PlanChangeRequest,
+    PlanUpgradeRequest,
     Result
 } from '@nangohq/types';
 
@@ -149,24 +152,25 @@ export class OrbClient implements BillingClient {
                 external_plan_id: planExternalId,
                 start_date: startDate
             });
-            return Ok({ id: subscription.id, planExternalId: planExternalId });
+            return Ok({ id: subscription.id, planExternalId, ...growthAddonStateFromOrb(subscription.price_intervals) });
         } catch (err) {
             return Err(new Error('failed_to_create_subscription', { cause: err }));
         }
     }
 
-    async getSubscription(accountId: number): Promise<Result<BillingSubscription | null>> {
+    async getSubscription(accountId: number): Promise<Result<BillingSubscription>> {
         try {
             const subs = await this.orbSDK.subscriptions.list({ external_customer_id: [String(accountId)], status: 'active' });
             if (subs.data.length === 0) {
-                return Ok(null);
+                return Err(new Error('failed_to_get_subscription', { cause: 'no active subscription' }));
             }
 
             const sub = subs.data[0]!;
             return Ok({
                 id: sub.id,
                 pendingChangeId: sub.pending_subscription_change?.id,
-                planExternalId: sub.plan?.external_plan_id || ''
+                planExternalId: sub.plan?.external_plan_id || '',
+                ...growthAddonStateFromOrb(sub.price_intervals)
             });
         } catch (err) {
             return Err(new Error('failed_to_get_customer', { cause: err }));
@@ -414,7 +418,7 @@ export class OrbClient implements BillingClient {
         }
     }
 
-    async upgrade(opts: { subscriptionId: string; planExternalId: string }): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
+    async upgrade(opts: PlanUpgradeRequest): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
         try {
             // We schedule the upgrade but we don't apply it yet
             // We apply it when the first payment is made to confirm the card
@@ -423,7 +427,8 @@ export class OrbClient implements BillingClient {
                 {
                     change_option: 'immediate', // It will be immediate after first payment
                     auto_collection: true,
-                    external_plan_id: opts.planExternalId
+                    external_plan_id: opts.planExternalId,
+                    ...toOrbAddPrices(opts)
                 },
                 { headers: { 'Create-Pending-Subscription-Change': 'true' } }
             );
@@ -454,7 +459,22 @@ export class OrbClient implements BillingClient {
         }
     }
 
-    async downgrade(opts: { subscriptionId: string; planExternalId: string }): Promise<Result<void>> {
+    /**
+     * Schedules the disablement of the growth add-on to the end of the term.
+     */
+    async endGrowthAddon(opts: { subscriptionId: string; priceIntervalId: string }): Promise<Result<{ growthFeaturesEndsAt: Date | null }>> {
+        try {
+            const subscription = await this.orbSDK.subscriptions.priceIntervals(opts.subscriptionId, {
+                edit: [{ price_interval_id: opts.priceIntervalId, end_date: 'end_of_term' }]
+            });
+
+            return Ok({ growthFeaturesEndsAt: growthAddonStateFromOrb(subscription.price_intervals).growthFeaturesEndsAt });
+        } catch (err) {
+            return Err(new Error('failed_to_end_growth_addon', { cause: err }));
+        }
+    }
+
+    async downgrade(opts: PlanChangeRequest): Promise<Result<void>> {
         try {
             await this.orbSDK.subscriptions.schedulePlanChange(opts.subscriptionId, {
                 change_option: 'end_of_subscription_term',
@@ -464,7 +484,7 @@ export class OrbClient implements BillingClient {
 
             return Ok(undefined);
         } catch (err) {
-            return Err(new Error('failed_to_upgrade_customer', { cause: err }));
+            return Err(new Error('failed_to_downgrade_customer', { cause: err }));
         }
     }
 
@@ -497,7 +517,8 @@ export class OrbClient implements BillingClient {
 
             return Ok({
                 id: res.subscription.id,
-                planExternalId: res.subscription.plan!.external_plan_id!
+                planExternalId: res.subscription.plan!.external_plan_id!,
+                ...growthAddonStateFromOrb(res.subscription.price_intervals)
             });
         } catch (err) {
             return Err(new Error('failed_to_apply_pending_changes', { cause: err }));
@@ -533,6 +554,11 @@ export class OrbClient implements BillingClient {
             return Err(new Error('failed_to_get_plan_by_id', { cause: err }));
         }
     }
+}
+
+function toOrbAddPrices(opts: PlanUpgradeRequest) {
+    // Orb rejects an empty array, so the key is omitted entirely when there is nothing to add
+    return opts.addPriceExternalIds?.length ? { add_prices: opts.addPriceExternalIds.map((id) => ({ external_price_id: id })) } : {};
 }
 
 function isOrbNotFoundError(err: unknown): err is InstanceType<typeof Orb.NotFoundError> {

--- a/packages/billing/lib/index.ts
+++ b/packages/billing/lib/index.ts
@@ -17,3 +17,4 @@ if (!orbConfigured) {
 export const billing = new Billing(orbConfigured ? new OrbClient() : new NoopBillingClient());
 
 export { getStripe } from './stripe.js';
+export { growthAddonStateFromOrb } from './clients/orb/adapters.js';

--- a/packages/database/lib/migrations/20260829120000_plans_add_growth_addon.cjs
+++ b/packages/database/lib/migrations/20260829120000_plans_add_growth_addon.cjs
@@ -1,0 +1,12 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE plans ADD COLUMN IF NOT EXISTS has_growth_features boolean NOT NULL DEFAULT false`);
+    await knex.raw(`ALTER TABLE plans ADD COLUMN IF NOT EXISTS growth_features_ends_at timestamptz`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/server/lib/controllers/v1/orb/postWebhooks.ts
+++ b/packages/server/lib/controllers/v1/orb/postWebhooks.ts
@@ -91,7 +91,14 @@ type Webhooks =
     | SubscriptionCostExceededEvent;
 
 async function handleWebhook(body: Webhooks): Promise<Result<void>> {
-    logger.info('[orb-hook]', body.type);
+    logger.info('[orb-hook]', {
+        id: body.id,
+        createdAt: body.created_at,
+        type: body.type,
+        subscriptionId: body.subscription.id,
+        accountId: body.subscription.customer.external_customer_id,
+        plan: body.subscription.plan.external_plan_id
+    });
 
     switch (body.type) {
         case 'subscription.started':

--- a/packages/server/lib/controllers/v1/orb/postWebhooks.ts
+++ b/packages/server/lib/controllers/v1/orb/postWebhooks.ts
@@ -1,4 +1,4 @@
-import { billing } from '@nangohq/billing';
+import { billing, growthAddonStateFromOrb } from '@nangohq/billing';
 import db from '@nangohq/database';
 import { accountService, handlePlanChanged, updatePlanByTeam } from '@nangohq/shared';
 import { Err, getLogger, Ok, report } from '@nangohq/utils';
@@ -49,6 +49,7 @@ interface SubscriptionEvent extends BaseWebhookEvent {
         id: string;
         customer: { id: string; external_customer_id: string };
         plan: { id: string; external_plan_id: string };
+        price_intervals: { start_date?: string | null; end_date: string | null; price?: { external_price_id?: string | null } | null }[];
     };
 }
 
@@ -107,10 +108,14 @@ async function handleWebhook(body: Webhooks): Promise<Result<void>> {
             }
 
             logger.info(`Sub started for team "${team.id}"`);
+
+            const growthAddon = growthAddonStateFromOrb(body.subscription.price_intervals);
             const changed = await handlePlanChanged(db.knex, team, {
                 newPlanCode: body.subscription.plan.external_plan_id,
                 orbCustomerId: body.subscription.customer.id,
-                orbSubscriptionId: body.subscription.id
+                orbSubscriptionId: body.subscription.id,
+                hasGrowthFeatures: growthAddon.hasGrowthFeatures,
+                growthFeaturesEndsAt: growthAddon.growthFeaturesEndsAt
             });
 
             if (changed.isErr()) {

--- a/packages/server/lib/controllers/v1/orb/postWebhooks.ts
+++ b/packages/server/lib/controllers/v1/orb/postWebhooks.ts
@@ -1,4 +1,4 @@
-import { billing, growthAddonStateFromOrb } from '@nangohq/billing';
+import { billing } from '@nangohq/billing';
 import db from '@nangohq/database';
 import { accountService, handlePlanChanged, updatePlanByTeam } from '@nangohq/shared';
 import { Err, getLogger, Ok, report } from '@nangohq/utils';
@@ -109,13 +109,10 @@ async function handleWebhook(body: Webhooks): Promise<Result<void>> {
 
             logger.info(`Sub started for team "${team.id}"`);
 
-            const growthAddon = growthAddonStateFromOrb(body.subscription.price_intervals);
             const changed = await handlePlanChanged(db.knex, team, {
                 newPlanCode: body.subscription.plan.external_plan_id,
                 orbCustomerId: body.subscription.customer.id,
-                orbSubscriptionId: body.subscription.id,
-                hasGrowthFeatures: growthAddon.hasGrowthFeatures,
-                growthFeaturesEndsAt: growthAddon.growthFeaturesEndsAt
+                orbSubscriptionId: body.subscription.id
             });
 
             if (changed.isErr()) {

--- a/packages/server/lib/controllers/v1/orb/postWebhooks.ts
+++ b/packages/server/lib/controllers/v1/orb/postWebhooks.ts
@@ -49,7 +49,6 @@ interface SubscriptionEvent extends BaseWebhookEvent {
         id: string;
         customer: { id: string; external_customer_id: string };
         plan: { id: string; external_plan_id: string };
-        price_intervals: { start_date?: string | null; end_date: string | null; price?: { external_price_id?: string | null } | null }[];
     };
 }
 

--- a/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
@@ -802,7 +802,8 @@ describe(`POST ${route}`, () => {
         });
 
         it('should downgrade the plan when the add-on removal is already scheduled', async () => {
-            const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
+            const { plan, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
             await setupPlan({
                 id: plan.id,
                 name: 'pay-as-you-go',
@@ -826,7 +827,7 @@ describe(`POST ${route}`, () => {
             const res = await api.fetch(route, {
                 method: 'POST',
                 query: { env: 'dev' },
-                token: apiKey.secret,
+                session,
                 body: { orbId: 'free', withGrowthFeatures: false }
             });
 

--- a/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
@@ -801,59 +801,38 @@ describe(`POST ${route}`, () => {
             expect(upgradeSpy.mock.invocationCallOrder[0]).toBeLessThan(startGrowthAddonSpy.mock.invocationCallOrder[0]);
         });
 
-        it('should refuse to enable the add-on when an auto-confirmed payment leaves the change pending', async () => {
+        it('should downgrade the plan when the add-on removal is already scheduled', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await setupPlan({ id: plan.id, orb_subscription_id: 'sub_123', stripe_customer_id: 'cus_123', stripe_payment_id: 'pm_123' });
+            await setupPlan({
+                id: plan.id,
+                name: 'pay-as-you-go',
+                has_growth_features: true,
+                growth_features_ends_at: new Date('2026-10-01T00:00:00Z'),
+                orb_subscription_id: 'sub_123',
+                stripe_customer_id: 'cus_123',
+                stripe_payment_id: 'pm_123'
+            });
 
             getSubscriptionSpy.mockResolvedValue(
                 Ok({
                     id: 'sub_123',
-                    planExternalId: 'free',
-                    hasGrowthFeatures: false,
-                    growthFeaturesEndsAt: null,
-                    growthFeaturesPriceIntervalId: null
+                    planExternalId: 'pay-as-you-go',
+                    hasGrowthFeatures: true,
+                    growthFeaturesEndsAt: new Date('2026-10-01T00:00:00Z'),
+                    growthFeaturesPriceIntervalId: 'pi_growth'
                 } satisfies BillingSubscription)
             );
-            upgradeSpy.mockResolvedValue(Ok({ pendingChangeId: 'pending_123', amountInCents: 5000 }));
-            mockPaymentIntentsCreate.mockResolvedValue({ id: 'pi_123', client_secret: 'secret_123', status: 'succeeded' });
 
             const res = await api.fetch(route, {
                 method: 'POST',
                 query: { env: 'dev' },
                 token: apiKey.secret,
-                body: { orbId: 'pay-as-you-go', withGrowthFeatures: true }
+                body: { orbId: 'free', withGrowthFeatures: false }
             });
 
-            isError(res.json);
-            expect(res.res.status).toBe(500);
-            expect(startGrowthAddonSpy).not.toHaveBeenCalled();
-        });
-
-        it('should refuse to enable the add-on when the plan change is still awaiting payment', async () => {
-            const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
-            await setupPlan({ id: plan.id, orb_subscription_id: 'sub_123', stripe_customer_id: 'cus_123', stripe_payment_id: 'pm_123' });
-
-            getSubscriptionSpy.mockResolvedValue(
-                Ok({
-                    id: 'sub_123',
-                    planExternalId: 'free',
-                    hasGrowthFeatures: false,
-                    growthFeaturesEndsAt: null,
-                    growthFeaturesPriceIntervalId: null
-                } satisfies BillingSubscription)
-            );
-            upgradeSpy.mockResolvedValue(Ok({ pendingChangeId: 'pending_123', amountInCents: 5000 }));
-
-            const res = await api.fetch(route, {
-                method: 'POST',
-                query: { env: 'dev' },
-                token: apiKey.secret,
-                body: { orbId: 'pay-as-you-go', withGrowthFeatures: true }
-            });
-
-            isError(res.json);
-            expect(res.res.status).toBe(500);
-            expect(startGrowthAddonSpy).not.toHaveBeenCalled();
+            isSuccess(res.json);
+            expect(downgradeSpy).toHaveBeenCalledWith({ subscriptionId: 'sub_123', planExternalId: 'free' });
+            expect(endGrowthAddonSpy).not.toHaveBeenCalled();
         });
 
         it('should reject a request that changes neither the plan nor the add-on', async () => {

--- a/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
@@ -5,6 +5,7 @@ import db from '@nangohq/database';
 import { getPlan, productTracking, seeders, updatePlan } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
+import { envs } from '../../../../env.js';
 import { authenticateUser, isError, isSuccess, runServer, shouldBeProtected, shouldRequireSessionEnv } from '../../../../utils/tests.js';
 
 import type { BillingSubscription } from '@nangohq/types';
@@ -34,6 +35,7 @@ let api: Awaited<ReturnType<typeof runServer>>;
 let getSubscriptionSpy: any;
 let upgradeSpy: any;
 let downgradeSpy: any;
+let endGrowthAddonSpy: any;
 let cancelPendingChangesSpy: any;
 let applyPendingChangesSpy: any;
 let productTrackingSpy: any;
@@ -46,6 +48,7 @@ describe(`POST ${route}`, () => {
         getSubscriptionSpy = vi.spyOn(billing, 'getSubscription');
         upgradeSpy = vi.spyOn(billing, 'upgrade');
         downgradeSpy = vi.spyOn(billing, 'downgrade');
+        endGrowthAddonSpy = vi.spyOn(billing, 'endGrowthAddon');
         cancelPendingChangesSpy = vi.spyOn(billing.client, 'cancelPendingChanges');
         applyPendingChangesSpy = vi.spyOn(billing.client, 'applyPendingChanges');
         productTrackingSpy = vi.spyOn(productTracking, 'track');
@@ -61,8 +64,11 @@ describe(`POST ${route}`, () => {
         getSubscriptionSpy.mockResolvedValue(Ok(null));
         upgradeSpy.mockResolvedValue(Ok({ pendingChangeId: 'pending_123', amountInCents: 5000 }));
         downgradeSpy.mockResolvedValue(Ok(undefined));
+        endGrowthAddonSpy.mockResolvedValue(Ok({ growthFeaturesEndsAt: new Date('2026-10-01T00:00:00Z') }));
         cancelPendingChangesSpy.mockResolvedValue(Ok(undefined));
-        applyPendingChangesSpy.mockResolvedValue(Ok({ id: 'sub_123', planExternalId: 'pay-as-you-go' }));
+        applyPendingChangesSpy.mockResolvedValue(
+            Ok({ id: 'sub_123', planExternalId: 'pay-as-you-go', hasGrowthFeatures: false, growthFeaturesEndsAt: null, growthFeaturesPriceIntervalId: null })
+        );
         productTrackingSpy.mockImplementation(() => {
             // no-op
         });
@@ -74,7 +80,7 @@ describe(`POST ${route}`, () => {
             const res = await api.fetch(route, {
                 method: 'POST',
                 query: { env: 'dev' },
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             shouldBeProtected(res);
@@ -88,7 +94,7 @@ describe(`POST ${route}`, () => {
                 session,
                 // @ts-expect-error missing env on purpose
                 query: {},
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             shouldRequireSessionEnv(res);
@@ -120,7 +126,7 @@ describe(`POST ${route}`, () => {
                 query: { env: 'dev' },
                 session,
                 // @ts-expect-error extra fields on purpose
-                body: { orbId: 'starter-v2', extraField: 'invalid' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false, extraField: 'invalid' }
             });
 
             isError(res.json);
@@ -135,7 +141,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'invalid-plan-code' }
+                body: { orbId: 'invalid-plan-code', withGrowthFeatures: false }
             });
 
             isError(res.json);
@@ -151,7 +157,7 @@ describe(`POST ${route}`, () => {
                 // @ts-expect-error invalidParam on purpose
                 query: { env: 'dev', invalidParam: 'value' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isError(res.json);
@@ -171,14 +177,14 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isError(res.json);
             expect(res.res.status).toBe(400);
             expect(res.json.error).toStrictEqual({
                 code: 'invalid_body',
-                message: "team doesn't not have a subscription"
+                message: 'team does not have a subscription'
             });
         });
 
@@ -196,7 +202,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isError(res.json);
@@ -212,12 +218,21 @@ describe(`POST ${route}`, () => {
             const session = await authenticateUser(api, user);
             // Ensure plan has subscription
             await setupPlan({ id: plan.id, orb_subscription_id: 'sub_123' });
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'free',
+                    hasGrowthFeatures: false,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: null
+                } satisfies BillingSubscription)
+            );
 
             const res = await api.fetch(route, {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'free' } // Already on free plan
+                body: { orbId: 'free', withGrowthFeatures: false } // Already on free plan
             });
 
             isError(res.json);
@@ -235,20 +250,19 @@ describe(`POST ${route}`, () => {
             const session = await authenticateUser(api, user);
             await setupPlan({ id: plan.id, orb_subscription_id: 'sub_123' });
 
-            getSubscriptionSpy.mockResolvedValue(Ok(null));
+            getSubscriptionSpy.mockResolvedValue(Err(new Error('failed_to_get_subscription', { cause: 'no subscription' })));
 
             const res = await api.fetch(route, {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isError(res.json);
-            expect(res.res.status).toBe(400);
+            expect(res.res.status).toBe(500);
             expect(res.json.error).toStrictEqual({
-                code: 'invalid_body',
-                message: "team doesn't not have a subscription"
+                code: 'server_error'
             });
         });
 
@@ -264,8 +278,11 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123',
-                pendingChangeId: 'pending_123'
+                planExternalId: 'free',
+                pendingChangeId: 'pending_123',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -277,7 +294,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             expect(billing.client.cancelPendingChanges).toHaveBeenCalledWith({ pendingChangeId: 'pending_123' });
@@ -296,9 +313,14 @@ describe(`POST ${route}`, () => {
                 orb_subscription_id: 'sub_123'
             });
 
+            // Orb and the DB have to agree on the current plan, otherwise the sync guard rejects the
+            // request before it ever reaches the transition check this test is about
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'starter-v2',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -307,7 +329,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'growth-v2' }
+                body: { orbId: 'growth-v2', withGrowthFeatures: false }
             });
 
             isError(res.json);
@@ -330,7 +352,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'free',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -339,7 +364,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isError(res.json);
@@ -362,7 +387,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'free',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -375,7 +403,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isSuccess(res.json);
@@ -402,7 +430,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'free',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -415,7 +446,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isSuccess(res.json);
@@ -438,7 +469,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'free',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -451,7 +485,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isSuccess(res.json);
@@ -471,14 +505,22 @@ describe(`POST ${route}`, () => {
                 stripe_payment_id: 'pm_123'
             });
 
-            getSubscriptionSpy.mockResolvedValue(Ok({ id: 'sub_123', planExternalId: 'free' } satisfies BillingSubscription));
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'free',
+                    hasGrowthFeatures: false,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: null
+                } satisfies BillingSubscription)
+            );
             upgradeSpy.mockResolvedValue(Ok({ pendingChangeId: 'pending_123', amountInCents: null }));
 
             const res = await api.fetch(route, {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'pay-as-you-go' }
+                body: { orbId: 'pay-as-you-go', withGrowthFeatures: false }
             });
 
             isSuccess(res.json);
@@ -507,7 +549,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'free',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -519,7 +564,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             // Left for Orb's `expiration_time` and the next attempt's cleanup rather than compensated here
@@ -541,7 +586,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'free',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -551,12 +599,261 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isError(res.json);
             expect(res.res.status).toBe(500);
             expect(res.json.error.code).toBe('server_error');
+        });
+    });
+
+    describe('Growth features add-on', () => {
+        it('should enable add-on while staying on the same plan', async () => {
+            const { plan, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+            await setupPlan({
+                id: plan.id,
+                name: 'pay-as-you-go',
+                orb_subscription_id: 'sub_123',
+                stripe_customer_id: 'cus_123',
+                stripe_payment_id: 'pm_123'
+            });
+
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'pay-as-you-go',
+                    hasGrowthFeatures: false,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: null
+                } satisfies BillingSubscription)
+            );
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                session,
+                body: { orbId: 'pay-as-you-go', withGrowthFeatures: true }
+            });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+
+            // One Orb call carrying the unchanged plan alongside the added price
+            expect(upgradeSpy).toHaveBeenCalledWith({
+                subscriptionId: 'sub_123',
+                planExternalId: 'pay-as-you-go',
+                addPriceExternalIds: [envs.ORB_GROWTH_ADDON_PRICE_ID]
+            });
+        });
+
+        it('should disable add-on at the end of the term rather than immediately', async () => {
+            const { account, plan, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+            await setupPlan({
+                id: plan.id,
+                name: 'pay-as-you-go',
+                has_growth_features: true,
+                orb_subscription_id: 'sub_123',
+                stripe_customer_id: 'cus_123',
+                stripe_payment_id: 'pm_123'
+            });
+
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'pay-as-you-go',
+                    hasGrowthFeatures: true,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: 'pi_growth'
+                } satisfies BillingSubscription)
+            );
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                session,
+                body: { orbId: 'pay-as-you-go', withGrowthFeatures: false }
+            });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+
+            expect(endGrowthAddonSpy).toHaveBeenCalledWith({ subscriptionId: 'sub_123', priceIntervalId: 'pi_growth' });
+            expect(downgradeSpy).not.toHaveBeenCalled();
+            expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+
+            const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+            expect(updated.growth_features_ends_at).toEqual(new Date('2026-10-01T00:00:00Z'));
+            expect(updated.has_growth_features).toBe(true);
+
+            expect(productTrackingSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: 'account:billing:downgraded',
+                    eventProperties: expect.objectContaining({
+                        previousPlan: 'pay-as-you-go',
+                        newPlan: 'pay-as-you-go',
+                        previousGrowthFeatures: true,
+                        newGrowthFeatures: false
+                    })
+                })
+            );
+        });
+
+        it('should end the add-on and then schedule the plan change when both move', async () => {
+            const { plan, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+            await setupPlan({
+                id: plan.id,
+                name: 'pay-as-you-go',
+                has_growth_features: true,
+                orb_subscription_id: 'sub_123',
+                stripe_customer_id: 'cus_123',
+                stripe_payment_id: 'pm_123'
+            });
+
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'pay-as-you-go',
+                    hasGrowthFeatures: true,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: 'pi_growth'
+                } satisfies BillingSubscription)
+            );
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                session,
+                body: { orbId: 'free', withGrowthFeatures: false }
+            });
+
+            isSuccess(res.json);
+            expect(endGrowthAddonSpy).toHaveBeenCalledWith({ subscriptionId: 'sub_123', priceIntervalId: 'pi_growth' });
+            expect(downgradeSpy).toHaveBeenCalledWith({ subscriptionId: 'sub_123', planExternalId: 'free' });
+            expect(endGrowthAddonSpy.mock.invocationCallOrder[0]).toBeLessThan(downgradeSpy.mock.invocationCallOrder[0]);
+        });
+
+        it('should not schedule the plan change when ending the add-on fails', async () => {
+            const { plan, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+            await setupPlan({
+                id: plan.id,
+                name: 'pay-as-you-go',
+                has_growth_features: true,
+                orb_subscription_id: 'sub_123',
+                stripe_customer_id: 'cus_123',
+                stripe_payment_id: 'pm_123'
+            });
+
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'pay-as-you-go',
+                    hasGrowthFeatures: true,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: 'pi_growth'
+                } satisfies BillingSubscription)
+            );
+
+            endGrowthAddonSpy.mockResolvedValue(Err(new Error('failed_to_end_growth_addon')));
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                session,
+                body: { orbId: 'free', withGrowthFeatures: false }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(500);
+            expect(downgradeSpy).not.toHaveBeenCalled();
+        });
+
+        it('should upgrade the plan and enable the add-on in a single change', async () => {
+            const { plan, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+            await setupPlan({ id: plan.id, orb_subscription_id: 'sub_123', stripe_customer_id: 'cus_123', stripe_payment_id: 'pm_123' });
+
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'free',
+                    hasGrowthFeatures: false,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: null
+                } satisfies BillingSubscription)
+            );
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                session,
+                body: { orbId: 'pay-as-you-go', withGrowthFeatures: true }
+            });
+
+            isSuccess(res.json);
+            expect(upgradeSpy).toHaveBeenCalledTimes(1);
+            expect(upgradeSpy).toHaveBeenCalledWith({
+                subscriptionId: 'sub_123',
+                planExternalId: 'pay-as-you-go',
+                addPriceExternalIds: [envs.ORB_GROWTH_ADDON_PRICE_ID]
+            });
+        });
+
+        it('should reject a request that changes neither the plan nor the add-on', async () => {
+            const { plan, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+            await setupPlan({ id: plan.id, name: 'pay-as-you-go', orb_subscription_id: 'sub_123' });
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'pay-as-you-go',
+                    hasGrowthFeatures: false,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: null
+                } satisfies BillingSubscription)
+            );
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                session,
+                body: { orbId: 'pay-as-you-go', withGrowthFeatures: false }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error).toStrictEqual({ code: 'invalid_body', message: 'team is already on this plan' });
+        });
+
+        it('should reject add-on on a plan that cannot carry it', async () => {
+            const { plan, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+            await setupPlan({ id: plan.id, orb_subscription_id: 'sub_123', stripe_customer_id: 'cus_123', stripe_payment_id: 'pm_123' });
+
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'free',
+                    hasGrowthFeatures: false,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: null
+                } satisfies BillingSubscription)
+            );
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                session,
+                body: { orbId: 'starter-v2', withGrowthFeatures: true }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error).toStrictEqual({ code: 'invalid_body', message: 'growth features are not available on this plan' });
         });
     });
 
@@ -574,7 +871,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'starter-v2',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -584,7 +884,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'free' }
+                body: { orbId: 'free', withGrowthFeatures: false }
             });
 
             isSuccess(res.json);
@@ -603,7 +903,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'growth-v2',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -612,7 +915,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isError(res.json);
@@ -635,7 +938,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'starter-v2',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -644,14 +950,14 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'free' }
+                body: { orbId: 'free', withGrowthFeatures: false }
             });
 
             isError(res.json);
             expect(res.res.status).toBe(400);
             expect(res.json.error).toStrictEqual({
                 code: 'invalid_body',
-                message: 'team is already scheduled to be downgraded'
+                message: 'this change is already scheduled'
             });
         });
 
@@ -666,7 +972,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'starter-v2',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -676,7 +985,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'free' }
+                body: { orbId: 'free', withGrowthFeatures: false }
             });
 
             isSuccess(res.json);
@@ -695,7 +1004,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'starter-v2',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -705,7 +1017,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'free' }
+                body: { orbId: 'free', withGrowthFeatures: false }
             });
 
             isError(res.json);
@@ -729,7 +1041,7 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isError(res.json);
@@ -749,7 +1061,10 @@ describe(`POST ${route}`, () => {
 
             const mockSubscription: BillingSubscription = {
                 id: 'sub_123',
-                planExternalId: 'plan_123'
+                planExternalId: 'free',
+                hasGrowthFeatures: false,
+                growthFeaturesEndsAt: null,
+                growthFeaturesPriceIntervalId: null
             };
 
             getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
@@ -761,13 +1076,46 @@ describe(`POST ${route}`, () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 session,
-                body: { orbId: 'starter-v2' }
+                body: { orbId: 'starter-v2', withGrowthFeatures: false }
             });
 
             isError(res.json);
             expect(res.res.status).toBe(500);
             expect(res.json.error.code).toBe('server_error');
             // Left for Orb's `expiration_time` and the next attempt's cleanup rather than compensated here
+            expect(cancelPendingChangesSpy).not.toHaveBeenCalled();
+        });
+
+        it('should return a conflict when Orb and the database disagree', async () => {
+            const { plan, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+            await setupPlan({ id: plan.id, name: 'free', orb_subscription_id: 'sub_123', stripe_customer_id: 'cus_123', stripe_payment_id: 'pm_123' });
+
+            // Orb has already moved the account onto pay-as-you-go; our row still says free
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'pay-as-you-go',
+                    hasGrowthFeatures: false,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: null
+                } satisfies BillingSubscription)
+            );
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                session,
+                body: { orbId: 'pay-as-you-go', withGrowthFeatures: false }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(409);
+            expect(res.json.error.code).toBe('conflict');
+
+            // Nothing was sent to Orb on a baseline we could not trust
+            expect(upgradeSpy).not.toHaveBeenCalled();
+            expect(downgradeSpy).not.toHaveBeenCalled();
             expect(cancelPendingChangesSpy).not.toHaveBeenCalled();
         });
     });

--- a/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
@@ -5,7 +5,6 @@ import db from '@nangohq/database';
 import { getPlan, productTracking, seeders, updatePlan } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
-import { envs } from '../../../../env.js';
 import { authenticateUser, isError, isSuccess, runServer, shouldBeProtected, shouldRequireSessionEnv } from '../../../../utils/tests.js';
 
 import type { BillingSubscription } from '@nangohq/types';
@@ -35,6 +34,7 @@ let api: Awaited<ReturnType<typeof runServer>>;
 let getSubscriptionSpy: any;
 let upgradeSpy: any;
 let downgradeSpy: any;
+let startGrowthAddonSpy: any;
 let endGrowthAddonSpy: any;
 let cancelPendingChangesSpy: any;
 let applyPendingChangesSpy: any;
@@ -48,6 +48,7 @@ describe(`POST ${route}`, () => {
         getSubscriptionSpy = vi.spyOn(billing, 'getSubscription');
         upgradeSpy = vi.spyOn(billing, 'upgrade');
         downgradeSpy = vi.spyOn(billing, 'downgrade');
+        startGrowthAddonSpy = vi.spyOn(billing, 'startGrowthAddon');
         endGrowthAddonSpy = vi.spyOn(billing, 'endGrowthAddon');
         cancelPendingChangesSpy = vi.spyOn(billing.client, 'cancelPendingChanges');
         applyPendingChangesSpy = vi.spyOn(billing.client, 'applyPendingChanges');
@@ -64,6 +65,7 @@ describe(`POST ${route}`, () => {
         getSubscriptionSpy.mockResolvedValue(Ok(null));
         upgradeSpy.mockResolvedValue(Ok({ pendingChangeId: 'pending_123', amountInCents: 5000 }));
         downgradeSpy.mockResolvedValue(Ok(undefined));
+        startGrowthAddonSpy.mockResolvedValue(Ok({ priceIntervalId: 'pi_growth' }));
         endGrowthAddonSpy.mockResolvedValue(Ok({ growthFeaturesEndsAt: new Date('2026-10-01T00:00:00Z') }));
         cancelPendingChangesSpy.mockResolvedValue(Ok(undefined));
         applyPendingChangesSpy.mockResolvedValue(
@@ -640,12 +642,8 @@ describe(`POST ${route}`, () => {
             isSuccess(res.json);
             expect(res.res.status).toBe(200);
 
-            // One Orb call carrying the unchanged plan alongside the added price
-            expect(upgradeSpy).toHaveBeenCalledWith({
-                subscriptionId: 'sub_123',
-                planExternalId: 'pay-as-you-go',
-                addPriceExternalIds: [envs.ORB_GROWTH_ADDON_PRICE_ID]
-            });
+            expect(startGrowthAddonSpy).toHaveBeenCalledWith({ subscriptionId: 'sub_123' });
+            expect(upgradeSpy).not.toHaveBeenCalled();
         });
 
         it('should disable add-on at the end of the term rather than immediately', async () => {
@@ -787,6 +785,8 @@ describe(`POST ${route}`, () => {
                 } satisfies BillingSubscription)
             );
 
+            upgradeSpy.mockResolvedValue(Ok({ pendingChangeId: 'pending_123', amountInCents: null }));
+
             const res = await api.fetch(route, {
                 method: 'POST',
                 query: { env: 'dev' },
@@ -796,11 +796,64 @@ describe(`POST ${route}`, () => {
 
             isSuccess(res.json);
             expect(upgradeSpy).toHaveBeenCalledTimes(1);
-            expect(upgradeSpy).toHaveBeenCalledWith({
-                subscriptionId: 'sub_123',
-                planExternalId: 'pay-as-you-go',
-                addPriceExternalIds: [envs.ORB_GROWTH_ADDON_PRICE_ID]
+            expect(upgradeSpy).toHaveBeenCalledWith({ subscriptionId: 'sub_123', planExternalId: 'pay-as-you-go' });
+            expect(startGrowthAddonSpy).toHaveBeenCalledWith({ subscriptionId: 'sub_123' });
+            expect(upgradeSpy.mock.invocationCallOrder[0]).toBeLessThan(startGrowthAddonSpy.mock.invocationCallOrder[0]);
+        });
+
+        it('should refuse to enable the add-on when an auto-confirmed payment leaves the change pending', async () => {
+            const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
+            await setupPlan({ id: plan.id, orb_subscription_id: 'sub_123', stripe_customer_id: 'cus_123', stripe_payment_id: 'pm_123' });
+
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'free',
+                    hasGrowthFeatures: false,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: null
+                } satisfies BillingSubscription)
+            );
+            upgradeSpy.mockResolvedValue(Ok({ pendingChangeId: 'pending_123', amountInCents: 5000 }));
+            mockPaymentIntentsCreate.mockResolvedValue({ id: 'pi_123', client_secret: 'secret_123', status: 'succeeded' });
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                token: apiKey.secret,
+                body: { orbId: 'pay-as-you-go', withGrowthFeatures: true }
             });
+
+            isError(res.json);
+            expect(res.res.status).toBe(500);
+            expect(startGrowthAddonSpy).not.toHaveBeenCalled();
+        });
+
+        it('should refuse to enable the add-on when the plan change is still awaiting payment', async () => {
+            const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
+            await setupPlan({ id: plan.id, orb_subscription_id: 'sub_123', stripe_customer_id: 'cus_123', stripe_payment_id: 'pm_123' });
+
+            getSubscriptionSpy.mockResolvedValue(
+                Ok({
+                    id: 'sub_123',
+                    planExternalId: 'free',
+                    hasGrowthFeatures: false,
+                    growthFeaturesEndsAt: null,
+                    growthFeaturesPriceIntervalId: null
+                } satisfies BillingSubscription)
+            );
+            upgradeSpy.mockResolvedValue(Ok({ pendingChangeId: 'pending_123', amountInCents: 5000 }));
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                token: apiKey.secret,
+                body: { orbId: 'pay-as-you-go', withGrowthFeatures: true }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(500);
+            expect(startGrowthAddonSpy).not.toHaveBeenCalled();
         });
 
         it('should reject a request that changes neither the plan nor the add-on', async () => {

--- a/packages/server/lib/controllers/v1/plans/change/postChange.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.ts
@@ -123,11 +123,6 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         }
     }
 
-    // NOTE: changes are ordered so that the impact to an account is mitigated in the face of failure
-    // between operations. Joint operations (eg. upgrade with add-on enabling) can't be carried out
-    // atomically due to a limitation in Orb's api: one can't remove an add-on price via a `schedule_plan_change`
-    // operation; rather it requires a call to `price_intervals`.
-
     if (change.addon === 'disable') {
         const disabled = await disableGrowthAddon(context, sub);
         if (disabled.isErr()) {

--- a/packages/server/lib/controllers/v1/plans/change/postChange.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.ts
@@ -4,7 +4,7 @@ import { billing } from '@nangohq/billing';
 import { plansList } from '@nangohq/shared';
 import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { downgradePlan, upgradePlan } from '../../../../services/planChange.service.js';
+import { downgradePlan, getPlanChangeContext, getPlanChangeDirection, upgradePlan } from '../../../../services/planChange.service.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { PlanChangeError } from '../../../../services/planChange.service.js';
@@ -20,7 +20,31 @@ function sendPlanChangeError(res: PlanChangeResponse, error: PlanChangeError): v
             res.status(400).send({ error: { code: 'invalid_body', message: 'team is not linked to stripe' } });
             return;
         case 'already_scheduled':
-            res.status(400).send({ error: { code: 'invalid_body', message: 'team is already scheduled to be downgraded' } });
+            res.status(400).send({ error: { code: 'invalid_body', message: 'this change is already scheduled' } });
+            return;
+        case 'transition_not_allowed':
+            res.status(400).send({ error: { code: 'invalid_body', message: 'team cannot change to this plan' } });
+            return;
+        case 'no_change_requested':
+            res.status(400).send({ error: { code: 'invalid_body', message: 'team is already on this plan' } });
+            return;
+        case 'out_of_sync':
+            res.status(409).send({ error: { code: 'conflict', message: 'billing state is being reconciled, please try again shortly' } });
+            return;
+        case 'conflicting_directions':
+            res.status(400).send({ error: { code: 'invalid_body', message: 'invalid plan change' } });
+            return;
+        case 'invalid_plan':
+            res.status(400).send({ error: { code: 'invalid_body', message: 'team has an invalid plan' } });
+            return;
+        case 'no_subscription':
+            res.status(400).send({ error: { code: 'invalid_body', message: 'team does not have a subscription' } });
+            return;
+        case 'plan_not_changeable':
+            res.status(400).send({ error: { code: 'invalid_body', message: 'team cannot change plan' } });
+            return;
+        case 'growth_features_unavailable':
+            res.status(400).send({ error: { code: 'invalid_body', message: 'growth features are not available on this plan' } });
             return;
         case 'upgrade_failed':
         case 'downgrade_failed':
@@ -37,7 +61,8 @@ function sendPlanChangeError(res: PlanChangeResponse, error: PlanChangeError): v
 const orbIds = plansList.map((p) => p.code).filter(Boolean) as string[];
 const validation = z
     .object({
-        orbId: z.enum(orbIds as [string, ...string[]])
+        orbId: z.enum(orbIds as [string, ...string[]]),
+        withGrowthFeatures: z.boolean()
     })
     .strict();
 
@@ -58,67 +83,52 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
 
     const { account, plan } = res.locals;
     const body: PostPlanChange['Body'] = val.data;
-    const currentDef = plansList.find((p) => p.code === plan!.name);
-    if (!currentDef) {
-        res.status(400).send({ error: { code: 'invalid_body', message: 'team has an invalid plan' } });
+
+    const resContext = getPlanChangeContext(account, plan, body.orbId, body.withGrowthFeatures);
+    if (resContext.isErr()) {
+        sendPlanChangeError(res, resContext.error);
         return;
     }
-    if (!plan?.orb_subscription_id) {
-        res.status(400).send({ error: { code: 'invalid_body', message: "team doesn't not have a subscription" } });
+    const context = resContext.value;
+
+    const resSub = await billing.getSubscription(account.id);
+    if (resSub.isErr()) {
+        report(resSub.error);
+        res.status(500).send({ error: { code: 'server_error' } });
         return;
     }
-    if (!currentDef.canChange) {
-        res.status(400).send({ error: { code: 'invalid_body', message: 'team cannot change plan' } });
+    const sub = resSub.value;
+
+    const changeDirection = getPlanChangeDirection(context, sub);
+    if (changeDirection.isErr()) {
+        sendPlanChangeError(res, changeDirection.error);
         return;
     }
 
-    const newPlan = plansList.find((p) => p.code === body.orbId)!;
-
-    if (newPlan.code === currentDef.code) {
-        res.status(400).send({ error: { code: 'invalid_body', message: 'team is already on this plan' } });
-        return;
-    }
-
-    const isUpgrade = plansList.filter((p) => currentDef.nextPlan?.includes(p.code))?.find((p) => p.code === body.orbId);
-    const isDowngrade = currentDef.prevPlan?.includes(body.orbId);
-    if (!isUpgrade && !isDowngrade) {
-        res.status(400).send({ error: { code: 'invalid_body', message: 'team cannot change to this plan' } });
-        return;
-    }
-
-    try {
-        const sub = (await billing.getSubscription(account.id)).unwrap();
-        if (!sub) {
-            res.status(400).send({ error: { code: 'invalid_body', message: "team doesn't not have a subscription" } });
+    if (sub.pendingChangeId) {
+        // There is a pending change on Orb already; we must cancel it before moving forward with our change
+        const cancelled = await billing.client.cancelPendingChanges({ pendingChangeId: sub.pendingChangeId });
+        if (cancelled.isErr()) {
+            report(cancelled.error);
+            res.status(500).send({ error: { code: 'server_error' } });
             return;
         }
-
-        // We can't change the plan if there's a pending change; need to cancel it first.
-        if (sub?.pendingChangeId) {
-            (await billing.client.cancelPendingChanges({ pendingChangeId: sub.pendingChangeId })).unwrap();
-        }
-    } catch (err) {
-        res.status(500).send({ error: { code: 'server_error' } });
-        report(err);
-        return;
     }
 
-    const context = { team: account, plan, subscriptionId: plan.orb_subscription_id, newPlanCode: body.orbId };
-
-    if (isUpgrade) {
+    if (changeDirection.value === 'upgrade') {
         const upgraded = await upgradePlan(context);
         if (upgraded.isErr()) {
             sendPlanChangeError(res, upgraded.error);
             return;
         }
 
-        // A pending intent still needs the client to confirm the card; without one, the change is done
+        // A pending intent still needs the client to confirm the card; if it is absent, the change is done
         const { paymentIntent } = upgraded.value;
         res.status(200).send({ data: paymentIntent ? { paymentIntent } : { success: true } });
         return;
     }
 
-    const downgraded = await downgradePlan(context);
+    const downgraded = await downgradePlan(context, sub);
     if (downgraded.isErr()) {
         sendPlanChangeError(res, downgraded.error);
         return;

--- a/packages/server/lib/controllers/v1/plans/change/postChange.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { billing } from '@nangohq/billing';
 import { plansList } from '@nangohq/shared';
-import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { getLogger, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import {
     disableGrowthAddon,
@@ -15,15 +15,30 @@ import {
 } from '../../../../services/planChange.service.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
-import type { PlanChangeError } from '../../../../services/planChange.service.js';
+import type { PlanChangeContext, PlanChangeError, PlanChanges } from '../../../../services/planChange.service.js';
 import type { RequestLocals } from '../../../../utils/express.js';
-import type { PostPlanChange } from '@nangohq/types';
+import type { BillingSubscription, PostPlanChange } from '@nangohq/types';
 import type { Response } from 'express';
 import type Stripe from 'stripe';
 
+const logger = getLogger('Server.PostChange');
+
 type PlanChangeResponse = Response<PostPlanChange['Reply'], RequestLocals>;
 
+function logContext(context: PlanChangeContext, subscription: BillingSubscription, changes: PlanChanges) {
+    return {
+        accountId: context.team.id,
+        currentPlan: context.currentPlan.name,
+        requestedPlan: context.requested.newPlanCode,
+        requestedWithGrowthAddon: context.requested.withGrowthFeatures,
+        subscriptionId: context.subscriptionId,
+        subscription,
+        changes
+    };
+}
+
 function sendPlanChangeError(res: PlanChangeResponse, error: PlanChangeError): void {
+    report(error);
     switch (error.code) {
         case 'not_linked_to_stripe':
             res.status(400).send({ error: { code: 'invalid_body', message: 'team is not linked to stripe' } });
@@ -104,18 +119,19 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         res.status(500).send({ error: { code: 'server_error' } });
         return;
     }
-    const sub = resSub.value;
+    const subscription = resSub.value;
 
-    const resChange = resolvePlanChange(context, sub);
+    const resChange = resolvePlanChange(context, subscription);
     if (resChange.isErr()) {
         sendPlanChangeError(res, resChange.error);
         return;
     }
-    const change = resChange.value;
+    const changes = resChange.value;
 
-    if (sub.pendingChangeId) {
+    if (subscription.pendingChangeId) {
+        logger.info('Detected pending plan change, canceling it', logContext(context, subscription, changes));
         // There is a pending change on Orb already; we must cancel it before moving forward with our change
-        const cancelled = await billing.client.cancelPendingChanges({ pendingChangeId: sub.pendingChangeId });
+        const cancelled = await billing.client.cancelPendingChanges({ pendingChangeId: subscription.pendingChangeId });
         if (cancelled.isErr()) {
             report(cancelled.error);
             res.status(500).send({ error: { code: 'server_error' } });
@@ -123,8 +139,9 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         }
     }
 
-    if (change.addon === 'disable') {
-        const disabled = await disableGrowthAddon(context, sub);
+    if (changes.addon === 'disable') {
+        logger.info('Disabling growth add-on', logContext(context, subscription, changes));
+        const disabled = await disableGrowthAddon(context, subscription);
         if (disabled.isErr()) {
             sendPlanChangeError(res, disabled.error);
             return;
@@ -132,14 +149,16 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
     }
 
     let paymentIntent: Stripe.PaymentIntent | undefined;
-    if (change.plan === 'upgrade') {
+    if (changes.plan === 'upgrade') {
+        logger.info('Upgrading plan', logContext(context, subscription, changes));
         const upgraded = await upgradePlan(context);
         if (upgraded.isErr()) {
             sendPlanChangeError(res, upgraded.error);
             return;
         }
         paymentIntent = upgraded.value.paymentIntent;
-    } else if (change.plan === 'downgrade') {
+    } else if (changes.plan === 'downgrade') {
+        logger.info('Downgrading plan', logContext(context, subscription, changes));
         const downgraded = await downgradePlan(context);
         if (downgraded.isErr()) {
             sendPlanChangeError(res, downgraded.error);
@@ -147,7 +166,8 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         }
     }
 
-    if (change.addon === 'enable') {
+    if (changes.addon === 'enable') {
+        logger.info('Enabling growth add-on', logContext(context, subscription, changes));
         const enabled = await enableGrowthAddon(context);
         if (enabled.isErr()) {
             sendPlanChangeError(res, enabled.error);
@@ -155,7 +175,7 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         }
     }
 
-    trackPlanChange(context, change);
+    trackPlanChange(context, changes);
 
     res.status(200).send({ data: paymentIntent ? { paymentIntent } : { success: true } });
 });

--- a/packages/server/lib/controllers/v1/plans/change/postChange.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.ts
@@ -4,13 +4,22 @@ import { billing } from '@nangohq/billing';
 import { plansList } from '@nangohq/shared';
 import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { downgradePlan, getPlanChangeContext, getPlanChangeDirection, upgradePlan } from '../../../../services/planChange.service.js';
+import {
+    disableGrowthAddon,
+    downgradePlan,
+    enableGrowthAddon,
+    getPlanChangeContext,
+    resolvePlanChange,
+    trackPlanChange,
+    upgradePlan
+} from '../../../../services/planChange.service.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { PlanChangeError } from '../../../../services/planChange.service.js';
 import type { RequestLocals } from '../../../../utils/express.js';
 import type { PostPlanChange } from '@nangohq/types';
 import type { Response } from 'express';
+import type Stripe from 'stripe';
 
 type PlanChangeResponse = Response<PostPlanChange['Reply'], RequestLocals>;
 
@@ -31,9 +40,6 @@ function sendPlanChangeError(res: PlanChangeResponse, error: PlanChangeError): v
         case 'out_of_sync':
             res.status(409).send({ error: { code: 'conflict', message: 'billing state is being reconciled, please try again shortly' } });
             return;
-        case 'conflicting_directions':
-            res.status(400).send({ error: { code: 'invalid_body', message: 'invalid plan change' } });
-            return;
         case 'invalid_plan':
             res.status(400).send({ error: { code: 'invalid_body', message: 'team has an invalid plan' } });
             return;
@@ -48,6 +54,7 @@ function sendPlanChangeError(res: PlanChangeResponse, error: PlanChangeError): v
             return;
         case 'upgrade_failed':
         case 'downgrade_failed':
+        case 'addon_failed':
             // Already reported with its cause by the service, which has the context to describe it
             res.status(500).send({ error: { code: 'server_error' } });
             return;
@@ -99,11 +106,12 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
     }
     const sub = resSub.value;
 
-    const changeDirection = getPlanChangeDirection(context, sub);
-    if (changeDirection.isErr()) {
-        sendPlanChangeError(res, changeDirection.error);
+    const resChange = resolvePlanChange(context, sub);
+    if (resChange.isErr()) {
+        sendPlanChangeError(res, resChange.error);
         return;
     }
+    const change = resChange.value;
 
     if (sub.pendingChangeId) {
         // There is a pending change on Orb already; we must cancel it before moving forward with our change
@@ -115,24 +123,44 @@ export const postPlanChange = asyncWrapper<PostPlanChange>(async (req, res) => {
         }
     }
 
-    if (changeDirection.value === 'upgrade') {
+    // NOTE: changes are ordered so that the impact to an account is mitigated in the face of failure
+    // between operations. Joint operations (eg. upgrade with add-on enabling) can't be carried out
+    // atomically due to a limitation in Orb's api: one can't remove an add-on price via a `schedule_plan_change`
+    // operation; rather it requires a call to `price_intervals`.
+
+    if (change.addon === 'disable') {
+        const disabled = await disableGrowthAddon(context, sub);
+        if (disabled.isErr()) {
+            sendPlanChangeError(res, disabled.error);
+            return;
+        }
+    }
+
+    let paymentIntent: Stripe.PaymentIntent | undefined;
+    if (change.plan === 'upgrade') {
         const upgraded = await upgradePlan(context);
         if (upgraded.isErr()) {
             sendPlanChangeError(res, upgraded.error);
             return;
         }
-
-        // A pending intent still needs the client to confirm the card; if it is absent, the change is done
-        const { paymentIntent } = upgraded.value;
-        res.status(200).send({ data: paymentIntent ? { paymentIntent } : { success: true } });
-        return;
+        paymentIntent = upgraded.value.paymentIntent;
+    } else if (change.plan === 'downgrade') {
+        const downgraded = await downgradePlan(context);
+        if (downgraded.isErr()) {
+            sendPlanChangeError(res, downgraded.error);
+            return;
+        }
     }
 
-    const downgraded = await downgradePlan(context, sub);
-    if (downgraded.isErr()) {
-        sendPlanChangeError(res, downgraded.error);
-        return;
+    if (change.addon === 'enable') {
+        const enabled = await enableGrowthAddon(context);
+        if (enabled.isErr()) {
+            sendPlanChangeError(res, enabled.error);
+            return;
+        }
     }
 
-    res.status(200).send({ data: { success: true } });
+    trackPlanChange(context, change);
+
+    res.status(200).send({ data: paymentIntent ? { paymentIntent } : { success: true } });
 });

--- a/packages/server/lib/controllers/v1/stripe/postWebhooks.ts
+++ b/packages/server/lib/controllers/v1/stripe/postWebhooks.ts
@@ -165,8 +165,8 @@ async function handleWebhook(event: Stripe.Event, stripe: Stripe): Promise<Resul
             }
 
             const sub = resSub.value;
-            if (!sub || !sub.pendingChangeId) {
-                return Err("team doesn't not have a subscription or pending changes");
+            if (!sub.pendingChangeId) {
+                return Err('team has no pending subscription change');
             }
 
             const team = await accountService.getAccountById(db.knex, plan.account_id);
@@ -204,8 +204,8 @@ async function handleWebhook(event: Stripe.Event, stripe: Stripe): Promise<Resul
                 return Err(resSub.error);
             }
             const sub = resSub.value;
-            if (!sub || !sub.pendingChangeId) {
-                return Err("team doesn't not have a subscription or pending changes");
+            if (!sub.pendingChangeId) {
+                return Err('team has no pending subscription change');
             }
 
             const resCancel = await billing.client.cancelPendingChanges({

--- a/packages/server/lib/formatters/plan.ts
+++ b/packages/server/lib/formatters/plan.ts
@@ -8,6 +8,7 @@ export function planToApi(plan: DBPlan): ApiPlan {
         trial_end_notified_at: plan.trial_end_notified_at ? plan.trial_end_notified_at.toISOString() : null,
         orb_future_plan_at: plan.orb_future_plan_at?.toISOString() || null,
         orb_subscribed_at: plan.orb_subscribed_at?.toISOString() || null,
+        growth_features_ends_at: plan.growth_features_ends_at?.toISOString() || null,
         created_at: plan.created_at.toISOString(),
         updated_at: plan.updated_at.toISOString()
     };

--- a/packages/server/lib/services/planChange.service.ts
+++ b/packages/server/lib/services/planChange.service.ts
@@ -1,16 +1,47 @@
 import { billing, getStripe } from '@nangohq/billing';
 import db from '@nangohq/database';
-import { handlePlanChanged, productTracking } from '@nangohq/shared';
+import { canHaveGrowthAddon, getPlanDefinition, handlePlanChanged, productTracking, updatePlanByTeam } from '@nangohq/shared';
 import { Err, getLogger, Ok, report } from '@nangohq/utils';
 
+import { envs } from '../env.js';
 import { clearSpendAlertOnPlanChange } from './spendAlertNotification.service.js';
 
-import type { DBPlan, DBTeam, Result } from '@nangohq/types';
+import type { BillingSubscription, DBPlan, DBTeam, PlanDefinition, Result } from '@nangohq/types';
 import type Stripe from 'stripe';
 
 const logger = getLogger('Server.PlanChange');
 
-export type PlanChangeErrorCode = 'not_linked_to_stripe' | 'already_scheduled' | 'upgrade_failed' | 'downgrade_failed';
+export interface PlanUpgradeResult {
+    paymentIntent?: Stripe.PaymentIntent | undefined;
+}
+
+export interface PlanChangeContext {
+    team: DBTeam;
+    currentPlan: DBPlan;
+    currentPlanDefinition: PlanDefinition;
+    subscriptionId: string;
+    requested: {
+        /** Orb external plan id. */
+        newPlanCode: string;
+        /** Whether growth features should be enabled. */
+        withGrowthFeatures: boolean;
+    };
+}
+
+export type PlanChangeDirection = 'upgrade' | 'downgrade';
+export type PlanChangeErrorCode =
+    | 'invalid_plan'
+    | 'no_subscription'
+    | 'plan_not_changeable'
+    | 'out_of_sync'
+    | 'transition_not_allowed'
+    | 'no_change_requested'
+    | 'conflicting_directions'
+    | 'growth_features_unavailable'
+    | 'not_linked_to_stripe'
+    | 'already_scheduled'
+    | 'upgrade_failed'
+    | 'downgrade_failed';
 
 export class PlanChangeError extends Error {
     constructor(
@@ -21,16 +52,92 @@ export class PlanChangeError extends Error {
     }
 }
 
-export interface PlanChangeContext {
-    team: DBTeam;
-    plan: DBPlan;
-    subscriptionId: string;
-    /** Orb external plan id. */
-    newPlanCode: string;
+export function getPlanChangeContext(
+    team: DBTeam,
+    currentPlan: DBPlan | null,
+    newPlanCode: string,
+    withGrowthFeatures: boolean
+): Result<PlanChangeContext, PlanChangeError> {
+    const definition = currentPlan ? getPlanDefinition(currentPlan.name) : null;
+    if (!currentPlan || !definition) {
+        return Err(new PlanChangeError('invalid_plan'));
+    }
+    if (!currentPlan.orb_subscription_id) {
+        return Err(new PlanChangeError('no_subscription'));
+    }
+    if (!definition.canChange) {
+        return Err(new PlanChangeError('plan_not_changeable'));
+    }
+
+    return Ok({
+        team,
+        currentPlan: currentPlan,
+        currentPlanDefinition: definition,
+        subscriptionId: currentPlan.orb_subscription_id,
+        requested: {
+            newPlanCode: newPlanCode,
+            withGrowthFeatures
+        }
+    });
 }
 
-export interface PlanUpgradeResult {
-    paymentIntent?: Stripe.PaymentIntent | undefined;
+export function getPlanChangeDirection(context: PlanChangeContext, subscription: BillingSubscription): Result<PlanChangeDirection, PlanChangeError> {
+    const { currentPlan, currentPlanDefinition, subscriptionId, requested } = context;
+
+    // Our record is a mirror of Orb's, so if it drifts, fail loudly rather than attempting the plan change
+    if (
+        subscription.id !== subscriptionId ||
+        subscription.planExternalId !== currentPlan.name ||
+        subscription.hasGrowthFeatures !== currentPlan.has_growth_features
+    ) {
+        return Err(new PlanChangeError('out_of_sync'));
+    }
+
+    if (requested.withGrowthFeatures && !canHaveGrowthAddon(requested.newPlanCode as DBPlan['name'])) {
+        return Err(new PlanChangeError('growth_features_unavailable'));
+    }
+
+    let planDirection: PlanChangeDirection | null = null;
+    if (requested.newPlanCode !== currentPlanDefinition.code) {
+        if (currentPlanDefinition.nextPlan?.includes(requested.newPlanCode)) {
+            planDirection = 'upgrade';
+        } else if (currentPlanDefinition.prevPlan?.includes(requested.newPlanCode)) {
+            planDirection = 'downgrade';
+        } else {
+            return Err(new PlanChangeError('transition_not_allowed'));
+        }
+    }
+
+    const hasGrowthFeatures = currentPlan.has_growth_features;
+    const growthDirection: PlanChangeDirection | null =
+        requested.withGrowthFeatures === hasGrowthFeatures ? null : requested.withGrowthFeatures ? 'upgrade' : 'downgrade';
+
+    // A scheduled downgrade for the growth add-on should not block plan downgrades.
+    if (!planDirection && growthDirection === 'downgrade' && subscription.growthFeaturesEndsAt) {
+        return Err(new PlanChangeError('already_scheduled'));
+    }
+
+    if (planDirection === 'downgrade' && requested.newPlanCode === currentPlan.orb_future_plan) {
+        return Err(new PlanChangeError('already_scheduled'));
+    }
+
+    if (!planDirection && !growthDirection) {
+        return Err(new PlanChangeError('no_change_requested'));
+    }
+
+    if (planDirection && growthDirection && planDirection !== growthDirection) {
+        return Err(new PlanChangeError('conflicting_directions'));
+    }
+
+    return Ok(planDirection ?? growthDirection!);
+}
+
+/**
+ * Produces the Orb external price IDs to attach for an upgrade.
+ */
+export function withAddonChanges(context: PlanChangeContext): { addPriceExternalIds: string[] } {
+    const { currentPlan, requested } = context;
+    return { addPriceExternalIds: requested.withGrowthFeatures && !currentPlan.has_growth_features ? [envs.ORB_GROWTH_ADDON_PRICE_ID] : [] };
 }
 
 /**
@@ -59,7 +166,9 @@ export async function applyPendingPlanChange({
 
     const resChanged = await handlePlanChanged(db.knex, team, {
         newPlanCode: subscription.planExternalId,
-        orbSubscriptionId: subscription.id
+        orbSubscriptionId: subscription.id,
+        hasGrowthFeatures: subscription.hasGrowthFeatures,
+        growthFeaturesEndsAt: subscription.growthFeaturesEndsAt
     });
     if (resChanged.isErr()) {
         return Err(new Error('failed_to_sync_applied_plan_change', { cause: resChanged.error }));
@@ -79,15 +188,20 @@ export async function applyPendingPlanChange({
  * Schedules an upgrade in Orb and settles it, either by collecting the base fee or, when there is
  * nothing payable now, by applying the change immediately.
  */
-export async function upgradePlan({ team, plan, subscriptionId, newPlanCode }: PlanChangeContext): Promise<Result<PlanUpgradeResult, PlanChangeError>> {
-    if (!plan.stripe_payment_id || !plan.stripe_customer_id) {
+export async function upgradePlan(context: PlanChangeContext): Promise<Result<PlanUpgradeResult, PlanChangeError>> {
+    const { team, currentPlan, subscriptionId, requested } = context;
+    if (!currentPlan.stripe_payment_id || !currentPlan.stripe_customer_id) {
         return Err(new PlanChangeError('not_linked_to_stripe'));
     }
 
     try {
-        logger.info(`Upgrading ${team.id} to ${newPlanCode}`);
+        logger.info(`Upgrading ${team.id} to ${requested.newPlanCode}${requested.withGrowthFeatures ? ' with growth features' : ''}`);
 
-        const resUpgrade = await billing.upgrade({ subscriptionId, planExternalId: newPlanCode });
+        // NOTE: we always schedule the upgrade as a pending change.
+        // Whether we'll settle the change synchronously or asynchronously (via webhook) depends on whether we need to charge the
+        // customer first (up front vs in-arrears). When charging the customer up front, we rely on Stripe and thus must await
+        // the payment confirmation via webhook.
+        const resUpgrade = await billing.upgrade({ subscriptionId, planExternalId: requested.newPlanCode, ...withAddonChanges(context) });
         if (resUpgrade.isErr()) {
             report(resUpgrade.error);
             return Err(new PlanChangeError('upgrade_failed', { cause: resUpgrade.error }));
@@ -117,8 +231,8 @@ export async function upgradePlan({ team, plan, subscriptionId, newPlanCode }: P
             metadata: { accountUuid: team.uuid },
             amount: Math.round(resUpgrade.value.amountInCents),
             currency: 'usd',
-            customer: plan.stripe_customer_id,
-            payment_method: plan.stripe_payment_id
+            customer: currentPlan.stripe_customer_id,
+            payment_method: currentPlan.stripe_payment_id
         });
 
         return Ok(paymentIntent.status === 'succeeded' ? {} : { paymentIntent });
@@ -129,28 +243,69 @@ export async function upgradePlan({ team, plan, subscriptionId, newPlanCode }: P
 }
 
 /** Schedules a downgrade in Orb, which takes effect at the end of the current term. */
-export async function downgradePlan({ team, plan, subscriptionId, newPlanCode }: PlanChangeContext): Promise<Result<void, PlanChangeError>> {
-    if (newPlanCode === plan.orb_future_plan) {
-        return Err(new PlanChangeError('already_scheduled'));
-    }
+export async function downgradePlan(context: PlanChangeContext, subscription: BillingSubscription): Promise<Result<void, PlanChangeError>> {
+    const { team, currentPlan, subscriptionId, requested } = context;
 
-    if (newPlanCode !== 'free' && (!plan.stripe_payment_id || !plan.stripe_customer_id)) {
+    const planChanged = requested.newPlanCode !== currentPlan.name;
+    const changedToNonFree = planChanged && requested.newPlanCode !== 'free';
+    if (changedToNonFree && (!currentPlan.stripe_payment_id || !currentPlan.stripe_customer_id)) {
         return Err(new PlanChangeError('not_linked_to_stripe'));
     }
 
-    logger.info(`Downgrading ${team.id} to ${newPlanCode}`);
+    if (!requested.withGrowthFeatures && currentPlan.has_growth_features) {
+        logger.info(`Disabling growth add-on for ${team.id}`);
+        const resDisabled = await disableGrowthAddon(context, subscription);
 
-    const resDowngrade = await billing.downgrade({ subscriptionId, planExternalId: newPlanCode });
-    if (resDowngrade.isErr()) {
-        report(resDowngrade.error);
-        return Err(new PlanChangeError('downgrade_failed', { cause: resDowngrade.error }));
+        if (resDisabled?.isErr()) {
+            report(resDisabled.error);
+            return Err(new PlanChangeError('downgrade_failed', { cause: resDisabled.error }));
+        }
+    }
+
+    // End of term, so the customer keeps what they have paid for. Flags only drop once Orb applies it.
+    if (planChanged) {
+        logger.info(`Downgrading ${team.id} to ${requested.newPlanCode}${requested.withGrowthFeatures ? ' with growth features' : ''}`);
+
+        const resDowngrade = await billing.downgrade({ subscriptionId, planExternalId: requested.newPlanCode });
+        if (resDowngrade.isErr()) {
+            report(resDowngrade.error);
+            return Err(new PlanChangeError('downgrade_failed', { cause: resDowngrade.error }));
+        }
     }
 
     productTracking.track({
         name: 'account:billing:downgraded',
         team,
-        eventProperties: { previousPlan: plan.name, newPlan: newPlanCode, orbCustomerId: plan.orb_customer_id }
+        eventProperties: {
+            previousPlan: currentPlan.name,
+            newPlan: requested.newPlanCode,
+            previousGrowthFeatures: currentPlan.has_growth_features,
+            newGrowthFeatures: requested.withGrowthFeatures,
+            orbCustomerId: currentPlan.orb_customer_id
+        }
     });
 
     return Ok(undefined);
+}
+
+async function disableGrowthAddon(context: PlanChangeContext, subscription: BillingSubscription): Promise<Result<void>> {
+    const { team, subscriptionId } = context;
+
+    if (!subscription.growthFeaturesPriceIntervalId) {
+        return Err(new PlanChangeError('downgrade_failed', { cause: `Growth add-on price interval not found in subscription: ${subscriptionId}` }));
+    }
+
+    const resEnd = await billing.endGrowthAddon({ subscriptionId, priceIntervalId: subscription.growthFeaturesPriceIntervalId });
+    if (resEnd.isErr()) {
+        return Err(new PlanChangeError('downgrade_failed', { cause: resEnd.error }));
+    }
+
+    // NOTE: removing the add-on (an external price) from the subscription does not trigger any webhook events
+    // so to reflect the date in which the add-on will be disabled, we must update the plan inline here.
+    const resRecord = await updatePlanByTeam(db.knex, { account_id: team.id, growth_features_ends_at: resEnd.value.growthFeaturesEndsAt });
+    if (resRecord.isErr()) {
+        return Err(new PlanChangeError('downgrade_failed', { cause: resRecord.error }));
+    }
+
+    return Ok();
 }

--- a/packages/server/lib/services/planChange.service.ts
+++ b/packages/server/lib/services/planChange.service.ts
@@ -1,7 +1,7 @@
 import { billing, getStripe } from '@nangohq/billing';
 import db from '@nangohq/database';
 import { canHaveGrowthAddon, getPlanDefinition, handlePlanChanged, productTracking, setGrowthAddon } from '@nangohq/shared';
-import { Err, getLogger, Ok, report } from '@nangohq/utils';
+import { Err, getLogger, Ok } from '@nangohq/utils';
 
 import { clearSpendAlertOnPlanChange } from './spendAlertNotification.service.js';
 
@@ -12,6 +12,7 @@ const logger = getLogger('Server.PlanChange');
 
 export interface PlanUpgradeResult {
     paymentIntent?: Stripe.PaymentIntent | undefined;
+    paymentMode: 'in-arrears' | 'some-up-front';
 }
 
 export interface PlanChangeContext {
@@ -100,7 +101,14 @@ export function resolvePlanChange(context: PlanChangeContext, subscription: Bill
         subscription.planExternalId !== currentPlan.name ||
         subscription.hasGrowthFeatures !== currentPlan.has_growth_features
     ) {
-        return Err(new PlanChangeError('out_of_sync'));
+        return Err(
+            new PlanChangeError('out_of_sync', {
+                cause: {
+                    ours: { subscriptionId, planId: currentPlan.name, hasGrowthFeatures: currentPlan.has_growth_features },
+                    theirs: { subscriptionId: subscription.id, planId: subscription.planExternalId, hasGrowthFeatures: subscription.hasGrowthFeatures }
+                }
+            })
+        );
     }
 
     // The Growth add-on is only available for a subset of the available plans; reject any request to
@@ -200,15 +208,12 @@ export async function upgradePlan(context: PlanChangeContext): Promise<Result<Pl
     }
 
     try {
-        logger.info(`Upgrading ${team.id} to ${requested.newPlanCode}`);
-
         // NOTE: we always schedule the upgrade as a pending change.
         // Whether we'll settle the change synchronously or asynchronously (via webhook) depends on whether we need to charge the
         // customer first (up front vs in-arrears). When charging the customer up front, we rely on Stripe and thus must await
         // the payment confirmation via webhook.
         const resUpgrade = await billing.upgrade({ subscriptionId, planExternalId: requested.newPlanCode });
         if (resUpgrade.isErr()) {
-            report(resUpgrade.error);
             return Err(new PlanChangeError('upgrade_failed', { cause: resUpgrade.error }));
         }
         const pendingChangeId = resUpgrade.value.pendingChangeId;
@@ -216,20 +221,15 @@ export async function upgradePlan(context: PlanChangeContext): Promise<Result<Pl
         if (!resUpgrade.value.amountInCents) {
             // Orb reported no pending payments found, so apply the pending change inline rather than
             // asynchronously (via Stripe's webhook).
-            logger.info(`Nothing to collect upfront, applying ${pendingChangeId} for ${team.id}`);
-
             const applied = await applyPendingPlanChange({ team, pendingChangeId });
             if (applied.isErr()) {
-                report(applied.error);
                 return Err(new PlanChangeError('upgrade_failed', { cause: applied.error }));
             }
 
-            return Ok({});
+            return Ok({ paymentMode: 'in-arrears' });
         }
 
         const stripe = getStripe();
-
-        logger.info(`Asking for base fee ${resUpgrade.value.amountInCents} for ${team.id}`);
 
         // Create a payment intent to confirm the card
         const paymentIntent = await stripe.paymentIntents.create({
@@ -240,26 +240,25 @@ export async function upgradePlan(context: PlanChangeContext): Promise<Result<Pl
             payment_method: currentPlan.stripe_payment_id
         });
 
-        return Ok(paymentIntent.status === 'succeeded' ? {} : { paymentIntent });
+        return Ok({
+            paymentMode: 'some-up-front',
+            ...(paymentIntent.status === 'succeeded' ? {} : { paymentIntent })
+        });
     } catch (err) {
-        report(err);
         return Err(new PlanChangeError('upgrade_failed', { cause: err }));
     }
 }
 
 /** Schedules a downgrade in Orb, which takes effect at the end of the current term. */
 export async function downgradePlan(context: PlanChangeContext): Promise<Result<void, PlanChangeError>> {
-    const { team, currentPlan, subscriptionId, requested } = context;
+    const { currentPlan, subscriptionId, requested } = context;
 
     if (requested.newPlanCode !== 'free' && (!currentPlan.stripe_payment_id || !currentPlan.stripe_customer_id)) {
         return Err(new PlanChangeError('not_linked_to_stripe'));
     }
 
-    logger.info(`Downgrading ${team.id} to ${requested.newPlanCode}`);
-
     const resDowngrade = await billing.downgrade({ subscriptionId, planExternalId: requested.newPlanCode });
     if (resDowngrade.isErr()) {
-        report(resDowngrade.error);
         return Err(new PlanChangeError('downgrade_failed', { cause: resDowngrade.error }));
     }
 
@@ -289,17 +288,13 @@ export function trackPlanChange(context: PlanChangeContext, change: PlanChanges)
 export async function enableGrowthAddon(context: PlanChangeContext): Promise<Result<void, PlanChangeError>> {
     const { team, subscriptionId } = context;
 
-    logger.info(`Enabling growth add-on for ${team.id}`);
-
     const resStart = await billing.startGrowthAddon({ subscriptionId });
     if (resStart.isErr()) {
-        report(resStart.error);
         return Err(new PlanChangeError('addon_failed', { cause: resStart.error }));
     }
 
     const resRecord = await setGrowthAddon(db.knex, team, { hasGrowthFeatures: true });
     if (resRecord.isErr()) {
-        report(resRecord.error);
         return Err(new PlanChangeError('addon_failed', { cause: resRecord.error }));
     }
 
@@ -309,21 +304,17 @@ export async function enableGrowthAddon(context: PlanChangeContext): Promise<Res
 export async function disableGrowthAddon(context: PlanChangeContext, subscription: BillingSubscription): Promise<Result<void, PlanChangeError>> {
     const { team, subscriptionId } = context;
 
-    logger.info(`Disabling growth add-on for ${team.id}`);
-
     if (!subscription.growthFeaturesPriceIntervalId) {
         return Err(new PlanChangeError('addon_failed', { cause: `Growth add-on price interval not found in subscription: ${subscriptionId}` }));
     }
 
     const resEnd = await billing.endGrowthAddon({ subscriptionId, priceIntervalId: subscription.growthFeaturesPriceIntervalId });
     if (resEnd.isErr()) {
-        report(resEnd.error);
         return Err(new PlanChangeError('addon_failed', { cause: resEnd.error }));
     }
 
     const resRecord = await setGrowthAddon(db.knex, team, { hasGrowthFeatures: true, endsAt: resEnd.value.growthFeaturesEndsAt });
     if (resRecord.isErr()) {
-        report(resRecord.error);
         return Err(new PlanChangeError('addon_failed', { cause: resRecord.error }));
     }
 

--- a/packages/server/lib/services/planChange.service.ts
+++ b/packages/server/lib/services/planChange.service.ts
@@ -114,11 +114,17 @@ export function resolvePlanChange(context: PlanChangeContext, subscription: Bill
         }
     }
 
-    const addon: AddonDirection | null =
+    let addon: AddonDirection | null =
         requested.withGrowthFeatures === currentPlan.has_growth_features ? null : requested.withGrowthFeatures ? 'enable' : 'disable';
 
     if (addon === 'disable' && subscription.growthFeaturesEndsAt) {
-        return Err(new PlanChangeError('already_scheduled'));
+        if (!plan) {
+            // if the add-on is being disabled but it's disablement is already scheduled
+            // and no other plan changes were made in the request, there's nothing left to do here.
+            return Err(new PlanChangeError('already_scheduled'));
+        }
+        // otherwise, ignore the add-on change and carry on with the plan change
+        addon = null;
     }
 
     if (plan === 'downgrade' && requested.newPlanCode === currentPlan.orb_future_plan) {

--- a/packages/server/lib/services/planChange.service.ts
+++ b/packages/server/lib/services/planChange.service.ts
@@ -27,12 +27,12 @@ export interface PlanChangeContext {
     };
 }
 
-export type PlanDirection = 'upgrade' | 'downgrade';
-export type AddonDirection = 'enable' | 'disable';
+export type PlanChange = 'upgrade' | 'downgrade';
+export type AddonChange = 'enable' | 'disable';
 
-export interface PlanChangePlan {
-    plan: PlanDirection | null;
-    addon: AddonDirection | null;
+export interface PlanChanges {
+    plan: PlanChange | null;
+    addon: AddonChange | null;
 }
 
 export type PlanChangeErrorCode =
@@ -87,7 +87,11 @@ export function getPlanChangeContext(
     });
 }
 
-export function resolvePlanChange(context: PlanChangeContext, subscription: BillingSubscription): Result<PlanChangePlan, PlanChangeError> {
+function isAddonDisablingScheduled(subscription: BillingSubscription): boolean {
+    return subscription.growthFeaturesEndsAt !== null;
+}
+
+export function resolvePlanChange(context: PlanChangeContext, subscription: BillingSubscription): Result<PlanChanges, PlanChangeError> {
     const { currentPlan, currentPlanDefinition, subscriptionId, requested } = context;
 
     // Our record is a mirror of Orb's, so if it drifts, fail loudly rather than attempting the change
@@ -99,44 +103,50 @@ export function resolvePlanChange(context: PlanChangeContext, subscription: Bill
         return Err(new PlanChangeError('out_of_sync'));
     }
 
+    // The Growth add-on is only available for a subset of the available plans; reject any request to
+    // add it to a plan outside of that set.
     if (requested.withGrowthFeatures && !canHaveGrowthAddon(requested.newPlanCode as DBPlan['name'])) {
         return Err(new PlanChangeError('growth_features_unavailable'));
     }
 
-    let plan: PlanDirection | null = null;
+    // Resolve the plan change direction: to upgrade, downgrade or do nothing.
+    let planChange: PlanChange | null = null;
     if (requested.newPlanCode !== currentPlanDefinition.code) {
         if (currentPlanDefinition.nextPlan?.includes(requested.newPlanCode)) {
-            plan = 'upgrade';
+            planChange = 'upgrade';
         } else if (currentPlanDefinition.prevPlan?.includes(requested.newPlanCode)) {
-            plan = 'downgrade';
+            planChange = 'downgrade';
         } else {
             return Err(new PlanChangeError('transition_not_allowed'));
         }
     }
 
-    let addon: AddonDirection | null =
+    // Resolve the add-on change direction: to enable, disable or do nothing.
+    let addonChange: AddonChange | null =
         requested.withGrowthFeatures === currentPlan.has_growth_features ? null : requested.withGrowthFeatures ? 'enable' : 'disable';
 
-    if (addon === 'disable' && subscription.growthFeaturesEndsAt) {
-        if (!plan) {
-            // if the add-on is being disabled but it's disablement is already scheduled
-            // and no other plan changes were made in the request, there's nothing left to do here.
+    if (addonChange === 'disable' && isAddonDisablingScheduled(subscription)) {
+        if (!planChange) {
+            // If the add-on is being disabled but it's disablement is already scheduled and no other
+            // plan changes were made in the request, there's nothing left to do here.
             return Err(new PlanChangeError('already_scheduled'));
         }
-        // otherwise, ignore the add-on change and carry on with the plan change
-        addon = null;
+        // Otherwise, ignore the request to disable it (as it is already scheduled to disable) so that
+        // the plan change can be fulfilled.
+        addonChange = null;
     }
 
-    if (plan === 'downgrade' && requested.newPlanCode === currentPlan.orb_future_plan) {
+    if (planChange === 'downgrade' && requested.newPlanCode === currentPlan.orb_future_plan) {
         return Err(new PlanChangeError('already_scheduled'));
     }
 
-    if (!plan && !addon) {
+    if (!planChange && !addonChange) {
         return Err(new PlanChangeError('no_change_requested'));
     }
 
-    return Ok({ plan, addon });
+    return Ok({ plan: planChange, addon: addonChange });
 }
+
 /**
  * Applies a pending Orb subscription change and persists the resulting plan in the database.
  *
@@ -256,7 +266,7 @@ export async function downgradePlan(context: PlanChangeContext): Promise<Result<
     return Ok(undefined);
 }
 
-export function trackPlanChange(context: PlanChangeContext, change: PlanChangePlan): void {
+export function trackPlanChange(context: PlanChangeContext, change: PlanChanges): void {
     const { team, currentPlan, requested } = context;
 
     if (change.plan !== 'downgrade' && change.addon !== 'disable') {

--- a/packages/server/lib/services/planChange.service.ts
+++ b/packages/server/lib/services/planChange.service.ts
@@ -1,9 +1,8 @@
 import { billing, getStripe } from '@nangohq/billing';
 import db from '@nangohq/database';
-import { canHaveGrowthAddon, getPlanDefinition, handlePlanChanged, productTracking, updatePlanByTeam } from '@nangohq/shared';
+import { canHaveGrowthAddon, getPlanDefinition, handlePlanChanged, productTracking, setGrowthAddon } from '@nangohq/shared';
 import { Err, getLogger, Ok, report } from '@nangohq/utils';
 
-import { envs } from '../env.js';
 import { clearSpendAlertOnPlanChange } from './spendAlertNotification.service.js';
 
 import type { BillingSubscription, DBPlan, DBTeam, PlanDefinition, Result } from '@nangohq/types';
@@ -28,7 +27,14 @@ export interface PlanChangeContext {
     };
 }
 
-export type PlanChangeDirection = 'upgrade' | 'downgrade';
+export type PlanDirection = 'upgrade' | 'downgrade';
+export type AddonDirection = 'enable' | 'disable';
+
+export interface PlanChangePlan {
+    plan: PlanDirection | null;
+    addon: AddonDirection | null;
+}
+
 export type PlanChangeErrorCode =
     | 'invalid_plan'
     | 'no_subscription'
@@ -36,12 +42,12 @@ export type PlanChangeErrorCode =
     | 'out_of_sync'
     | 'transition_not_allowed'
     | 'no_change_requested'
-    | 'conflicting_directions'
     | 'growth_features_unavailable'
     | 'not_linked_to_stripe'
     | 'already_scheduled'
     | 'upgrade_failed'
-    | 'downgrade_failed';
+    | 'downgrade_failed'
+    | 'addon_failed';
 
 export class PlanChangeError extends Error {
     constructor(
@@ -81,10 +87,10 @@ export function getPlanChangeContext(
     });
 }
 
-export function getPlanChangeDirection(context: PlanChangeContext, subscription: BillingSubscription): Result<PlanChangeDirection, PlanChangeError> {
+export function resolvePlanChange(context: PlanChangeContext, subscription: BillingSubscription): Result<PlanChangePlan, PlanChangeError> {
     const { currentPlan, currentPlanDefinition, subscriptionId, requested } = context;
 
-    // Our record is a mirror of Orb's, so if it drifts, fail loudly rather than attempting the plan change
+    // Our record is a mirror of Orb's, so if it drifts, fail loudly rather than attempting the change
     if (
         subscription.id !== subscriptionId ||
         subscription.planExternalId !== currentPlan.name ||
@@ -97,49 +103,34 @@ export function getPlanChangeDirection(context: PlanChangeContext, subscription:
         return Err(new PlanChangeError('growth_features_unavailable'));
     }
 
-    let planDirection: PlanChangeDirection | null = null;
+    let plan: PlanDirection | null = null;
     if (requested.newPlanCode !== currentPlanDefinition.code) {
         if (currentPlanDefinition.nextPlan?.includes(requested.newPlanCode)) {
-            planDirection = 'upgrade';
+            plan = 'upgrade';
         } else if (currentPlanDefinition.prevPlan?.includes(requested.newPlanCode)) {
-            planDirection = 'downgrade';
+            plan = 'downgrade';
         } else {
             return Err(new PlanChangeError('transition_not_allowed'));
         }
     }
 
-    const hasGrowthFeatures = currentPlan.has_growth_features;
-    const growthDirection: PlanChangeDirection | null =
-        requested.withGrowthFeatures === hasGrowthFeatures ? null : requested.withGrowthFeatures ? 'upgrade' : 'downgrade';
+    const addon: AddonDirection | null =
+        requested.withGrowthFeatures === currentPlan.has_growth_features ? null : requested.withGrowthFeatures ? 'enable' : 'disable';
 
-    // A scheduled downgrade for the growth add-on should not block plan downgrades.
-    if (!planDirection && growthDirection === 'downgrade' && subscription.growthFeaturesEndsAt) {
+    if (addon === 'disable' && subscription.growthFeaturesEndsAt) {
         return Err(new PlanChangeError('already_scheduled'));
     }
 
-    if (planDirection === 'downgrade' && requested.newPlanCode === currentPlan.orb_future_plan) {
+    if (plan === 'downgrade' && requested.newPlanCode === currentPlan.orb_future_plan) {
         return Err(new PlanChangeError('already_scheduled'));
     }
 
-    if (!planDirection && !growthDirection) {
+    if (!plan && !addon) {
         return Err(new PlanChangeError('no_change_requested'));
     }
 
-    if (planDirection && growthDirection && planDirection !== growthDirection) {
-        return Err(new PlanChangeError('conflicting_directions'));
-    }
-
-    return Ok(planDirection ?? growthDirection!);
+    return Ok({ plan, addon });
 }
-
-/**
- * Produces the Orb external price IDs to attach for an upgrade.
- */
-export function withAddonChanges(context: PlanChangeContext): { addPriceExternalIds: string[] } {
-    const { currentPlan, requested } = context;
-    return { addPriceExternalIds: requested.withGrowthFeatures && !currentPlan.has_growth_features ? [envs.ORB_GROWTH_ADDON_PRICE_ID] : [] };
-}
-
 /**
  * Applies a pending Orb subscription change and persists the resulting plan in the database.
  *
@@ -166,9 +157,7 @@ export async function applyPendingPlanChange({
 
     const resChanged = await handlePlanChanged(db.knex, team, {
         newPlanCode: subscription.planExternalId,
-        orbSubscriptionId: subscription.id,
-        hasGrowthFeatures: subscription.hasGrowthFeatures,
-        growthFeaturesEndsAt: subscription.growthFeaturesEndsAt
+        orbSubscriptionId: subscription.id
     });
     if (resChanged.isErr()) {
         return Err(new Error('failed_to_sync_applied_plan_change', { cause: resChanged.error }));
@@ -195,13 +184,13 @@ export async function upgradePlan(context: PlanChangeContext): Promise<Result<Pl
     }
 
     try {
-        logger.info(`Upgrading ${team.id} to ${requested.newPlanCode}${requested.withGrowthFeatures ? ' with growth features' : ''}`);
+        logger.info(`Upgrading ${team.id} to ${requested.newPlanCode}`);
 
         // NOTE: we always schedule the upgrade as a pending change.
         // Whether we'll settle the change synchronously or asynchronously (via webhook) depends on whether we need to charge the
         // customer first (up front vs in-arrears). When charging the customer up front, we rely on Stripe and thus must await
         // the payment confirmation via webhook.
-        const resUpgrade = await billing.upgrade({ subscriptionId, planExternalId: requested.newPlanCode, ...withAddonChanges(context) });
+        const resUpgrade = await billing.upgrade({ subscriptionId, planExternalId: requested.newPlanCode });
         if (resUpgrade.isErr()) {
             report(resUpgrade.error);
             return Err(new PlanChangeError('upgrade_failed', { cause: resUpgrade.error }));
@@ -243,34 +232,29 @@ export async function upgradePlan(context: PlanChangeContext): Promise<Result<Pl
 }
 
 /** Schedules a downgrade in Orb, which takes effect at the end of the current term. */
-export async function downgradePlan(context: PlanChangeContext, subscription: BillingSubscription): Promise<Result<void, PlanChangeError>> {
+export async function downgradePlan(context: PlanChangeContext): Promise<Result<void, PlanChangeError>> {
     const { team, currentPlan, subscriptionId, requested } = context;
 
-    const planChanged = requested.newPlanCode !== currentPlan.name;
-    const changedToNonFree = planChanged && requested.newPlanCode !== 'free';
-    if (changedToNonFree && (!currentPlan.stripe_payment_id || !currentPlan.stripe_customer_id)) {
+    if (requested.newPlanCode !== 'free' && (!currentPlan.stripe_payment_id || !currentPlan.stripe_customer_id)) {
         return Err(new PlanChangeError('not_linked_to_stripe'));
     }
 
-    if (!requested.withGrowthFeatures && currentPlan.has_growth_features) {
-        logger.info(`Disabling growth add-on for ${team.id}`);
-        const resDisabled = await disableGrowthAddon(context, subscription);
+    logger.info(`Downgrading ${team.id} to ${requested.newPlanCode}`);
 
-        if (resDisabled?.isErr()) {
-            report(resDisabled.error);
-            return Err(new PlanChangeError('downgrade_failed', { cause: resDisabled.error }));
-        }
+    const resDowngrade = await billing.downgrade({ subscriptionId, planExternalId: requested.newPlanCode });
+    if (resDowngrade.isErr()) {
+        report(resDowngrade.error);
+        return Err(new PlanChangeError('downgrade_failed', { cause: resDowngrade.error }));
     }
 
-    // End of term, so the customer keeps what they have paid for. Flags only drop once Orb applies it.
-    if (planChanged) {
-        logger.info(`Downgrading ${team.id} to ${requested.newPlanCode}${requested.withGrowthFeatures ? ' with growth features' : ''}`);
+    return Ok(undefined);
+}
 
-        const resDowngrade = await billing.downgrade({ subscriptionId, planExternalId: requested.newPlanCode });
-        if (resDowngrade.isErr()) {
-            report(resDowngrade.error);
-            return Err(new PlanChangeError('downgrade_failed', { cause: resDowngrade.error }));
-        }
+export function trackPlanChange(context: PlanChangeContext, change: PlanChangePlan): void {
+    const { team, currentPlan, requested } = context;
+
+    if (change.plan !== 'downgrade' && change.addon !== 'disable') {
+        return;
     }
 
     productTracking.track({
@@ -284,28 +268,48 @@ export async function downgradePlan(context: PlanChangeContext, subscription: Bi
             orbCustomerId: currentPlan.orb_customer_id
         }
     });
+}
+
+export async function enableGrowthAddon(context: PlanChangeContext): Promise<Result<void, PlanChangeError>> {
+    const { team, subscriptionId } = context;
+
+    logger.info(`Enabling growth add-on for ${team.id}`);
+
+    const resStart = await billing.startGrowthAddon({ subscriptionId });
+    if (resStart.isErr()) {
+        report(resStart.error);
+        return Err(new PlanChangeError('addon_failed', { cause: resStart.error }));
+    }
+
+    const resRecord = await setGrowthAddon(db.knex, team, { hasGrowthFeatures: true });
+    if (resRecord.isErr()) {
+        report(resRecord.error);
+        return Err(new PlanChangeError('addon_failed', { cause: resRecord.error }));
+    }
 
     return Ok(undefined);
 }
 
-async function disableGrowthAddon(context: PlanChangeContext, subscription: BillingSubscription): Promise<Result<void>> {
+export async function disableGrowthAddon(context: PlanChangeContext, subscription: BillingSubscription): Promise<Result<void, PlanChangeError>> {
     const { team, subscriptionId } = context;
 
+    logger.info(`Disabling growth add-on for ${team.id}`);
+
     if (!subscription.growthFeaturesPriceIntervalId) {
-        return Err(new PlanChangeError('downgrade_failed', { cause: `Growth add-on price interval not found in subscription: ${subscriptionId}` }));
+        return Err(new PlanChangeError('addon_failed', { cause: `Growth add-on price interval not found in subscription: ${subscriptionId}` }));
     }
 
     const resEnd = await billing.endGrowthAddon({ subscriptionId, priceIntervalId: subscription.growthFeaturesPriceIntervalId });
     if (resEnd.isErr()) {
-        return Err(new PlanChangeError('downgrade_failed', { cause: resEnd.error }));
+        report(resEnd.error);
+        return Err(new PlanChangeError('addon_failed', { cause: resEnd.error }));
     }
 
-    // NOTE: removing the add-on (an external price) from the subscription does not trigger any webhook events
-    // so to reflect the date in which the add-on will be disabled, we must update the plan inline here.
-    const resRecord = await updatePlanByTeam(db.knex, { account_id: team.id, growth_features_ends_at: resEnd.value.growthFeaturesEndsAt });
+    const resRecord = await setGrowthAddon(db.knex, team, { hasGrowthFeatures: true, endsAt: resEnd.value.growthFeaturesEndsAt });
     if (resRecord.isErr()) {
-        return Err(new PlanChangeError('downgrade_failed', { cause: resRecord.error }));
+        report(resRecord.error);
+        return Err(new PlanChangeError('addon_failed', { cause: resRecord.error }));
     }
 
-    return Ok();
+    return Ok(undefined);
 }

--- a/packages/server/lib/services/planChange.service.unit.test.ts
+++ b/packages/server/lib/services/planChange.service.unit.test.ts
@@ -96,6 +96,18 @@ describe('resolvePlanChange', () => {
         });
     });
 
+    it('lets a plan downgrade through when the add-on removal is already scheduled', () => {
+        const res = resolve({
+            from: 'pay-as-you-go',
+            to: 'free',
+            addonNow: true,
+            addonRequested: false,
+            subscription: { growthFeaturesEndsAt: new Date('2026-10-01') }
+        });
+        // The add-on is already in the requested state, so only the plan moves
+        expect(res.unwrap()).toEqual({ plan: 'downgrade', addon: null });
+    });
+
     it('rejects disabling the add-on when removal is already scheduled', () => {
         const res = resolve({
             from: 'pay-as-you-go',

--- a/packages/server/lib/services/planChange.service.unit.test.ts
+++ b/packages/server/lib/services/planChange.service.unit.test.ts
@@ -2,13 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import { seeders } from '@nangohq/shared';
 
-import { envs } from '../env.js';
-import { getPlanChangeContext, getPlanChangeDirection, withAddonChanges } from './planChange.service.js';
+import { getPlanChangeContext, resolvePlanChange } from './planChange.service.js';
 
-import type { PlanChangeDirection } from './planChange.service.js';
 import type { BillingSubscription, DBPlan, DBTeam, PlanDefinition } from '@nangohq/types';
 
-// getPlanChangeDirection never reads the team; it only rides along in the context
 const team = { id: 1 } as DBTeam;
 
 function planOf(name: PlanDefinition['code'], hasGrowthFeatures: boolean, plan?: Partial<DBPlan>): DBPlan {
@@ -36,7 +33,7 @@ function resolve({
 }) {
     const context = getPlanChangeContext(team, planOf(from, addonNow, plan), to, addonRequested).unwrap();
 
-    return getPlanChangeDirection(context, {
+    return resolvePlanChange(context, {
         id: 'sub_123',
         planExternalId: from,
         hasGrowthFeatures: addonNow,
@@ -46,18 +43,18 @@ function resolve({
     });
 }
 
-describe('getPlanChangeDirection', () => {
+describe('resolvePlanChange', () => {
     it.each([
-        { from: 'free', to: 'pay-as-you-go', expectedDirection: 'upgrade' },
-        { from: 'free', to: 'enterprise', expectedDirection: 'upgrade' },
-        { from: 'pay-as-you-go', to: 'enterprise', expectedDirection: 'upgrade' },
-        { from: 'pay-as-you-go', to: 'free', expectedDirection: 'downgrade' },
-        { from: 'starter-v2', to: 'enterprise', expectedDirection: 'upgrade' },
-        { from: 'starter-v2', to: 'free', expectedDirection: 'downgrade' }
-    ] as { from: PlanDefinition['code']; to: PlanDefinition['code']; expectedDirection: PlanChangeDirection }[])(
-        'resolves $from -> $to as: $expectedDirection',
-        ({ from, to, expectedDirection }) => {
-            expect(resolve({ from, to }).unwrap()).toBe(expectedDirection);
+        { from: 'free', to: 'pay-as-you-go', plan: 'upgrade' },
+        { from: 'free', to: 'enterprise', plan: 'upgrade' },
+        { from: 'pay-as-you-go', to: 'enterprise', plan: 'upgrade' },
+        { from: 'pay-as-you-go', to: 'free', plan: 'downgrade' },
+        { from: 'starter-v2', to: 'enterprise', plan: 'upgrade' },
+        { from: 'starter-v2', to: 'free', plan: 'downgrade' }
+    ] as { from: PlanDefinition['code']; to: PlanDefinition['code']; plan: 'upgrade' | 'downgrade' }[])(
+        'resolves $from -> $to as: $plan',
+        ({ from, to, plan }) => {
+            expect(resolve({ from, to }).unwrap()).toEqual({ plan, addon: null });
         }
     );
 
@@ -77,15 +74,6 @@ describe('getPlanChangeDirection', () => {
         expect(res.isErr() && res.error.code).toBe('out_of_sync');
     });
 
-    it('rejects a downgrade to a plan that is already scheduled', () => {
-        const res = resolve({ from: 'pay-as-you-go', to: 'free', plan: { orb_future_plan: 'free' } });
-        expect(res.isErr() && res.error.code).toBe('already_scheduled');
-    });
-
-    it('allows an upgrade to a plan that is already scheduled', () => {
-        expect(resolve({ from: 'free', to: 'pay-as-you-go', plan: { orb_future_plan: 'pay-as-you-go' } }).unwrap()).toBe('upgrade');
-    });
-
     it('rejects when Orb and the database disagree on the subscription id', () => {
         const res = resolve({ from: 'free', to: 'pay-as-you-go', subscription: { id: 'sub_replaced' } });
         expect(res.isErr() && res.error.code).toBe('out_of_sync');
@@ -96,8 +84,16 @@ describe('getPlanChangeDirection', () => {
         expect(res.isErr() && res.error.code).toBe('out_of_sync');
     });
 
-    it('proceeds when both sides agree', () => {
-        expect(resolve({ from: 'free', to: 'pay-as-you-go' }).unwrap()).toBe('upgrade');
+    it('rejects a downgrade to a plan that is already scheduled', () => {
+        const res = resolve({ from: 'pay-as-you-go', to: 'free', plan: { orb_future_plan: 'free' } });
+        expect(res.isErr() && res.error.code).toBe('already_scheduled');
+    });
+
+    it('allows an upgrade to a plan that is already scheduled', () => {
+        expect(resolve({ from: 'free', to: 'pay-as-you-go', plan: { orb_future_plan: 'pay-as-you-go' } }).unwrap()).toEqual({
+            plan: 'upgrade',
+            addon: null
+        });
     });
 
     it('rejects disabling the add-on when removal is already scheduled', () => {
@@ -111,25 +107,18 @@ describe('getPlanChangeDirection', () => {
         expect(res.isErr() && res.error.code).toBe('already_scheduled');
     });
 
-    it('resolves same plan transitions with add-on enabled as an upgrade', () => {
-        expect(resolve({ from: 'pay-as-you-go', to: 'pay-as-you-go', addonRequested: true }).unwrap()).toBe('upgrade');
+    it('resolves an add-on change on an unchanged plan as add-on only', () => {
+        expect(resolve({ from: 'pay-as-you-go', to: 'pay-as-you-go', addonRequested: true }).unwrap()).toEqual({ plan: null, addon: 'enable' });
+        expect(resolve({ from: 'pay-as-you-go', to: 'pay-as-you-go', addonNow: true }).unwrap()).toEqual({ plan: null, addon: 'disable' });
     });
 
-    it('resolves same plan transitions with add-on disabled as a downgrade', () => {
-        expect(resolve({ from: 'pay-as-you-go', to: 'pay-as-you-go', addonNow: true }).unwrap()).toBe('downgrade');
+    it('resolves a plan change that also moves the add-on as both', () => {
+        expect(resolve({ from: 'free', to: 'pay-as-you-go', addonRequested: true }).unwrap()).toEqual({ plan: 'upgrade', addon: 'enable' });
+        expect(resolve({ from: 'pay-as-you-go', to: 'free', addonNow: true }).unwrap()).toEqual({ plan: 'downgrade', addon: 'disable' });
     });
 
-    it('resolves a plan upgrade that also enables the add-on as an upgrade', () => {
-        expect(resolve({ from: 'free', to: 'pay-as-you-go', addonRequested: true }).unwrap()).toBe('upgrade');
-    });
-
-    it('resolves a plan downgrade that also disables the add-on as a downgrade', () => {
-        expect(resolve({ from: 'pay-as-you-go', to: 'free', addonNow: true }).unwrap()).toBe('downgrade');
-    });
-
-    it('rejects disabling the add-on while upgrading the plan', () => {
-        const res = resolve({ from: 'pay-as-you-go', to: 'enterprise', addonNow: true });
-        expect(res.isErr() && res.error.code).toBe('conflicting_directions');
+    it('resolves dropping the add-on while upgrading the plan as both', () => {
+        expect(resolve({ from: 'pay-as-you-go', to: 'enterprise', addonNow: true }).unwrap()).toEqual({ plan: 'upgrade', addon: 'disable' });
     });
 
     it('rejects enabling the add-on on a plan that cannot carry it', () => {
@@ -140,15 +129,6 @@ describe('getPlanChangeDirection', () => {
     it('rejects a downgrade that would carry the add-on onto a plan that cannot have it', () => {
         const res = resolve({ from: 'pay-as-you-go', to: 'free', addonNow: true, addonRequested: true });
         expect(res.isErr() && res.error.code).toBe('growth_features_unavailable');
-    });
-});
-
-describe('withAddonChanges', () => {
-    const diff = (has: boolean, want: boolean) => withAddonChanges(getPlanChangeContext(team, planOf('pay-as-you-go', has), 'pay-as-you-go', want).unwrap());
-
-    it('adds the price only when it is not already there', () => {
-        expect(diff(false, true)).toEqual({ addPriceExternalIds: [envs.ORB_GROWTH_ADDON_PRICE_ID] });
-        expect(diff(true, true)).toEqual({ addPriceExternalIds: [] });
     });
 });
 

--- a/packages/server/lib/services/planChange.service.unit.test.ts
+++ b/packages/server/lib/services/planChange.service.unit.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+
+import { seeders } from '@nangohq/shared';
+
+import { envs } from '../env.js';
+import { getPlanChangeContext, getPlanChangeDirection, withAddonChanges } from './planChange.service.js';
+
+import type { PlanChangeDirection } from './planChange.service.js';
+import type { BillingSubscription, DBPlan, DBTeam, PlanDefinition } from '@nangohq/types';
+
+// getPlanChangeDirection never reads the team; it only rides along in the context
+const team = { id: 1 } as DBTeam;
+
+function planOf(name: PlanDefinition['code'], hasGrowthFeatures: boolean, plan?: Partial<DBPlan>): DBPlan {
+    return seeders.getTestPlan({ name, has_growth_features: hasGrowthFeatures, orb_subscription_id: 'sub_123', ...plan });
+}
+
+/**
+ * Orb and the database agree by default, which is the state every transition case cares about. The
+ * disagreement cases below override one side deliberately.
+ */
+function resolve({
+    from,
+    to,
+    addonNow = false,
+    addonRequested = false,
+    subscription,
+    plan
+}: {
+    from: PlanDefinition['code'];
+    to: PlanDefinition['code'];
+    addonNow?: boolean;
+    addonRequested?: boolean;
+    subscription?: Partial<BillingSubscription>;
+    plan?: Partial<DBPlan>;
+}) {
+    const context = getPlanChangeContext(team, planOf(from, addonNow, plan), to, addonRequested).unwrap();
+
+    return getPlanChangeDirection(context, {
+        id: 'sub_123',
+        planExternalId: from,
+        hasGrowthFeatures: addonNow,
+        growthFeaturesEndsAt: null,
+        growthFeaturesPriceIntervalId: addonNow ? 'pi_growth' : null,
+        ...subscription
+    });
+}
+
+describe('getPlanChangeDirection', () => {
+    it.each([
+        { from: 'free', to: 'pay-as-you-go', expectedDirection: 'upgrade' },
+        { from: 'free', to: 'enterprise', expectedDirection: 'upgrade' },
+        { from: 'pay-as-you-go', to: 'enterprise', expectedDirection: 'upgrade' },
+        { from: 'pay-as-you-go', to: 'free', expectedDirection: 'downgrade' },
+        { from: 'starter-v2', to: 'enterprise', expectedDirection: 'upgrade' },
+        { from: 'starter-v2', to: 'free', expectedDirection: 'downgrade' }
+    ] as { from: PlanDefinition['code']; to: PlanDefinition['code']; expectedDirection: PlanChangeDirection }[])(
+        'resolves $from -> $to as: $expectedDirection',
+        ({ from, to, expectedDirection }) => {
+            expect(resolve({ from, to }).unwrap()).toBe(expectedDirection);
+        }
+    );
+
+    // The startup deal is granted, never self-served, so free lists it in neither direction
+    it('rejects a transition that is in neither nextPlan nor prevPlan', () => {
+        const res = resolve({ from: 'free', to: 'startup-deal' });
+        expect(res.isErr() && res.error.code).toBe('transition_not_allowed');
+    });
+
+    it.each([{ addon: false }, { addon: true }])('rejects a same plan transition with the add-on unchanged ($addon)', ({ addon }) => {
+        const res = resolve({ from: 'pay-as-you-go', to: 'pay-as-you-go', addonNow: addon, addonRequested: addon });
+        expect(res.isErr() && res.error.code).toBe('no_change_requested');
+    });
+
+    it('rejects when Orb and the database disagree on the plan', () => {
+        const res = resolve({ from: 'free', to: 'pay-as-you-go', subscription: { planExternalId: 'pay-as-you-go' } });
+        expect(res.isErr() && res.error.code).toBe('out_of_sync');
+    });
+
+    it('rejects a downgrade to a plan that is already scheduled', () => {
+        const res = resolve({ from: 'pay-as-you-go', to: 'free', plan: { orb_future_plan: 'free' } });
+        expect(res.isErr() && res.error.code).toBe('already_scheduled');
+    });
+
+    it('allows an upgrade to a plan that is already scheduled', () => {
+        expect(resolve({ from: 'free', to: 'pay-as-you-go', plan: { orb_future_plan: 'pay-as-you-go' } }).unwrap()).toBe('upgrade');
+    });
+
+    it('rejects when Orb and the database disagree on the subscription id', () => {
+        const res = resolve({ from: 'free', to: 'pay-as-you-go', subscription: { id: 'sub_replaced' } });
+        expect(res.isErr() && res.error.code).toBe('out_of_sync');
+    });
+
+    it('rejects when Orb and the database disagree on the add-on', () => {
+        const res = resolve({ from: 'pay-as-you-go', to: 'enterprise', subscription: { hasGrowthFeatures: true } });
+        expect(res.isErr() && res.error.code).toBe('out_of_sync');
+    });
+
+    it('proceeds when both sides agree', () => {
+        expect(resolve({ from: 'free', to: 'pay-as-you-go' }).unwrap()).toBe('upgrade');
+    });
+
+    it('rejects disabling the add-on when removal is already scheduled', () => {
+        const res = resolve({
+            from: 'pay-as-you-go',
+            to: 'pay-as-you-go',
+            addonNow: true,
+            addonRequested: false,
+            subscription: { growthFeaturesEndsAt: new Date('2026-10-01') }
+        });
+        expect(res.isErr() && res.error.code).toBe('already_scheduled');
+    });
+
+    it('resolves same plan transitions with add-on enabled as an upgrade', () => {
+        expect(resolve({ from: 'pay-as-you-go', to: 'pay-as-you-go', addonRequested: true }).unwrap()).toBe('upgrade');
+    });
+
+    it('resolves same plan transitions with add-on disabled as a downgrade', () => {
+        expect(resolve({ from: 'pay-as-you-go', to: 'pay-as-you-go', addonNow: true }).unwrap()).toBe('downgrade');
+    });
+
+    it('resolves a plan upgrade that also enables the add-on as an upgrade', () => {
+        expect(resolve({ from: 'free', to: 'pay-as-you-go', addonRequested: true }).unwrap()).toBe('upgrade');
+    });
+
+    it('resolves a plan downgrade that also disables the add-on as a downgrade', () => {
+        expect(resolve({ from: 'pay-as-you-go', to: 'free', addonNow: true }).unwrap()).toBe('downgrade');
+    });
+
+    it('rejects disabling the add-on while upgrading the plan', () => {
+        const res = resolve({ from: 'pay-as-you-go', to: 'enterprise', addonNow: true });
+        expect(res.isErr() && res.error.code).toBe('conflicting_directions');
+    });
+
+    it('rejects enabling the add-on on a plan that cannot carry it', () => {
+        const res = resolve({ from: 'pay-as-you-go', to: 'free', addonRequested: true });
+        expect(res.isErr() && res.error.code).toBe('growth_features_unavailable');
+    });
+
+    it('rejects a downgrade that would carry the add-on onto a plan that cannot have it', () => {
+        const res = resolve({ from: 'pay-as-you-go', to: 'free', addonNow: true, addonRequested: true });
+        expect(res.isErr() && res.error.code).toBe('growth_features_unavailable');
+    });
+});
+
+describe('withAddonChanges', () => {
+    const diff = (has: boolean, want: boolean) => withAddonChanges(getPlanChangeContext(team, planOf('pay-as-you-go', has), 'pay-as-you-go', want).unwrap());
+
+    it('adds the price only when it is not already there', () => {
+        expect(diff(false, true)).toEqual({ addPriceExternalIds: [envs.ORB_GROWTH_ADDON_PRICE_ID] });
+        expect(diff(true, true)).toEqual({ addPriceExternalIds: [] });
+    });
+});
+
+describe('getPlanChangeContext', () => {
+    const plan = (override: Partial<DBPlan>): DBPlan => seeders.getTestPlan({ orb_subscription_id: 'sub_123', ...override });
+    const context = (p: DBPlan | null, newPlanCode = 'pay-as-you-go', withGrowthFeatures = false) =>
+        getPlanChangeContext(team, p, newPlanCode, withGrowthFeatures);
+
+    it('resolves the team, definition and subscription for a changeable plan', () => {
+        expect(context(plan({ name: 'free' })).unwrap()).toMatchObject({
+            team,
+            currentPlan: { name: 'free' },
+            currentPlanDefinition: { code: 'free' },
+            subscriptionId: 'sub_123'
+        });
+    });
+
+    // The requested state is carried verbatim: whether it is a legal change is getPlanChangeDirection's
+    // question, so nothing here interprets or normalises it.
+    it.each([
+        { newPlanCode: 'pay-as-you-go', withGrowthFeatures: true },
+        { newPlanCode: 'pay-as-you-go', withGrowthFeatures: false },
+        { newPlanCode: 'enterprise', withGrowthFeatures: false },
+        { newPlanCode: 'free', withGrowthFeatures: true }
+    ])('carries the requested $newPlanCode / add-on $withGrowthFeatures through untouched', ({ newPlanCode, withGrowthFeatures }) => {
+        const res = context(plan({ name: 'free' }), newPlanCode, withGrowthFeatures);
+        expect(res.unwrap().requested).toEqual({ newPlanCode, withGrowthFeatures });
+    });
+
+    it('rejects an account with no plan at all', () => {
+        const res = context(null);
+        expect(res.isErr() && res.error.code).toBe('invalid_plan');
+    });
+
+    it('rejects a plan name that matches no definition', () => {
+        const res = context(plan({ name: 'not-a-plan' as DBPlan['name'] }));
+        expect(res.isErr() && res.error.code).toBe('invalid_plan');
+    });
+
+    it('rejects a plan with no orb subscription to change', () => {
+        const res = context(plan({ name: 'free', orb_subscription_id: null }));
+        expect(res.isErr() && res.error.code).toBe('no_subscription');
+    });
+
+    it('rejects a plan the customer cannot change themselves', () => {
+        const res = context(plan({ name: 'enterprise' }));
+        expect(res.isErr() && res.error.code).toBe('plan_not_changeable');
+    });
+});

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -5,6 +5,8 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         id: 1,
         account_id: 1,
         name: 'free',
+        has_growth_features: false,
+        growth_features_ends_at: null,
         stripe_customer_id: null,
         stripe_payment_id: null,
         orb_customer_id: null,

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -385,6 +385,28 @@ export const growthLegacyPlan: PlanDefinition = {
     }
 };
 
+/**
+ * The feature flags the growth add-on grants.
+ *
+ * NOTE: Only the boolean flags are listed here, the numeric limits (e.g. `api_rate_limit_size`, `environments_max`)
+ * are resolved via `mergePlanFlags` following the precedence rules implemented therein.
+ * This is so a hand-granted limit is not pulled back down when the add-on is disabled. */
+type GrowthFeatureFlag = 'has_otel' | 'has_rbac' | 'can_override_docs_connect_url' | 'can_customize_connect_ui_theme' | 'can_disable_connect_ui_watermark';
+
+export const GROWTH_FEATURE_FLAGS = {
+    has_otel: true,
+    has_rbac: true,
+    can_override_docs_connect_url: true,
+    can_customize_connect_ui_theme: true,
+    can_disable_connect_ui_watermark: true
+} satisfies Record<GrowthFeatureFlag, boolean>;
+
+export const PLANS_WITH_GROWTH_ADD_ON: PlanDefinition['code'][] = ['pay-as-you-go'];
+
+export function canHaveGrowthAddon(planCode: PlanDefinition['code']): boolean {
+    return PLANS_WITH_GROWTH_ADD_ON.includes(planCode);
+}
+
 export const plansList: PlanDefinition[] = [
     freePlan,
     freeUncappedPlan,

--- a/packages/shared/lib/services/plans/plans.integration.test.ts
+++ b/packages/shared/lib/services/plans/plans.integration.test.ts
@@ -14,7 +14,12 @@ describe('handlePlanChanged', () => {
     it('reports no change when the plan is already the one requested', async () => {
         const { account, plan } = await seedAccountEnvAndUser();
 
-        const res = await handlePlanChanged(db.knex, account, { newPlanCode: plan.name, orbSubscriptionId: 'orb_sub_1' });
+        const res = await handlePlanChanged(db.knex, account, {
+            newPlanCode: plan.name,
+            orbSubscriptionId: 'orb_sub_1',
+            hasGrowthFeatures: false,
+            growthFeaturesEndsAt: null
+        });
 
         expect(res.unwrap()).toBe(false);
     });
@@ -22,7 +27,12 @@ describe('handlePlanChanged', () => {
     it('reports a change and applies the new plan', async () => {
         const { account } = await seedAccountEnvAndUser();
 
-        const res = await handlePlanChanged(db.knex, account, { newPlanCode: 'growth-v2', orbSubscriptionId: 'orb_sub_2' });
+        const res = await handlePlanChanged(db.knex, account, {
+            newPlanCode: 'growth-v2',
+            orbSubscriptionId: 'orb_sub_2',
+            hasGrowthFeatures: false,
+            growthFeaturesEndsAt: null
+        });
 
         expect(res.unwrap()).toBe(true);
         const updated = await getPlan(db.knex, { accountId: account.id });
@@ -35,7 +45,12 @@ describe('handlePlanChanged', () => {
             plan: { name: 'free', auto_idle: true, trial_start_at: new Date(), trial_end_at: new Date(Date.now() + ms('10days')) }
         });
 
-        const res = await handlePlanChanged(db.knex, account, { newPlanCode: 'pay-as-you-go', orbSubscriptionId: 'orb_sub_payg' });
+        const res = await handlePlanChanged(db.knex, account, {
+            newPlanCode: 'pay-as-you-go',
+            orbSubscriptionId: 'orb_sub_payg',
+            hasGrowthFeatures: false,
+            growthFeaturesEndsAt: null
+        });
 
         expect(res.unwrap()).toBe(true);
         const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
@@ -58,7 +73,12 @@ describe('handlePlanChanged', () => {
     it('restarts the trial and resets the flags when pay-as-you-go downgrades to free', async () => {
         const { account } = await seedAccountEnvAndUser({ plan: { name: 'pay-as-you-go', auto_idle: false, connections_max: null } });
 
-        const res = await handlePlanChanged(db.knex, account, { newPlanCode: 'free', orbSubscriptionId: 'orb_sub_free' });
+        const res = await handlePlanChanged(db.knex, account, {
+            newPlanCode: 'free',
+            orbSubscriptionId: 'orb_sub_free',
+            hasGrowthFeatures: false,
+            growthFeaturesEndsAt: null
+        });
 
         expect(res.unwrap()).toBe(true);
         const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
@@ -68,5 +88,57 @@ describe('handlePlanChanged', () => {
         expect(updated.trial_expired).toBe(false);
         // pg hands back the bigint column as a string
         expect(Number(updated.connections_max)).toBe(10);
+    });
+
+    it('grants the growth feature set when the add-on is active', async () => {
+        const { account } = await seedAccountEnvAndUser({ plan: { name: 'free', auto_idle: true } });
+
+        const res = await handlePlanChanged(db.knex, account, {
+            newPlanCode: 'pay-as-you-go',
+            orbSubscriptionId: 'orb_sub_addon',
+            hasGrowthFeatures: true,
+            growthFeaturesEndsAt: null
+        });
+        expect(res.unwrap()).toBe(true);
+
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.name).toBe('pay-as-you-go');
+        expect(updated.has_growth_features).toBe(true);
+        expect(updated.has_rbac).toBe(true);
+        expect(updated.has_otel).toBe(true);
+        expect(updated.can_customize_connect_ui_theme).toBe(true);
+    });
+
+    it('revokes the growth feature set when the add-on is dropped', async () => {
+        const { account } = await seedAccountEnvAndUser({
+            plan: { name: 'pay-as-you-go', has_growth_features: true, auto_idle: false, has_rbac: true, has_otel: true }
+        });
+
+        // Same plan, no add-on: the only thing that changed is the add-on set
+        const res = await handlePlanChanged(db.knex, account, {
+            newPlanCode: 'pay-as-you-go',
+            orbSubscriptionId: 'orb_sub_addon',
+            hasGrowthFeatures: false,
+            growthFeaturesEndsAt: null
+        });
+        expect(res.unwrap()).toBe(true);
+
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.has_growth_features).toBe(false);
+        expect(updated.has_rbac).toBe(false);
+        expect(updated.has_otel).toBe(false);
+    });
+
+    it('reports no change when the plan and the add-on are both the same', async () => {
+        const { account } = await seedAccountEnvAndUser({ plan: { name: 'pay-as-you-go', has_growth_features: true, auto_idle: false } });
+
+        const res = await handlePlanChanged(db.knex, account, {
+            newPlanCode: 'pay-as-you-go',
+            orbSubscriptionId: 'orb_sub_addon',
+            hasGrowthFeatures: true,
+            growthFeaturesEndsAt: null
+        });
+
+        expect(res.unwrap()).toBe(false);
     });
 });

--- a/packages/shared/lib/services/plans/plans.integration.test.ts
+++ b/packages/shared/lib/services/plans/plans.integration.test.ts
@@ -4,7 +4,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import db, { multipleMigrations } from '@nangohq/database';
 
 import { seedAccountEnvAndUser } from '../../seeders/global.seeder.js';
-import { getPlan, handlePlanChanged } from './plans.js';
+import { getPlan, handlePlanChanged, setGrowthAddon } from './plans.js';
 
 describe('handlePlanChanged', () => {
     beforeAll(async () => {
@@ -16,9 +16,7 @@ describe('handlePlanChanged', () => {
 
         const res = await handlePlanChanged(db.knex, account, {
             newPlanCode: plan.name,
-            orbSubscriptionId: 'orb_sub_1',
-            hasGrowthFeatures: false,
-            growthFeaturesEndsAt: null
+            orbSubscriptionId: 'orb_sub_1'
         });
 
         expect(res.unwrap()).toBe(false);
@@ -29,9 +27,7 @@ describe('handlePlanChanged', () => {
 
         const res = await handlePlanChanged(db.knex, account, {
             newPlanCode: 'growth-v2',
-            orbSubscriptionId: 'orb_sub_2',
-            hasGrowthFeatures: false,
-            growthFeaturesEndsAt: null
+            orbSubscriptionId: 'orb_sub_2'
         });
 
         expect(res.unwrap()).toBe(true);
@@ -47,9 +43,7 @@ describe('handlePlanChanged', () => {
 
         const res = await handlePlanChanged(db.knex, account, {
             newPlanCode: 'pay-as-you-go',
-            orbSubscriptionId: 'orb_sub_payg',
-            hasGrowthFeatures: false,
-            growthFeaturesEndsAt: null
+            orbSubscriptionId: 'orb_sub_payg'
         });
 
         expect(res.unwrap()).toBe(true);
@@ -75,9 +69,7 @@ describe('handlePlanChanged', () => {
 
         const res = await handlePlanChanged(db.knex, account, {
             newPlanCode: 'free',
-            orbSubscriptionId: 'orb_sub_free',
-            hasGrowthFeatures: false,
-            growthFeaturesEndsAt: null
+            orbSubscriptionId: 'orb_sub_free'
         });
 
         expect(res.unwrap()).toBe(true);
@@ -90,55 +82,96 @@ describe('handlePlanChanged', () => {
         expect(Number(updated.connections_max)).toBe(10);
     });
 
-    it('grants the growth feature set when the add-on is active', async () => {
-        const { account } = await seedAccountEnvAndUser({ plan: { name: 'free', auto_idle: true } });
-
-        const res = await handlePlanChanged(db.knex, account, {
-            newPlanCode: 'pay-as-you-go',
-            orbSubscriptionId: 'orb_sub_addon',
-            hasGrowthFeatures: true,
-            growthFeaturesEndsAt: null
-        });
-        expect(res.unwrap()).toBe(true);
-
-        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
-        expect(updated.name).toBe('pay-as-you-go');
-        expect(updated.has_growth_features).toBe(true);
-        expect(updated.has_rbac).toBe(true);
-        expect(updated.has_otel).toBe(true);
-        expect(updated.can_customize_connect_ui_theme).toBe(true);
-    });
-
-    it('revokes the growth feature set when the add-on is dropped', async () => {
+    it('keeps the growth feature set through a plan change while the add-on is active', async () => {
         const { account } = await seedAccountEnvAndUser({
             plan: { name: 'pay-as-you-go', has_growth_features: true, auto_idle: false, has_rbac: true, has_otel: true }
         });
 
-        // Same plan, no add-on: the only thing that changed is the add-on set
-        const res = await handlePlanChanged(db.knex, account, {
-            newPlanCode: 'pay-as-you-go',
-            orbSubscriptionId: 'orb_sub_addon',
-            hasGrowthFeatures: false,
-            growthFeaturesEndsAt: null
-        });
+        const res = await handlePlanChanged(db.knex, account, { newPlanCode: 'growth-v2', orbSubscriptionId: 'orb_sub_addon' });
         expect(res.unwrap()).toBe(true);
 
         const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
-        expect(updated.has_growth_features).toBe(false);
-        expect(updated.has_rbac).toBe(false);
-        expect(updated.has_otel).toBe(false);
+        expect(updated.name).toBe('growth-v2');
+        expect(updated.has_growth_features).toBe(true);
     });
 
-    it('reports no change when the plan and the add-on are both the same', async () => {
-        const { account } = await seedAccountEnvAndUser({ plan: { name: 'pay-as-you-go', has_growth_features: true, auto_idle: false } });
-
-        const res = await handlePlanChanged(db.knex, account, {
-            newPlanCode: 'pay-as-you-go',
-            orbSubscriptionId: 'orb_sub_addon',
-            hasGrowthFeatures: true,
-            growthFeaturesEndsAt: null
+    it('leaves add-on state untouched, however stale the caller is', async () => {
+        const endsAt = new Date('2026-10-01T00:00:00Z');
+        const { account } = await seedAccountEnvAndUser({
+            plan: { name: 'pay-as-you-go', has_growth_features: true, growth_features_ends_at: endsAt, auto_idle: false, has_rbac: true }
         });
 
+        const res = await handlePlanChanged(db.knex, account, { newPlanCode: 'pay-as-you-go', orbSubscriptionId: 'orb_sub_addon' });
         expect(res.unwrap()).toBe(false);
+
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.has_growth_features).toBe(true);
+        expect(updated.growth_features_ends_at).toEqual(endsAt);
+        expect(updated.has_rbac).toBe(true);
+    });
+});
+
+describe('setGrowthAddon', () => {
+    beforeAll(async () => {
+        await multipleMigrations();
+    });
+
+    it('grants the gated flags when the add-on is turned on', async () => {
+        const { account } = await seedAccountEnvAndUser({ plan: { name: 'pay-as-you-go', auto_idle: false } });
+
+        (await setGrowthAddon(db.knex, account, { hasGrowthFeatures: true })).unwrap();
+
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.has_growth_features).toBe(true);
+        expect(updated.growth_features_ends_at).toBeNull();
+        expect(updated.has_otel).toBe(true);
+        expect(updated.has_rbac).toBe(true);
+        expect(updated.can_customize_connect_ui_theme).toBe(true);
+    });
+
+    // Scheduling the removal is not the removal: they keep the features through the term they paid for
+    it('records the end date while leaving the add-on active', async () => {
+        const endsAt = new Date('2026-10-01T00:00:00Z');
+        const { account } = await seedAccountEnvAndUser({
+            plan: { name: 'pay-as-you-go', has_growth_features: true, auto_idle: false, has_otel: true, has_rbac: true }
+        });
+
+        (await setGrowthAddon(db.knex, account, { hasGrowthFeatures: true, endsAt })).unwrap();
+
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.has_growth_features).toBe(true);
+        expect(updated.growth_features_ends_at).toEqual(endsAt);
+        expect(updated.has_otel).toBe(true);
+    });
+
+    it('revokes the gated flags and clears the date once the add-on is gone', async () => {
+        const { account } = await seedAccountEnvAndUser({
+            plan: {
+                name: 'pay-as-you-go',
+                has_growth_features: true,
+                growth_features_ends_at: new Date('2026-10-01T00:00:00Z'),
+                auto_idle: false,
+                has_otel: true,
+                has_rbac: true
+            }
+        });
+
+        (await setGrowthAddon(db.knex, account, { hasGrowthFeatures: false })).unwrap();
+
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.has_growth_features).toBe(false);
+        expect(updated.growth_features_ends_at).toBeNull();
+        expect(updated.has_otel).toBe(false);
+        expect(updated.has_rbac).toBe(false);
+    });
+
+    // Flags the add-on does not gate are none of its business, overrides included
+    it('leaves ungated flags alone', async () => {
+        const { account } = await seedAccountEnvAndUser({ plan: { name: 'pay-as-you-go', auto_idle: false, environments_max: 50 } });
+
+        (await setGrowthAddon(db.knex, account, { hasGrowthFeatures: true })).unwrap();
+
+        const updated = (await getPlan(db.knex, { accountId: account.id })).unwrap();
+        expect(updated.environments_max).toBe(50);
     });
 });

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -3,7 +3,7 @@ import ms from 'ms';
 import { Err, flagHasPlan, Ok } from '@nangohq/utils';
 
 import { productTracking } from '../../utils/productTracking.js';
-import { freePlan, isPotentialDowngrade, plansList } from './definitions.js';
+import { canHaveGrowthAddon, freePlan, GROWTH_FEATURE_FLAGS, isPotentialDowngrade, plansList } from './definitions.js';
 
 import type { DBEnvironment, DBPlan, DBTeam, PlanDefinition } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -149,11 +149,30 @@ export async function getExpiredTrials(db: Knex): Promise<DBPlan[]> {
         .where('plans.auto_idle', true);
 }
 
+function isPlanUnchanged(currentPlan: DBPlan, newPlan: PlanDefinition, hasGrowthFeatures: boolean, growthFeaturesEndsAt: Date | null): boolean {
+    const growthAddonUnchanged = currentPlan.has_growth_features === hasGrowthFeatures;
+    const growthAddonIntervalUnchanged = (currentPlan.growth_features_ends_at?.getTime() ?? null) === (growthFeaturesEndsAt?.getTime() ?? null);
+    const planUnchanged = currentPlan.name === newPlan.code;
+    return planUnchanged && growthAddonUnchanged && growthAddonIntervalUnchanged;
+}
+
 /** Resolves to whether the plan actually changed, so callers can react only when it did. */
 export async function handlePlanChanged(
     db: Knex,
     team: DBTeam,
-    { newPlanCode, orbCustomerId, orbSubscriptionId }: { newPlanCode: string; orbCustomerId?: string | undefined; orbSubscriptionId: string }
+    {
+        newPlanCode,
+        orbCustomerId,
+        orbSubscriptionId,
+        hasGrowthFeatures,
+        growthFeaturesEndsAt
+    }: {
+        newPlanCode: string;
+        orbCustomerId?: string | undefined;
+        orbSubscriptionId: string;
+        hasGrowthFeatures: boolean;
+        growthFeaturesEndsAt: Date | null;
+    }
 ): Promise<Result<boolean>> {
     const newPlan = plansList.find((p) => p.code === newPlanCode);
     if (!newPlan) {
@@ -165,13 +184,12 @@ export async function handlePlanChanged(
         return Err(new Error('Failed to get current plan', { cause: currentPlan.error }));
     }
 
-    // Plan hasn't changed
-    if (currentPlan.value.name === newPlan.code) {
+    if (isPlanUnchanged(currentPlan.value, newPlan, hasGrowthFeatures, growthFeaturesEndsAt)) {
         return Ok(false);
     }
 
     // Merge current plan flags with new plan defaults
-    const mergedFlags = mergeFlags({ currentPlan: currentPlan.value, newPlanDefinition: newPlan });
+    const mergedFlags = mergeFlags({ currentPlan: currentPlan.value, newPlanDefinition: newPlan, hasGrowthFeatures });
 
     // Only update subscription date from free to paid (undefined = no update)
     const isCurrentFree = currentPlan.value.name === freePlan.code;
@@ -182,6 +200,8 @@ export async function handlePlanChanged(
     const updated = await updatePlanByTeam(db, {
         account_id: team.id,
         name: newPlan.code,
+        has_growth_features: hasGrowthFeatures,
+        growth_features_ends_at: growthFeaturesEndsAt,
         orb_subscription_id: orbSubscriptionId,
         orb_future_plan: null,
         orb_future_plan_at: null,
@@ -213,7 +233,32 @@ export async function handlePlanChanged(
     return Ok(true);
 }
 
-export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DBPlan; newPlanDefinition: PlanDefinition }): PlanDefinition['flags'] {
+export function mergeFlags({
+    currentPlan,
+    newPlanDefinition,
+    hasGrowthFeatures = false
+}: {
+    currentPlan: DBPlan;
+    newPlanDefinition: PlanDefinition;
+    hasGrowthFeatures?: boolean;
+}): PlanDefinition['flags'] {
+    let flags = mergePlanFlags({ currentPlan, newPlanDefinition });
+
+    if (canHaveGrowthAddon(newPlanDefinition.code)) {
+        // Force-update growth feature flags on top of merged plan flags, based on whether the add-on is enabled or not.
+        const growth: Partial<PlanDefinition['flags']> = {};
+        const growthFeatureFlags = Object.keys(GROWTH_FEATURE_FLAGS) as (keyof typeof GROWTH_FEATURE_FLAGS)[];
+        for (const featureFlag of growthFeatureFlags) {
+            growth[featureFlag] = hasGrowthFeatures ? GROWTH_FEATURE_FLAGS[featureFlag] : (newPlanDefinition.flags[featureFlag] as boolean);
+        }
+
+        flags = { ...flags, ...growth };
+    }
+
+    return flags;
+}
+
+function mergePlanFlags({ currentPlan, newPlanDefinition }: { currentPlan: DBPlan; newPlanDefinition: PlanDefinition }): PlanDefinition['flags'] {
     // Downgrades always use new plan defaults and reset any overrides
     if (isPotentialDowngrade({ from: currentPlan.name, to: newPlanDefinition.code })) {
         return newPlanDefinition.flags;
@@ -250,6 +295,9 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
             case 'records_store':
             case 'created_at':
             case 'updated_at':
+            // Growth add-on related, skip them
+            case 'has_growth_features':
+            case 'growth_features_ends_at':
                 break;
             // BOOLEAN FLAGS - keep override if false
             case 'has_records_autopruning':

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -149,11 +149,53 @@ export async function getExpiredTrials(db: Knex): Promise<DBPlan[]> {
         .where('plans.auto_idle', true);
 }
 
-function isPlanUnchanged(currentPlan: DBPlan, newPlan: PlanDefinition, hasGrowthFeatures: boolean, growthFeaturesEndsAt: Date | null): boolean {
-    const growthAddonUnchanged = currentPlan.has_growth_features === hasGrowthFeatures;
-    const growthAddonIntervalUnchanged = (currentPlan.growth_features_ends_at?.getTime() ?? null) === (growthFeaturesEndsAt?.getTime() ?? null);
-    const planUnchanged = currentPlan.name === newPlan.code;
-    return planUnchanged && growthAddonUnchanged && growthAddonIntervalUnchanged;
+function isPlanUnchanged(currentPlan: DBPlan, newPlan: PlanDefinition): boolean {
+    return currentPlan.name === newPlan.code;
+}
+
+/**
+ * The one place growth add-on state is written outside the reconcile cron.
+ *
+ * Kept apart from `handlePlanChanged` on purpose: that function is reachable from the Orb webhook,
+ * whose payload is a snapshot from when the event was generated and can arrive up to ~28 hours late
+ * after retries. Callers here have just performed the change against Orb, or have just read it live,
+ * so nothing they write can be contradicted by an older event.
+ *
+ * @param endsAt - When the add-on stops billing, once its removal is scheduled. The add-on is still
+ * active until then, so `hasGrowthFeatures` stays true alongside it.
+ */
+export async function setGrowthAddon(
+    db: Knex,
+    team: DBTeam,
+    { hasGrowthFeatures, endsAt = null }: { hasGrowthFeatures: boolean; endsAt?: Date | null }
+): Promise<Result<void>> {
+    const plan = await getPlan(db, { accountId: team.id });
+    if (plan.isErr()) {
+        return Err(new Error('Failed to get current plan', { cause: plan.error }));
+    }
+
+    const definition = plansList.find((p) => p.code === plan.value.name);
+    if (!definition) {
+        return Err('Received a plan not linked to the plansList');
+    }
+
+    // Granted while the add-on is on, back to whatever the plan itself allows once it is off.
+    const flags: Partial<PlanDefinition['flags']> = {};
+    for (const flag of Object.keys(GROWTH_FEATURE_FLAGS) as (keyof typeof GROWTH_FEATURE_FLAGS)[]) {
+        flags[flag] = hasGrowthFeatures ? GROWTH_FEATURE_FLAGS[flag] : (definition.flags[flag] as boolean);
+    }
+
+    const updated = await updatePlanByTeam(db, {
+        account_id: team.id,
+        has_growth_features: hasGrowthFeatures,
+        growth_features_ends_at: hasGrowthFeatures ? endsAt : null,
+        ...flags
+    });
+    if (updated.isErr()) {
+        return Err(new Error('Failed to update growth add-on', { cause: updated.error }));
+    }
+
+    return Ok(undefined);
 }
 
 /** Resolves to whether the plan actually changed, so callers can react only when it did. */
@@ -163,15 +205,11 @@ export async function handlePlanChanged(
     {
         newPlanCode,
         orbCustomerId,
-        orbSubscriptionId,
-        hasGrowthFeatures,
-        growthFeaturesEndsAt
+        orbSubscriptionId
     }: {
         newPlanCode: string;
         orbCustomerId?: string | undefined;
         orbSubscriptionId: string;
-        hasGrowthFeatures: boolean;
-        growthFeaturesEndsAt: Date | null;
     }
 ): Promise<Result<boolean>> {
     const newPlan = plansList.find((p) => p.code === newPlanCode);
@@ -184,12 +222,12 @@ export async function handlePlanChanged(
         return Err(new Error('Failed to get current plan', { cause: currentPlan.error }));
     }
 
-    if (isPlanUnchanged(currentPlan.value, newPlan, hasGrowthFeatures, growthFeaturesEndsAt)) {
+    if (isPlanUnchanged(currentPlan.value, newPlan)) {
         return Ok(false);
     }
 
     // Merge current plan flags with new plan defaults
-    const mergedFlags = mergeFlags({ currentPlan: currentPlan.value, newPlanDefinition: newPlan, hasGrowthFeatures });
+    const mergedFlags = mergeFlags({ currentPlan: currentPlan.value, newPlanDefinition: newPlan });
 
     // Only update subscription date from free to paid (undefined = no update)
     const isCurrentFree = currentPlan.value.name === freePlan.code;
@@ -200,8 +238,6 @@ export async function handlePlanChanged(
     const updated = await updatePlanByTeam(db, {
         account_id: team.id,
         name: newPlan.code,
-        has_growth_features: hasGrowthFeatures,
-        growth_features_ends_at: growthFeaturesEndsAt,
         orb_subscription_id: orbSubscriptionId,
         orb_future_plan: null,
         orb_future_plan_at: null,
@@ -233,15 +269,8 @@ export async function handlePlanChanged(
     return Ok(true);
 }
 
-export function mergeFlags({
-    currentPlan,
-    newPlanDefinition,
-    hasGrowthFeatures = false
-}: {
-    currentPlan: DBPlan;
-    newPlanDefinition: PlanDefinition;
-    hasGrowthFeatures?: boolean;
-}): PlanDefinition['flags'] {
+export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DBPlan; newPlanDefinition: PlanDefinition }): PlanDefinition['flags'] {
+    const hasGrowthFeatures = currentPlan.has_growth_features;
     let flags = mergePlanFlags({ currentPlan, newPlanDefinition });
 
     if (canHaveGrowthAddon(newPlanDefinition.code)) {

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -153,17 +153,6 @@ function isPlanUnchanged(currentPlan: DBPlan, newPlan: PlanDefinition): boolean 
     return currentPlan.name === newPlan.code;
 }
 
-/**
- * The one place growth add-on state is written outside the reconcile cron.
- *
- * Kept apart from `handlePlanChanged` on purpose: that function is reachable from the Orb webhook,
- * whose payload is a snapshot from when the event was generated and can arrive up to ~28 hours late
- * after retries. Callers here have just performed the change against Orb, or have just read it live,
- * so nothing they write can be contradicted by an older event.
- *
- * @param endsAt - When the add-on stops billing, once its removal is scheduled. The add-on is still
- * active until then, so `hasGrowthFeatures` stays true alongside it.
- */
 export async function setGrowthAddon(
     db: Knex,
     team: DBTeam,
@@ -179,7 +168,6 @@ export async function setGrowthAddon(
         return Err('Received a plan not linked to the plansList');
     }
 
-    // Granted while the add-on is on, back to whatever the plan itself allows once it is off.
     const flags: Partial<PlanDefinition['flags']> = {};
     for (const flag of Object.keys(GROWTH_FEATURE_FLAGS) as (keyof typeof GROWTH_FEATURE_FLAGS)[]) {
         flags[flag] = hasGrowthFeatures ? GROWTH_FEATURE_FLAGS[flag] : (definition.flags[flag] as boolean);

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -154,8 +154,7 @@ describe('mergeFlags', () => {
             it('should apply the plan defaults for the gated flags when no add-on is active', () => {
                 const newFlags = mergeFlags({
                     currentPlan: makePlan({ code: from, flagOverrides: {} }),
-                    newPlanDefinition: payAsYouGo,
-                    hasGrowthFeatures: false
+                    newPlanDefinition: payAsYouGo
                 });
                 expect(newFlags).toMatchObject({
                     has_otel: false,
@@ -169,8 +168,7 @@ describe('mergeFlags', () => {
             it('should keep a higher limit the source plan carries', () => {
                 const newFlags = mergeFlags({
                     currentPlan: makePlan({ code: from, flagOverrides: {} }),
-                    newPlanDefinition: payAsYouGo,
-                    hasGrowthFeatures: false
+                    newPlanDefinition: payAsYouGo
                 });
                 const source = getPlanDefinition(from)!;
                 expect(newFlags.environments_max).toBe(Math.max(source.flags.environments_max ?? 0, payAsYouGo.flags.environments_max ?? 0));
@@ -178,22 +176,21 @@ describe('mergeFlags', () => {
 
             it('should keep overrides on flags the growth add-on does not gate', () => {
                 const currentPlan = makePlan({ code: from, flagOverrides: { environments_max: 50, api_rate_limit_size: '2xl' } });
-                const newFlags = mergeFlags({ currentPlan, newPlanDefinition: payAsYouGo, hasGrowthFeatures: false });
+                const newFlags = mergeFlags({ currentPlan, newPlanDefinition: payAsYouGo });
                 expect(newFlags).toMatchObject({ environments_max: 50, api_rate_limit_size: '2xl' });
             });
 
             it('should revoke add-on-gated flags when no add-on is active, override or not', () => {
                 const currentPlan = makePlan({ code: from, flagOverrides: { has_otel: true, has_rbac: true, can_customize_connect_ui_theme: true } });
-                const newFlags = mergeFlags({ currentPlan, newPlanDefinition: payAsYouGo, hasGrowthFeatures: false });
+                const newFlags = mergeFlags({ currentPlan, newPlanDefinition: payAsYouGo });
 
                 expect(newFlags).toMatchObject({ has_otel: false, has_rbac: false, can_customize_connect_ui_theme: false });
             });
 
             it('should grant the growth feature set when the add-on is active', () => {
                 const newFlags = mergeFlags({
-                    currentPlan: makePlan({ code: from, flagOverrides: {} }),
-                    newPlanDefinition: payAsYouGo,
-                    hasGrowthFeatures: true
+                    currentPlan: makePlan({ code: from, flagOverrides: {}, hasGrowthFeatures: true }),
+                    newPlanDefinition: payAsYouGo
                 });
 
                 expect(newFlags).toMatchObject({
@@ -212,8 +209,8 @@ describe('mergeFlags', () => {
         const enterprise = getPlanDefinition('enterprise')!;
         const currentPlan = makePlan({ code: 'growth-v2', flagOverrides: { has_rbac: true, has_otel: true } });
 
-        expect(mergeFlags({ currentPlan, newPlanDefinition: enterprise, hasGrowthFeatures: false })).toEqual(
-            mergeFlags({ currentPlan, newPlanDefinition: enterprise, hasGrowthFeatures: true })
+        expect(mergeFlags({ currentPlan, newPlanDefinition: enterprise })).toEqual(
+            mergeFlags({ currentPlan: { ...currentPlan, has_growth_features: true }, newPlanDefinition: enterprise })
         );
     });
 });
@@ -237,13 +234,21 @@ describe('self-serve transitions', () => {
     });
 });
 
-function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides: PlanDefinition['flags'] }): DBPlan {
+function makePlan({
+    code,
+    flagOverrides,
+    hasGrowthFeatures = false
+}: {
+    code: DBPlan['name'];
+    flagOverrides: PlanDefinition['flags'];
+    hasGrowthFeatures?: boolean;
+}): DBPlan {
     const defaultPlanDefinition = getPlanDefinition(code)!;
     return {
         id: 1,
         account_id: 1,
         name: code,
-        has_growth_features: false,
+        has_growth_features: hasGrowthFeatures,
         growth_features_ends_at: null,
         created_at: new Date(),
         updated_at: new Date(),

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -99,10 +99,9 @@ describe('mergeFlags', () => {
         { from: 'starter', to: 'starter-v2' }, // migration
         { from: 'starter-legacy', to: 'starter-v2' }, // migration
         { from: 'starter', to: 'growth-v2' }, // upgrade and migration
-        { from: 'starter-legacy', to: 'growth-v2' }, // upgrade and migration
-        { from: 'free', to: 'pay-as-you-go' }, // upgrade from free
-        { from: 'starter-v2', to: 'pay-as-you-go' }, // migration off a sunset plan
-        { from: 'growth-v2', to: 'pay-as-you-go' } // migration off a sunset plan
+        { from: 'starter-legacy', to: 'growth-v2' } // upgrade and migration
+        // NOTE: pay-as-you-go is deliberately absent: its add-on-gated flags are recomputed rather than
+        // merged, so the "keep more generous overrides" rule does not hold for them. Covered below.
     ] as { from: PlanDefinition['code']; to: PlanDefinition['code'] }[])('when upgrading/migrating from $from to $to', ({ from, to }) => {
         it('should apply new plan defaults if no overrides', () => {
             const currentPlan = makePlan({ code: from, flagOverrides: {} });
@@ -147,31 +146,75 @@ describe('mergeFlags', () => {
         });
     });
 
-    // pay-as-you-go carries starter-level flags until the growth add-on exists, so migrating a
-    // Growth customer onto it must not be a downgrade — otherwise mergeFlags would reset their
-    // flags to the starter defaults and silently revoke the features they pay for today.
-    it('should keep growth features when migrating a growth-v2 account to pay-as-you-go', () => {
-        const currentPlan = makePlan({
-            code: 'growth-v2',
-            flagOverrides: {
-                has_rbac: true,
-                has_otel: true,
-                can_customize_connect_ui_theme: true,
-                can_override_docs_connect_url: true,
-                api_rate_limit_size: 'xl'
-            }
-        });
-        const newPlanDefinition = getPlanDefinition('pay-as-you-go')!;
+    describe.each([{ from: 'free' }, { from: 'starter-v2' }, { from: 'growth-v2' }] as { from: PlanDefinition['code'] }[])(
+        'when moving from $from to pay-as-you-go',
+        ({ from }) => {
+            const payAsYouGo = getPlanDefinition('pay-as-you-go')!;
 
-        const newFlags = mergeFlags({ currentPlan, newPlanDefinition });
+            it('should apply the plan defaults for the gated flags when no add-on is active', () => {
+                const newFlags = mergeFlags({
+                    currentPlan: makePlan({ code: from, flagOverrides: {} }),
+                    newPlanDefinition: payAsYouGo,
+                    hasGrowthFeatures: false
+                });
+                expect(newFlags).toMatchObject({
+                    has_otel: false,
+                    has_rbac: false,
+                    can_override_docs_connect_url: false,
+                    can_customize_connect_ui_theme: false,
+                    can_disable_connect_ui_watermark: false
+                });
+            });
 
-        expect(newFlags).toMatchObject({
-            has_rbac: true,
-            has_otel: true,
-            can_customize_connect_ui_theme: true,
-            can_override_docs_connect_url: true,
-            api_rate_limit_size: 'xl'
-        });
+            it('should keep a higher limit the source plan carries', () => {
+                const newFlags = mergeFlags({
+                    currentPlan: makePlan({ code: from, flagOverrides: {} }),
+                    newPlanDefinition: payAsYouGo,
+                    hasGrowthFeatures: false
+                });
+                const source = getPlanDefinition(from)!;
+                expect(newFlags.environments_max).toBe(Math.max(source.flags.environments_max ?? 0, payAsYouGo.flags.environments_max ?? 0));
+            });
+
+            it('should keep overrides on flags the growth add-on does not gate', () => {
+                const currentPlan = makePlan({ code: from, flagOverrides: { environments_max: 50, api_rate_limit_size: '2xl' } });
+                const newFlags = mergeFlags({ currentPlan, newPlanDefinition: payAsYouGo, hasGrowthFeatures: false });
+                expect(newFlags).toMatchObject({ environments_max: 50, api_rate_limit_size: '2xl' });
+            });
+
+            it('should revoke add-on-gated flags when no add-on is active, override or not', () => {
+                const currentPlan = makePlan({ code: from, flagOverrides: { has_otel: true, has_rbac: true, can_customize_connect_ui_theme: true } });
+                const newFlags = mergeFlags({ currentPlan, newPlanDefinition: payAsYouGo, hasGrowthFeatures: false });
+
+                expect(newFlags).toMatchObject({ has_otel: false, has_rbac: false, can_customize_connect_ui_theme: false });
+            });
+
+            it('should grant the growth feature set when the add-on is active', () => {
+                const newFlags = mergeFlags({
+                    currentPlan: makePlan({ code: from, flagOverrides: {} }),
+                    newPlanDefinition: payAsYouGo,
+                    hasGrowthFeatures: true
+                });
+
+                expect(newFlags).toMatchObject({
+                    has_otel: true,
+                    has_rbac: true,
+                    can_customize_connect_ui_theme: true,
+                    can_override_docs_connect_url: true,
+                    can_disable_connect_ui_watermark: true
+                });
+            });
+        }
+    );
+
+    it('should leave every other plan untouched by the add-on pass', () => {
+        // Enterprise grants the same features directly, so it must not be affected by add-on state
+        const enterprise = getPlanDefinition('enterprise')!;
+        const currentPlan = makePlan({ code: 'growth-v2', flagOverrides: { has_rbac: true, has_otel: true } });
+
+        expect(mergeFlags({ currentPlan, newPlanDefinition: enterprise, hasGrowthFeatures: false })).toEqual(
+            mergeFlags({ currentPlan, newPlanDefinition: enterprise, hasGrowthFeatures: true })
+        );
     });
 });
 
@@ -200,6 +243,8 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         id: 1,
         account_id: 1,
         name: code,
+        has_growth_features: false,
+        growth_features_ends_at: null,
         created_at: new Date(),
         updated_at: new Date(),
         stripe_customer_id: null,
@@ -249,7 +294,7 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         records_store: 'default',
         lambda_tenant_isolation: defaultPlanDefinition.flags.lambda_tenant_isolation ?? false,
         export_runner_telemetry: defaultPlanDefinition.flags.export_runner_telemetry ?? false,
-        ...defaultPlanDefinition,
+        ...defaultPlanDefinition.flags,
         ...flagOverrides
     };
 }

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -84,7 +84,7 @@ export interface BillingSubscription {
     growthFeaturesEndsAt: Date | null;
     /** Orb's price interval is the allocation of a price for a given time period.
      * The Growth add-on is an external price that gets attached to the plan, so we must parse
-     * it's interval in order to know whether there's a scheduled operation in the future.
+     * its interval in order to know whether there's a scheduled operation in the future.
      */
     growthFeaturesPriceIntervalId: string | null;
 }

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -8,7 +8,7 @@ export interface BillingClient {
     getOrCreateCustomer: (accountId: number, defaultTo: Pick<BillingInvoicingDetails, 'legalEntityName' | 'email'>) => Promise<Result<BillingCustomer>>;
     getCustomer: (accountId: number) => Promise<Result<BillingCustomer>>;
     putCustomer: (accountId: number, invoicingDetails: BillingInvoicingDetails) => Promise<Result<BillingCustomer>>;
-    getSubscription: (accountId: number) => Promise<Result<BillingSubscription | null>>;
+    getSubscription: (accountId: number) => Promise<Result<BillingSubscription>>;
     getOverdueInvoices: (accountId: number) => Promise<Result<BillingOverdueInvoices>>;
     getUpcomingInvoice: (subscriptionId: string) => Promise<Result<BillingUpcomingInvoice | null>>;
     getPeriodCosts: (subscriptionId: string) => Promise<Result<BillingPeriodCosts | null>>;
@@ -17,8 +17,9 @@ export interface BillingClient {
     removeSpendAlert: (subscriptionId: string) => Promise<Result<void>>;
     createSubscription: (team: DBTeam, planExternalId: string) => Promise<Result<BillingSubscription>>;
     getUsage: (subscriptionId: string, opts?: GetBillingUsageOpts) => Promise<Result<BillingUsageMetrics>>;
-    upgrade: (opts: { subscriptionId: string; planExternalId: string }) => Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>>;
-    downgrade: (opts: { subscriptionId: string; planExternalId: string }) => Promise<Result<void>>;
+    upgrade: (opts: PlanUpgradeRequest) => Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>>;
+    downgrade: (opts: PlanChangeRequest) => Promise<Result<void>>;
+    endGrowthAddon: (opts: { subscriptionId: string; priceIntervalId: string }) => Promise<Result<{ growthFeaturesEndsAt: Date | null }>>;
     applyPendingChanges: (opts: {
         pendingChangeId: string;
         /**
@@ -38,6 +39,15 @@ export interface BillingClient {
     cancelPendingChanges: (opts: { pendingChangeId: string }) => Promise<Result<void>>;
     verifyWebhookSignature(body: string, headers: Record<string, unknown>, secret: string): Result<true>;
     getPlanById(planId: string): Promise<Result<BillingPlan>>;
+}
+
+export interface PlanChangeRequest {
+    subscriptionId: string;
+    planExternalId: string;
+}
+
+export interface PlanUpgradeRequest extends PlanChangeRequest {
+    addPriceExternalIds?: string[] | undefined;
 }
 
 export interface BillingCustomer {
@@ -73,6 +83,10 @@ export interface BillingSubscription {
     id: string;
     pendingChangeId?: string | undefined;
     planExternalId: string;
+    hasGrowthFeatures: boolean;
+    growthFeaturesEndsAt: Date | null;
+    /** The price interval to target when ending the add-on. Null when the subscription carries none. */
+    growthFeaturesPriceIntervalId: string | null;
 }
 
 export interface BillingOverdueInvoices {

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -82,7 +82,10 @@ export interface BillingSubscription {
     planExternalId: string;
     hasGrowthFeatures: boolean;
     growthFeaturesEndsAt: Date | null;
-    /** The price interval to target when ending the add-on. Null when the subscription carries none. */
+    /** Orb's price interval is the allocation of a price for a given time period.
+     * The Growth add-on is an external price that gets attached to the plan, so we must parse
+     * it's interval in order to know whether there's a scheduled operation in the future.
+     */
     growthFeaturesPriceIntervalId: string | null;
 }
 

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -17,8 +17,9 @@ export interface BillingClient {
     removeSpendAlert: (subscriptionId: string) => Promise<Result<void>>;
     createSubscription: (team: DBTeam, planExternalId: string) => Promise<Result<BillingSubscription>>;
     getUsage: (subscriptionId: string, opts?: GetBillingUsageOpts) => Promise<Result<BillingUsageMetrics>>;
-    upgrade: (opts: PlanUpgradeRequest) => Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>>;
+    upgrade: (opts: PlanChangeRequest) => Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>>;
     downgrade: (opts: PlanChangeRequest) => Promise<Result<void>>;
+    startGrowthAddon: (opts: { subscriptionId: string }) => Promise<Result<{ priceIntervalId: string | null }>>;
     endGrowthAddon: (opts: { subscriptionId: string; priceIntervalId: string }) => Promise<Result<{ growthFeaturesEndsAt: Date | null }>>;
     applyPendingChanges: (opts: {
         pendingChangeId: string;
@@ -44,10 +45,6 @@ export interface BillingClient {
 export interface PlanChangeRequest {
     subscriptionId: string;
     planExternalId: string;
-}
-
-export interface PlanUpgradeRequest extends PlanChangeRequest {
-    addPriceExternalIds?: string[] | undefined;
 }
 
 export interface BillingCustomer {

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -30,6 +30,8 @@ export interface DBPlan extends Timestamps {
     orb_future_plan: string | null;
     orb_future_plan_at: Date | null;
     orb_subscribed_at: Date | null;
+    has_growth_features: boolean;
+    growth_features_ends_at: Date | null;
 
     // Trial
     // Remove all values when you upgrade a customer

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -250,7 +250,7 @@ export type PostPlanChange = ApiEndpoint<{
     Method: 'POST';
     Path: '/api/v1/plans/change';
     Querystring: { env: string };
-    Body: { orbId: string };
+    Body: { orbId: string; withGrowthFeatures: boolean };
     Success: {
         data: { success: true } | { paymentIntent: any };
     };

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -507,7 +507,6 @@ const ENVS_SHAPE = z.object({
     ORB_API_KEY: z.string().optional(),
     ORB_WEBHOOKS_SECRET: z.string().optional(),
     /** External price id of the growth add-on: it can differ per Orb environment. */
-    ORB_GROWTH_ADDON_PRICE_ID: z.string().optional().default('growth-addon-price-v2'),
     ORB_MAX_RETRIES: z.coerce.number().optional().default(3),
     ORB_RETRY_MAX_ATTEMPTS: z.coerce.number().optional().default(3),
     ORB_RETRY_INITIAL_DELAY_MS: z.coerce.number().optional().default(10_000),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -506,7 +506,6 @@ const ENVS_SHAPE = z.object({
     FLAG_USAGE_ENABLED: z.stringbool().optional().default(false),
     ORB_API_KEY: z.string().optional(),
     ORB_WEBHOOKS_SECRET: z.string().optional(),
-    /** External price id of the growth add-on: it can differ per Orb environment. */
     ORB_MAX_RETRIES: z.coerce.number().optional().default(3),
     ORB_RETRY_MAX_ATTEMPTS: z.coerce.number().optional().default(3),
     ORB_RETRY_INITIAL_DELAY_MS: z.coerce.number().optional().default(10_000),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -506,6 +506,8 @@ const ENVS_SHAPE = z.object({
     FLAG_USAGE_ENABLED: z.stringbool().optional().default(false),
     ORB_API_KEY: z.string().optional(),
     ORB_WEBHOOKS_SECRET: z.string().optional(),
+    /** External price id of the growth add-on: it can differ per Orb environment. */
+    ORB_GROWTH_ADDON_PRICE_ID: z.string().optional().default('growth-addon-price-v1'),
     ORB_MAX_RETRIES: z.coerce.number().optional().default(3),
     ORB_RETRY_MAX_ATTEMPTS: z.coerce.number().optional().default(3),
     ORB_RETRY_INITIAL_DELAY_MS: z.coerce.number().optional().default(10_000),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -507,7 +507,7 @@ const ENVS_SHAPE = z.object({
     ORB_API_KEY: z.string().optional(),
     ORB_WEBHOOKS_SECRET: z.string().optional(),
     /** External price id of the growth add-on: it can differ per Orb environment. */
-    ORB_GROWTH_ADDON_PRICE_ID: z.string().optional().default('growth-addon-price-v1'),
+    ORB_GROWTH_ADDON_PRICE_ID: z.string().optional().default('growth-addon-price-v2'),
     ORB_MAX_RETRIES: z.coerce.number().optional().default(3),
     ORB_RETRY_MAX_ATTEMPTS: z.coerce.number().optional().default(3),
     ORB_RETRY_INITIAL_DELAY_MS: z.coerce.number().optional().default(10_000),

--- a/packages/webapp/src/pages/Team/Billing/usePlanChangeRequest.tsx
+++ b/packages/webapp/src/pages/Team/Billing/usePlanChangeRequest.tsx
@@ -73,7 +73,8 @@ export function usePlanChangeRequest(env: string) {
 
             let json: Awaited<ReturnType<typeof postPlanChange>>;
             try {
-                json = await postPlanChange({ orbId });
+                // TODO: set a real value once the UI lets customers self-serve the growth add-on.
+                json = await postPlanChange({ orbId, withGrowthFeatures: false });
             } catch {
                 return fail('Something went wrong', true);
             }


### PR DESCRIPTION
Pay-as-you-go ships with starter-level flags. The growth feature set — RBAC, OTel, connect-UI customisation — is now unlocked by an optional add-on, modelled in Orb as a standalone price on the subscription. Flags stop being a function of the plan alone and become a function of the plan and the add-on.

`POST /api/v1/plans/change` takes the desired end state, `{ orbId, withGrowthFeatures }`. Orb's `schedulePlanChange` can't schedule add-on price removals: it only supports removing plan prices, so changing plan and managing the add-on state are done separately.

`mergeFlags` merges plan flags as before, then recomputes the add-on's flags based on the presence of `plans.has_growth_features` — merged flags preserve a per-account override, recomputed ones do not, which makes disabling the add-on actually revoke the features. The additional computation only runs for plans that can carry the add-on, so every other plan is unaffected.

Both are asserted to agree before a change is resolved: our record is a mirror of Orb's, and we treat that as an invariant. A mismatch answers 409 rather than guessing, with recovery being a possibility via Orb's webhook or manual intervention.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

