### PR TITLE
feat(webapp): rework the billing overrides dev panel

### DIFF
--- a/packages/design-system/src/components/ui/tooltip.tsx
+++ b/packages/design-system/src/components/ui/tooltip.tsx
@@ -28,7 +28,9 @@ const TooltipContent = React.forwardRef<React.ElementRef<typeof TooltipPrimitive
                 data-slot="tooltip-content"
                 sideOffset={sideOffset}
                 className={cn(
-                    'bg-surface-inverse text-text-inverse type-label-sm shadow-container-panel rounded-ds-xs px-1.5 py-1',
+                    'group bg-surface-inverse text-text-inverse type-label-sm shadow-container-panel rounded-ds-xs px-1.5 py-1',
+                    // The arrow paints over the chip, so the side it sits on needs room the text can't use.
+                    'data-[side=left]:pr-2.5 data-[side=right]:pl-2.5',
                     'origin-(--radix-tooltip-content-transform-origin) z-80 w-fit max-w-96',
                     // Link tokens are tuned for the page surface and lose contrast on the inverse chip. Redefining
                     // them in scope covers every state, since the link variants read these vars; the underline then
@@ -43,7 +45,17 @@ const TooltipContent = React.forwardRef<React.ElementRef<typeof TooltipPrimitive
                 {...props}
             >
                 {children}
-                <TooltipPrimitive.Arrow className="bg-surface-inverse fill-surface-inverse rounded-ds-xs z-80 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45" />
+                <TooltipPrimitive.Arrow
+                    className={cn(
+                        'bg-surface-inverse fill-surface-inverse rounded-ds-xs z-80 size-2.5 rotate-45',
+                        // The diamond is tucked back into the chip along whichever axis it sits on, so a
+                        // left/right tooltip must move on X — moving it on Y leaves it over the first word.
+                        'group-data-[side=top]:translate-y-[calc(-50%_-_2px)]',
+                        'group-data-[side=bottom]:translate-y-[calc(50%_+_2px)]',
+                        'group-data-[side=left]:translate-x-[calc(-50%_-_2px)]',
+                        'group-data-[side=right]:translate-x-[calc(50%_+_2px)]'
+                    )}
+                />
             </TooltipPrimitive.Content>
         </TooltipPrimitive.Portal>
     )

--- a/packages/webapp/src/features/DevToolPanel.tsx
+++ b/packages/webapp/src/features/DevToolPanel.tsx
@@ -128,7 +128,7 @@ export const DevToolPanel: React.FC = () => {
                                     className="flex w-full cursor-pointer items-center gap-2.5 rounded px-2 py-1.5 text-sm text-text-default hover:bg-surface-panel-inset"
                                 >
                                     <CreditCard className="size-4 shrink-0 text-text-muted" />
-                                    <span className="flex-1 text-left">Plan Override</span>
+                                    <span className="flex-1 text-left">Billing Overrides</span>
                                     <ChevronRight className="size-4 shrink-0 text-text-muted" />
                                 </button>
                             </li>

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -265,10 +265,16 @@ const Row: React.FC<{ label: string; hint?: string; indent?: boolean; children: 
     );
 };
 
-const RowTrigger: React.FC<{ placeholder: string }> = ({ placeholder }) => (
-    <SelectTrigger aria-labelledby={useContext(RowLabelContext)} className="w-52 text-sm px-2.5 gap-2">
-        <SelectValue placeholder={placeholder} />
-    </SelectTrigger>
-);
+const RowTrigger: React.FC<{ placeholder: string }> = ({ placeholder }) => {
+    const labelId = useContext(RowLabelContext);
+    // Naming the trigger by the row label alone would drop the selected value from its name, so it
+    // also points at itself — the two ids read as "<label> <value>".
+    const valueId = useId();
+    return (
+        <SelectTrigger id={valueId} aria-labelledby={labelId ? `${labelId} ${valueId}` : undefined} className="w-52 text-sm px-2.5 gap-2">
+            <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+    );
+};
 
 const RowSwitch: React.FC<React.ComponentProps<typeof Switch>> = (props) => <Switch aria-labelledby={useContext(RowLabelContext)} {...props} />;

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, X } from 'lucide-react';
-import { Children, useMemo } from 'react';
+import { Children, createContext, useContext, useId, useMemo } from 'react';
 
 import { Button, IconButton } from '@nangohq/design-system';
 
@@ -168,16 +168,16 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
 
                 <Section title="Billing">
                     <Row label="Card on file" hint="Local dev has no Stripe keys, so the real answer is always none.">
