### PR TITLE
fix(audit): name the integration when a bulk sync pause or start targets nothing (NAN-6791)

### DIFF
--- a/packages/server/lib/controllers/mcp/syncs/setState.ts
+++ b/packages/server/lib/controllers/mcp/syncs/setState.ts
@@ -2,16 +2,15 @@ import { logContextGetter } from '@nangohq/logs';
 import { normalizedSyncParams, SyncCommand, syncManager } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
-import { makeAuditTarget } from '../../../audit.js';
+import { syncTargets } from '../../../middleware/audit/index.js';
 import { getOrchestrator } from '../../../utils/utils.js';
-import { normalizeSyncParams, syncTargetId } from '../../sync/helpers.js';
 import { defineManagementMcpTool } from '../managementTool.js';
 import { PublicMcpError } from '../utils.js';
 import { syncCommandErrorToMcp } from './errors.js';
 import { setSyncsStateArgumentsSchema, setSyncsStateOutputSchema } from './schema.js';
 
 import type { SetSyncsStateOutput } from './schema.js';
-import type { AuditPolicy, AuditTarget } from '@nangohq/types';
+import type { AuditPolicy } from '@nangohq/types';
 
 const orchestrator = getOrchestrator();
 
@@ -24,7 +23,7 @@ export const setSyncsStateTool = defineManagementMcpTool<typeof setSyncsStateArg
     audit: {
         kind: 'dynamic-audit',
         policy: ({ args }) => syncStateAuditPolicy(args),
-        targetFromOutput: ({ args }) => syncTargets(args.syncs),
+        targetFromOutput: ({ args }) => syncTargets(args.syncs, args.integration_id),
         metadata: ({ args }) => ({
             providerConfigKey: args.integration_id,
             ...(args.connection_id ? { connectionId: args.connection_id } : {})
@@ -59,14 +58,6 @@ export const setSyncsStateTool = defineManagementMcpTool<typeof setSyncsStateArg
         return Ok({ success: true as const });
     }
 });
