### PR TITLE
fix(webapp): align usage bars across metric rows

### DIFF
--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -78,12 +78,13 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                         <span className="text-text-default type-text-regular-sm truncate">{label}</span>
                     </div>
                     {variant !== 'usage' ? (
-                        <div className="flex items-center gap-5">
+                        // Fixed track: every row's bar starts at the same x, whatever the figure's width.
+                        <div className={cn('items-center gap-5', showLimits ? 'grid grid-cols-[120px_minmax(0,1fr)]' : 'flex')}>
                             {capsLoading ? (
                                 <Skeleton className="h-5 w-32" />
                             ) : (
                                 <>
-                                    <span className="text-text-default type-text-regular-sm shrink-0" title={formatMetricUsageExact(metric, usage)}>
+                                    <span className="text-text-default type-text-regular-sm truncate" title={formatMetricUsageExact(metric, usage)}>
                                         {figures.usage}
                                         {figures.limit != null && <span className="text-text-muted"> / {figures.limit}</span>}
                                     </span>

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -79,7 +79,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                     </div>
                     {variant !== 'usage' ? (
                         // Fixed track: every row's bar starts at the same x, whatever the figure's width.
-                        <div className={cn('items-center gap-5', showLimits ? 'grid grid-cols-[120px_minmax(0,1fr)]' : 'flex')}>
+                        <div className={cn('items-center gap-5', showLimits ? 'grid grid-cols-[80px_minmax(0,1fr)]' : 'flex')}>
                             {capsLoading ? (
                                 <Skeleton className="h-5 w-32" />
                             ) : (

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -67,6 +67,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
     const percent = limit ? Math.round((usage / limit) * 100) : null;
     const showLimits = variant === 'caps';
     const figures = showLimits && limit != null ? formatMetricPair(metric, usage, limit) : { usage: formatMetricUsage(metric, usage), limit: null };
+    const exactFigure = formatMetricUsageExact(metric, usage) + (figures.limit != null ? ` / ${figures.limit}` : '');
     // The charge and usage queries resolve independently.
     const isPending = variant === 'charges' ? charge?.pending : capsLoading;
 
@@ -81,10 +82,10 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                         // Fixed track: every row's bar starts at the same x, whatever the figure's width.
                         <div className={cn('items-center gap-5', showLimits ? 'grid grid-cols-[80px_minmax(0,1fr)]' : 'flex')}>
                             {capsLoading ? (
-                                <Skeleton className="h-5 w-32" />
+                                <Skeleton className={cn('h-5', showLimits ? 'w-full' : 'w-32')} />
                             ) : (
                                 <>
-                                    <span className="text-text-default type-text-regular-sm truncate" title={formatMetricUsageExact(metric, usage)}>
+                                    <span className="text-text-default type-text-regular-sm truncate" title={exactFigure}>
                                         {figures.usage}
                                         {figures.limit != null && <span className="text-text-muted"> / {figures.limit}</span>}
                                     </span>


### PR DESCRIPTION
## Problem

The used/limit figure and the progress bar share one flex row, so each bar starts wherever its figure ends. `10 / 10` and `0.03h / 10h` aren't the same width, so no two rows' bars line up. The design has the track at a fixed offset in every row.

Reported by design against [the Figma frame](https://www.figma.com/design/UPhGLAHKgFxGfnb7vwJ6YK/Nango-%E2%80%94-Product?node-id=575-4899).

## Solution

- Fixed 80px track for the figure in the `caps` variant, so every bar starts at the same x.
- 80px rather than the design's 64px box, because our figures are wider than the mock's `2/10` — the widest the table renders today measures 69px.
- `shrink-0` → `truncate`, so a long figure clips instead of shoving the bar out of column, and the hover title now carries the pair (`0.0339h / 10h`) so a clipped figure stays readable.
- `charges` and `usage` have no bar to align and keep the flex layout.

## Testing

Measured on `/dev/team/billing` as a Free account at its connection cap: all three bars land at x=754, every figure in an 80px track, none clipped.

## Visual checklist

[App preview](https://pr-7331.app-development.nango.dev/team/billing) — needs a **Free** account.

| Location | Action | Comment |
| --- | --- | --- |
| Usage table | Look down the bar column | Every bar starts at the same x |
| Usage table | Reload the page | Skeleton sits in the figure's track, no jump when it resolves |

## Follow-ups

Data transfer shows no gauge: there's no `data_transfer_max` in the plan flags, and free's `function_duration_seconds_max` is `null`. A pricing decision, untouched here.