-                        <Switch checked={paymentMethodOverride} onCheckedChange={setPaymentMethodOverride} />
+                        <RowSwitch checked={paymentMethodOverride} onCheckedChange={setPaymentMethodOverride} />
                     </Row>
                     <Row label="Overdue invoices">
-                        <Switch checked={overdueOverride} onCheckedChange={setOverdueOverride} />
+                        <RowSwitch checked={overdueOverride} onCheckedChange={setOverdueOverride} />
                     </Row>
 
                     {leadsWithSpend && (
                         <>
                             <Row label="Spend headline" hint="Unverified against real Orb invoices, so customers do not see it yet.">
-                                <Switch checked={spendHeadlineEnabled} onCheckedChange={setSpendHeadlineEnabled} />
+                                <RowSwitch checked={spendHeadlineEnabled} onCheckedChange={setSpendHeadlineEnabled} />
                             </Row>
                             {spendHeadlineEnabled && (
                                 <Row label="Spend" indent>
@@ -208,7 +208,7 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                             )}
 
                             <Row label="Charges column" hint="Unverified against real Orb invoices, so customers do not see it yet.">
-                                <Switch checked={metricChargesEnabled} onCheckedChange={setMetricChargesEnabled} />
+                                <RowSwitch checked={metricChargesEnabled} onCheckedChange={setMetricChargesEnabled} />
                             </Row>
                             {metricChargesEnabled && (
                                 <Row label="Charges" indent>
@@ -249,18 +249,26 @@ const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title
     );
 };
 
-const Row: React.FC<{ label: string; hint?: string; indent?: boolean; children: React.ReactNode }> = ({ label, hint, indent, children }) => (
-    <div className={cn('flex items-center justify-between gap-3 min-h-8 px-1', indent && 'pl-5')}>
-        <span className="flex items-center gap-1.5 text-sm text-text-default">
-            {label}
-            {hint && <InfoTooltip side="right">{hint}</InfoTooltip>}
-        </span>
-        {children}
-    </div>
-);
+// A row's control is named by the label beside it rather than by any text of its own.
+const RowLabelContext = createContext<string | undefined>(undefined);
+
+const Row: React.FC<{ label: string; hint?: string; indent?: boolean; children: React.ReactNode }> = ({ label, hint, indent, children }) => {
+    const labelId = useId();
+    return (
+        <div className={cn('flex items-center justify-between gap-3 min-h-8 px-1', indent && 'pl-5')}>
+            <span className="flex items-center gap-1.5 text-sm text-text-default">
+                <span id={labelId}>{label}</span>
+                {hint && <InfoTooltip side="right">{hint}</InfoTooltip>}
+            </span>
+            <RowLabelContext.Provider value={labelId}>{children}</RowLabelContext.Provider>
+        </div>
+    );
+};
 
 const RowTrigger: React.FC<{ placeholder: string }> = ({ placeholder }) => (
-    <SelectTrigger className="w-52 text-sm px-2.5 gap-2">
+    <SelectTrigger aria-labelledby={useContext(RowLabelContext)} className="w-52 text-sm px-2.5 gap-2">
         <SelectValue placeholder={placeholder} />
     </SelectTrigger>
 );
+
+const RowSwitch: React.FC<React.ComponentProps<typeof Switch>> = (props) => <Switch aria-labelledby={useContext(RowLabelContext)} {...props} />;

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -1,37 +1,37 @@
 import { ChevronLeft, X } from 'lucide-react';
-import { useMemo } from 'react';
+import { Children, useMemo } from 'react';
 
-import { IconButton } from '@nangohq/design-system';
+import { Button, IconButton } from '@nangohq/design-system';
 
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
+import { Switch } from '@/components/ui/Switch';
+import { Tag } from '@/components/ui/Tag';
+import { useEnvironment } from '@/hooks/useEnvironment';
 import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
 import { hasMonthlySpend } from '@/pages/Team/Billing/planVisibility';
 import { useStore } from '@/store';
-import { usePlanOverrideStore } from './planOverride';
+import { cn } from '@/utils/utils';
+import { DEFAULTS, usePlanOverrideStore } from './planOverride';
 
 import type { PeriodCostsOverride, SpendOverride, UsageLimitOverride } from './planOverride';
 import type { PlanDefinition } from '@nangohq/types';
 
 const REAL_PLAN_VALUE = '__real__';
 const NO_SCHEDULED_CHANGE_VALUE = '__none__';
-const REAL_OVERDUE_VALUE = '__real_state__';
-const OVERDUE_VALUE = '__overdue__';
 const REAL_USAGE_VALUE = '__real_usage__';
 const REAL_SPEND_VALUE = '__real_spend__';
 const UNAVAILABLE_SPEND_VALUE = 'unavailable';
 // A base-only Starter bill, a mid-period Growth bill, and the startup deal's real zero.
 const SPEND_PRESETS_IN_CENTS = [0, 5000, 128430];
 const REAL_PERIOD_COSTS_VALUE = '__real_period_costs__';
-// Only these 3 self-serve tiers have a real downgrade/cancellation path — legacy and Enterprise
-// plans never schedule a change in practice, so they're not offered as scheduled-change targets.
-const MAIN_PLAN_ORDER: PlanDefinition['code'][] = ['free', 'pay-as-you-go', 'starter-v2', 'growth-v2'];
-
 interface PlanOverrideContentProps {
     onBack: () => void;
     onClose: () => void;
 }
 
 export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack, onClose }) => {
+    const store = usePlanOverrideStore();
     const env = useStore((s) => s.env);
     const { data: plansList } = useApiGetPlans(env);
     const overrideCode = usePlanOverrideStore((s) => s.overrideCode);
@@ -50,6 +50,9 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
     const setMetricChargesEnabled = usePlanOverrideStore((s) => s.setMetricChargesEnabled);
     const periodCostsOverride = usePlanOverrideStore((s) => s.periodCostsOverride);
     const setPeriodCostsOverride = usePlanOverrideStore((s) => s.setPeriodCostsOverride);
+    const paymentMethodOverride = usePlanOverrideStore((s) => s.paymentMethodOverride);
+    const setPaymentMethodOverride = usePlanOverrideStore((s) => s.setPaymentMethodOverride);
+    const resetAll = usePlanOverrideStore((s) => s.resetAll);
 
     // Plan caps are enforced on Free only, so that simulator is offered there alone. Overdue invoices
     // aren't plan-specific — a downgraded account can still owe one — so that one is always offered.
@@ -72,10 +75,14 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
         return duplicated;
     }, [plansList]);
 
