### PR TITLE
feat(audit): name the deprecated public-key flow as its own actor

### DIFF
--- a/packages/server/lib/middleware/audit/auditable.ts
+++ b/packages/server/lib/middleware/audit/auditable.ts
@@ -85,6 +85,12 @@ export function resolveActor(locals: Partial<RequestLocals>): AuditActor {
             ...(locals.apiKeyDisplayName ? { display: locals.apiKeyDisplayName } : {})
         };
     }
+    // Deprecated and closed to accounts created after PUBLIC_AUTHENTICATION_DEPRECATION_DATE. The key
+    // belongs to an environment, so there is no person to name — but saying which mechanism was used
+    // keeps `unknown` for events we cannot explain.
+    if (locals.authType === 'publicKey') {
+        return { type: 'public_key', id: 'unknown' };
+    }
     // An end user is optional when the session carries tags, so the session can name nobody.
     if (locals.authType === 'connectSession') {
         return connectSessionActor(locals.endUser);
@@ -93,7 +99,6 @@ export function resolveActor(locals: Partial<RequestLocals>): AuditActor {
     if (locals.user) {
         return { type: 'user', id: String(locals.user.id), display: locals.user.email };
     }
-    // Includes the deprecated public-key flow: it identifies an environment, never a person.
     return UNKNOWN_ACTOR;
 }
 

--- a/packages/server/lib/middleware/audit/auditable.ts
+++ b/packages/server/lib/middleware/audit/auditable.ts
@@ -85,9 +85,6 @@ export function resolveActor(locals: Partial<RequestLocals>): AuditActor {
             ...(locals.apiKeyDisplayName ? { display: locals.apiKeyDisplayName } : {})
         };
     }
-    // Deprecated and closed to accounts created after PUBLIC_AUTHENTICATION_DEPRECATION_DATE. The key
-    // belongs to an environment, so there is no person to name — but saying which mechanism was used
-    // keeps `unknown` for events we cannot explain.
     if (locals.authType === 'publicKey') {
         return { type: 'public_key', id: 'unknown' };
     }

