### PR TITLE
fix(webapp): link the Growth add-on to support

### DIFF
--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -219,6 +219,24 @@ const PlanCard: React.FC<{
                                 <span className="text-text-secondary text-body-small-regular">{feature}</span>
                             </li>
                         ))}
+                        {card.supportLink && (
+                            <li className="flex gap-2 items-baseline">
+                                <span className="text-text-muted text-body-small-regular">&middot;</span>
+                                <span className="text-text-secondary text-body-small-regular">
+                                    {card.supportLink.label}{' '}
+                                    <span className="whitespace-nowrap">
+                                        &mdash;{' '}
+                                        <button
+                                            type="button"
+                                            onClick={openSupportChat}
+                                            className="text-text-default underline underline-offset-2 cursor-pointer hover:text-text-strong"
+                                        >
+                                            {card.supportLink.cta}
+                                        </button>
+                                    </span>
+                                </span>
+                            </li>
+                        )}
                     </ul>
                 </div>
                 <div className="w-full px-4 py-6">{ButtonComponent}</div>

--- a/packages/webapp/src/pages/Team/Billing/components/planCardCopy.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/planCardCopy.ts
@@ -44,6 +44,8 @@ export interface S26PlanCard {
     priceSuffix?: string;
     tagline: string;
     features: string[];
+    /** Last bullet of the feature list; `cta` is a button that opens the support chat. */
+    supportLink?: { label: string; cta: string };
 }
 
 /** In the order they are offered. */
@@ -60,7 +62,8 @@ export const S26_PLAN_CARDS: readonly S26PlanCard[] = [
         price: '$50',
         priceSuffix: '/mo minimum',
         tagline: '$50 in credits per month included.',
-        features: ['$0.29 / connection / mo', '$0.72 / h of compute time', '$0.50 / GB data transfer', 'SOC 2 Type II', 'Growth add-on available for $450/mo']
+        features: ['$0.29 / connection / mo', '$0.72 / h of compute time', '$0.50 / GB data transfer', 'SOC 2 Type II'],
+        supportLink: { label: 'Growth add-on available for $450/mo', cta: 'contact us' }
     },
     {
         code: 'enterprise',


### PR DESCRIPTION
## Problem

The Pay-as-you-go plan card lists `Growth add-on available for $450/mo` as a plain feature bullet. It's the only line on any card that names something the reader can't decode — nothing in the app says what the add-on is — and it quotes a price with no way to act on it, so the natural reaction ("how do I get this?") has no answer on screen.

## Solution

- Move the add-on line out of `features` into a new optional `supportLink` on the plan card, rendered as the list's last bullet.
- End the bullet in a `contact us` button wired to `openSupportChat`, the same handler behind the Enterprise CTA.

Follow-up on [NAN-6741](https://linear.app/nango/issue/NAN-6741/show-the-new-plans-and-the-growth-add-on-in-the-app).

## Testing

Verified on the Billing & usage page against the dev API as a Free-plan account (`s26Pricing` on): the bullet reads `Growth add-on available for $450/mo — contact us`, and clicking it opens the Plain chat. Checked light and dark themes.

## Follow-ups

- Enterprise's card still says `Includes Growth add-on` — same undefined term, and it sits next to `2-day requested integration delivery` while the add-on's own selling point on the public pricing page is 5-day delivery.