-
-function syncTargets(syncs: (string | { name: string; variant: string })[]): AuditTarget[] | undefined {
-    const targets = normalizeSyncParams(syncs)
-        .map(({ syncName, syncVariant }) => makeAuditTarget('sync', syncTargetId(syncName, syncVariant)))
-        .filter((target): target is AuditTarget => Boolean(target));
-
-    return targets.length > 0 ? targets : undefined;
-}
 
 function syncStateAuditPolicy(args: unknown): AuditPolicy<'sync', 'started' | 'paused', 'environment'> | undefined {
     if (typeof args !== 'object' || args === null) {

--- a/packages/server/lib/middleware/audit/index.ts
+++ b/packages/server/lib/middleware/audit/index.ts
@@ -83,7 +83,8 @@ export {
     auditSyncPaused,
     auditSyncStarted,
     auditSyncVariantCreated,
-    auditSyncVariantDeleted
+    auditSyncVariantDeleted,
+    syncTargets
 } from './sync.middleware.js';
 export { auditTeamUpdated } from './team.middleware.js';
 export { auditUserUpdated } from './user.middleware.js';

--- a/packages/server/lib/middleware/audit/sync.middleware.ts
+++ b/packages/server/lib/middleware/audit/sync.middleware.ts
@@ -35,13 +35,13 @@ export const auditSyncDisabled = auditable<PatchFlowDisable>({
 
 export const auditSyncPaused = auditable<PostPublicSyncPause>({
     policy: Audit.auditable({ resource: 'sync', action: 'paused', scope: 'environment' }),
-    target: (req) => syncTargetsFromBody(req.body?.syncs),
+    target: (req) => syncTargets(req.body?.syncs, req.body?.provider_config_key),
     metadata: (req) => syncBaseMeta(req.body.provider_config_key, req.body.connection_id)
 });
 
 export const auditSyncStarted = auditable<PostPublicSyncStart>({
     policy: Audit.auditable({ resource: 'sync', action: 'started', scope: 'environment' }),
-    target: (req) => syncTargetsFromBody(req.body?.syncs),
+    target: (req) => syncTargets(req.body?.syncs, req.body?.provider_config_key),
     metadata: (req) => syncBaseMeta(req.body.provider_config_key, req.body.connection_id)
 });
 
@@ -90,14 +90,32 @@ function syncBaseMeta(providerConfigKey: unknown, connectionId?: unknown): Recor
     return omitUndefined({ providerConfigKey: nonEmptyString(providerConfigKey), connectionId: nonEmptyString(connectionId) });
 }
 
-function syncTargetsFromBody(syncs: (string | { name: string; variant: string })[] | undefined): AuditTarget[] | undefined {
-    if (!Array.isArray(syncs)) {
-        return undefined;
-    }
-    const targets = normalizeSyncParams(syncs)
+/** An empty or absent `syncs` means every sync, expanded only after this has run, so the integration is the widest scope the request itself names. */
+export function syncTargets(syncs: unknown, providerConfigKey: unknown): AuditTarget | AuditTarget[] | undefined {
+    const targets = normalizeSyncParams(validSyncParams(syncs))
         .map(({ syncName, syncVariant }) => makeTarget('sync', syncTargetId(syncName, syncVariant)))
         .filter((t): t is AuditTarget => Boolean(t));
-    return targets.length > 0 ? targets : undefined;
+    return targets.length > 0 ? targets : makeTarget('integration', providerConfigKey);
+}
+
+type SyncParam = Parameters<typeof normalizeSyncParams>[0][number];
+
+/** Nothing has validated the members yet, so drop the ones that are not a sync rather than lose the rest. */
+function validSyncParams(syncs: unknown): SyncParam[] {
+    if (!Array.isArray(syncs)) {
+        return [];
+    }
+    return syncs.flatMap((sync): SyncParam[] => {
+        if (typeof sync === 'string') {
+            return [sync];
+        }
+        if (!sync || typeof sync !== 'object') {
+            return [];
+        }
+        const { name, variant } = sync as Record<string, unknown>;
+        const syncName = nonEmptyString(name);
+        return syncName ? [{ name: syncName, variant: nonEmptyString(variant) ?? 'base' }] : [];
+    });
 }
 
 type SyncCommandAudit = { action: 'paused' | 'started' | 'cancelled' } | { action: 'triggered'; metadata: SyncTriggerOptions };

--- a/packages/server/lib/middleware/audit/sync.middleware.ts
+++ b/packages/server/lib/middleware/audit/sync.middleware.ts
@@ -100,7 +100,7 @@ export function syncTargets(syncs: unknown, providerConfigKey: unknown): AuditTa
 
 type SyncParam = Parameters<typeof normalizeSyncParams>[0][number];
 
-/** Nothing has validated the members yet, so drop the ones that are not a sync rather than lose the rest. */
+/** Members are unvalidated, and a non-string name would concatenate into the target id — drop those, keep the rest. */
 function validSyncParams(syncs: unknown): SyncParam[] {
     if (!Array.isArray(syncs)) {
         return [];

--- a/packages/server/lib/middleware/audit/sync.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/sync.middleware.unit.test.ts
@@ -71,6 +71,44 @@ describe('sync audit middleware (unit)', () => {
         expect(event?.metadata).toBeUndefined();
     });
 
+    it.each([
+        ['pause', auditSyncPaused],
+        ['start', auditSyncStarted]
+    ])('sync %s: targets the integration when the caller named no syncs', async (name, handler) => {
+        const req = fakeReq({ body: { syncs: [], provider_config_key: 'algolia', connection_id: 'conn-1' } });
+        const event = await runAudit(handler as RequestHandler, req, fakeRes(secretKeyLocals));
+        expect(event).toMatchObject({
+            resource: 'sync',
+            action: name === 'pause' ? 'paused' : 'started',
+            outcome: 'success',
+            accountId: 42,
+            environment: { id: 9, display: 'dev' },
+            targets: [{ type: 'integration', id: 'algolia' }],
+            metadata: { providerConfigKey: 'algolia', connectionId: 'conn-1' }
+        });
+    });
+
+    it('sync pause: targets the integration when the body carries no syncs field at all', async () => {
+        const req = fakeReq({ body: { provider_config_key: 'algolia' } });
+        const event = await runAudit(auditSyncPaused, req, fakeRes(secretKeyLocals));
+        expect(event.targets).toEqual([{ type: 'integration', id: 'algolia' }]);
+    });
+
+    it('sync pause: keeps the valid syncs beside a malformed one rather than losing every target', async () => {
+        const req = fakeReq({ body: { syncs: ['sync-a', null, 42, { name: 'sync-b' }], provider_config_key: 'algolia' } });
+        const event = await runAudit(auditSyncPaused, req, fakeRes(secretKeyLocals));
+        expect(event.targets).toEqual([
+            { type: 'sync', id: 'sync-a' },
+            { type: 'sync', id: 'sync-b' }
+        ]);
+    });
+
+    it('sync pause: never invents a sync name out of a non-string one', async () => {
+        const req = fakeReq({ body: { syncs: [{ name: {}, variant: [] }], provider_config_key: 'algolia' } });
+        const event = await runAudit(auditSyncPaused, req, fakeRes(secretKeyLocals));
+        expect(event.targets).toEqual([{ type: 'integration', id: 'algolia' }]);
+    });
+
     it('sync start: one target per sync, the variant inside the id', async () => {
         const req = fakeReq({ body: { syncs: ['sync-a', { name: 'sync-b', variant: 'v2' }], provider_config_key: 'algolia' } });
         const event = await runAudit(auditSyncStarted, req, fakeRes(secretKeyLocals));

--- a/packages/server/lib/middleware/audit/sync.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/sync.middleware.unit.test.ts
@@ -103,10 +103,16 @@ describe('sync audit middleware (unit)', () => {
         ]);
     });
 
-    it('sync pause: never invents a sync name out of a non-string one', async () => {
-        const req = fakeReq({ body: { syncs: [{ name: {}, variant: [] }], provider_config_key: 'algolia' } });
+    it('sync pause: drops a member whose name is not a string instead of concatenating it into a target id', async () => {
+        const req = fakeReq({ body: { syncs: [{ name: {}, variant: 'v2' }], provider_config_key: 'algolia' } });
         const event = await runAudit(auditSyncPaused, req, fakeRes(secretKeyLocals));
         expect(event.targets).toEqual([{ type: 'integration', id: 'algolia' }]);
+    });
+
+    it('sync pause: reads a member whose variant is not a string as the base variant', async () => {
+        const req = fakeReq({ body: { syncs: [{ name: 'sync-a', variant: [] }], provider_config_key: 'algolia' } });
+        const event = await runAudit(auditSyncPaused, req, fakeRes(secretKeyLocals));
+        expect(event.targets).toEqual([{ type: 'sync', id: 'sync-a' }]);
     });
 
     it('sync start: one target per sync, the variant inside the id', async () => {


### PR DESCRIPTION
- `POST /sync/pause` and `POST /sync/start` accept an empty `syncs` list to mean "every sync", and the controller expands it only after the audit resolver has run, so those events recorded no target at all. They now fall back to the integration, which is the widest scope the request itself names. Measured in production: 4 of the 5 no-target `sync.started` events in a 24h window were successful bulk calls, across 4 accounts.
- The same resolver threw on a malformed member, losing the valid targets beside it, and turned a non-string name into a fabricated `[object Object]::v2` id. Invalid members are now dropped and the rest survive.
- The MCP `syncs_set_state` tool emits the same two events from its own copy of the resolver, with the same empty-list behaviour, so both now share one function.

A `sync.paused` row names the syncs when the caller named them and the integration when they did not, so the target type tells a reader which shape the call had. The connection is unchanged and stays in metadata, where both emitters already put it. Design and the reproduction matrix are on NAN-6791.

## Test plan

- [x] Six unit cases: the integration fallback on both endpoints, an absent `syncs` field, valid syncs surviving a malformed neighbour, a non-string name, a non-string variant
- [x] Mutation-checked: breaking each guard fails a test, and each case is the only catcher of at least one break
- [x] `ts-build`, oxlint and prettier clean; 284 audit + MCP unit tests pass
- [ ] After deploy: confirm no-target `sync.paused` / `sync.started` rows drop to zero in ClickHouse