### PR TITLE
feat(plans): block moves between Starter and Growth

### DIFF
--- a/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/change/postChange.integration.test.ts
@@ -277,6 +277,36 @@ describe(`POST ${route}`, () => {
     });
 
     describe('Upgrade Flow', () => {
+        it('should reject an upgrade from starter-v2 to growth-v2', async () => {
+            const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
+            await setupPlan({
+                id: plan.id,
+                name: 'starter-v2',
+                orb_subscription_id: 'sub_123'
+            });
+
+            const mockSubscription: BillingSubscription = {
+                id: 'sub_123',
+                planExternalId: 'plan_123'
+            };
+
+            getSubscriptionSpy.mockResolvedValue(Ok(mockSubscription));
+
+            const res = await api.fetch(route, {
+                method: 'POST',
+                query: { env: 'dev' },
+                token: apiKey.secret,
+                body: { orbId: 'growth-v2' }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error).toStrictEqual({
+                code: 'invalid_body',
+                message: 'team cannot change to this plan'
+            });
+        });
+
         it('should reject upgrade without Stripe linkage', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
             await setupPlan({
@@ -543,14 +573,12 @@ describe(`POST ${route}`, () => {
             expect(res.json.data).toStrictEqual({ success: true });
         });
 
-        it('should require Stripe for paid plan downgrade', async () => {
+        it('should reject a downgrade from growth-v2 to starter-v2', async () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
             await setupPlan({
                 id: plan.id,
                 name: 'growth-v2',
-                orb_subscription_id: 'sub_123',
-                stripe_customer_id: null,
-                stripe_payment_id: null
+                orb_subscription_id: 'sub_123'
             });
 
             const mockSubscription: BillingSubscription = {
@@ -571,7 +599,7 @@ describe(`POST ${route}`, () => {
             expect(res.res.status).toBe(400);
             expect(res.json.error).toStrictEqual({
                 code: 'invalid_body',
-                message: 'team is not linked to stripe'
+                message: 'team cannot change to this plan'
             });
         });
 

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -135,8 +135,6 @@ export const starterV2Plan: PlanDefinition = {
     title: 'Starter',
     description: 'For small teams.',
     prevPlan: ['free'],
-    // Growth is deliberately absent: it is sunset too, so a move between the two only restarts a
-    // subscription we are winding down.
     nextPlan: ['enterprise'],
     canChange: true,
     basePrice: 50,

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -135,7 +135,9 @@ export const starterV2Plan: PlanDefinition = {
     title: 'Starter',
     description: 'For small teams.',
     prevPlan: ['free'],
-    nextPlan: ['growth-v2', 'enterprise'],
+    // Growth is deliberately absent: it is sunset too, so a move between the two only restarts a
+    // subscription we are winding down.
+    nextPlan: ['enterprise'],
     canChange: true,
     basePrice: 50,
     flags: {
@@ -151,7 +153,7 @@ export const growthV2Plan: PlanDefinition = {
     code: 'growth-v2',
     title: 'Growth',
     description: 'For growing teams.',
-    prevPlan: ['free', 'starter-v2'],
+    prevPlan: ['free'],
     nextPlan: ['enterprise'],
     canChange: true,
     basePrice: 500,

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -162,6 +162,25 @@ describe('mergeFlags', () => {
     });
 });
 
+describe('self-serve transitions', () => {
+    const starter = getPlanDefinition('starter-v2')!;
+    const growth = getPlanDefinition('growth-v2')!;
+
+    it('should not offer a move between the sunset starter-v2 and growth-v2 plans', () => {
+        expect(starter.nextPlan).not.toContain('growth-v2');
+        expect(starter.prevPlan).not.toContain('growth-v2');
+        expect(growth.nextPlan).not.toContain('starter-v2');
+        expect(growth.prevPlan).not.toContain('starter-v2');
+    });
+
+    it('should keep the moves off a sunset plan that stay open', () => {
+        expect(starter.prevPlan).toContain('free');
+        expect(starter.nextPlan).toContain('enterprise');
+        expect(growth.prevPlan).toContain('free');
+        expect(growth.nextPlan).toContain('enterprise');
+    });
+});
+
 function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides: PlanDefinition['flags'] }): DBPlan {
     const defaultPlanDefinition = getPlanDefinition(code)!;
     return {


### PR DESCRIPTION
## Problem

Starter and Growth are retired by the September 2026 pricing, and every account on one is scheduled to migrate to Pay-as-you-go. The app still sells moves between them: `starterV2Plan.nextPlan` lists `growth-v2` and `growthV2Plan.prevPlan` lists `starter-v2`, so Starter is offered a Growth upgrade and Growth a Starter downgrade.

#7306 hides those cards for accounts with the `s26-pricing` flag on, but that is per-account UI — `POST /api/v1/plans/change` validates against the same two lists and still accepts both transitions.

## Solution

- Drop `growth-v2` from `starterV2Plan.nextPlan` and `starter-v2` from `growthV2Plan.prevPlan`.
- Both surfaces read those lists: the billing page stops rendering the CTA (the card falls through to "Contact us") and the endpoint rejects with `team cannot change to this plan`.
- Only the v2 pair is affected — v1 `starter` and `growth` already offer no move to each other.

Fixes [NAN-6841](https://linear.app/nango/issue/NAN-6841)

## Testing

- Unit test that neither plan lists the other, and that Free and Enterprise stay reachable.
- Integration tests for both rejected directions. "should require Stripe for paid plan downgrade" used `growth-v2 → starter-v2` and now hits the new guard first, so it became a rejection test.
- Browser check with the dev plan override, flag off: on Growth the Starter card reads "Contact us", on Starter the Growth card reads "Contact us".

## Follow-ups

- `downgradePlan`'s `newPlanCode !== 'free'` Stripe guard is now unreachable from this endpoint — every remaining self-serve downgrade targets Free. Left in place as a guard.
