### PR TITLE
fix(docs): point nango.dev/demo links at /contact

### DIFF
--- a/docs/guides/platform/security.mdx
+++ b/docs/guides/platform/security.mdx
@@ -14,7 +14,7 @@ Nango is **SOC 2 Type II** certified, **GDPR** compliant, and **HIPAA** complian
 | - | - |
 | SOC 2 Type II | Annual audit covering security, availability, and confidentiality. [View report →](https://trust.nango.dev) |
 | GDPR | Data Processing Agreement (DPA) automatically applies to all cloud accounts. [View DPA →](https://nango.dev/terms#dpa) |
-| HIPAA | Business Associate Agreement (BAA) available on request. [Contact us →](https://nango.dev/demo) |
+| HIPAA | Business Associate Agreement (BAA) available on request. [Contact us →](https://nango.dev/contact) |
 
 Our security practices include:
 

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -195,7 +195,7 @@ Once the server restarts, users can turn it on from their profile settings by pa
 
 A limited free self-hosting option is available for hobby projects. It is intended for lightweight deployments that need Auth and Proxy, without the managed features and support included with Enterprise self-hosting or Nango Cloud.
 
-For more details, see the [pricing page](https://nango.dev/pricing) or [schedule a call](https://nango.dev/demo) to discuss the Enterprise self-hosted version.
+For more details, see the [pricing page](https://nango.dev/pricing) or [schedule a call](https://nango.dev/contact) to discuss the Enterprise self-hosted version.
 
 ### Feature availability
 
@@ -577,7 +577,7 @@ docker-compose up -d
 ```
 
 <Tip>
-If you are interested in the Enterprise self-hosting version, please get in touch with us in the [community](https://nango.dev/slack) or [book a demo](https://nango.dev/demo).
+If you are interested in the Enterprise self-hosting version, please get in touch with us in the [community](https://nango.dev/slack) or [book a call](https://nango.dev/contact).
 </Tip>
 
 ## Related guides

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6316,7 +6316,7 @@ Nango is **SOC 2 Type II** certified, **GDPR** compliant, and **HIPAA** complian
 | - | - |
 | SOC 2 Type II | Annual audit covering security, availability, and confidentiality. [View report →](https://trust.nango.dev) |
 | GDPR | Data Processing Agreement (DPA) automatically applies to all cloud accounts. [View DPA →](https://nango.dev/terms#dpa) |
-| HIPAA | Business Associate Agreement (BAA) available on request. [Contact us →](https://nango.dev/demo) |
+| HIPAA | Business Associate Agreement (BAA) available on request. [Contact us →](https://nango.dev/contact) |
 
 Our security practices include:
 
@@ -6865,7 +6865,7 @@ Once the server restarts, users can turn it on from their profile settings by pa
 
 A limited free self-hosting option is available for hobby projects. It is intended for lightweight deployments that need Auth and Proxy, without the managed features and support included with Enterprise self-hosting or Nango Cloud.
 
-For more details, see the [pricing page](https://nango.dev/pricing) or [schedule a call](https://nango.dev/demo) to discuss the Enterprise self-hosted version.
+For more details, see the [pricing page](https://nango.dev/pricing) or [schedule a call](https://nango.dev/contact) to discuss the Enterprise self-hosted version.
 
 ### Feature availability
 
@@ -7247,7 +7247,7 @@ docker-compose up -d
 ```
 
 <Tip>
-If you are interested in the Enterprise self-hosting version, please get in touch with us in the [community](https://nango.dev/slack) or [book a demo](https://nango.dev/demo).
+If you are interested in the Enterprise self-hosting version, please get in touch with us in the [community](https://nango.dev/slack) or [book a call](https://nango.dev/contact).
 </Tip>
 
 ## Related guides
@@ -15944,6 +15944,6 @@ Use these slugs to construct provider-specific docs URLs only when needed.
 
 - [Blog](https://nango.dev/blog): Articles, product updates, and integration deep-dives from the Nango team.
 - [Pricing](https://nango.dev/pricing): Plans and pricing for Nango Cloud.
-- [Talk to the team](https://nango.dev/demo): Book a call with Nango for sales, onboarding, or technical questions.
+- [Talk to the team](https://nango.dev/contact): Book a call with Nango for sales, onboarding, or technical questions.
 - [Community Slack](https://nango.dev/slack): Get help, share feedback, and connect with other Nango developers.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -154,7 +154,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 
 - [Blog](https://nango.dev/blog): Articles, product updates, and integration deep-dives from the Nango team.
 - [Pricing](https://nango.dev/pricing): Plans and pricing for Nango Cloud.
-- [Talk to the team](https://nango.dev/demo): Book a call with Nango for sales, onboarding, or technical questions.
+- [Talk to the team](https://nango.dev/contact): Book a call with Nango for sales, onboarding, or technical questions.
 - [Community Slack](https://nango.dev/slack): Get help, share feedback, and connect with other Nango developers.
 
 ## Optional

--- a/scripts/docs-generate-llms.ts
+++ b/scripts/docs-generate-llms.ts
@@ -28,7 +28,7 @@ const resourceLinks: ResourceLink[] = [
     },
     {
         title: 'Talk to the team',
-        url: 'https://nango.dev/demo',
+        url: 'https://nango.dev/contact',
         description: 'Book a call with Nango for sales, onboarding, or technical questions.'
     },
     {


### PR DESCRIPTION
## Problem

The website's demo page is moving from `/demo` to `/contact` ([website#147](https://github.com/NangoHQ/website/pull/147)) — we run Q&A calls, not demos, and the URL shouldn't promise otherwise. Four `nango.dev/demo` links in this repo point at the old path.

## Solution

- Docs: the HIPAA BAA link in the security guide, and both Enterprise links in the self-hosting guide
- `scripts/docs-generate-llms.ts`: the "Talk to the team" resource link, plus the regenerated `llms.txt` / `llms-full.txt`
- Self-hosting's "book a demo" link text becomes "book a call"

Fixes [NAN-6366](https://linear.app/nango/issue/NAN-6366)

## Testing

Grepped the repo for remaining `nango.dev/demo` references — none left; the other `/demo` hits are third-party demo instances and a changelog entry. Prettier and the oxlint pre-commit hook pass.

## Follow-ups

- `/demo` keeps redirecting to `/contact` indefinitely, so this can merge before or after the website PR
- Email templates and any GTM triggers keyed on the `/demo` path live outside both repos and still need a manual pass
