### PR TITLE
fix(api): use UUIDs for public environment management 

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9495,7 +9495,7 @@ Source: https://nango.dev/docs/reference/backend/http-api/environments/delete-ap
   Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys). Create one from [Account API keys](https://app.nango.dev/api-keys) in the dashboard.
 </Info>
 
-Deletes an Environment API key. `environment_id` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create). `key_id` is the numeric ID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).
+Deletes an Environment API key. `environmentId` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create). `keyId` is the numeric ID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).
 
 ## List all integrations
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9472,7 +9472,7 @@ Source: https://nango.dev/docs/reference/backend/http-api/environments/create-ap
 
 Creates an Environment API key. Keys created by this endpoint always have full environment access (`environment:*`). This endpoint does not accept custom scopes. Create keys with custom scopes under **Environment Settings > API Keys**.
 
-`environmentUuid` is the UUID path parameter returned when the environment was [created](/reference/backend/http-api/environments/create).
+`environmentUuid` is the UUID returned when the environment was [created](/reference/backend/http-api/environments/create).
 
 <ResponseExample>
 ```json Example Response

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9436,13 +9436,14 @@ Creates a new environment. Additional environments are limited by your [pricing 
 
 You can create a production environment by setting `is_production: true`.
 
-The response includes the numeric environment `id`. Use it to [create an Environment API key](/reference/backend/http-api/environments/create-api-key) or [delete the environment](/reference/backend/http-api/environments/delete). Creating an environment also creates a default full-access Environment API key, but the secret is not returned.
+The response includes an environment `uuid`. Use it to [create an Environment API key](/reference/backend/http-api/environments/create-api-key) or [delete the environment](/reference/backend/http-api/environments/delete). Creating an environment also creates a default full-access Environment API key, but the secret is not returned.
 
 <ResponseExample>
 ```json Example Response
 {
   "data": {
     "id": 123,
+    "uuid": "123e4567-e89b-12d3-a456-426614174000",
     "name": "staging"
   }
 }
@@ -9457,7 +9458,7 @@ Source: https://nango.dev/docs/reference/backend/http-api/environments/delete.md
   Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys). Create one from [Account API keys](https://app.nango.dev/api-keys) in the dashboard.
 </Info>
 
-Deletes an environment. `environmentId` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create).
+Deletes an environment. `environmentUuid` is the UUID returned when the environment was [created](/reference/backend/http-api/environments/create).
 
 The reserved `prod` environment cannot be deleted.
 
@@ -9471,13 +9472,14 @@ Source: https://nango.dev/docs/reference/backend/http-api/environments/create-ap
 
 Creates an Environment API key. Keys created by this endpoint always have full environment access (`environment:*`). This endpoint does not accept custom scopes. Create keys with custom scopes under **Environment Settings > API Keys**.
 