--- a/packages/server/lib/middleware/audit/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/audit/auditable.unit.test.ts
@@ -8,12 +8,11 @@ vi.mock('@nangohq/shared', async (importOriginal) => (await import('./testing.js
 describe('resolveActor (unit)', () => {
     const account = { id: 42, uuid: 'acc-uuid' };
 
-    it('is unknown for a caller no middleware attributed', () => {
+    it('resolves to unknown when no authType was set', () => {
         expect(resolveActor({ authType: undefined, account } as any)).toEqual({ type: 'unknown', id: 'unknown', display: 'unknown' });
     });
 
-    // Same shape as a connect session that carries no end user: the mechanism is known, the person is not.
-    it('names the mechanism but nobody for the deprecated public-key flow', () => {
+    it('resolves a public key to the public_key type with an unknown id', () => {
         expect(resolveActor({ authType: 'publicKey', account } as any)).toEqual({ type: 'public_key', id: 'unknown' });
     });
 

--- a/packages/server/lib/middleware/audit/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/audit/auditable.unit.test.ts
@@ -8,8 +8,13 @@ vi.mock('@nangohq/shared', async (importOriginal) => (await import('./testing.js
 describe('resolveActor (unit)', () => {
     const account = { id: 42, uuid: 'acc-uuid' };
 
-    it.each(['publicKey', undefined] as const)('is unknown for an unattributed caller (authType %s)', (authType) => {
-        expect(resolveActor({ authType, account } as any)).toEqual({ type: 'unknown', id: 'unknown', display: 'unknown' });
+    it('is unknown for a caller no middleware attributed', () => {
+        expect(resolveActor({ authType: undefined, account } as any)).toEqual({ type: 'unknown', id: 'unknown', display: 'unknown' });
+    });
+
+    // Same shape as a connect session that carries no end user: the mechanism is known, the person is not.
+    it('names the mechanism but nobody for the deprecated public-key flow', () => {
+        expect(resolveActor({ authType: 'publicKey', account } as any)).toEqual({ type: 'public_key', id: 'unknown' });
     });
 
     it('names the end user behind a connect session, with their email as display', () => {

--- a/packages/server/lib/middleware/audit/connection.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/connection.middleware.unit.test.ts
@@ -115,20 +115,6 @@ describe('connection audit middleware (unit)', () => {
         });
     });
 
-    it('resolves a public_key actor rather than unknown, so the deprecated flow is not mistaken for a bug', async () => {
-        const publicKeyLocals = { account: { id: 42, uuid: 'acc-uuid' }, environment: { id: 9, name: 'dev' }, authType: 'publicKey' };
-        const req = fakeReq({ params: { connectionId: 'conn-1' }, query: { provider_config_key: 'algolia' } });
-        const event = await runAudit(auditPublicConnectionDeleted, req, fakeRes(publicKeyLocals));
-        expect(event).toMatchObject({
-            resource: 'connection',
-            action: 'deleted',
-            accountId: 42,
-            environment: { id: 9, display: 'dev' },
-            actor: { type: 'public_key', id: 'unknown' },
-            targets: [{ type: 'connection', id: 'conn-1' }]
-        });
-    });
-
     it('resolves an api_key actor (secret-key auth) rather than a user', async () => {
         const req = fakeReq({ params: { connectionId: 'conn-1' }, query: { provider_config_key: 'algolia' } });
         const event = await runAudit(auditPublicConnectionDeleted, req, fakeRes(secretKeyLocals));

--- a/packages/server/lib/middleware/audit/connection.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/connection.middleware.unit.test.ts
@@ -115,6 +115,20 @@ describe('connection audit middleware (unit)', () => {
         });
     });
 
+    it('resolves a public_key actor rather than unknown, so the deprecated flow is not mistaken for a bug', async () => {
+        const publicKeyLocals = { account: { id: 42, uuid: 'acc-uuid' }, environment: { id: 9, name: 'dev' }, authType: 'publicKey' };
+        const req = fakeReq({ params: { connectionId: 'conn-1' }, query: { provider_config_key: 'algolia' } });
+        const event = await runAudit(auditPublicConnectionDeleted, req, fakeRes(publicKeyLocals));
+        expect(event).toMatchObject({
+            resource: 'connection',
+            action: 'deleted',
+            accountId: 42,
+            environment: { id: 9, display: 'dev' },
+            actor: { type: 'public_key', id: 'unknown' },
+            targets: [{ type: 'connection', id: 'conn-1' }]
+        });
+    });
+
     it('resolves an api_key actor (secret-key auth) rather than a user', async () => {
         const req = fakeReq({ params: { connectionId: 'conn-1' }, query: { provider_config_key: 'algolia' } });
         const event = await runAudit(auditPublicConnectionDeleted, req, fakeRes(secretKeyLocals));

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -31,7 +31,7 @@ import type {
 // Canonical audit event vocabulary — the single source of truth shared by the emit side
 // (@nangohq/audit's AuditEvent) and the read/API side (ApiAuditTrailEvent).
 export type AuditTrailVersion = '2026-07-16';
-export type AuditActorType = 'user' | 'api_key' | 'connect_session' | 'anonymous' | 'unknown';
+export type AuditActorType = 'user' | 'api_key' | 'public_key' | 'connect_session' | 'anonymous' | 'unknown';
 export type AuditOutcome = 'success' | 'failure' | 'denied';
 export type AuditViaType = 'impersonation';
 export type AuditInterface = 'api' | 'mcp';


### PR DESCRIPTION
- `resolveActor` returns a `public_key` actor for the deprecated public-key flow instead of falling through to `unknown`. Same shape as a connect session that names nobody: `{ type: 'public_key', id: 'unknown' }`. `authType` was already `'publicKey'` on `res.locals`.

44% of `connection.created` events were unattributed. 90% of those come from accounts that authenticate with a public key, cross-referenced against `nango.auth.withPublicKey`. The rest are `/oauth/callback` and `/app-auth/connect`, the two connection routes with no auth middleware, where a provider completes the connection — left as `unknown` deliberately.

Docs are on #7164, since that page is not on master yet.

## Test plan

- [x] `ts-build`, `lint`, `format:check`, 1,095 server tests
- [x] The new `resolveActor` case break-checked
- [ ] After deploy: unknown-actor `connection.created` should drop ~90%