### PR TITLE
feat(audit): record the policy scope on every event (NAN-6802)

### DIFF
--- a/packages/audit/lib/client.unit.test.ts
+++ b/packages/audit/lib/client.unit.test.ts
@@ -31,6 +31,7 @@ class RecordingStore implements AuditWriter, AuditReader {
 const event: AuditEvent = {
     occurredAt: '2026-01-01T00:00:00.000Z',
     accountId: 1,
+    scope: 'environment',
     environment: { id: 2, display: 'dev' },
     actor: { type: 'user', id: '5', display: 'a@b.co' },
     resource: 'connection',
@@ -43,6 +44,7 @@ const event: AuditEvent = {
 const roleEvent: AuditEvent = {
     occurredAt: '2026-01-01T00:00:00.000Z',
     accountId: 1,
+    scope: 'account',
     environment: null,
     actor: { type: 'user', id: '5', display: 'admin@b.co' },
     resource: 'member',

--- a/packages/audit/lib/csv.ts
+++ b/packages/audit/lib/csv.ts
@@ -4,6 +4,7 @@ import type { ApiAuditTrailEvent } from '@nangohq/types';
 const COLUMNS: { name: string; of: (event: ApiAuditTrailEvent) => string | undefined }[] = [
     { name: 'occurred_at', of: (event) => event.occurredAt },
     { name: 'event_id', of: (event) => event.id },
+    { name: 'scope', of: (event) => event.scope },
     { name: 'environment', of: (event) => event.environment?.display },
     { name: 'actor_type', of: (event) => event.actor.type },
     { name: 'actor_id', of: (event) => event.actor.id },

--- a/packages/audit/lib/csv.unit.test.ts
+++ b/packages/audit/lib/csv.unit.test.ts
@@ -9,6 +9,7 @@ const event = (overrides: Partial<ApiAuditTrailEvent> = {}): ApiAuditTrailEvent 
     version: '2026-07-16',
     occurredAt: '2026-01-01T00:00:00.000Z',
     accountId: 42,
+    scope: 'environment',
     environment: { id: 2, display: 'dev' },
     actor: { type: 'user', id: '5', display: 'a@b.co' },
     resource: 'connection',
@@ -22,17 +23,17 @@ const event = (overrides: Partial<ApiAuditTrailEvent> = {}): ApiAuditTrailEvent 
 describe('auditCsvRows', () => {
     it('writes one row per event, in the header order', () => {
         expect(auditCsvHeader()).toBe(
-            'occurred_at,event_id,environment,actor_type,actor_id,actor_display,via,via_actor_id,resource,action,target_types,target_ids,target_displays,outcome,ip,user_agent,interface,metadata'
+            'occurred_at,event_id,scope,environment,actor_type,actor_id,actor_display,via,via_actor_id,resource,action,target_types,target_ids,target_displays,outcome,ip,user_agent,interface,metadata'
         );
         expect(auditCsvRows([event()])).toBe(
-            '2026-01-01T00:00:00.000Z,11111111-1111-1111-1111-111111111111,dev,user,5,a@b.co,,,connection,deleted,connection,10,,success,1.2.3.4,curl/8,api,'
+            '2026-01-01T00:00:00.000Z,11111111-1111-1111-1111-111111111111,environment,dev,user,5,a@b.co,,,connection,deleted,connection,10,,success,1.2.3.4,curl/8,api,'
         );
     });
 
     it('leaves absent optional fields empty rather than writing undefined', () => {
-        const row = auditCsvRows([event({ environment: null, actor: { type: 'anonymous', id: 'anonymous' }, context: {}, targets: [] })]);
+        const row = auditCsvRows([event({ scope: 'account', environment: null, actor: { type: 'anonymous', id: 'anonymous' }, context: {}, targets: [] })]);
         expect(row).not.toContain('undefined');
-        expect(row).toBe('2026-01-01T00:00:00.000Z,11111111-1111-1111-1111-111111111111,,anonymous,anonymous,,,,connection,deleted,,,,success,,,,');
+        expect(row).toBe('2026-01-01T00:00:00.000Z,11111111-1111-1111-1111-111111111111,account,,anonymous,anonymous,,,,connection,deleted,,,,success,,,,');
     });
 
     it('keeps a target display, so the same person is not an email in one column and a bare id in another', () => {

--- a/packages/audit/lib/export.unit.test.ts
+++ b/packages/audit/lib/export.unit.test.ts
@@ -12,6 +12,7 @@ const event = (n: number): ApiAuditTrailEvent => ({
     version: '2026-07-16',
     occurredAt: `2026-01-0${n}T00:00:00.000Z`,
     accountId: 42,
+    scope: 'environment',
     environment: null,
     actor: { type: 'user', id: '5' },
     resource: 'connection',

--- a/packages/audit/lib/stores/clickhouse.integration.test.ts
+++ b/packages/audit/lib/stores/clickhouse.integration.test.ts
@@ -36,6 +36,7 @@ async function insertEvent({
         version: '2026-07-16',
         occurredAt,
         accountId,
+        scope: 'environment',
         environment: null,
         actor: { type: 'user', id: '5', display: 'a@b.co' },
         resource,
@@ -167,6 +168,7 @@ describe('AuditClient.record through ClickhouseAuditStore', () => {
         const event: AuditEvent = {
             occurredAt: at(5000),
             accountId: 7,
+            scope: 'environment',
             environment: { id: 2, display: 'dev' },
             actor: { type: 'user', id: '5', display: 'a@b.co' },
             resource: 'connection',

--- a/packages/metering/lib/processors/audit.unit.test.ts
+++ b/packages/metering/lib/processors/audit.unit.test.ts
@@ -198,6 +198,7 @@ describe('unstorableReason contract with the emitter', () => {
             await new AuditClient(writer, {} as never).record({
                 occurredAt: new Date().toISOString(),
                 accountId: 42,
+                scope: 'environment',
                 environment: { id: 1, display: 'dev' },
                 actor: { type: 'user', id: '5', display: 'a@b.co' },
                 resource: 'connection',

--- a/packages/server/lib/controllers/mcp/audit.ts
+++ b/packages/server/lib/controllers/mcp/audit.ts
@@ -31,6 +31,7 @@ export function recordManagementMcpAudit({
     const event = {
         occurredAt: new Date().toISOString(),
         accountId: account.id,
+        scope: policy.scope,
         environment: policy.scope === 'account' ? null : { id: environment.id, display: environment.name },
         actor: auditContext.actor,
         resource: policy.resource,

--- a/packages/server/lib/controllers/mcp/integrations/create.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/create.unit.test.ts
@@ -204,6 +204,7 @@ describe('createIntegrationsTool', () => {
             expect(auditSpy).toHaveBeenCalledWith({
                 occurredAt: expect.any(String),
                 accountId: 1,
+                scope: 'environment',
                 environment: { id: 42, display: 'dev' },
                 actor: { type: 'api_key', id: '7', display: 'Management key' },
                 resource: 'integration',

--- a/packages/server/lib/controllers/mcp/integrations/delete.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/delete.unit.test.ts
@@ -90,6 +90,7 @@ describe('integrationsDeleteTool', () => {
             expect(auditSpy).toHaveBeenCalledWith({
                 occurredAt: expect.any(String),
                 accountId: 1,
+                scope: 'environment',
                 environment: { id: 42, display: 'dev' },
                 actor: { type: 'api_key', id: '7', display: 'Management key' },
                 resource: 'integration',

--- a/packages/server/lib/controllers/mcp/integrations/update.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/update.unit.test.ts
@@ -121,6 +121,7 @@ describe('updateIntegrationsTool', () => {
             expect(auditSpy).toHaveBeenCalledWith({
                 occurredAt: expect.any(String),
                 accountId: 1,
+                scope: 'environment',
                 environment: { id: 42, display: 'dev' },
                 actor: { type: 'api_key', id: '7', display: 'Management key' },
                 resource: 'integration',

--- a/packages/server/lib/controllers/mcp/managementTool.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/managementTool.unit.test.ts
@@ -87,6 +87,7 @@ describe('defineManagementMcpTool', () => {
             expect(auditSpy).toHaveBeenCalledWith({
                 occurredAt: expect.any(String),
                 accountId: 1,
+                scope: 'environment',
                 environment: { id: 2, display: 'dev' },
                 actor: { type: 'api_key', id: '7', display: 'Management key' },
                 resource: 'integration',

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
@@ -25,6 +25,7 @@ function auditEvent(accountId: number, occurredAt: string, resourceAction: Audit
     return {
         occurredAt,
         accountId,
+        scope: 'environment',
         environment: null,
         actor: { type: 'user', id: '5', display: 'a@b.co' },
         targets: [{ type: 'connection', id: '10' }],
@@ -132,6 +133,7 @@ describe('GET /api/v1/audit-trail', () => {
         expect(event.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
         expect(event.resource).toBe('connection');
         expect(event.action).toBe('deleted');
+        expect(event.scope).toBe('environment');
     });
 
     it('caps how many values one filter param can carry', async () => {

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrailExport.integration.test.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrailExport.integration.test.ts
@@ -33,6 +33,7 @@ function auditEvent(accountId: number, occurredAt: string, resourceAction: Audit
     return {
         occurredAt,
         accountId,
+        scope: 'environment',
         environment: { id: 2, display: 'dev' },
         actor: { type: 'user', id: '5', display: 'a@b.co' },
         targets: [{ type: 'connection', id: '10' }],
@@ -109,7 +110,7 @@ describe('GET /api/v1/audit-trail/export', () => {
 
         const lines = body.trim().split('\n');
         expect(lines[0]).toBe(
-            'occurred_at,event_id,environment,actor_type,actor_id,actor_display,via,via_actor_id,resource,action,target_types,target_ids,target_displays,outcome,ip,user_agent,interface,metadata'
+            'occurred_at,event_id,scope,environment,actor_type,actor_id,actor_display,via,via_actor_id,resource,action,target_types,target_ids,target_displays,outcome,ip,user_agent,interface,metadata'
         );
         expect(lines).toHaveLength(3);
         expect(lines[1]).toContain('dev,user,5,a@b.co,,,sync,paused,connection,10,,success,1.2.3.4,curl/8');
@@ -165,6 +166,7 @@ describe('GET /api/v1/audit-trail/export', () => {
                 version: '2026-07-16',
                 occurredAt: new Date(base + i * 1000).toISOString(),
                 accountId: account.id,
+                scope: 'environment',
                 environment: null,
                 actor: { type: 'user', id: '5' },
                 resource: 'connection',

--- a/packages/server/lib/hooks/auditConnection.ts
+++ b/packages/server/lib/hooks/auditConnection.ts
@@ -45,6 +45,7 @@ export async function recordConnectionCreated(params: {
         const event: AuditEvent = {
             occurredAt,
             accountId: params.account.id,
+            scope: 'environment',
             environment: { id: params.environment.id, display: params.environment.name },
             actor: connectionCreatedActor(attributed?.actor, params.endUser),
             resource: 'connection',

--- a/packages/server/lib/middleware/audit/appAuth.middleware.ts
+++ b/packages/server/lib/middleware/audit/appAuth.middleware.ts
@@ -128,6 +128,7 @@ async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
         const common = {
             occurredAt,
             accountId: principal.account.id,
+            scope: 'account' as const,
             environment: null,
             actor,
             targets: [ref],

--- a/packages/server/lib/middleware/audit/auditable.ts
+++ b/packages/server/lib/middleware/audit/auditable.ts
@@ -189,6 +189,7 @@ async function emit(
         const event = {
             occurredAt,
             accountId: account.id,
+            scope: policy.scope,
             environment: policy.scope === 'account' || !environment ? null : { id: environment.id, display: environment.name },
             actor: actorOverride ?? resolveActor(locals),
             resource: policy.resource,

--- a/packages/server/lib/middleware/audit/member.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/member.middleware.unit.test.ts
@@ -37,6 +37,7 @@ describe('member audit middleware (unit)', () => {
             action: 'invited',
             outcome: 'success',
             accountId: 42,
+            scope: 'account',
             environment: null,
             actor: { type: 'user', id: '7', display: 'dev@example.com' },
             targets: [

--- a/packages/server/lib/middleware/audit/member.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/member.middleware.unit.test.ts
@@ -51,7 +51,7 @@ describe('member audit middleware (unit)', () => {
     it('member invited: a non-string role is omitted rather than recorded', async () => {
         const req = fakeReq({ body: { emails: ['alice@example.com'], role: { admin: true } } });
         const event = await runAudit(auditMemberInvited, req, fakeRes(locals));
-        expect(event).toMatchObject({ resource: 'member', action: 'invited', accountId: 42, environment: null });
+        expect(event).toMatchObject({ resource: 'member', action: 'invited', accountId: 42, scope: 'account', environment: null });
         expect(event?.metadata).toBeUndefined();
     });
 
@@ -63,6 +63,7 @@ describe('member audit middleware (unit)', () => {
             action: 'invite_revoked',
             outcome: 'success',
             accountId: 42,
+            scope: 'account',
             environment: null,
             targets: [{ type: 'member', id: 'revoke-me@example.com', display: 'revoke-me@example.com' }]
         });
@@ -78,6 +79,7 @@ describe('member audit middleware (unit)', () => {
             outcome: 'success',
             // The inviting team (from the invitation), not the accepter's own account (42).
             accountId: 100,
+            scope: 'account',
             environment: null,
             actor: { type: 'user', id: '7', display: 'dev@example.com' },
             targets: [{ type: 'member', id: '7', display: 'dev@example.com' }]
@@ -101,6 +103,7 @@ describe('member audit middleware (unit)', () => {
             action: 'invite_declined',
             outcome: 'success',
             accountId: 100,
+            scope: 'account',
             environment: null,
             actor: { type: 'user', id: '7', display: 'dev@example.com' },
             targets: [{ type: 'member', id: '7', display: 'dev@example.com' }]
@@ -125,6 +128,7 @@ describe('member audit middleware (unit)', () => {
             action: 'invite_accepted',
             outcome: 'failure',
             accountId: 100,
+            scope: 'account',
             environment: null,
             targets: [{ type: 'member', id: '7', display: 'dev@example.com' }]
         });

--- a/packages/server/lib/middleware/audit/mfa.middleware.ts
+++ b/packages/server/lib/middleware/audit/mfa.middleware.ts
@@ -77,6 +77,7 @@ async function emitMfaVerified(req: Request, res: Response, pendingUserId: numbe
         const event: AuditEvent = {
             occurredAt,
             accountId: account.id,
+            scope: mfaVerifiedPolicy.scope,
             environment: null,
             actor: { type: 'user', id: String(user.id), display: user.email },
             resource: mfaVerifiedPolicy.resource,

--- a/packages/server/lib/middleware/audit/mfa.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/mfa.middleware.unit.test.ts
@@ -25,7 +25,7 @@ describe('mfa audit middleware (unit)', () => {
             action: 'enabled',
             outcome: 'failure',
             accountId: 42,
-            // account-scoped policy → environment is never attributed.
+            scope: 'account',
             environment: null,
             actor: { type: 'user', id: '7', display: 'dev@example.com' },
             targets: [{ type: 'user', id: '7', display: 'dev@example.com' }]
@@ -39,7 +39,7 @@ describe('mfa audit middleware (unit)', () => {
     ])('mfa login verify: records the method for type %s', async (type, method) => {
         const req = fakeReq({ body: { type }, session: { pendingMfaLogin: { userId: 7 } } });
         const event = await runAudit(auditMfaVerified, req, fakeRes(locals));
-        expect(event).toMatchObject({ resource: 'mfa', action: 'verified', accountId: 42, environment: null, metadata: { method } });
+        expect(event).toMatchObject({ resource: 'mfa', action: 'verified', accountId: 42, scope: 'account', environment: null, metadata: { method } });
     });
 
     it('mfa login verify: a non-string type is not coerced into a method', async () => {

--- a/packages/server/lib/middleware/audit/sync.middleware.ts
+++ b/packages/server/lib/middleware/audit/sync.middleware.ts
@@ -194,6 +194,7 @@ async function emit(req: Request, res: Response): Promise<void> {
         const event = {
             occurredAt,
             accountId: account.id,
+            scope: 'environment',
             environment: environment ? { id: environment.id, display: environment.name } : null,
             actor: resolveActor(locals),
             resource: 'sync',

--- a/packages/server/lib/middleware/audit/sync.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/sync.middleware.unit.test.ts
@@ -38,6 +38,7 @@ describe('sync audit middleware (unit)', () => {
             action: 'paused',
             outcome: 'success',
             accountId: 42,
+            scope: 'environment',
             environment: { id: 9, display: 'dev' },
             targets: [
                 { type: 'sync', id: 'sync-a' },
@@ -226,7 +227,7 @@ describe('auditSyncCommand middleware behavior (unit)', () => {
     it.each([
         { command: 'PAUSE', publicSpec: auditSyncPaused, label: 'paused', body: {}, publicBody: {} },
         { command: 'UNPAUSE', publicSpec: auditSyncStarted, label: 'started', body: {}, publicBody: {} }
-    ])('records $label with the same target and metadata as the public route', async ({ command, publicSpec, body, publicBody }) => {
+    ])('records $label with the same scope, target and metadata as the public route', async ({ command, publicSpec, body, publicBody }) => {
         const privateEvent = await runAudit(auditSyncCommand, syncCommandReq(command, { sync_variant: 'v2', ...body }), fakeRes(locals));
 
         recordMock.mockReset().mockResolvedValue(undefined);
@@ -235,6 +236,7 @@ describe('auditSyncCommand middleware behavior (unit)', () => {
         });
         const publicEvent = await runAudit(publicSpec, publicReq, fakeRes(locals));
 
+        expect(privateEvent.scope).toEqual(publicEvent.scope);
         expect(privateEvent.targets).toEqual(publicEvent.targets);
         expect(privateEvent.metadata).toEqual(publicEvent.metadata);
     });

--- a/packages/types/lib/audit-trail/api.ts
+++ b/packages/types/lib/audit-trail/api.ts
@@ -21,7 +21,6 @@ export interface ApiAuditTrailEvent {
     version: AuditTrailVersion;
     occurredAt: string;
     accountId: number;
-    // Says why `environment` is null: an account-level action has none, rather than one having gone missing.
     scope: AuditScope;
     environment: { id: number; display: string } | null;
     actor: AuditActor;

--- a/packages/types/lib/audit-trail/api.ts
+++ b/packages/types/lib/audit-trail/api.ts
@@ -1,5 +1,16 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
-import type { AuditAction, AuditActor, AuditContext, AuditOutcome, AuditPolicy, AuditResource, AuditTarget, AuditTrailVersion, AuditVia } from './event.js';
+import type {
+    AuditAction,
+    AuditActor,
+    AuditContext,
+    AuditOutcome,
+    AuditPolicy,
+    AuditResource,
+    AuditScope,
+    AuditTarget,
+    AuditTrailVersion,
+    AuditVia
+} from './event.js';
 
 // The audit event returned to the dashboard — the stored blob, parsed. Typed strictly for the current
 // schema `version` (a literal discriminant). At a breaking version this becomes a `version`-discriminated
@@ -10,6 +21,8 @@ export interface ApiAuditTrailEvent {
     version: AuditTrailVersion;
     occurredAt: string;
     accountId: number;
+    // Says why `environment` is null: an account-level action has none, rather than one having gone missing.
+    scope: AuditScope;
     environment: { id: number; display: string } | null;
     actor: AuditActor;
     via?: AuditVia[];

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -216,6 +216,7 @@ export type AuditResourceAction = {
 interface AuditEventCommon {
     occurredAt: string;
     accountId: number;
+    scope: AuditScope;
     environment: { id: number; display: string } | null;
     actor: AuditActor;
     via?: AuditVia[];

--- a/packages/webapp/src/pages/Audit/Show.tsx
+++ b/packages/webapp/src/pages/Audit/Show.tsx
@@ -19,7 +19,18 @@ import { last14dPreset, logsPresets } from '@/utils/logs';
 import { formatDateToLogFormat } from '@/utils/utils';
 import { AuditEventDrawer } from './components/AuditEventDrawer';
 import { AuditExportDialog } from './components/AuditExportDialog';
-import { actionLabel, actionOptionsFor, actorLabel, ALL, environmentLabel, resourceLabel, resourceOptions, targetsLabel, viaLabel } from './constants';
+import {
+    actionLabel,
+    actionOptionsFor,
+    actorLabel,
+    ALL,
+    environmentLabel,
+    resourceLabel,
+    resourceOptions,
+    scopeLabel,
+    targetsLabel,
+    viaLabel
+} from './constants';
 
 import type { ActionFilter, ResourceFilter } from './constants';
 import type { Period } from '@/utils/dates';
@@ -140,6 +151,7 @@ export const AuditShow: React.FC = () => {
                     <thead>
                         <tr className="border-b border-border-muted">
                             <th className="px-4 py-2 text-left font-semibold">Time</th>
+                            <th className="px-4 py-2 text-left font-semibold">Scope</th>
                             <th className="px-4 py-2 text-left font-semibold">Environment</th>
                             <th className="px-4 py-2 text-left font-semibold">Actor</th>
                             <th className="px-4 py-2 text-left font-semibold">Resource</th>
@@ -161,6 +173,7 @@ export const AuditShow: React.FC = () => {
                                     <td className="px-4 py-2.5 align-middle">
                                         <div className="font-code text-s">{formatDateToLogFormat(event.occurredAt)}</div>
                                     </td>
+                                    <td className="px-4 py-2.5 align-middle">{scopeLabel(event.scope)}</td>
                                     <td className="px-4 py-2.5 align-middle">{environmentLabel(event.environment)}</td>
                                     <td className="px-4 py-2.5 align-middle">
                                         {actorLabel(event.actor)}

--- a/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
@@ -6,7 +6,7 @@ import { Sheet, SheetClose, SheetContent, SheetTitle } from '@/components/ui/She
 import { Tag } from '@/components/ui/Tag';
 import { darkModeSelector, useThemeStore } from '@/lib/theme';
 import { formatDateToLogFormat } from '@/utils/utils';
-import { actionLabel, actorLabel, environmentLabel, resourceLabel, targetsLabel, targetTypesLabel, viaLabel } from '../constants';
+import { actionLabel, actorLabel, environmentLabel, resourceLabel, scopeLabel, targetsLabel, targetTypesLabel, viaLabel } from '../constants';
 
 import type { ApiAuditTrailEvent, AuditOutcome } from '@nangohq/types';
 
@@ -62,6 +62,7 @@ export const AuditEventDrawer: React.FC<{ event: ApiAuditTrailEvent; onClose: ()
                     </div>
 
                     <dl className="grid grid-cols-[130px_1fr] gap-x-4 gap-y-2 text-s mb-6">
+                        <Meta label="Scope" value={scopeLabel(event.scope)} />
                         <Meta label="Environment" value={environmentLabel(event.environment)} />
                         <Meta label="Actor" value={actorLabel(event.actor)} />
                         {via && <Meta label="Via" value={via} />}

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -1,7 +1,7 @@
 import { formatKeyToLabel } from '@/utils/utils';
 
 import type { FilterOption } from '@/components/patterns/FilterMultiSelect';
-import type { ApiAuditTrailEvent, AuditAction, AuditActionOf, AuditEventKey, AuditResource } from '@nangohq/types';
+import type { ApiAuditTrailEvent, AuditAction, AuditActionOf, AuditEventKey, AuditResource, AuditScope } from '@nangohq/types';
 
 /**
  * Runtime twin of the audit event vocabulary, which `@nangohq/types` carries as types only. Kept in
@@ -88,6 +88,16 @@ export function targetTypesLabel(targets: ApiAuditTrailEvent['targets']): string
     return [...new Set(targets.map((target) => target.type))].join(', ');
 }
 
+const scopeLabels: Record<AuditScope, string> = {
+    account: 'Account',
+    environment: 'Environment'
+};
+
+export function scopeLabel(scope: ApiAuditTrailEvent['scope']): string {
+    return scopeLabels[scope];
+}
+
+// The scope column says why this is empty, so the cell no longer stands in for it.
 export function environmentLabel(environment: ApiAuditTrailEvent['environment']): string {
-    return environment?.display ?? 'Account';
+    return environment?.display ?? '—';
 }


### PR DESCRIPTION
- Every audit event now carries `scope`, either `account` or `environment`. `environment: null` meant two things until now — an account-scoped action has none to name, and an environment-scoped one that lost its environment is a defect — and nothing on the stored event said which. `resource_action` cannot break the tie either, because `api_key.created` is emitted at both scopes. The decisive query becomes `JSONType(event,'environment') = 'Null' AND JSONExtractString(event,'scope') = 'environment'`.
- The field reaches the read API response and the CSV export, where it sits before the `environment` column so an empty cell is explained by the column beside it.
- The dashboard gets a `Scope` column in the trail list and a `Scope` row above `Environment` in the event drawer.

All six emit paths already read the scope to decide whether to attribute an environment, so recording it is one line per path. No migration: the field lives in the event JSON blob, and only `id`, `account_id`, `occurred_at`, `resource` and `resource_action` are materialised.

## The one behaviour change worth a look

`environmentLabel` in the dashboard used to return `'Account'` when the environment was null — the table inventing a scope label because it had none. With a real Scope column that reads `Account | Account`, so the environment cell now falls back to the em dash the Target column already uses. It alters the display of every account-scoped row, and it is one line if you would rather the column stayed purely additive.

## Test plan

- [x] Scope asserted alongside `environment` on an account-scoped and an environment-scoped emitter, break-checked in both the generic and a hand-built tail
- [x] The private/public sync symmetry check now compares `scope`, so the two producers of `sync.paused` cannot drift; break-checked
- [x] Read-API test asserts the field survives the ClickHouse round-trip; CSV header and row assertions pin the new column
- [x] The four MCP tests that assert the whole event with `toHaveBeenCalledWith` list the new field
- [x] Full unit suite green: 4,262 tests across 317 files. `ts-build`, webapp typecheck, oxlint and prettier clean
- [ ] Deploy to development and confirm the Scope column and drawer row render, and that account-scoped rows show an em dash for environment
- [ ] Pre-change rows carry no `scope` while the response type declares it required, so their Scope cell renders empty — truncate before or shortly after rollout

<img width="1299" height="433" alt="Screenshot 2026-08-31 at 18 02 41" src="https://github.com/user-attachments/assets/45779b92-e22e-4632-aaf9-4be8c295efc4" />