-`environment_id` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create).
+`environmentUuid` is the UUID path parameter returned when the environment was [created](/reference/backend/http-api/environments/create).
 
 <ResponseExample>
 ```json Example Response
 {
   "data": {
     "id": 456,
+    "uuid": "123e4567-e89b-12d3-a456-426614174001",
     "display_name": "provisioned-ci",
     "scopes": ["environment:*"],
     "secret": "<YOUR-ENVIRONMENT-API-KEY>",
@@ -9495,7 +9497,7 @@ Source: https://nango.dev/docs/reference/backend/http-api/environments/delete-ap
   Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys). Create one from [Account API keys](https://app.nango.dev/api-keys) in the dashboard.
 </Info>
 
-Deletes an Environment API key. `environmentId` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create). `keyId` is the numeric ID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).
+Deletes an Environment API key. `environmentUuid` is the UUID returned when the environment was [created](/reference/backend/http-api/environments/create). `keyUuid` is the UUID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).
 
 ## List all integrations
 

--- a/docs/reference/backend/http-api/environments/create-api-key.mdx
+++ b/docs/reference/backend/http-api/environments/create-api-key.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create an environment API key'
-openapi: 'POST /environment/api-keys'
+openapi: 'POST /environments/{environmentUuid}/api-keys'
 ---
 
 <Info>
@@ -9,13 +9,14 @@ openapi: 'POST /environment/api-keys'
 
 Creates an Environment API key. Keys created by this endpoint always have full environment access (`environment:*`). This endpoint does not accept custom scopes. Create keys with custom scopes under **Environment Settings > API Keys**.
 
-`environment_id` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create).
+`environmentUuid` is the UUID returned when the environment was [created](/reference/backend/http-api/environments/create).
 
 <ResponseExample>
 ```json Example Response
 {
   "data": {
     "id": 456,
+    "uuid": "123e4567-e89b-12d3-a456-426614174001",
     "display_name": "provisioned-ci",
     "scopes": ["environment:*"],
     "secret": "<YOUR-ENVIRONMENT-API-KEY>",

--- a/docs/reference/backend/http-api/environments/create.mdx
+++ b/docs/reference/backend/http-api/environments/create.mdx
@@ -11,13 +11,14 @@ Creates a new environment. Additional environments are limited by your [pricing 
 
 You can create a production environment by setting `is_production: true`.
 
-The response includes the numeric environment `id`. Use it to [create an Environment API key](/reference/backend/http-api/environments/create-api-key) or [delete the environment](/reference/backend/http-api/environments/delete). Creating an environment also creates a default full-access Environment API key, but the secret is not returned.
+The response includes an environment `uuid`. Use it to [create an Environment API key](/reference/backend/http-api/environments/create-api-key) or [delete the environment](/reference/backend/http-api/environments/delete). Creating an environment also creates a default full-access Environment API key, but the secret is not returned.
 
 <ResponseExample>
 ```json Example Response
 {
   "data": {
     "id": 123,
+    "uuid": "123e4567-e89b-12d3-a456-426614174000",
     "name": "staging"
   }
 }

--- a/docs/reference/backend/http-api/environments/delete-api-key.mdx
+++ b/docs/reference/backend/http-api/environments/delete-api-key.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'Delete an environment API key'
-openapi: 'DELETE /environment/api-keys'
+openapi: 'DELETE /environments/{environmentId}/api-keys/{keyId}'
 ---
 
 <Info>
   Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys). Create one from [Account API keys](https://app.nango.dev/api-keys) in the dashboard.
 </Info>
 
-Deletes an Environment API key. `environment_id` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create). `key_id` is the numeric ID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).
+Deletes an Environment API key. `environmentId` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create). `keyId` is the numeric ID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).

--- a/docs/reference/backend/http-api/environments/delete-api-key.mdx
+++ b/docs/reference/backend/http-api/environments/delete-api-key.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'Delete an environment API key'
-openapi: 'DELETE /environments/{environmentId}/api-keys/{keyId}'
+openapi: 'DELETE /environments/{environmentUuid}/api-keys/{keyUuid}'
 ---
 
 <Info>
   Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys). Create one from [Account API keys](https://app.nango.dev/api-keys) in the dashboard.
 </Info>
 
-Deletes an Environment API key. `environmentId` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create). `keyId` is the numeric ID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).
+Deletes an Environment API key. `environmentUuid` is the UUID returned when the environment was [created](/reference/backend/http-api/environments/create). `keyUuid` is the UUID returned when the key was [created](/reference/backend/http-api/environments/create-api-key).

--- a/docs/reference/backend/http-api/environments/delete.mdx
+++ b/docs/reference/backend/http-api/environments/delete.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'Delete an environment'
-openapi: 'DELETE /environments/{environmentId}'
+openapi: 'DELETE /environments/{environmentUuid}'
 ---
 
 <Info>
   Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys). Create one from [Account API keys](https://app.nango.dev/api-keys) in the dashboard.
 </Info>
 
-Deletes an environment. `environmentId` is the numeric ID returned when the environment was [created](/reference/backend/http-api/environments/create).
+Deletes an environment. `environmentUuid` is the UUID returned when the environment was [created](/reference/backend/http-api/environments/create).
 
 The reserved `prod` environment cannot be deleted.

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2860,12 +2860,18 @@ paths:
                                         type: object
                                         required:
                                             - id
+                                            - uuid
                                             - name
                                         properties:
                                             id:
                                                 type: integer
-                                                description: Numeric environment ID. Use this in later account-level API calls.
+                                                description: Numeric environment ID.
                                                 example: 123
+                                            uuid:
+                                                type: string
+                                                format: uuid
+                                                description: Environment UUID. Use this in later account-level API calls.
+                                                example: 123e4567-e89b-12d3-a456-426614174000
                                             name:
                                                 type: string
                                                 description: The environment name.
@@ -2884,18 +2890,18 @@ paths:
                                 $ref: '#/components/schemas/StdError'
                 '500':
                     $ref: '#/components/responses/ServerError'
-    /environments/{environmentId}:
+    /environments/{environmentUuid}:
         delete:
             summary: Delete an environment
             description: Delete an environment
             parameters:
-                - name: environmentId
+                - name: environmentUuid
                   in: path
                   required: true
                   schema:
-                      type: integer
-                      minimum: 1
-                  description: Numeric environment ID returned when the environment was created.
+                      type: string
+                      format: uuid
+                  description: Environment UUID returned when the environment was created.
             responses:
                 '204':
                     description: Successfully deleted the environment
@@ -2911,10 +2917,19 @@ paths:
                     $ref: '#/components/responses/Forbidden'
                 '404':
                     $ref: '#/components/responses/NotFound'
-    /environment/api-keys:
+    /environments/{environmentUuid}/api-keys:
         post:
             summary: Create an environment API key
             description: Create a new environment API key
+            parameters:
+                - name: environmentUuid
+                  in: path
+                  required: true
+                  description: Environment UUID that will own the key.
+                  schema:
+                      type: string
+                      format: uuid
+                  example: 123e4567-e89b-12d3-a456-426614174000
             requestBody:
                 required: true
                 content:
@@ -2923,14 +2938,8 @@ paths:
                             type: object
                             additionalProperties: false
                             required:
-                                - environment_id
                                 - display_name
                             properties:
-                                environment_id:
-                                    type: integer
-                                    minimum: 1
-                                    description: Numeric environment ID returned when the environment was created.
-                                    example: 123
                                 display_name:
                                     type: string
                                     description: Display name for the key. Must be unique within the environment.
@@ -2951,6 +2960,7 @@ paths:
                                         type: object
                                         required:
                                             - id
+                                            - uuid
                                             - display_name
                                             - scopes
                                             - secret
@@ -2958,8 +2968,13 @@ paths:
                                         properties:
                                             id:
                                                 type: integer
-                                                description: Numeric key ID. Use this to delete the key later.
+                                                description: Numeric key ID.
                                                 example: 456
+                                            uuid:
+                                                type: string
+                                                format: uuid
+                                                description: API key UUID. Use this to delete the key later.
+                                                example: 123e4567-e89b-12d3-a456-426614174001
                                             display_name:
                                                 type: string
                                                 example: provisioned-ci
@@ -2992,27 +3007,27 @@ paths:
                                 $ref: '#/components/schemas/StdError'
                 '500':
                     $ref: '#/components/responses/ServerError'
-    /environments/{environmentId}/api-keys/{keyId}:
+    /environments/{environmentUuid}/api-keys/{keyUuid}:
         delete:
             summary: Delete an environment API key
             description: Delete an environment API key
             parameters:
-                - name: environmentId
+                - name: environmentUuid
                   in: path
                   required: true
-                  description: Numeric environment ID that owns the key.
+                  description: Environment UUID that owns the key.
                   schema:
-                      type: integer
-                      minimum: 1
-                  example: 123
-                - name: keyId
+                      type: string
+                      format: uuid
+                  example: 123e4567-e89b-12d3-a456-426614174000
+                - name: keyUuid
                   in: path
                   required: true
-                  description: Numeric key ID returned when the key was created.
+                  description: API key UUID returned when the key was created.
                   schema:
-                      type: integer
-                      minimum: 1
-                  example: 456
+                      type: string
+                      format: uuid
+                  example: 123e4567-e89b-12d3-a456-426614174001
             responses:
                 '200':
                     description: Successfully deleted the Environment API key

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2992,30 +2992,27 @@ paths:
                                 $ref: '#/components/schemas/StdError'
                 '500':
                     $ref: '#/components/responses/ServerError'
+    /environments/{environmentId}/api-keys/{keyId}:
         delete:
             summary: Delete an environment API key
             description: Delete an environment API key
-            requestBody:
-                required: true
-                content:
-                    application/json:
-                        schema:
-                            type: object
-                            additionalProperties: false
-                            required:
-                                - environment_id
-                                - key_id
-                            properties:
-                                environment_id:
-                                    type: integer
-                                    minimum: 1
-                                    description: Numeric environment ID that owns the key.
-                                    example: 123
-                                key_id:
-                                    type: integer
-                                    minimum: 1
-                                    description: Numeric key ID returned when the key was created.
-                                    example: 456
+            parameters:
+                - name: environmentId
+                  in: path
+                  required: true
+                  description: Numeric environment ID that owns the key.
+                  schema:
+                      type: integer
+                      minimum: 1
+                  example: 123
+                - name: keyId
+                  in: path
+                  required: true
+                  description: Numeric key ID returned when the key was created.
+                  schema:
+                      type: integer
+                      minimum: 1
+                  example: 456
             responses:
                 '200':
                     description: Successfully deleted the Environment API key

--- a/packages/database/lib/migrations/20260827120000_add_uuid_to_customer_keys.cjs
+++ b/packages/database/lib/migrations/20260827120000_add_uuid_to_customer_keys.cjs
@@ -16,7 +16,8 @@ exports.up = async function (knex) {
         .update({ uuid: knex.raw('uuid_generate_v4()') });
 
     await addUuidNotNullConstraint(knex);
-    await addUuidUniqueIndex(knex);
+
+    await knex.raw(`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ${uniqueIndexName} ON ${tableName} (uuid)`);
 };
 
 /**
@@ -31,6 +32,19 @@ exports.up = async function (knex) {
  *   won't have to scan the table to prove the constraint; it is already proven and it can rely on it.
  */
 async function addUuidNotNullConstraint(knex) {
+    const existingColumn = await knex.raw(
+        `
+        SELECT attnotnull
+        FROM pg_attribute
+        WHERE attrelid = ?::regclass AND attname = 'uuid' AND NOT attisdropped`,
+        [tableName]
+    );
+
+    // No need to add the constraint; the `uuid` column is already `NOT NULL`.
+    if (existingColumn.rows[0]?.attnotnull) {
+        return;
+    }
+
     await knex.raw(`
         DO $$
         BEGIN
@@ -49,15 +63,7 @@ async function addUuidNotNullConstraint(knex) {
 
     await knex.raw(`ALTER TABLE ${tableName} VALIDATE CONSTRAINT ${notNullConstraintName}`);
     await knex.raw(`ALTER TABLE ${tableName} ALTER COLUMN uuid SET NOT NULL`);
-}
-
-async function addUuidUniqueIndex(knex) {
-    const existingIndex = await knex.raw(`SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(?)`, [uniqueIndexName]);
-    if (existingIndex.rows[0]?.indisvalid === false) {
-        // Drop index if it is invalid.
-        await knex.raw(`DROP INDEX CONCURRENTLY ${uniqueIndexName}`);
-    }
-    await knex.raw(`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ${uniqueIndexName} ON ${tableName} (uuid)`);
+    await knex.raw(`ALTER TABLE ${tableName} DROP CONSTRAINT IF EXISTS ${notNullConstraintName}`);
 }
 
 exports.down = async function () {};

--- a/packages/database/lib/migrations/20260827120000_add_uuid_to_customer_keys.cjs
+++ b/packages/database/lib/migrations/20260827120000_add_uuid_to_customer_keys.cjs
@@ -1,0 +1,13 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw('ALTER TABLE customer_keys ADD COLUMN IF NOT EXISTS uuid UUID');
+    await knex('customer_keys')
+        .whereNull('uuid')
+        .update({ uuid: knex.raw('uuid_generate_v4()') });
+    await knex.raw('ALTER TABLE customer_keys ALTER COLUMN uuid SET NOT NULL, ALTER COLUMN uuid SET DEFAULT uuid_generate_v4()');
+    await knex.raw('CREATE UNIQUE INDEX IF NOT EXISTS customer_keys_uuid_unique ON customer_keys (uuid)');
+};
+
+exports.down = async function () {};

--- a/packages/database/lib/migrations/20260827120000_add_uuid_to_customer_keys.cjs
+++ b/packages/database/lib/migrations/20260827120000_add_uuid_to_customer_keys.cjs
@@ -1,13 +1,63 @@
+exports.config = { transaction: false };
+
+const tableName = 'customer_keys';
+const notNullConstraintName = `${tableName}_uuid_not_null`;
+const uniqueIndexName = `${tableName}_uuid_unique`;
+
 /**
  * @param {import('knex').Knex} knex
  */
 exports.up = async function (knex) {
-    await knex.raw('ALTER TABLE customer_keys ADD COLUMN IF NOT EXISTS uuid UUID');
-    await knex('customer_keys')
+    await knex.raw(`ALTER TABLE ${tableName} ADD COLUMN IF NOT EXISTS uuid UUID`);
+    await knex.raw(`ALTER TABLE ${tableName} ALTER COLUMN uuid SET DEFAULT uuid_generate_v4()`);
+
+    await knex(tableName)
         .whereNull('uuid')
         .update({ uuid: knex.raw('uuid_generate_v4()') });
-    await knex.raw('ALTER TABLE customer_keys ALTER COLUMN uuid SET NOT NULL, ALTER COLUMN uuid SET DEFAULT uuid_generate_v4()');
-    await knex.raw('CREATE UNIQUE INDEX IF NOT EXISTS customer_keys_uuid_unique ON customer_keys (uuid)');
+
+    await addUuidNotNullConstraint(knex);
+    await addUuidUniqueIndex(knex);
 };
+
+/**
+ * Adds a `NOT NULL` constraint to the new `uuid` column, avoiding holding an ACCESS EXCLUSIVE lock
+ * while the table is scanned to prove the constraint. The operation is retry-safe.
+ *
+ * Steps:
+ * 1. Add a CHECK constraint with initial NOT VALID state. This will take on ACCESS EXCLUSIVE, but only
+ *   briefly once acquired.
+ * 2. Validate the constraint. This allows concurrent reads/writes while it runs.
+ * 3. Mark the column NOT NULL. This will again take on ACCESS EXCLUSIVE, but it will be fast as it
+ *   won't have to scan the table to prove the constraint; it is already proven and it can rely on it.
+ */
+async function addUuidNotNullConstraint(knex) {
+    await knex.raw(`
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conrelid = '${tableName}'::regclass
+                  AND conname = '${notNullConstraintName}'
+            ) THEN
+                ALTER TABLE ${tableName}
+                    ADD CONSTRAINT ${notNullConstraintName}
+                    CHECK (uuid IS NOT NULL) NOT VALID;
+            END IF;
+        END $$;
+    `);
+
+    await knex.raw(`ALTER TABLE ${tableName} VALIDATE CONSTRAINT ${notNullConstraintName}`);
+    await knex.raw(`ALTER TABLE ${tableName} ALTER COLUMN uuid SET NOT NULL`);
+}
+
+async function addUuidUniqueIndex(knex) {
+    const existingIndex = await knex.raw(`SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(?)`, [uniqueIndexName]);
+    if (existingIndex.rows[0]?.indisvalid === false) {
+        // Drop index if it is invalid.
+        await knex.raw(`DROP INDEX CONCURRENTLY ${uniqueIndexName}`);
+    }
+    await knex.raw(`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ${uniqueIndexName} ON ${tableName} (uuid)`);
+}
 
 exports.down = async function () {};

--- a/packages/server/lib/controllers/environment/deleteApiKey.ts
+++ b/packages/server/lib/controllers/environment/deleteApiKey.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 
-import { environmentService } from '@nangohq/shared';
+import db from '@nangohq/database';
+import { customerKeyService, environmentService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
@@ -10,12 +11,12 @@ import type { DeletePublicApiKey } from '@nangohq/types';
 
 const validationParams = z
     .object({
-        environmentId: z.coerce.number().int().positive(),
-        keyId: z.coerce.number().int().positive()
+        environmentUuid: z.uuid(),
+        keyUuid: z.uuid()
     })
     .strict();
 
-export const deletePublicApiKey = asyncWrapper<DeletePublicApiKey>(async (req, res) => {
+export const deletePublicEnvironmentApiKey = asyncWrapper<DeletePublicApiKey>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
@@ -28,7 +29,7 @@ export const deletePublicApiKey = asyncWrapper<DeletePublicApiKey>(async (req, r
         return;
     }
 
-    const { environmentId, keyId } = valParams.data;
+    const { environmentUuid, keyUuid } = valParams.data;
 
     const account = res.locals.account;
     if (!account) {
@@ -36,11 +37,21 @@ export const deletePublicApiKey = asyncWrapper<DeletePublicApiKey>(async (req, r
         return;
     }
 
-    const environment = await environmentService.getByIdWithoutSecrets(environmentId, account.id);
+    const environment = await environmentService.getByUuidWithoutSecrets(environmentUuid, account.id);
     if (!environment) {
         res.status(404).send({ error: { code: 'not_found', message: 'Environment not found' } });
         return;
     }
 
-    await handleDeleteApiKey({ res, environmentId: environment.id, keyId });
+    const key = await customerKeyService.getApiKeyByUuid(db.knex, keyUuid, environment.id, account.id);
+    if (key.isErr()) {
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to delete API key' } });
+        return;
+    }
+    if (!key.value) {
+        res.status(404).send({ error: { code: 'not_found', message: 'API key not found' } });
+        return;
+    }
+
+    await handleDeleteApiKey({ res, environmentId: environment.id, keyId: key.value.id });
 });

--- a/packages/server/lib/controllers/environment/deleteApiKey.ts
+++ b/packages/server/lib/controllers/environment/deleteApiKey.ts
@@ -8,10 +8,10 @@ import { handleDeleteApiKey } from '../shared/environments/deleteApiKey.js';
 
 import type { DeletePublicApiKey } from '@nangohq/types';
 
-const validationBody = z
+const validationParams = z
     .object({
-        environment_id: z.coerce.number().int().positive(),
-        key_id: z.coerce.number().int().positive()
+        environmentId: z.coerce.number().int().positive(),
+        keyId: z.coerce.number().int().positive()
     })
     .strict();
 
@@ -22,13 +22,13 @@ export const deletePublicApiKey = asyncWrapper<DeletePublicApiKey>(async (req, r
         return;
     }
 
-    const valBody = validationBody.safeParse(req.body);
-    if (!valBody.success) {
-        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
         return;
     }
 
-    const { environment_id: environmentId, key_id: keyId } = valBody.data;
+    const { environmentId, keyId } = valParams.data;
 
     const account = res.locals.account;
     if (!account) {

--- a/packages/server/lib/controllers/environment/deleteApiKey.ts
+++ b/packages/server/lib/controllers/environment/deleteApiKey.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { customerKeyService, environmentService } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import { handleDeleteApiKey } from '../shared/environments/deleteApiKey.js';
@@ -45,6 +45,7 @@ export const deletePublicEnvironmentApiKey = asyncWrapper<DeletePublicApiKey>(as
 
     const key = await customerKeyService.getApiKeyByUuid(db.knex, keyUuid, environment.id, account.id);
     if (key.isErr()) {
+        report(key.error);
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to delete API key' } });
         return;
     }

--- a/packages/server/lib/controllers/environment/deleteApiKey.ts
+++ b/packages/server/lib/controllers/environment/deleteApiKey.ts
@@ -45,7 +45,7 @@ export const deletePublicEnvironmentApiKey = asyncWrapper<DeletePublicApiKey>(as
 
     const key = await customerKeyService.getApiKeyByUuid(db.knex, keyUuid, environment.id, account.id);
     if (key.isErr()) {
-        report(key.error);
+        report(key.error, { accountId: account.id, environmentId: environment.id });
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to delete API key' } });
         return;
     }

--- a/packages/server/lib/controllers/environment/deleteEnvironment.ts
+++ b/packages/server/lib/controllers/environment/deleteEnvironment.ts
@@ -8,7 +8,7 @@ import { getOrchestrator } from '../../utils/utils.js';
 
 import type { DeletePublicEnvironment } from '@nangohq/types';
 
-const validationParams = z.object({ environmentId: z.coerce.number().int().positive() }).strict();
+const validationParams = z.object({ environmentUuid: z.uuid() }).strict();
 
 export const deletePublicEnvironment = asyncWrapper<DeletePublicEnvironment>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
@@ -30,7 +30,7 @@ export const deletePublicEnvironment = asyncWrapper<DeletePublicEnvironment>(asy
     }
 
     const params: DeletePublicEnvironment['Params'] = valParams.data;
-    const environment = await environmentService.getByIdWithoutSecrets(params.environmentId, account.id);
+    const environment = await environmentService.getByUuidWithoutSecrets(params.environmentUuid, account.id);
     if (!environment) {
         res.status(404).send({ error: { code: 'not_found', message: 'Environment not found' } });
         return;

--- a/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
@@ -116,11 +116,11 @@ describe('Public environment API key management', () => {
         });
     });
 
-    describe('DELETE /environment/api-keys', () => {
+    describe('DELETE /environments/:environmentId/api-keys/:keyId', () => {
         it('should be protected', async () => {
-            const res = await api.fetch('/environment/api-keys', {
+            const res = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
-                body: { environment_id: 1, key_id: 1 }
+                params: { environmentId: 1, keyId: 1 }
             });
 
             shouldBeProtected(res);
@@ -139,10 +139,10 @@ describe('Public environment API key management', () => {
             expect(created.res.status).toBe(200);
             isSuccess(created.json);
 
-            const deniedDelete = await api.fetch('/environment/api-keys', {
+            const deniedDelete = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
                 token: createKey.secret,
-                body: { environment_id: env.id, key_id: created.json.data.id }
+                params: { environmentId: env.id, keyId: created.json.data.id }
             });
             expect(deniedDelete.res.status).toBe(403);
 
@@ -153,10 +153,10 @@ describe('Public environment API key management', () => {
             });
             expect(deniedCreate.res.status).toBe(403);
 
-            const deleted = await api.fetch('/environment/api-keys', {
+            const deleted = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
                 token: deleteKey.secret,
-                body: { environment_id: env.id, key_id: created.json.data.id }
+                params: { environmentId: env.id, keyId: created.json.data.id }
             });
             expect(deleted.res.status).toBe(200);
             isSuccess(deleted.json);
@@ -175,10 +175,10 @@ describe('Public environment API key management', () => {
             ).unwrap();
             const deleteKey = await createAccountKey(first.account.id, ['account:environments:api_keys:delete']);
 
-            const res = await api.fetch('/environment/api-keys', {
+            const res = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
                 token: deleteKey.secret,
-                body: { environment_id: second.env.id, key_id: created.id }
+                params: { environmentId: second.env.id, keyId: created.id }
             });
 
             expect(res.res.status).toBe(404);
@@ -201,10 +201,10 @@ describe('Public environment API key management', () => {
             expect(created.res.status).toBe(200);
             isSuccess(created.json);
 
-            const deleted = await api.fetch('/environment/api-keys', {
+            const deleted = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
                 token: accountKey.secret,
-                body: { environment_id: env.id, key_id: created.json.data.id }
+                params: { environmentId: env.id, keyId: created.json.data.id }
             });
             expect(deleted.res.status).toBe(200);
             isSuccess(deleted.json);

--- a/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
@@ -33,11 +33,12 @@ describe('Public environment API key management', () => {
         api.server.close();
     });
 
-    describe('POST /environment/api-keys', () => {
+    describe('POST /environments/:environmentUuid/api-keys', () => {
         it('should be protected', async () => {
-            const res = await api.fetch('/environment/api-keys', {
+            const res = await api.fetch('/environments/:environmentUuid/api-keys', {
                 method: 'POST',
-                body: { environment_id: 1, display_name: 'unauthenticated' }
+                params: { environmentUuid: '123e4567-e89b-12d3-a456-426614174000' },
+                body: { display_name: 'unauthenticated' }
             });
 
             shouldBeProtected(res);
@@ -46,10 +47,11 @@ describe('Public environment API key management', () => {
         it('should deny environment API keys', async () => {
             const { env, apiKey } = await seedAccount();
 
-            const res = await api.fetch('/environment/api-keys', {
+            const res = await api.fetch('/environments/:environmentUuid/api-keys', {
                 method: 'POST',
                 token: apiKey.secret,
-                body: { environment_id: env.id, display_name: 'not-from-an-environment-key' }
+                params: { environmentUuid: env.uuid },
+                body: { display_name: 'not-from-an-environment-key' }
             });
 
             expect(res.res.status).toBe(403);
@@ -64,10 +66,11 @@ describe('Public environment API key management', () => {
             const { account, env } = await seedAccount();
             const accountKey = await createAccountKey(account.id, ['account:environments:api_keys:delete']);
 
-            const res = await api.fetch('/environment/api-keys', {
+            const res = await api.fetch('/environments/:environmentUuid/api-keys', {
                 method: 'POST',
                 token: accountKey.secret,
-                body: { environment_id: env.id, display_name: 'not-with-delete-scope' }
+                params: { environmentUuid: env.uuid },
+                body: { display_name: 'not-with-delete-scope' }
             });
 
             expect(res.res.status).toBe(403);
@@ -82,21 +85,24 @@ describe('Public environment API key management', () => {
             const { account, env } = await seedAccount();
             const accountKey = await createAccountKey(account.id, ['account:environments:api_keys:create']);
 
-            const res = await api.fetch('/environment/api-keys', {
+            const res = await api.fetch('/environments/:environmentUuid/api-keys', {
                 method: 'POST',
                 token: accountKey.secret,
-                body: { environment_id: env.id, display_name: 'provisioned-ci' }
+                params: { environmentUuid: env.uuid },
+                body: { display_name: 'provisioned-ci' }
             });
 
             expect(res.res.status).toBe(200);
             isSuccess(res.json);
             expect(res.json.data).toEqual({
                 id: expect.any(Number),
+                uuid: expect.any(String),
                 display_name: 'provisioned-ci',
                 scopes: ['environment:*'],
                 secret: expect.any(String),
                 created_at: expect.any(String)
             });
+            expect(res.json.data.uuid).toBeUUID();
         });
 
         it('should not create a key for an environment from another account', async () => {
@@ -104,10 +110,11 @@ describe('Public environment API key management', () => {
             const second = await seedAccount();
             const accountKey = await createAccountKey(first.account.id, ['account:environments:api_keys:create']);
 
-            const res = await api.fetch('/environment/api-keys', {
+            const res = await api.fetch('/environments/:environmentUuid/api-keys', {
                 method: 'POST',
                 token: accountKey.secret,
-                body: { environment_id: second.env.id, display_name: 'cross-account' }
+                params: { environmentUuid: second.env.uuid },
+                body: { display_name: 'cross-account' }
             });
 
             expect(res.res.status).toBe(404);
@@ -116,11 +123,11 @@ describe('Public environment API key management', () => {
         });
     });
 
-    describe('DELETE /environments/:environmentId/api-keys/:keyId', () => {
+    describe('DELETE /environments/:environmentUuid/api-keys/:keyUuid', () => {
         it('should be protected', async () => {
-            const res = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
                 method: 'DELETE',
-                params: { environmentId: 1, keyId: 1 }
+                params: { environmentUuid: '123e4567-e89b-12d3-a456-426614174000', keyUuid: '123e4567-e89b-12d3-a456-426614174001' }
             });
 
             shouldBeProtected(res);
@@ -131,32 +138,34 @@ describe('Public environment API key management', () => {
             const createKey = await createAccountKey(account.id, ['account:environments:api_keys:create']);
             const deleteKey = await createAccountKey(account.id, ['account:environments:api_keys:delete']);
 
-            const created = await api.fetch('/environment/api-keys', {
+            const created = await api.fetch('/environments/:environmentUuid/api-keys', {
                 method: 'POST',
                 token: createKey.secret,
-                body: { environment_id: env.id, display_name: 'scope-boundary' }
+                params: { environmentUuid: env.uuid },
+                body: { display_name: 'scope-boundary' }
             });
             expect(created.res.status).toBe(200);
             isSuccess(created.json);
 
-            const deniedDelete = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
+            const deniedDelete = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
                 method: 'DELETE',
                 token: createKey.secret,
-                params: { environmentId: env.id, keyId: created.json.data.id }
+                params: { environmentUuid: env.uuid, keyUuid: created.json.data.uuid }
             });
             expect(deniedDelete.res.status).toBe(403);
 
-            const deniedCreate = await api.fetch('/environment/api-keys', {
+            const deniedCreate = await api.fetch('/environments/:environmentUuid/api-keys', {
                 method: 'POST',
                 token: deleteKey.secret,
-                body: { environment_id: env.id, display_name: 'not-with-delete-scope' }
+                params: { environmentUuid: env.uuid },
+                body: { display_name: 'not-with-delete-scope' }
             });
             expect(deniedCreate.res.status).toBe(403);
 
-            const deleted = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
+            const deleted = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
                 method: 'DELETE',
                 token: deleteKey.secret,
-                params: { environmentId: env.id, keyId: created.json.data.id }
+                params: { environmentUuid: env.uuid, keyUuid: created.json.data.uuid }
             });
             expect(deleted.res.status).toBe(200);
             isSuccess(deleted.json);
@@ -175,10 +184,10 @@ describe('Public environment API key management', () => {
             ).unwrap();
             const deleteKey = await createAccountKey(first.account.id, ['account:environments:api_keys:delete']);
 
-            const res = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
                 method: 'DELETE',
                 token: deleteKey.secret,
-                params: { environmentId: second.env.id, keyId: created.id }
+                params: { environmentUuid: second.env.uuid, keyUuid: created.uuid }
             });
 
             expect(res.res.status).toBe(404);
@@ -193,18 +202,19 @@ describe('Public environment API key management', () => {
             const { account, env } = await seedAccount();
             const accountKey = await createAccountKey(account.id, ['account:*']);
 
-            const created = await api.fetch('/environment/api-keys', {
+            const created = await api.fetch('/environments/:environmentUuid/api-keys', {
                 method: 'POST',
                 token: accountKey.secret,
-                body: { environment_id: env.id, display_name: 'full-account-access' }
+                params: { environmentUuid: env.uuid },
+                body: { display_name: 'full-account-access' }
             });
             expect(created.res.status).toBe(200);
             isSuccess(created.json);
 
-            const deleted = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
+            const deleted = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
                 method: 'DELETE',
                 token: accountKey.secret,
-                params: { environmentId: env.id, keyId: created.json.data.id }
+                params: { environmentUuid: env.uuid, keyUuid: created.json.data.uuid }
             });
             expect(deleted.res.status).toBe(200);
             isSuccess(deleted.json);

--- a/packages/server/lib/controllers/environment/environmentManagement.integration.test.ts
+++ b/packages/server/lib/controllers/environment/environmentManagement.integration.test.ts
@@ -103,7 +103,8 @@ describe('Public environment management', () => {
 
             expect(res.res.status).toBe(200);
             isSuccess(res.json);
-            expect(res.json.data).toEqual({ id: expect.any(Number), name: 'managed-dev' });
+            expect(res.json.data).toEqual({ id: expect.any(Number), uuid: expect.any(String), name: 'managed-dev' });
+            expect(res.json.data.uuid).toBeUUID();
 
             const environment = await environmentService.getByIdWithoutSecrets(res.json.data.id, account.id);
             expect(environment).toMatchObject({ account_id: account.id, name: 'managed-dev', is_production: false });
@@ -153,11 +154,11 @@ describe('Public environment management', () => {
         });
     });
 
-    describe('DELETE /environments/:environmentId', () => {
+    describe('DELETE /environments/:environmentUuid', () => {
         it('should be protected', async () => {
-            const res = await api.fetch('/environments/:environmentId', {
+            const res = await api.fetch('/environments/:environmentUuid', {
                 method: 'DELETE',
-                params: { environmentId: 1 }
+                params: { environmentUuid: '123e4567-e89b-12d3-a456-426614174000' }
             });
 
             shouldBeProtected(res);
@@ -169,10 +170,10 @@ describe('Public environment management', () => {
             const createKey = await createAccountKey(account.id, ['account:environments:create']);
             const deleteKey = await createAccountKey(account.id, ['account:environments:delete']);
 
-            const deniedDelete = await api.fetch('/environments/:environmentId', {
+            const deniedDelete = await api.fetch('/environments/:environmentUuid', {
                 method: 'DELETE',
                 token: createKey.secret,
-                params: { environmentId: environment.id }
+                params: { environmentUuid: environment.uuid }
             });
             expect(deniedDelete.res.status).toBe(403);
 
@@ -183,10 +184,10 @@ describe('Public environment management', () => {
             });
             expect(deniedCreate.res.status).toBe(403);
 
-            const deleted = await api.fetch('/environments/:environmentId', {
+            const deleted = await api.fetch('/environments/:environmentUuid', {
                 method: 'DELETE',
                 token: deleteKey.secret,
-                params: { environmentId: environment.id }
+                params: { environmentUuid: environment.uuid }
             });
             expect(deleted.res.status).toBe(204);
             expect(await environmentService.getById(environment.id)).toBeNull();
@@ -197,10 +198,10 @@ describe('Public environment management', () => {
             const second = await seedAccount();
             const deleteKey = await createAccountKey(first.account.id, ['account:environments:delete']);
 
-            const res = await api.fetch('/environments/:environmentId', {
+            const res = await api.fetch('/environments/:environmentUuid', {
                 method: 'DELETE',
                 token: deleteKey.secret,
-                params: { environmentId: second.env.id }
+                params: { environmentUuid: second.env.uuid }
             });
 
             expect(res.res.status).toBe(404);
@@ -219,10 +220,10 @@ describe('Public environment management', () => {
             ).unwrap();
             const deleteKey = await createAccountKey(account.id, ['account:environments:delete']);
 
-            const res = await api.fetch('/environments/:environmentId', {
+            const res = await api.fetch('/environments/:environmentUuid', {
                 method: 'DELETE',
                 token: deleteKey.secret,
-                params: { environmentId: production.id }
+                params: { environmentUuid: production.uuid }
             });
 
             expect(res.res.status).toBe(400);
@@ -245,10 +246,10 @@ describe('Public environment management', () => {
             expect(created.res.status).toBe(200);
             isSuccess(created.json);
 
-            const deleted = await api.fetch('/environments/:environmentId', {
+            const deleted = await api.fetch('/environments/:environmentUuid', {
                 method: 'DELETE',
                 token: accountKey.secret,
-                params: { environmentId: created.json.data.id }
+                params: { environmentUuid: created.json.data.uuid }
             });
             expect(deleted.res.status).toBe(204);
         });

--- a/packages/server/lib/controllers/environment/postApiKey.ts
+++ b/packages/server/lib/controllers/environment/postApiKey.ts
@@ -10,12 +10,13 @@ import type { PostPublicApiKey } from '@nangohq/types';
 
 const validationBody = z
     .object({
-        environment_id: z.coerce.number().int().positive(),
         display_name: z.string().min(1).max(255)
     })
     .strict();
 
-export const postPublicApiKey = asyncWrapper<PostPublicApiKey>(async (req, res) => {
+const validationParams = z.object({ environmentUuid: z.uuid() }).strict();
+
+export const postPublicEnvironmentApiKey = asyncWrapper<PostPublicApiKey>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
@@ -28,7 +29,14 @@ export const postPublicApiKey = asyncWrapper<PostPublicApiKey>(async (req, res) 
         return;
     }
 
-    const { environment_id: environmentId, display_name: displayName } = valBody.data;
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { environmentUuid } = valParams.data;
+    const { display_name: displayName } = valBody.data;
 
     const account = res.locals.account;
     if (!account) {
@@ -36,7 +44,7 @@ export const postPublicApiKey = asyncWrapper<PostPublicApiKey>(async (req, res) 
         return;
     }
 
-    const environment = await environmentService.getByIdWithoutSecrets(environmentId, account.id);
+    const environment = await environmentService.getByUuidWithoutSecrets(environmentUuid, account.id);
     if (!environment) {
         res.status(404).send({ error: { code: 'not_found', message: 'Environment not found' } });
         return;

--- a/packages/server/lib/controllers/shared/environments/postApiKey.ts
+++ b/packages/server/lib/controllers/shared/environments/postApiKey.ts
@@ -48,6 +48,7 @@ export async function handleCreateApiKey({
     res.status(200).send({
         data: {
             id: key.id,
+            uuid: key.uuid,
             display_name: key.display_name,
             scopes: (key.scopes ?? []) as ApiKeyScope[],
             secret: key.secret,

--- a/packages/server/lib/controllers/shared/environments/postEnvironment.ts
+++ b/packages/server/lib/controllers/shared/environments/postEnvironment.ts
@@ -4,10 +4,10 @@ import { flagHasPlan } from '@nangohq/utils';
 
 import type { RequestLocals } from '../../../utils/express.js';
 import type { CreateEnvironmentError } from '@nangohq/shared';
-import type { DBEnvironment, DBPlan } from '@nangohq/types';
+import type { DBEnvironment, DBPlan, PostEnvironment, PostPublicEnvironment } from '@nangohq/types';
 import type { Response } from 'express';
 
-type PostEnvironmentResponse = Response<any, RequestLocals>;
+type PostEnvironmentResponse = Response<PostEnvironment['Reply'] | PostPublicEnvironment['Reply'], RequestLocals>;
 
 function sendCreateEnvironmentError(res: PostEnvironmentResponse, error: CreateEnvironmentError): void {
     switch (error.code) {

--- a/packages/server/lib/controllers/shared/environments/postEnvironment.ts
+++ b/packages/server/lib/controllers/shared/environments/postEnvironment.ts
@@ -4,10 +4,10 @@ import { flagHasPlan } from '@nangohq/utils';
 
 import type { RequestLocals } from '../../../utils/express.js';
 import type { CreateEnvironmentError } from '@nangohq/shared';
-import type { DBEnvironment, DBPlan, PostEnvironment, PostPublicEnvironment } from '@nangohq/types';
+import type { DBEnvironment, DBPlan } from '@nangohq/types';
 import type { Response } from 'express';
 
-type PostEnvironmentResponse = Response<PostEnvironment['Reply'] | PostPublicEnvironment['Reply'], RequestLocals>;
+type PostEnvironmentResponse = Response<any, RequestLocals>;
 
 function sendCreateEnvironmentError(res: PostEnvironmentResponse, error: CreateEnvironmentError): void {
     switch (error.code) {
@@ -89,5 +89,5 @@ export async function handlePostEnvironment({
         return;
     }
 
-    res.status(200).send({ data: { id: created.value.id, name: created.value.name } });
+    res.status(200).send({ data: { id: created.value.id, uuid: created.value.uuid, name: created.value.name } });
 }

--- a/packages/server/lib/controllers/v1/environment/apiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/apiKeys.integration.test.ts
@@ -65,11 +65,13 @@ describe('API Keys endpoints', () => {
             isSuccess(res.json);
             expect(res.json.data).toMatchObject({
                 id: expect.any(Number),
+                uuid: expect.any(String),
                 display_name: 'CI Deploy Key',
                 scopes: ['environment:deploy'],
                 secret: expect.any(String),
                 created_at: expect.any(String)
             });
+            expect(res.json.data.uuid).toBeUUID();
         });
 
         it('should default to environment:* scopes', async () => {

--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -288,6 +288,7 @@ describe('audit middleware — live-stack contract', () => {
 
             expect(res.res.status).toBe(200);
             isSuccess(res.json);
+            expect(res.json.data.uuid).toBeUUID();
             const createdId = String(res.json.data.id);
             await vi.waitFor(() => {
                 expect(auditEvent('environment', 'created')).toBeDefined();
@@ -322,7 +323,7 @@ describe('audit middleware — live-stack contract', () => {
 
             expect(create.res.status).toBe(200);
             isSuccess(create.json);
-            const createdId = String(create.json.data.id);
+            const createdId = create.json.data.uuid;
             await vi.waitFor(() => {
                 expect(auditEvent('environment', 'created')).toBeDefined();
             });
@@ -338,10 +339,10 @@ describe('audit middleware — live-stack contract', () => {
             });
 
             auditSpy.mockClear();
-            const deletion = await api.fetch('/environments/:environmentId', {
+            const deletion = await api.fetch('/environments/:environmentUuid', {
                 method: 'DELETE',
                 token: accountKey.secret,
-                params: { environmentId: create.json.data.id }
+                params: { environmentUuid: create.json.data.uuid }
             });
 
             expect(deletion.res.status).toBe(204);
@@ -402,15 +403,16 @@ describe('audit middleware — live-stack contract', () => {
                 })
             ).unwrap();
 
-            const create = await api.fetch('/environment/api-keys', {
+            const create = await api.fetch('/environments/:environmentUuid/api-keys', {
                 method: 'POST',
                 token: accountKey.secret,
-                body: { environment_id: env.id, display_name: 'provisioned-ci' }
+                params: { environmentUuid: env.uuid },
+                body: { display_name: 'provisioned-ci' }
             });
 
             expect(create.res.status).toBe(200);
             isSuccess(create.json);
-            const createdId = String(create.json.data.id);
+            const createdId = create.json.data.uuid;
             const secret = create.json.data.secret;
             await vi.waitFor(() => {
                 expect(auditEvent('api_key', 'created')).toBeDefined();
@@ -425,14 +427,13 @@ describe('audit middleware — live-stack contract', () => {
                 targets: [{ type: 'api_key', id: createdId, display: 'provisioned-ci' }],
                 metadata: { displayName: 'provisioned-ci', scopes: ['environment:*'] }
             });
-            expect(JSON.stringify(auditEvent('api_key', 'created'))).not.toContain('environmentId');
             expect(JSON.stringify(auditEvent('api_key', 'created'))).not.toContain(secret);
 
             auditSpy.mockClear();
-            const deletion = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
+            const deletion = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
                 method: 'DELETE',
                 token: accountKey.secret,
-                params: { environmentId: env.id, keyId: create.json.data.id }
+                params: { environmentUuid: env.uuid, keyUuid: create.json.data.uuid }
             });
 
             expect(deletion.res.status).toBe(200);

--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -429,10 +429,10 @@ describe('audit middleware — live-stack contract', () => {
             expect(JSON.stringify(auditEvent('api_key', 'created'))).not.toContain(secret);
 
             auditSpy.mockClear();
-            const deletion = await api.fetch('/environment/api-keys', {
+            const deletion = await api.fetch('/environments/:environmentId/api-keys/:keyId', {
                 method: 'DELETE',
                 token: accountKey.secret,
-                body: { environment_id: env.id, key_id: create.json.data.id }
+                params: { environmentId: env.id, keyId: create.json.data.id }
             });
 
             expect(deletion.res.status).toBe(200);

--- a/packages/server/lib/middleware/audit/apiKey.middleware.ts
+++ b/packages/server/lib/middleware/audit/apiKey.middleware.ts
@@ -1,7 +1,7 @@
 import { makeAuditTarget as makeTarget } from '../../audit.js';
 import { Audit, auditable } from './auditable.js';
 import { nonEmptyString, omitUndefined } from './input.js';
-import { accountApiKeyTarget, apiKeyTarget, environmentFromBody, publicEnvApiKeyTarget } from './lookups.js';
+import { accountApiKeyTarget, apiKeyTarget, environmentFromUuid, publicEnvApiKeyTarget } from './lookups.js';
 
 import type { CreateAccountApiKey, CreateApiKey, DeleteAccountApiKey, DeleteApiKey, DeletePublicApiKey, PatchApiKey, PostPublicApiKey } from '@nangohq/types';
 
@@ -15,8 +15,8 @@ export const auditApiKeyCreated = auditable<CreateApiKey>({
 
 export const auditPublicApiKeyCreated = auditable<PostPublicApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'created', scope: 'environment' }),
-    environment: (req, locals) => environmentFromBody(req.body.environment_id, locals),
-    targetFromResponse: (response) => makeTarget('api_key', response.data.id, response.data.display_name),
+    environment: (req, locals) => environmentFromUuid(req.params.environmentUuid, locals),
+    targetFromResponse: (response) => makeTarget('api_key', response.data.uuid, response.data.display_name),
     metadata: (req) => omitUndefined({ displayName: nonEmptyString(req.body.display_name) }),
     metadataFromResponse: (response) => omitUndefined({ scopes: response.data.scopes })
 });
@@ -47,8 +47,8 @@ export const auditApiKeyDeleted = auditable<DeleteApiKey>({
 
 export const auditPublicApiKeyDeleted = auditable<DeletePublicApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'deleted', scope: 'environment' }),
-    environment: (req, locals) => environmentFromBody(req.body.environment_id, locals),
-    target: (req, locals) => publicEnvApiKeyTarget(req.body.key_id, req.body.environment_id, locals)
+    environment: (req, locals) => environmentFromUuid(req.params.environmentUuid, locals),
+    target: (req, locals) => publicEnvApiKeyTarget(req.params.keyUuid, req.params.environmentUuid, locals)
 });
 
 export const auditAccountApiKeyDeleted = auditable<DeleteAccountApiKey>({

--- a/packages/server/lib/middleware/audit/apiKey.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/apiKey.middleware.unit.test.ts
@@ -6,8 +6,10 @@ import { auditAccountApiKeyCreated, auditApiKeyDeleted, auditPublicApiKeyCreated
 import {
     fakeReq,
     fakeRes,
+    getApiKeyByUuidMock,
     getApiKeyDisplayNameMock,
     getEnvironmentByIdMock,
+    getEnvironmentByUuidMock,
     installAuditMockDefaults,
     locals,
     recordMock,
@@ -23,7 +25,9 @@ describe('apiKey audit middleware (unit)', () => {
     beforeEach(() => {
         installAuditMockDefaults();
         getEnvironmentByIdMock.mockReset().mockResolvedValue({ id: 12, name: 'prod' });
+        getEnvironmentByUuidMock.mockReset().mockResolvedValue({ id: 12, name: 'prod' });
         getApiKeyDisplayNameMock.mockReset().mockResolvedValue(Ok('ci-key'));
+        getApiKeyByUuidMock.mockReset().mockResolvedValue(Ok({ id: 2551, display_name: 'ci-key' }));
     });
 
     afterEach(() => {
@@ -50,10 +54,10 @@ describe('apiKey audit middleware (unit)', () => {
     });
 
     it('public api key create: names the environment the key was made in, not the one it authenticated against', async () => {
-        const req = fakeReq({ body: { environment_id: 12, display_name: 'ci-key' } });
+        const req = fakeReq({ params: { environmentUuid: '00000000-0000-4000-8000-000000000012' }, body: { display_name: 'ci-key' } });
         const res = fakeRes(secretKeyLocals);
         await new Promise<void>((resolve) => auditPublicApiKeyCreated(req, res, () => resolve()));
-        res.json({ data: { id: 2551, display_name: 'ci-key', scopes: ['environment:*'] } });
+        res.json({ data: { id: 2551, uuid: '00000000-0000-4000-8000-000000002551', display_name: 'ci-key', scopes: ['environment:*'] } });
         res.emit('finish');
         await vi.waitFor(() => expect(recordMock).toHaveBeenCalled());
         const event = recordMock.mock.calls[0]?.[0];
@@ -63,53 +67,72 @@ describe('apiKey audit middleware (unit)', () => {
             outcome: 'success',
             accountId: 42,
             environment: { id: 12, display: 'prod' },
-            targets: [{ type: 'api_key', id: '2551', display: 'ci-key' }],
+            targets: [{ type: 'api_key', id: '00000000-0000-4000-8000-000000002551', display: 'ci-key' }],
             metadata: { displayName: 'ci-key', scopes: ['environment:*'] }
         });
         expect(event?.metadata).not.toHaveProperty('environmentId');
     });
 
     it('public api key delete: an environment key is separable from an account key by the environment alone', async () => {
-        const envKey = await runAudit(auditPublicApiKeyDeleted, fakeReq({ body: { environment_id: 12, key_id: 2551 } }), fakeRes(secretKeyLocals));
+        const envKey = await runAudit(
+            auditPublicApiKeyDeleted,
+            fakeReq({ params: { environmentUuid: '00000000-0000-4000-8000-000000000012', keyUuid: '00000000-0000-4000-8000-000000002551' } }),
+            fakeRes(secretKeyLocals)
+        );
         recordMock.mockClear();
         const accountKey = await runAudit(auditAccountApiKeyCreated, fakeReq({ body: { display_name: 'acct-key' } }), fakeRes(locals));
         expect(envKey).toMatchObject({ resource: 'api_key', action: 'deleted', accountId: 42, environment: { id: 12, display: 'prod' } });
         expect(accountKey?.environment).toBeNull();
     });
 
-    it('public api key create: an environment id sent as a string still resolves, as the endpoint accepts it', async () => {
-        const event = await runAudit(auditPublicApiKeyCreated, fakeReq({ body: { environment_id: '12', display_name: 'ci-key' } }), fakeRes(secretKeyLocals));
+    it('public api key create: resolves the environment from its UUID path parameter', async () => {
+        const environmentUuid = '00000000-0000-4000-8000-000000000012';
+        const event = await runAudit(
+            auditPublicApiKeyCreated,
+            fakeReq({ params: { environmentUuid }, body: { display_name: 'ci-key' } }),
+            fakeRes(secretKeyLocals)
+        );
         expect(event).toMatchObject({ resource: 'api_key', action: 'created', accountId: 42, environment: { id: 12, display: 'prod' } });
-        expect(getEnvironmentByIdMock).toHaveBeenCalledWith(12, 42);
+        expect(getEnvironmentByUuidMock).toHaveBeenCalledWith(environmentUuid, 42);
     });
 
     it.each([
         ['a boolean', true],
         ['an empty string', ''],
         ['null', null],
-        ['an array', []],
-        ['zero', 0],
-        ['a negative', -1],
-        ['a fraction', 1.5]
-    ])('public api key create: %s is not an environment id', async (_name, environment_id) => {
-        const event = await runAudit(auditPublicApiKeyCreated, fakeReq({ body: { environment_id, display_name: 'ci-key' } }), fakeRes(secretKeyLocals));
+        ['an array', []]
+    ])('public api key create: %s is not an environment UUID', async (_name, environmentUuid) => {
+        const event = await runAudit(
+            auditPublicApiKeyCreated,
+            fakeReq({ params: { environmentUuid }, body: { display_name: 'ci-key' } }),
+            fakeRes(secretKeyLocals)
+        );
         expect(event).toMatchObject({ resource: 'api_key', action: 'created', accountId: 42 });
         expect(event?.environment).toBeNull();
-        expect(getEnvironmentByIdMock).not.toHaveBeenCalled();
+        expect(getEnvironmentByUuidMock).not.toHaveBeenCalled();
     });
 
     it("public api key create: another account's environment is never named", async () => {
-        getEnvironmentByIdMock.mockResolvedValue(null);
-        const event = await runAudit(auditPublicApiKeyCreated, fakeReq({ body: { environment_id: 999, display_name: 'ci-key' } }), fakeRes(secretKeyLocals));
+        const environmentUuid = '00000000-0000-4000-8000-000000000999';
+        getEnvironmentByUuidMock.mockResolvedValue(null);
+        const event = await runAudit(
+            auditPublicApiKeyCreated,
+            fakeReq({ params: { environmentUuid }, body: { display_name: 'ci-key' } }),
+            fakeRes(secretKeyLocals)
+        );
         expect(event).toMatchObject({ resource: 'api_key', action: 'created', accountId: 42 });
         expect(event?.environment).toBeNull();
-        expect(getEnvironmentByIdMock).toHaveBeenCalledWith(999, 42);
+        expect(getEnvironmentByUuidMock).toHaveBeenCalledWith(environmentUuid, 42);
     });
 
     it('public api key create: an environment lookup failure still records the event, and counts the degradation', async () => {
         const increment = vi.spyOn(metrics, 'increment');
-        getEnvironmentByIdMock.mockRejectedValue(new Error('db down'));
-        const event = await runAudit(auditPublicApiKeyCreated, fakeReq({ body: { environment_id: 12, display_name: 'ci-key' } }), fakeRes(secretKeyLocals));
+        getEnvironmentByUuidMock.mockRejectedValue(new Error('db down'));
+        const event = await runAudit(
+            auditPublicApiKeyCreated,
+            fakeReq({ params: { environmentUuid: '00000000-0000-4000-8000-000000000012' }, body: { display_name: 'ci-key' } }),
+            fakeRes(secretKeyLocals)
+        );
         expect(event).toMatchObject({ resource: 'api_key', action: 'created', accountId: 42 });
         expect(event?.environment).toBeNull();
         expect(increment).toHaveBeenCalledWith(metrics.Types.AUDIT_EVENT_ENRICHMENT_FAILED, 1, { field: 'environment', resource: 'api_key' });

--- a/packages/server/lib/middleware/audit/apiKey.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/apiKey.middleware.unit.test.ts
@@ -100,7 +100,8 @@ describe('apiKey audit middleware (unit)', () => {
         ['a boolean', true],
         ['an empty string', ''],
         ['null', null],
-        ['an array', []]
+        ['an array', []],
+        ['a malformed UUID', 'not-a-uuid']
     ])('public api key create: %s is not an environment UUID', async (_name, environmentUuid) => {
         const event = await runAudit(
             auditPublicApiKeyCreated,
@@ -110,6 +111,17 @@ describe('apiKey audit middleware (unit)', () => {
         expect(event).toMatchObject({ resource: 'api_key', action: 'created', accountId: 42 });
         expect(event?.environment).toBeNull();
         expect(getEnvironmentByUuidMock).not.toHaveBeenCalled();
+    });
+
+    it('public api key delete: malformed UUIDs do not trigger audit lookups', async () => {
+        const event = await runAudit(
+            auditPublicApiKeyDeleted,
+            fakeReq({ params: { environmentUuid: 'not-a-uuid', keyUuid: 'also-not-a-uuid' } }),
+            fakeRes(secretKeyLocals)
+        );
+        expect(event).toMatchObject({ resource: 'api_key', action: 'deleted', accountId: 42, environment: null, targets: [] });
+        expect(getEnvironmentByUuidMock).not.toHaveBeenCalled();
+        expect(getApiKeyByUuidMock).not.toHaveBeenCalled();
     });
 
     it("public api key create: another account's environment is never named", async () => {

--- a/packages/server/lib/middleware/audit/environment.middleware.ts
+++ b/packages/server/lib/middleware/audit/environment.middleware.ts
@@ -80,7 +80,7 @@ export const auditEnvironmentDeleted = auditable<DeleteEnvironment>({
 
 export const auditPublicEnvironmentDeleted = auditable<DeletePublicEnvironment>({
     policy: Audit.auditable({ resource: 'environment', action: 'deleted', scope: 'account' }),
-    target: (req, locals) => accountEnvironmentTarget(req.params.environmentId, locals)
+    target: (req, locals) => accountEnvironmentTarget(req.params.environmentUuid, locals)
 });
 
 // Keep only the origin (scheme + host) of a URL — a webhook URL can carry a secret token in its path,

--- a/packages/server/lib/middleware/audit/environment.middleware.ts
+++ b/packages/server/lib/middleware/audit/environment.middleware.ts
@@ -23,7 +23,7 @@ export const auditEnvironmentCreated = auditable<PostEnvironment>({
 
 export const auditPublicEnvironmentCreated = auditable<PostPublicEnvironment>({
     policy: Audit.auditable({ resource: 'environment', action: 'created', scope: 'account' }),
-    targetFromResponse: (response) => makeTarget('environment', response.data.id, response.data.name),
+    targetFromResponse: (response) => makeTarget('environment', response.data.uuid, response.data.name),
     metadata: (req) => omitUndefined({ name: nonEmptyString(req.body.name) })
 });
 

--- a/packages/server/lib/middleware/audit/environment.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/environment.middleware.unit.test.ts
@@ -6,7 +6,8 @@ import {
     auditEnvironmentCreated,
     auditEnvironmentUpdated,
     auditEnvironmentVariablesChanged,
-    auditEnvironmentWebhookUrlsChanged
+    auditEnvironmentWebhookUrlsChanged,
+    auditPublicEnvironmentCreated
 } from './environment.middleware.js';
 import { fakeReq, fakeRes, installAuditMockDefaults, locals, recordMock, resetAuditMocks, runAudit } from './testing.js';
 
@@ -32,6 +33,21 @@ describe('environment audit middleware (unit)', () => {
         const event = await runAudit(auditEnvironmentCreated, fakeReq({ body: { name: '' } }), fakeRes(locals));
         expect(event).toMatchObject({ resource: 'environment', action: 'created', accountId: 42 });
         expect(event?.metadata).toBeUndefined();
+    });
+
+    it('public environment create: identifies the created environment by UUID', async () => {
+        const req = fakeReq({ body: { name: 'staging' } });
+        const res = fakeRes(locals);
+        await new Promise<void>((resolve) => auditPublicEnvironmentCreated(req, res, () => resolve()));
+        res.json({ data: { id: 12, uuid: '00000000-0000-4000-8000-000000000012', name: 'staging' } });
+        res.emit('finish');
+        await vi.waitFor(() => expect(recordMock).toHaveBeenCalled());
+        expect(recordMock.mock.calls[0]?.[0]).toMatchObject({
+            resource: 'environment',
+            action: 'created',
+            environment: null,
+            targets: [{ type: 'environment', id: '00000000-0000-4000-8000-000000000012', display: 'staging' }]
+        });
     });
 
     it('environment update: echoes the name but never a credential in the same body', async () => {

--- a/packages/server/lib/middleware/audit/input.ts
+++ b/packages/server/lib/middleware/audit/input.ts
@@ -1,3 +1,5 @@
+import { validate as isUuid } from 'uuid';
+
 import type { Request } from 'express';
 
 export function param(req: Request<any, any, any, any>, key: string): unknown {
@@ -20,6 +22,10 @@ export function positiveInt(value: unknown): number | undefined {
 
 export function nonEmptyString(value: unknown): string | undefined {
     return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function uuid(value: unknown): string | undefined {
+    return typeof value === 'string' && isUuid(value) ? value : undefined;
 }
 
 export function omitUndefined<T extends object>(obj: { [K in keyof T]?: T[K] | undefined }): T | undefined {

--- a/packages/server/lib/middleware/audit/lookups.ts
+++ b/packages/server/lib/middleware/audit/lookups.ts
@@ -30,12 +30,12 @@ export function memberTarget(req: Request<{ id: number }>, locals: Partial<Reque
     });
 }
 
-export async function environmentFromBody(value: unknown, locals: Partial<RequestLocals>): Promise<{ id: number; name: string } | null> {
-    const environmentId = positiveInt(value);
-    if (environmentId === undefined || !locals.account) {
+export async function environmentFromUuid(value: unknown, locals: Partial<RequestLocals>): Promise<{ id: number; name: string } | null> {
+    const environmentUuid = nonEmptyString(value);
+    if (!environmentUuid || !locals.account) {
         return null;
     }
-    const environment = await environmentService.getByIdWithoutSecrets(environmentId, locals.account.id);
+    const environment = await environmentService.getByUuidWithoutSecrets(environmentUuid, locals.account.id);
     return environment ? { id: environment.id, name: environment.name } : null;
 }
 
@@ -93,28 +93,30 @@ export function accountApiKeyTarget(value: unknown, locals: Partial<RequestLocal
     });
 }
 
-export function publicEnvApiKeyTarget(keyId: unknown, environmentId: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
-    return dbTarget('api_key', keyId, async (id) => {
-        const numericId = positiveInt(id);
-        const numericEnvId = positiveInt(environmentId);
-        if (numericId === undefined || numericEnvId === undefined || !locals.account) {
+export function publicEnvApiKeyTarget(keyUuid: unknown, environmentUuid: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
+    return dbTarget('api_key', keyUuid, async (id) => {
+        const envUuid = nonEmptyString(environmentUuid);
+        if (!envUuid || !locals.account) {
             return undefined;
         }
-        const result = await customerKeyService.getApiKeyDisplayName(db.knex, numericId, numericEnvId, locals.account.id);
+        const environment = await environmentService.getByUuidWithoutSecrets(envUuid, locals.account.id);
+        if (!environment) {
+            return undefined;
+        }
+        const result = await customerKeyService.getApiKeyByUuid(db.knex, id, environment.id, locals.account.id);
         if (result.isErr()) {
             throw result.error;
         }
-        return result.value;
+        return result.value?.display_name;
     });
 }
 
 export function accountEnvironmentTarget(value: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
     return dbTarget('environment', value, async (id) => {
-        const numericId = positiveInt(id);
-        if (numericId === undefined || !locals.account) {
+        if (!locals.account) {
             return undefined;
         }
-        const environment = await environmentService.getByIdWithoutSecrets(numericId, locals.account.id);
+        const environment = await environmentService.getByUuidWithoutSecrets(id, locals.account.id);
         return environment?.name;
     });
 }

--- a/packages/server/lib/middleware/audit/lookups.ts
+++ b/packages/server/lib/middleware/audit/lookups.ts
@@ -3,7 +3,7 @@ import { configService, customerKeyService, environmentService, userService } fr
 
 import { toAuditId as toId } from '../../audit.js';
 import { auditEnrichmentFailed, resolveDisplay } from './auditable.js';
-import { nonEmptyString, omitUndefined, positiveInt } from './input.js';
+import { nonEmptyString, omitUndefined, positiveInt, uuid } from './input.js';
 
 import type { RequestLocals } from '../../utils/express.js';
 import type { AuditTarget, AuditTargetType } from '@nangohq/audit';
@@ -31,7 +31,7 @@ export function memberTarget(req: Request<{ id: number }>, locals: Partial<Reque
 }
 
 export async function environmentFromUuid(value: unknown, locals: Partial<RequestLocals>): Promise<{ id: number; name: string } | null> {
-    const environmentUuid = nonEmptyString(value);
+    const environmentUuid = uuid(value);
     if (!environmentUuid || !locals.account) {
         return null;
     }
@@ -94,16 +94,19 @@ export function accountApiKeyTarget(value: unknown, locals: Partial<RequestLocal
 }
 
 export function publicEnvApiKeyTarget(keyUuid: unknown, environmentUuid: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
-    return dbTarget('api_key', keyUuid, async (id) => {
-        const envUuid = nonEmptyString(environmentUuid);
-        if (!envUuid || !locals.account) {
-            return undefined;
-        }
-        const environment = await environmentService.getByUuidWithoutSecrets(envUuid, locals.account.id);
+    const validKeyUuid = uuid(keyUuid);
+    const validEnvironmentUuid = uuid(environmentUuid);
+    const account = locals.account;
+    if (!validKeyUuid || !validEnvironmentUuid || !account) {
+        return Promise.resolve(undefined);
+    }
+
+    return dbTarget('api_key', validKeyUuid, async (id) => {
+        const environment = await environmentService.getByUuidWithoutSecrets(validEnvironmentUuid, account.id);
         if (!environment) {
             return undefined;
         }
-        const result = await customerKeyService.getApiKeyByUuid(db.knex, id, environment.id, locals.account.id);
+        const result = await customerKeyService.getApiKeyByUuid(db.knex, id, environment.id, account.id);
         if (result.isErr()) {
             throw result.error;
         }
@@ -112,11 +115,14 @@ export function publicEnvApiKeyTarget(keyUuid: unknown, environmentUuid: unknown
 }
 
 export function accountEnvironmentTarget(value: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
-    return dbTarget('environment', value, async (id) => {
-        if (!locals.account) {
-            return undefined;
-        }
-        const environment = await environmentService.getByUuidWithoutSecrets(id, locals.account.id);
+    const environmentUuid = uuid(value);
+    const account = locals.account;
+    if (!environmentUuid || !account) {
+        return Promise.resolve(undefined);
+    }
+
+    return dbTarget('environment', environmentUuid, async (id) => {
+        const environment = await environmentService.getByUuidWithoutSecrets(id, account.id);
         return environment?.name;
     });
 }

--- a/packages/server/lib/middleware/audit/testing.ts
+++ b/packages/server/lib/middleware/audit/testing.ts
@@ -16,7 +16,9 @@ export const getInvitationMock: Mock = vi.fn();
 export const getAccountByIdMock: Mock = vi.fn();
 export const getPlanSafeMock: Mock = vi.fn();
 export const getEnvironmentByIdMock: Mock = vi.fn();
+export const getEnvironmentByUuidMock: Mock = vi.fn();
 export const getApiKeyDisplayNameMock: Mock = vi.fn();
+export const getApiKeyByUuidMock: Mock = vi.fn();
 export const getIntegrationSummaryMock: Mock = vi.fn();
 export const getConnectionByIdMock: Mock = vi.fn();
 export const getUserByIdMock: Mock = vi.fn();
@@ -31,8 +33,8 @@ export async function sharedModuleMock(importOriginal: () => Promise<typeof Nang
         ...actual,
         getInvitation: getInvitationMock,
         getPlanSafe: getPlanSafeMock,
-        environmentService: { ...actual.environmentService, getByIdWithoutSecrets: getEnvironmentByIdMock },
-        customerKeyService: { ...actual.customerKeyService, getApiKeyDisplayName: getApiKeyDisplayNameMock },
+        environmentService: { ...actual.environmentService, getByIdWithoutSecrets: getEnvironmentByIdMock, getByUuidWithoutSecrets: getEnvironmentByUuidMock },
+        customerKeyService: { ...actual.customerKeyService, getApiKeyDisplayName: getApiKeyDisplayNameMock, getApiKeyByUuid: getApiKeyByUuidMock },
         configService: { ...actual.configService, getIntegrationSummary: getIntegrationSummaryMock },
         accountService: { ...actual.accountService, getAccountById: getAccountByIdMock },
         connectionService: { ...actual.connectionService, getConnectionById: getConnectionByIdMock },

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -314,9 +314,9 @@ publicAPI.use('/environment-variables', jsonContentTypeMiddleware);
 publicAPI.route('/environment-variables').get(apiAuth, withScope('environment:variables:read'), getPublicEnvironmentVariables);
 
 publicAPI.use('/environment', jsonContentTypeMiddleware);
+publicAPI.route('/environment/api-keys').post(apiAuth, auditPublicApiKeyCreated, withScope('account:environments:api_keys:create'), postPublicApiKey);
 publicAPI
-    .route('/environment/api-keys')
-    .post(apiAuth, auditPublicApiKeyCreated, withScope('account:environments:api_keys:create'), postPublicApiKey)
+    .route('/environments/:environmentId/api-keys/:keyId')
     .delete(apiAuth, auditPublicApiKeyDeleted, withScope('account:environments:api_keys:delete'), deletePublicApiKey);
 publicAPI
     .route('/environment/webhook-signing-key/rotate')

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -37,10 +37,10 @@ import { postPublicMetadata } from './controllers/connection/connectionId/metada
 import { patchPublicConnection } from './controllers/connection/connectionId/patchConnection.js';
 import { getPublicConnections } from './controllers/connection/getConnections.js';
 import { postPublicConnection } from './controllers/connection/postConnection.js';
-import { deletePublicApiKey } from './controllers/environment/deleteApiKey.js';
+import { deletePublicEnvironmentApiKey } from './controllers/environment/deleteApiKey.js';
 import { deletePublicEnvironment } from './controllers/environment/deleteEnvironment.js';
 import { getPublicEnvironmentVariables } from './controllers/environment/getVariables.js';
-import { postPublicApiKey } from './controllers/environment/postApiKey.js';
+import { postPublicEnvironmentApiKey } from './controllers/environment/postApiKey.js';
 import { postPublicEnvironment } from './controllers/environment/postEnvironment.js';
 import { postPublicRotateWebhookSigningKey } from './controllers/environment/postPublicRotateWebhookSigningKey.js';
 import { postFunctionCompile } from './controllers/functions/compile/postCompile.js';
@@ -232,8 +232,14 @@ publicAPI.route('/providers/:provider/templates').get(apiAuth, withEnvironmentTa
 publicAPI.use('/environments', jsonContentTypeMiddleware);
 publicAPI.route('/environments').post(apiAuth, auditPublicEnvironmentCreated, withScope('account:environments:create'), postPublicEnvironment);
 publicAPI
-    .route('/environments/:environmentId')
+    .route('/environments/:environmentUuid')
     .delete(apiAuth, auditPublicEnvironmentDeleted, withScope('account:environments:delete'), deletePublicEnvironment);
+publicAPI
+    .route('/environments/:environmentUuid/api-keys')
+    .post(apiAuth, auditPublicApiKeyCreated, withScope('account:environments:api_keys:create'), postPublicEnvironmentApiKey);
+publicAPI
+    .route('/environments/:environmentUuid/api-keys/:keyUuid')
+    .delete(apiAuth, auditPublicApiKeyDeleted, withScope('account:environments:api_keys:delete'), deletePublicEnvironmentApiKey);
 
 // @deprecated rollbacked for one customer, to delete asap
 publicAPI
@@ -314,10 +320,6 @@ publicAPI.use('/environment-variables', jsonContentTypeMiddleware);
 publicAPI.route('/environment-variables').get(apiAuth, withScope('environment:variables:read'), getPublicEnvironmentVariables);
 
 publicAPI.use('/environment', jsonContentTypeMiddleware);
-publicAPI.route('/environment/api-keys').post(apiAuth, auditPublicApiKeyCreated, withScope('account:environments:api_keys:create'), postPublicApiKey);
-publicAPI
-    .route('/environments/:environmentId/api-keys/:keyId')
-    .delete(apiAuth, auditPublicApiKeyDeleted, withScope('account:environments:api_keys:delete'), deletePublicApiKey);
 publicAPI
     .route('/environment/webhook-signing-key/rotate')
     .post(apiAuth, auditPublicWebhookSigningKeyRotated, withScope('environment:webhook_signing_key:rotate'), postPublicRotateWebhookSigningKey);

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -267,6 +267,24 @@ class CustomerKeyService {
         }
     }
 
+    public async getApiKeyByUuid(trx: Knex, keyUuid: string, envId: number, accountId: number): Promise<Result<DBCustomerKey | null>> {
+        try {
+            const row = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                .select(`${CUSTOMER_KEYS_TABLE}.*`)
+                .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
+                .where(`${CUSTOMER_KEYS_TABLE}.uuid`, keyUuid)
+                .where(`${CUSTOMER_KEYS_TABLE}.account_id`, accountId)
+                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
+                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
+                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                .first();
+            return Ok(row ?? null);
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
     public async createWebhookSigningKey(
         trx: Knex,
         {

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -24,6 +24,8 @@ export const defaultEnvironments = [PROD_ENVIRONMENT_NAME, 'dev'];
 
 export type CreateEnvironmentErrorCode = 'invalid_is_prod_flag' | 'conflict' | 'resource_capped' | 'creation_failed';
 
+type EnvironmentIdentifier = { type: 'id'; id: number } | { type: 'uuid'; uuid: string };
+
 export class CreateEnvironmentError extends Error {
     constructor(
         public readonly code: CreateEnvironmentErrorCode,
@@ -102,7 +104,7 @@ class EnvironmentService {
 
     async getById(id: number): Promise<DBEnvironment | null> {
         return await db.readOnly.transaction(async (trx) => {
-            const env = await this.findByIdWithoutSecrets(trx, id);
+            const env = await this.getWithoutSecrets(trx, { type: 'id', id });
             if (!env) {
                 return null;
             }
@@ -112,12 +114,22 @@ class EnvironmentService {
     }
 
     async getByIdWithoutSecrets(id: number, accountId: number | null = null): Promise<DBEnvironment | null> {
-        return await db.readOnly.transaction((trx) => this.findByIdWithoutSecrets(trx, id, accountId));
+        return await db.readOnly.transaction((trx) => this.getWithoutSecrets(trx, { type: 'id', id, accountId }));
     }
 
-    private async findByIdWithoutSecrets(trx: Knex, id: number, accountId: number | null = null): Promise<DBEnvironment | null> {
+    async getByUuidWithoutSecrets(uuid: string, accountId: number | null = null): Promise<DBEnvironment | null> {
+        return await db.readOnly.transaction((trx) => this.getWithoutSecrets(trx, { type: 'uuid', uuid, accountId }));
+    }
+
+    private async getWithoutSecrets(trx: Knex, identifier: EnvironmentIdentifier & { accountId?: number | null }): Promise<DBEnvironment | null> {
+        const accountId = identifier.accountId ?? null;
         try {
-            const query = trx<DBEnvironment>(TABLE).select('*').where({ id, deleted: false });
+            const query = trx<DBEnvironment>(TABLE).select('*').where({ deleted: false });
+            if (identifier.type === 'id') {
+                query.andWhere({ id: identifier.id });
+            } else {
+                query.andWhere({ uuid: identifier.uuid });
+            }
             if (accountId !== null) {
                 query.andWhere({ account_id: accountId });
             }
@@ -125,13 +137,11 @@ class EnvironmentService {
             return environment ?? null;
         } catch (err) {
             errorManager.report(err, {
-                environmentId: id,
                 source: ErrorSourceEnum.PLATFORM,
                 operation: LogActionEnum.DATABASE,
                 ...(accountId !== null && { accountId }),
-                metadata: {
-                    id
-                }
+                ...(identifier.type == 'id' ? { environmentId: identifier.id } : { environmentUuid: identifier.uuid }),
+                metadata: identifier.type == 'id' ? { id: identifier.id } : { uuid: identifier.uuid }
             });
             return null;
         }

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -140,8 +140,8 @@ class EnvironmentService {
                 source: ErrorSourceEnum.PLATFORM,
                 operation: LogActionEnum.DATABASE,
                 ...(accountId !== null && { accountId }),
-                ...(identifier.type == 'id' ? { environmentId: identifier.id } : { environmentUuid: identifier.uuid }),
-                metadata: identifier.type == 'id' ? { id: identifier.id } : { uuid: identifier.uuid }
+                ...(identifier.type === 'id' ? { environmentId: identifier.id } : { environmentUuid: identifier.uuid }),
+                metadata: identifier.type === 'id' ? { id: identifier.id } : { uuid: identifier.uuid }
             });
             return null;
         }

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -21,6 +21,7 @@ interface ErrorOptionalConfig {
     accountId?: number;
     userId?: number;
     environmentId?: number | undefined;
+    environmentUuid?: string | undefined;
     metadata?: Record<string, unknown>;
     operation?: string;
 }

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -193,11 +193,8 @@ export type PostPublicApiKey = ApiEndpoint<{
 export type DeletePublicApiKey = ApiEndpoint<{
     Audit: AuditPolicy<'api_key', 'deleted', 'environment'>;
     Method: 'DELETE';
-    Path: '/environment/api-keys';
-    Body: {
-        environment_id: number;
-        key_id: number;
-    };
+    Path: '/environments/:environmentId/api-keys/:keyId';
+    Params: { environmentId: number; keyId: number };
     Success: { success: true };
 }>;
 

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -25,7 +25,7 @@ export type PostEnvironment = ApiEndpoint<{
     Path: '/api/v1/environments';
     Body: { name: string };
     Success: {
-        data: Pick<DBEnvironment, 'id' | 'name'>;
+        data: Pick<DBEnvironment, 'id' | 'uuid' | 'name'>;
     };
     Error: ApiError<'conflict' | 'resource_capped' | 'invalid_is_prod_flag'>;
 }>;
@@ -45,7 +45,7 @@ export type PostPublicEnvironment = ApiEndpoint<{
         otlp_headers?: { name: string; value: string }[] | undefined;
     };
     Success: {
-        data: Pick<DBEnvironment, 'id' | 'name'>;
+        data: Pick<DBEnvironment, 'id' | 'uuid' | 'name'>;
     };
     Error: ApiError<'conflict' | 'resource_capped' | 'invalid_is_prod_flag'>;
 }>;
@@ -53,8 +53,8 @@ export type PostPublicEnvironment = ApiEndpoint<{
 export type DeletePublicEnvironment = ApiEndpoint<{
     Audit: AuditPolicy<'environment', 'deleted', 'account'>;
     Method: 'DELETE';
-    Path: '/environments/:environmentId';
-    Params: { environmentId: number };
+    Path: '/environments/:environmentUuid';
+    Params: { environmentUuid: string };
     Success: never;
     Error: ApiError<'cannot_delete_prod_environment'>;
 }>;
@@ -161,6 +161,7 @@ export type CreateApiKey = ApiEndpoint<{
     Success: {
         data: {
             id: number;
+            uuid: string;
             display_name: string;
             scopes: ApiKeyScope[];
             secret: string;
@@ -173,14 +174,15 @@ export type CreateApiKey = ApiEndpoint<{
 export type PostPublicApiKey = ApiEndpoint<{
     Audit: AuditPolicy<'api_key', 'created', 'environment'>;
     Method: 'POST';
-    Path: '/environment/api-keys';
+    Path: '/environments/:environmentUuid/api-keys';
+    Params: { environmentUuid: string };
     Body: {
-        environment_id: number;
         display_name: string;
     };
     Success: {
         data: {
             id: number;
+            uuid: string;
             display_name: string;
             scopes: ApiKeyScope[];
             secret: string;
@@ -193,8 +195,8 @@ export type PostPublicApiKey = ApiEndpoint<{
 export type DeletePublicApiKey = ApiEndpoint<{
     Audit: AuditPolicy<'api_key', 'deleted', 'environment'>;
     Method: 'DELETE';
-    Path: '/environments/:environmentId/api-keys/:keyId';
-    Params: { environmentId: number; keyId: number };
+    Path: '/environments/:environmentUuid/api-keys/:keyUuid';
+    Params: { environmentUuid: string; keyUuid: string };
     Success: { success: true };
 }>;
 

--- a/packages/types/lib/environment/db.ts
+++ b/packages/types/lib/environment/db.ts
@@ -84,6 +84,7 @@ export type CustomerKeyType = 'api' | 'webhook_signing';
 
 export interface DBCustomerKey extends Timestamps {
     id: number;
+    uuid: string;
     account_id: number;
     key_type: CustomerKeyType;
     display_name: string;


### PR DESCRIPTION
Use UUIDs instead of numeric IDs throughout the public environment-management API.

- Add and backfill a non-null, unique UUID on customer API keys.
- Move public environment API-key creation under the environment UUID path.
- Resolve environment and API-key UUIDs with account-scoped lookups for create/delete operations.
- Return UUIDs from environment and API-key creation responses.
- Update audit targets, API types, OpenAPI/reference/generated docs, and integration coverage.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

