### PR TITLE
fix(webapp): show usage on the 1st of the month

### DIFF
--- a/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
+++ b/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
@@ -5,6 +5,7 @@ import { formatQuantity } from '@/utils/utils';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../../ui/Chart';
 import { niceCapAxis } from './chartFormat';
 import { REST_SERIES_KEY } from './usageChartColors';
+import { countDaysWithData } from './useChartData';
 
 import type { ChartConfig } from '../../ui/Chart';
 import type { ChartSeries } from './types';
@@ -60,6 +61,9 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({
     const bandClick = (s: ChartSeries) => () => toggleIsolate(s.key);
     const ChartComponent = isCumulative ? AreaChart : BarChart;
 
+    // An area spanning a single day has no width and paints nothing — the 1st of a month renders blank.
+    const areaDot = useMemo(() => (countDaysWithData(chartData) === 1 ? { r: 3 } : false), [chartData]);
+
     // Stacking follows declaration order (first series = bottom), so pin the neutral
     // "Rest" bucket to the bottom; the sized series stack above it. The legend/tooltip keep their own order.
     const stackSeries = [...series.filter((s) => s.key === REST_SERIES_KEY), ...series.filter((s) => s.key !== REST_SERIES_KEY)];
@@ -80,7 +84,7 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({
                             strokeOpacity={dimByHover(s.key) ? 0.3 : 1}
                             strokeWidth={1}
                             type="basis"
-                            dot={false}
+                            dot={areaDot}
                             // The active dot sits on top of the band; mirror the band's handlers so
                             // hovering it doesn't drop the highlight / single-series tooltip.
                             activeDot={{ onMouseEnter: () => hoverSeries(s.key), onMouseLeave: () => unhoverSeries(), onClick: bandClick(s) }}
@@ -119,7 +123,7 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({
                     stroke="var(--color-total)"
                     type="basis"
                     strokeWidth={2}
-                    dot={false}
+                    dot={areaDot}
                     isAnimationActive={false}
                 />
             ];

--- a/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
+++ b/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
@@ -5,7 +5,7 @@ import { formatQuantity } from '@/utils/utils';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../../ui/Chart';
 import { niceCapAxis } from './chartFormat';
 import { REST_SERIES_KEY } from './usageChartColors';
-import { countDaysWithData } from './useChartData';
+import { countPlottedDays } from './useChartData';
 
 import type { ChartConfig } from '../../ui/Chart';
 import type { ChartSeries } from './types';
@@ -62,7 +62,7 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({
     const ChartComponent = isCumulative ? AreaChart : BarChart;
 
     // An area spanning a single day has no width and paints nothing — the 1st of a month renders blank.
-    const areaDot = useMemo(() => (countDaysWithData(chartData) === 1 ? { r: 3 } : false), [chartData]);
+    const areaDot = useMemo(() => (countPlottedDays(chartData) === 1 ? { r: 3 } : false), [chartData]);
 
     // Stacking follows declaration order (first series = bottom), so pin the neutral
     // "Rest" bucket to the bottom; the sized series stack above it. The legend/tooltip keep their own order.

--- a/packages/webapp/src/components/patterns/chart/useChartData.ts
+++ b/packages/webapp/src/components/patterns/chart/useChartData.ts
@@ -134,8 +134,8 @@ export function visibleBreakdownTotal(rows: BreakdownChartRow[], visibleKeys: st
     return rows.reduce((sum, row) => sum + sumRow(row), 0);
 }
 
-/** A day with no data is `null` (future) or `undefined` (a gap), never 0 — so a number means real data. */
-export function countDaysWithData(rows: Record<string, string | number | null | undefined>[]): number {
+/** Unplotted days are `null` (future) or `undefined` (a gap in a base series); a breakdown zero-fills its gaps. */
+export function countPlottedDays(rows: Record<string, string | number | null | undefined>[]): number {
     return rows.filter((row) => Object.entries(row).some(([key, value]) => key !== 'date' && typeof value === 'number')).length;
 }
 

--- a/packages/webapp/src/components/patterns/chart/useChartData.ts
+++ b/packages/webapp/src/components/patterns/chart/useChartData.ts
@@ -134,6 +134,11 @@ export function visibleBreakdownTotal(rows: BreakdownChartRow[], visibleKeys: st
     return rows.reduce((sum, row) => sum + sumRow(row), 0);
 }
 
+/** A day with no data is `null` (future) or `undefined` (a gap), never 0 — so a number means real data. */
+export function countDaysWithData(rows: Record<string, string | number | null | undefined>[]): number {
+    return rows.filter((row) => Object.entries(row).some(([key, value]) => key !== 'date' && typeof value === 'number')).length;
+}
+
 /**
  * "No data this month", a property of the base metric (independent of breakdown).
  * Guarded on `data` being defined — an empty array is vacuously "every" falsy, which

--- a/packages/webapp/src/components/patterns/chart/useChartData.unit.test.ts
+++ b/packages/webapp/src/components/patterns/chart/useChartData.unit.test.ts
@@ -5,6 +5,7 @@ import {
     buildBreakdownChartData,
     buildCumulativeBaseChartData,
     buildCumulativeBreakdownChartData,
+    countDaysWithData,
     daysInTimeframe,
     isBaseUsageEmpty
 } from './useChartData.js';
@@ -163,6 +164,27 @@ describe('isBaseUsageEmpty', () => {
     it('is false when any day has usage', () => {
         const data = metric([{ timeframeStart: '2026-06-10T00:00:00.000Z', quantity: 5 }]);
         expect(isBaseUsageEmpty(data, buildBaseChartData(data, JUNE, TODAY))).toBe(false);
+    });
+});
+
+describe('countDaysWithData', () => {
+    it('counts the single day at the start of a month', () => {
+        const data = metric([{ timeframeStart: '2026-06-01T00:00:00.000Z', quantity: 3011.22 }]);
+        expect(countDaysWithData(buildBaseChartData(data, JUNE, '2026-06-01'))).toBe(1);
+    });
+
+    it('counts every elapsed day of a stacked breakdown, including the zeroed ones', () => {
+        const rows = buildBreakdownChartData([series('s0', [{ timeframeStart: '2026-06-01T00:00:00.000Z', quantity: 4 }])], JUNE, '2026-06-03');
+        expect(countDaysWithData(rows)).toBe(3); // 06-01 has usage, 06-02/03 are 0, the rest are future
+    });
+
+    it('is 0 when the metric has no usage at all', () => {
+        expect(countDaysWithData(buildBaseChartData(metric([]), JUNE, TODAY))).toBe(0);
+    });
+
+    it('skips the gaps a base series leaves on days it has no entry for', () => {
+        const data = metric([{ timeframeStart: '2026-06-10T00:00:00.000Z', quantity: 5 }]);
+        expect(countDaysWithData(buildBaseChartData(data, JUNE, TODAY))).toBe(1);
     });
 });
 

--- a/packages/webapp/src/components/patterns/chart/useChartData.unit.test.ts
+++ b/packages/webapp/src/components/patterns/chart/useChartData.unit.test.ts
@@ -5,7 +5,7 @@ import {
     buildBreakdownChartData,
     buildCumulativeBaseChartData,
     buildCumulativeBreakdownChartData,
-    countDaysWithData,
+    countPlottedDays,
     daysInTimeframe,
     isBaseUsageEmpty
 } from './useChartData.js';
@@ -167,24 +167,24 @@ describe('isBaseUsageEmpty', () => {
     });
 });
 
-describe('countDaysWithData', () => {
+describe('countPlottedDays', () => {
     it('counts the single day at the start of a month', () => {
         const data = metric([{ timeframeStart: '2026-06-01T00:00:00.000Z', quantity: 3011.22 }]);
-        expect(countDaysWithData(buildBaseChartData(data, JUNE, '2026-06-01'))).toBe(1);
+        expect(countPlottedDays(buildBaseChartData(data, JUNE, '2026-06-01'))).toBe(1);
     });
 
     it('counts every elapsed day of a stacked breakdown, including the zeroed ones', () => {
         const rows = buildBreakdownChartData([series('s0', [{ timeframeStart: '2026-06-01T00:00:00.000Z', quantity: 4 }])], JUNE, '2026-06-03');
-        expect(countDaysWithData(rows)).toBe(3); // 06-01 has usage, 06-02/03 are 0, the rest are future
+        expect(countPlottedDays(rows)).toBe(3); // 06-01 has usage, 06-02/03 are 0, the rest are future
     });
 
     it('is 0 when the metric has no usage at all', () => {
-        expect(countDaysWithData(buildBaseChartData(metric([]), JUNE, TODAY))).toBe(0);
+        expect(countPlottedDays(buildBaseChartData(metric([]), JUNE, TODAY))).toBe(0);
     });
 
     it('skips the gaps a base series leaves on days it has no entry for', () => {
         const data = metric([{ timeframeStart: '2026-06-10T00:00:00.000Z', quantity: 5 }]);
-        expect(countDaysWithData(buildBaseChartData(data, JUNE, TODAY))).toBe(1);
+        expect(countPlottedDays(buildBaseChartData(data, JUNE, TODAY))).toBe(1);
     });
 });
 


### PR DESCRIPTION
## Problem

On the 1st of every month the Connections and Sync records charts on `/team/billing` render as bare axes — no data — while the row above them shows a real number. It reads as a broken page, and it fixes itself on the 2nd.

The data is there. Those are running-average metrics, drawn as an area, and on the 1st the series holds a single day. An area spanning one point has no width to paint.

## Solution

- Show the point marker when only one day of the chart carries data, for both the single series and the stacked breakdown.
- Add `countDaysWithData` next to the chart-row builders in `useChartData.ts`, with unit tests.

Counter metrics are unaffected — they draw bars, and one day is one visible bar.

Fixes [NAN-6845](https://linear.app/nango/issue/NAN-6845)

## Testing

Verified against dev data on Sept 1 (a natural repro): single series, grouped by integration, and August as a no-regression check.

<img width="1269" height="534" alt="image" src="https://github.com/user-attachments/assets/bfde7768-f3db-48cb-bbf5-5113262d3561" />