-    // Valid scheduled-change targets are the main plans below the selected override in MAIN_PLAN_ORDER.
-    const overrideOrderIndex = overrideCode ? MAIN_PLAN_ORDER.indexOf(overrideCode) : -1;
-    const scheduledChangeCodes = overrideOrderIndex > 0 ? MAIN_PLAN_ORDER.slice(0, overrideOrderIndex) : [];
-    const scheduledChangeOptions = plansList?.data.filter((plan) => scheduledChangeCodes.includes(plan.code));
+    const prevPlanCodes = plansList?.data.find((plan) => plan.code === overrideCode)?.prevPlan;
+    const scheduledChangeOptions = plansList?.data.filter((plan) => prevPlanCodes?.includes(plan.code));
+
+    // `useCurrentPlan` already has the override applied, so the real plan has to come from the
+    // un-overridden query or the caption would name whatever is being previewed.
+    const realPlanName = useEnvironment(env).data?.plan?.name;
+    const realPlanTitle = plansList?.data.find((plan) => plan.code === realPlanName)?.title;
+    const overrides = Object.entries(DEFAULTS).filter(([key, value]) => store[key as keyof typeof DEFAULTS] !== value).length;
 
     return (
         <>
@@ -85,169 +92,175 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                         <ChevronLeft className="size-3.5" />
                     </IconButton>
                     <span className="font-medium text-text-default">Plan Override</span>
+                    {overrides > 0 && <Tag variant="info">{overrides} active</Tag>}
                 </div>
-                <IconButton variant="ghost" size="2xs" label="Close" onClick={onClose}>
-                    <X className="size-3.5" />
-                </IconButton>
+                <div className="flex items-center gap-1">
+                    {overrides > 0 && (
+                        <Button variant="link-accent" size="xs" onClick={resetAll}>
+                            Reset
+                        </Button>
+                    )}
+                    <IconButton variant="ghost" size="2xs" label="Close" onClick={onClose}>
+                        <X className="size-3.5" />
+                    </IconButton>
+                </div>
             </div>
 
-            <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
-                <p className="text-sm text-text-muted">
-                    Preview the app as if the account were on a different plan. This only changes what&apos;s displayed here in this browser — the
-                    account&apos;s real plan and billing are untouched.
-                </p>
-                <Select
-                    value={overrideCode ?? REAL_PLAN_VALUE}
-                    onValueChange={(value) => setOverride(value === REAL_PLAN_VALUE ? null : (value as PlanDefinition['code']))}
-                >
-                    <SelectTrigger className="w-full text-sm px-2.5 gap-2">
-                        <SelectValue placeholder="Real plan" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value={REAL_PLAN_VALUE}>Real plan (no override)</SelectItem>
-                        {plansList?.data.map((plan) => (
-                            <SelectItem key={plan.code} value={plan.code}>
-                                {ambiguousTitles.has(plan.title) ? `${plan.title} · ${plan.code}` : plan.title}
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
-
-                {scheduledChangeOptions && scheduledChangeOptions.length > 0 && (
-                    <div className="flex flex-col gap-1.5">
-                        <span className="text-sm text-text-muted">Simulate a scheduled change (downgrade/cancellation in progress)</span>
-                        <Select
-                            value={scheduledTargetCode ?? NO_SCHEDULED_CHANGE_VALUE}
-                            onValueChange={(value) => setScheduledTarget(value === NO_SCHEDULED_CHANGE_VALUE ? null : (value as PlanDefinition['code']))}
-                        >
-                            <SelectTrigger className="w-full text-sm px-2.5 gap-2">
-                                <SelectValue placeholder="None" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value={NO_SCHEDULED_CHANGE_VALUE}>None</SelectItem>
-                                {scheduledChangeOptions.map((plan) => (
-                                    <SelectItem key={plan.code} value={plan.code}>
-                                        {plan.code === 'free' ? 'Free (cancellation)' : `${plan.title} (downgrade)`}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </div>
-                )}
-
-                <div className="flex flex-col gap-1.5 border-t border-border-muted pt-4">
-                    <span className="text-sm text-text-muted">Simulate overdue invoices (sidebar card + Billing page banner)</span>
-                    <Select value={overdueOverride ? OVERDUE_VALUE : REAL_OVERDUE_VALUE} onValueChange={(value) => setOverdueOverride(value === OVERDUE_VALUE)}>
+            <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-5">
+                <div className="flex flex-col gap-2">
+                    <Select
+                        value={overrideCode ?? REAL_PLAN_VALUE}
+                        onValueChange={(value) => setOverride(value === REAL_PLAN_VALUE ? null : (value as PlanDefinition['code']))}
+                    >
                         <SelectTrigger className="w-full text-sm px-2.5 gap-2">
-                            <SelectValue placeholder="Real state" />
+                            <SelectValue placeholder="Real plan" />
                         </SelectTrigger>
                         <SelectContent>
-                            <SelectItem value={REAL_OVERDUE_VALUE}>Real state (no override)</SelectItem>
-                            <SelectItem value={OVERDUE_VALUE}>Overdue</SelectItem>
+                            <SelectItem value={REAL_PLAN_VALUE}>Real plan (no override)</SelectItem>
+                            {plansList?.data.map((plan) => (
+                                <SelectItem key={plan.code} value={plan.code}>
+                                    {ambiguousTitles.has(plan.title) ? `${plan.title} · ${plan.code}` : plan.title}
+                                </SelectItem>
+                            ))}
                         </SelectContent>
                     </Select>
+                    <p className="text-xs text-text-muted">
+                        {overrideCode ? `Display only — really on ${realPlanTitle ?? realPlanName}.` : 'Display only. Nothing here bills.'}
+                    </p>
                 </div>
 
-                {leadsWithSpend && (
-                    <div className="flex flex-col gap-3 border-t border-border-muted pt-4">
-                        <div className="flex flex-col gap-1.5">
-                            <span className="text-sm text-text-muted">Current period spend headline (unverified — hidden from customers)</span>
-                            <Select value={spendHeadlineEnabled ? 'on' : 'off'} onValueChange={(value) => setSpendHeadlineEnabled(value === 'on')}>
-                                <SelectTrigger className="w-full text-sm px-2.5 gap-2">
-                                    <SelectValue placeholder="Hidden" />
-                                </SelectTrigger>
+                <Section title="Plan state">
+                    {scheduledChangeOptions && scheduledChangeOptions.length > 0 && (
+                        <Row label="Scheduled change">
+                            <Select
+                                value={scheduledTargetCode ?? NO_SCHEDULED_CHANGE_VALUE}
+                                onValueChange={(value) => setScheduledTarget(value === NO_SCHEDULED_CHANGE_VALUE ? null : (value as PlanDefinition['code']))}
+                            >
+                                <RowTrigger placeholder="None" />
                                 <SelectContent>
-                                    <SelectItem value="off">Hidden (plan name headline)</SelectItem>
-                                    <SelectItem value="on">Shown</SelectItem>
+                                    <SelectItem value={NO_SCHEDULED_CHANGE_VALUE}>None</SelectItem>
+                                    {scheduledChangeOptions.map((plan) => (
+                                        <SelectItem key={plan.code} value={plan.code}>
+                                            {plan.code === 'free' ? 'Free (cancellation)' : `${plan.title} (downgrade)`}
+                                        </SelectItem>
+                                    ))}
                                 </SelectContent>
                             </Select>
-                        </div>
+                        </Row>
+                    )}
 
-                        {spendHeadlineEnabled && (
-                            <div className="flex flex-col gap-1.5">
-                                <span className="text-sm text-text-muted">Simulate spend (the local billing client returns none)</span>
-                                <Select
-                                    value={spendOverride === null ? REAL_SPEND_VALUE : String(spendOverride)}
-                                    onValueChange={(value) =>
-                                        setSpendOverride(
-                                            value === REAL_SPEND_VALUE
-                                                ? null
-                                                : value === UNAVAILABLE_SPEND_VALUE
-                                                  ? UNAVAILABLE_SPEND_VALUE
-                                                  : (Number(value) as SpendOverride)
-                                        )
-                                    }
-                                >
-                                    <SelectTrigger className="w-full text-sm px-2.5 gap-2">
-                                        <SelectValue placeholder="Real spend" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value={REAL_SPEND_VALUE}>Real spend (no override)</SelectItem>
-                                        {SPEND_PRESETS_IN_CENTS.map((cents) => (
-                                            <SelectItem key={cents} value={String(cents)}>
-                                                {(cents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
-                                            </SelectItem>
-                                        ))}
-                                        <SelectItem value={UNAVAILABLE_SPEND_VALUE}>Unavailable (falls back to plan name)</SelectItem>
-                                    </SelectContent>
-                                </Select>
-                            </div>
-                        )}
-
-                        <div className="flex flex-col gap-1.5 border-t border-border-muted pt-4">
-                            <span className="text-sm text-text-muted">Per-metric charges column (unverified — hidden from customers)</span>
-                            <Select value={metricChargesEnabled ? 'on' : 'off'} onValueChange={(value) => setMetricChargesEnabled(value === 'on')}>
-                                <SelectTrigger className="w-full text-sm px-2.5 gap-2">
-                                    <SelectValue placeholder="Hidden" />
-                                </SelectTrigger>
+                    {isFreePlan && (
+                        <Row label="Plan limits">
+                            <Select
+                                value={usageLimitOverride ?? REAL_USAGE_VALUE}
+                                onValueChange={(value) => setUsageLimitOverride(value === REAL_USAGE_VALUE ? null : (value as UsageLimitOverride))}
+                            >
+                                <RowTrigger placeholder="Real" />
                                 <SelectContent>
-                                    <SelectItem value="off">Hidden</SelectItem>
-                                    <SelectItem value="on">Shown</SelectItem>
+                                    <SelectItem value={REAL_USAGE_VALUE}>Real</SelectItem>
+                                    <SelectItem value="near">Nearing limits</SelectItem>
+                                    <SelectItem value="over">Limits reached</SelectItem>
                                 </SelectContent>
                             </Select>
-                        </div>
+                        </Row>
+                    )}
+                </Section>
 
-                        {metricChargesEnabled && (
-                            <div className="flex flex-col gap-1.5">
-                                <span className="text-sm text-text-muted">Simulate per-metric charges (the local billing client returns none)</span>
-                                <Select
-                                    value={periodCostsOverride ?? REAL_PERIOD_COSTS_VALUE}
-                                    onValueChange={(value) => setPeriodCostsOverride(value === REAL_PERIOD_COSTS_VALUE ? null : (value as PeriodCostsOverride))}
-                                >
-                                    <SelectTrigger className="w-full text-sm px-2.5 gap-2">
-                                        <SelectValue placeholder="Real charges" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value={REAL_PERIOD_COSTS_VALUE}>Real charges (no override)</SelectItem>
-                                        <SelectItem value="populated">A charge on some metrics</SelectItem>
-                                        <SelectItem value="zero">$0.00 on every metric</SelectItem>
-                                        <SelectItem value="unavailable">Unavailable (no figures)</SelectItem>
-                                    </SelectContent>
-                                </Select>
-                            </div>
-                        )}
-                    </div>
-                )}
+                <Section title="Billing">
+                    <Row label="Card on file" hint="Local dev has no Stripe keys, so the real answer is always none.">
+                        <Switch checked={paymentMethodOverride} onCheckedChange={setPaymentMethodOverride} />
+                    </Row>
+                    <Row label="Overdue invoices">
+                        <Switch checked={overdueOverride} onCheckedChange={setOverdueOverride} />
+                    </Row>
 
-                {isFreePlan && (
-                    <div className="flex flex-col gap-1.5 border-t border-border-muted pt-4">
-                        <span className="text-sm text-text-muted">Simulate plan limits (sidebar card)</span>
-                        <Select
-                            value={usageLimitOverride ?? REAL_USAGE_VALUE}
-                            onValueChange={(value) => setUsageLimitOverride(value === REAL_USAGE_VALUE ? null : (value as UsageLimitOverride))}
-                        >
-                            <SelectTrigger className="w-full text-sm px-2.5 gap-2">
-                                <SelectValue placeholder="Real usage" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value={REAL_USAGE_VALUE}>Real usage (no override)</SelectItem>
-                                <SelectItem value="near">Nearing plan limits</SelectItem>
-                                <SelectItem value="over">Plan limits reached</SelectItem>
-                            </SelectContent>
-                        </Select>
-                    </div>
-                )}
+                    {leadsWithSpend && (
+                        <>
+                            <Row label="Spend headline" hint="Unverified against real Orb invoices, so customers do not see it yet.">
+                                <Switch checked={spendHeadlineEnabled} onCheckedChange={setSpendHeadlineEnabled} />
+                            </Row>
+                            {spendHeadlineEnabled && (
+                                <Row label="Spend" indent>
+                                    <Select
+                                        value={spendOverride === null ? REAL_SPEND_VALUE : String(spendOverride)}
+                                        onValueChange={(value) =>
+                                            setSpendOverride(
+                                                value === REAL_SPEND_VALUE
+                                                    ? null
+                                                    : value === UNAVAILABLE_SPEND_VALUE
+                                                      ? UNAVAILABLE_SPEND_VALUE
+                                                      : (Number(value) as SpendOverride)
+                                            )
+                                        }
+                                    >
+                                        <RowTrigger placeholder="Real" />
+                                        <SelectContent>
+                                            <SelectItem value={REAL_SPEND_VALUE}>Real</SelectItem>
+                                            {SPEND_PRESETS_IN_CENTS.map((cents) => (
+                                                <SelectItem key={cents} value={String(cents)}>
+                                                    {(cents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
+                                                </SelectItem>
+                                            ))}
+                                            <SelectItem value={UNAVAILABLE_SPEND_VALUE}>Unavailable</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </Row>
+                            )}
+
+                            <Row label="Charges column" hint="Unverified against real Orb invoices, so customers do not see it yet.">
+                                <Switch checked={metricChargesEnabled} onCheckedChange={setMetricChargesEnabled} />
+                            </Row>
+                            {metricChargesEnabled && (
+                                <Row label="Charges" indent>
+                                    <Select
+                                        value={periodCostsOverride ?? REAL_PERIOD_COSTS_VALUE}
+                                        onValueChange={(value) =>
+                                            setPeriodCostsOverride(value === REAL_PERIOD_COSTS_VALUE ? null : (value as PeriodCostsOverride))
+                                        }
+                                    >
+                                        <RowTrigger placeholder="Real" />
+                                        <SelectContent>
+                                            <SelectItem value={REAL_PERIOD_COSTS_VALUE}>Real</SelectItem>
+                                            <SelectItem value="populated">Some metrics</SelectItem>
+                                            <SelectItem value="zero">$0.00 on all</SelectItem>
+                                            <SelectItem value="unavailable">Unavailable</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </Row>
+                            )}
+                        </>
+                    )}
+                </Section>
             </div>
         </>
     );
 };
+
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => {
+    const hasRows = Children.toArray(children).some(Boolean);
+    if (!hasRows) {
+        return null;
+    }
+    return (
+        <div className="flex flex-col gap-1">
+            <span className="type-label-xs uppercase text-text-muted px-1 pb-1">{title}</span>
+            {children}
+        </div>
+    );
+};
+
+const Row: React.FC<{ label: string; hint?: string; indent?: boolean; children: React.ReactNode }> = ({ label, hint, indent, children }) => (
+    <div className={cn('flex items-center justify-between gap-3 min-h-8 px-1', indent && 'pl-5')}>
+        <span className="flex items-center gap-1.5 text-sm text-text-default">
+            {label}
+            {hint && <InfoTooltip side="right">{hint}</InfoTooltip>}
+        </span>
+        {children}
+    </div>
+);
+
+const RowTrigger: React.FC<{ placeholder: string }> = ({ placeholder }) => (
+    <SelectTrigger className="w-52 text-sm px-2.5 gap-2">
+        <SelectValue placeholder={placeholder} />
+    </SelectTrigger>
+);

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -91,7 +91,7 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                     <IconButton variant="ghost" size="2xs" label="Back" onClick={onBack}>
                         <ChevronLeft className="size-3.5" />
                     </IconButton>
-                    <span className="font-medium text-text-default">Plan Override</span>
+                    <span className="font-medium text-text-default">Billing Overrides</span>
                     {overrides > 0 && <Tag variant="info">{overrides} active</Tag>}
                 </div>
                 <div className="flex items-center gap-1">
@@ -167,7 +167,7 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                 </Section>
 
                 <Section title="Billing">
-                    <Row label="Card on file" hint="Local dev has no Stripe keys, so the real answer is always none.">
+                    <Row label="Card on file" hint="A real card needs Stripe test keys and a setup round-trip; this skips both.">
                         <RowSwitch checked={paymentMethodOverride} onCheckedChange={setPaymentMethodOverride} />
                     </Row>
                     <Row label="Overdue invoices">

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -59,10 +59,8 @@ export const usePlanOverrideStore = create<PlanOverrideState>()(
     persist(
         (set) => ({
             ...DEFAULTS,
-            // Reset the simulated states too — each is only valid for the plan it was picked against,
-            // and the two are offered on opposite sides of the paid/free split.
-            // `spendHeadlineEnabled` is deliberately not reset — it's a rollout flag, not a
-            // simulated state scoped to the previewed plan.
+            // Switching plan clears the states picked against the old one. `spendHeadlineEnabled`
+            // survives here — a rollout flag, not a simulated state — though Reset still clears it.
             setOverride: (overrideCode) =>
                 set({
                     overrideCode,

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -3,7 +3,7 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 import { LocalStorageKeys } from '@/utils/local-storage';
 
-import type { ApiPlan, GetBillingPeriodCosts, GetOverdueInvoices, GetUpcomingInvoice, PlanDefinition } from '@nangohq/types';
+import type { ApiPlan, GetBillingPeriodCosts, GetOverdueInvoices, GetStripePaymentMethods, GetUpcomingInvoice, PlanDefinition } from '@nangohq/types';
 
 /** Simulated aggregate usage state, matching what `getAggregateUsageState` can return. */
 export type UsageLimitOverride = 'near' | 'over';
@@ -30,6 +30,7 @@ interface PlanOverrideState {
     spendOverride: SpendOverride | null;
     metricChargesEnabled: boolean;
     periodCostsOverride: PeriodCostsOverride | null;
+    paymentMethodOverride: boolean;
     setOverride: (code: PlanDefinition['code'] | null) => void;
     setScheduledTarget: (code: PlanDefinition['code'] | null) => void;
     setOverdueOverride: (override: boolean) => void;
@@ -38,19 +39,26 @@ interface PlanOverrideState {
     setSpendOverride: (override: SpendOverride | null) => void;
     setMetricChargesEnabled: (enabled: boolean) => void;
     setPeriodCostsOverride: (override: PeriodCostsOverride | null) => void;
+    setPaymentMethodOverride: (override: boolean) => void;
+    resetAll: () => void;
 }
+
+export const DEFAULTS = {
+    overrideCode: null,
+    scheduledTargetCode: null,
+    overdueOverride: false,
+    usageLimitOverride: null,
+    spendHeadlineEnabled: false,
+    spendOverride: null,
+    metricChargesEnabled: false,
+    periodCostsOverride: null,
+    paymentMethodOverride: false
+} satisfies Partial<PlanOverrideState>;
 
 export const usePlanOverrideStore = create<PlanOverrideState>()(
     persist(
         (set) => ({
-            overrideCode: null,
-            scheduledTargetCode: null,
-            overdueOverride: false,
-            usageLimitOverride: null,
-            spendHeadlineEnabled: false,
-            spendOverride: null,
-            metricChargesEnabled: false,
-            periodCostsOverride: null,
+            ...DEFAULTS,
             // Reset the simulated states too — each is only valid for the plan it was picked against,
             // and the two are offered on opposite sides of the paid/free split.
             // `spendHeadlineEnabled` is deliberately not reset — it's a rollout flag, not a
@@ -70,7 +78,9 @@ export const usePlanOverrideStore = create<PlanOverrideState>()(
             setSpendHeadlineEnabled: (spendHeadlineEnabled) => set({ spendHeadlineEnabled }),
             setSpendOverride: (spendOverride) => set({ spendOverride }),
             setMetricChargesEnabled: (metricChargesEnabled) => set({ metricChargesEnabled }),
-            setPeriodCostsOverride: (periodCostsOverride) => set({ periodCostsOverride })
+            setPeriodCostsOverride: (periodCostsOverride) => set({ periodCostsOverride }),
+            setPaymentMethodOverride: (paymentMethodOverride) => set({ paymentMethodOverride }),
+            resetAll: () => set(DEFAULTS)
         }),
         {
             name: LocalStorageKeys.DevPlanOverride,
@@ -93,6 +103,11 @@ export function buildOverdueOverride(realPortalUrl?: string | null): GetOverdueI
             portalUrl: realPortalUrl ?? null
         }
     };
+}
+
+/** Without Stripe keys `/stripe/payment_methods` can only answer empty, so every card-gated flow is unreachable. */
+export function buildPaymentMethodOverride(): GetStripePaymentMethods['Success'] {
+    return { data: [{ id: 'pm_preview', brand: 'visa', last4: '4242', expMonth: 8, expYear: 2030 }] };
 }
 
 /** Stands in for the real upcoming-invoice response when the override is on, for visual QA only. */
@@ -136,10 +151,9 @@ export function buildPeriodCostsOverride(override: PeriodCostsOverride): GetBill
 /** Overlays a dev-tool plan override (and optional simulated scheduled change) onto a real plan, for visual QA only. */
 export function applyPlanOverride(
     realPlan: ApiPlan | null | undefined,
-    overridePlan: PlanDefinition | null | undefined,
-    scheduledTarget?: PlanDefinition | null
+    { overridePlan, scheduledTarget }: { overridePlan?: PlanDefinition | null; scheduledTarget?: PlanDefinition | null }
 ): ApiPlan | null | undefined {
-    if (!overridePlan || !realPlan) {
+    if (!realPlan || !overridePlan) {
         return realPlan;
     }
 

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -103,7 +103,7 @@ export function buildOverdueOverride(realPortalUrl?: string | null): GetOverdueI
     };
 }
 
-/** Without Stripe keys `/stripe/payment_methods` can only answer empty, so every card-gated flow is unreachable. */
+/** Stands in for a card, so the payment slot can be previewed without configuring Stripe locally. */
 export function buildPaymentMethodOverride(): GetStripePaymentMethods['Success'] {
     return { data: [{ id: 'pm_preview', brand: 'visa', last4: '4242', expMonth: 8, expYear: 2030 }] };
 }

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -61,7 +61,7 @@ function usePlanOverride(env: string, realPlan: ApiPlan | null | undefined): Api
         }
         const overridePlan = plansList?.data.find((p) => p.code === overrideCode) ?? null;
         const scheduledTarget = plansList?.data.find((p) => p.code === scheduledTargetCode) ?? null;
-        return applyPlanOverride(realPlan, overridePlan, scheduledTarget);
+        return applyPlanOverride(realPlan, { overridePlan, scheduledTarget });
     }, [realPlan, overrideCode, scheduledTargetCode, plansList]);
 }
 

--- a/packages/webapp/src/hooks/useStripe.tsx
+++ b/packages/webapp/src/hooks/useStripe.tsx
@@ -1,13 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { buildPaymentMethodOverride, usePlanOverrideStore } from '../features/planOverride';
 import { APIError, apiFetch } from '../utils/api';
 
 import type { GetStripePaymentMethods, PostStripeCollectPayment } from '@nangohq/types';
 
 export function useStripePaymentMethods(env: string) {
+    const paymentMethodOverride = usePlanOverrideStore((s) => s.paymentMethodOverride);
     return useQuery<GetStripePaymentMethods['Success'], APIError>({
-        queryKey: ['stripe', 'payment_methods'],
+        queryKey: ['stripe', 'payment_methods', paymentMethodOverride],
         queryFn: async (): Promise<GetStripePaymentMethods['Success']> => {
+            if (paymentMethodOverride) {
+                return buildPaymentMethodOverride();
+            }
+
             const res = await apiFetch(`/api/v1/stripe/payment_methods?env=${env}`, {
                 method: 'GET'
             });


### PR DESCRIPTION
## Problem

The dev panel had grown to a dozen simulators, every one a full-width block of the same weight, so finding one meant reading all of them. Its downgrade targets came from a hardcoded plan order that each new plan has to be added to — `pay-as-you-go` was already missing.

## Solution

- Overrides become grouped label-and-control rows, and the panel is renamed **Billing Overrides** — only two of its eight rows are about the plan; the rest simulate cards, invoices, spend and charges.
- Downgrade targets come from each plan's own `prevPlan` rather than a hardcoded list.
- Adds a simulated card on file, so card-gated flows can be exercised without configuring Stripe locally.
- Fixes a design-system bug on the way: a `side="left"`/`"right"` tooltip tucked its arrow along the wrong axis and painted it over the first word. The collapsed sidebar and two other call sites had it too.

Split out of [NAN-6741](https://linear.app/nango/issue/NAN-6741). Dev-only — the panel sits behind the dev tools overlay.

## Testing

Walked every override on `/dev/team/billing`. Tooltip sides checked in Storybook: `arrowOverlapsText` is false on all four.

<img width="3728" height="2006" alt="image" src="https://github.com/user-attachments/assets/9602035f-65cb-4cc0-afbe-1269e05dec1f" />
