### PR TITLE
fix: name the Growth add-on in upgrade prompts

### DIFF
--- a/packages/server/lib/controllers/v1/invite/postInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/postInvite.ts
@@ -44,7 +44,7 @@ export const postInvite = asyncWrapper<PostInvite>(async (req, res) => {
     }
 
     if (!hasRbacRes.value && effectiveRole !== 'administrator') {
-        res.status(403).send({ error: { code: 'feature_disabled', message: 'Role-based access control requires a Growth plan or above' } });
+        res.status(403).send({ error: { code: 'feature_disabled', message: 'Role-based access control requires the Growth add-on' } });
         return;
     }
 

--- a/packages/server/lib/controllers/v1/team/users/patchTeamUser.ts
+++ b/packages/server/lib/controllers/v1/team/users/patchTeamUser.ts
@@ -50,7 +50,7 @@ export const patchTeamUser = asyncWrapper<PatchTeamUser>(async (req, res) => {
     }
 
     if (!hasRbacRes.value && body.role !== 'administrator') {
-        res.status(403).send({ error: { code: 'feature_disabled', message: 'Role-based access control requires a Growth plan or above' } });
+        res.status(403).send({ error: { code: 'feature_disabled', message: 'Role-based access control requires the Growth add-on' } });
         return;
     }
 

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
@@ -196,7 +196,7 @@ export const ConnectUISettings = () => {
                                         <TooltipTrigger>
                                             <Info size="14" />
                                         </TooltipTrigger>
-                                        <TooltipContent side="bottom">Available to &apos;Growth&apos; plans only</TooltipContent>
+                                        <TooltipContent side="bottom">Available with the Growth add-on</TooltipContent>
                                     </Tooltip>
                                 </div>
 
@@ -204,7 +204,7 @@ export const ConnectUISettings = () => {
                                 {!canDisableWatermark && <WatermarkToggle disabled={true} form={form} />}
 
                                 <ButtonLink to={`/team/billing#plans`} variant="outline" target="_blank">
-                                    Upgrade to &apos;Growth&apos; plan
+                                    Get the Growth add-on
                                 </ButtonLink>
                             </div>
                         )}

--- a/packages/webapp/src/pages/Team/components/RoleSelect.tsx
+++ b/packages/webapp/src/pages/Team/components/RoleSelect.tsx
@@ -38,7 +38,7 @@ export const RoleSelect: React.FC<{
                             contentClassName="pointer-events-auto"
                             content={
                                 <span>
-                                    RBAC is only available for &apos;Growth&apos; plans.{' '}
+                                    RBAC is only available with the Growth add-on.{' '}
                                     <Button asChild variant="link-accent" size="sm">
                                         <Link to={`/team/billing#plans`}>Upgrade</Link>
                                     </Button>

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -187,7 +187,7 @@ export const TeamMembers: React.FC = () => {
                                             variant="warning"
                                             tooltipContent={
                                                 <span>
-                                                    RBAC is only available for &apos;Growth&apos; plans. This role is overwritten by &apos;Full access&apos;.{' '}
+                                                    RBAC is only available with the Growth add-on. This role is overwritten by &apos;Full access&apos;.{' '}
                                                     <Button asChild variant="link-accent" size="sm">
                                                         <Link to={`/team/billing#plans`}>Upgrade</Link>
                                                     </Button>{' '}


### PR DESCRIPTION
## Problem

Five places told customers a feature needs a `'Growth'` plan: the RBAC notices on the team page and the role picker, the Connect UI branding tooltip and its upgrade link, and the two RBAC 403s. The new pricing sells those features as an add-on and retires the plan, so all five pointed at something no longer for sale.

## Solution

- RBAC notices (`RoleSelect`, `TeamMembers`): "RBAC is only available with the Growth add-on."
- Connect UI branding tooltip: "Available with the Growth add-on"
- Connect UI upgrade link: "Get the Growth add-on"
- `postInvite` / `patchTeamUser` 403s: "Role-based access control requires the Growth add-on"

Deliberately **not** behind the S26 pricing flag. Every account moves to the new plans within the month, and naming the add-on early is harmless for the ones still on an old plan — so this stays five string literals instead of a flag-aware helper.

Fixes [NAN-6742](https://linear.app/nango/issue/NAN-6742)

## Testing

Copy-only change, no logic touched. `tsc --noEmit` clean for webapp and server; webapp unit tests pass. The two 403 integration tests assert `error.code`, not the message, so they were unaffected.

Independent of #7306 despite sharing the ticket's project: this touches no file that PR touches, so it can merge in either order.

## Visual checklist

[App preview](https://pr-7316.app-development.nango.dev) · needs an account **without** RBAC (a Free plan) — the prompts only render when the feature is locked. No Storybook stories affected.

### [/team-settings](https://pr-7316.app-development.nango.dev/team-settings)
| Location | Action | Comment |
| --- | --- | --- |
| Role column, non-admin member | Hover the amber warning triangle | Reads "RBAC is only available with the Growth add-on. This role is overwritten by 'Full access'. Upgrade to reactivate role.", reading as one continuous sentence |
| Invite / edit-role dropdown | Open it, hover a disabled role | Reads "RBAC is only available with the Growth add-on. Upgrade" — tooltip still fits on one or two lines |

### [/environment-settings](https://pr-7316.app-development.nango.dev/environment-settings)
| Location | Action | Comment |
| --- | --- | --- |
| "Advanced Customization" panel | Hover the ⓘ next to the heading | Reads "Available with the Growth add-on" |
| Same panel, button at the bottom | Look at the outline button | Reads "Get the Growth add-on"; label sits on one line, button not stretched or clipped |
