### PR TITLE
fix(webhooks): extend SQS visibility during dispatch

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -58,7 +58,8 @@ try {
               maxMessages: envs.NANGO_TASK_DISPATCH_MAX_MESSAGES,
               waitTimeSeconds: envs.NANGO_TASK_DISPATCH_WAIT_TIME_SECONDS,
               visibilityTimeoutSeconds: envs.NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS,
-              maxAgeMs: envs.NANGO_TASK_DISPATCH_MAX_AGE_SECONDS * 1000
+              maxAgeMs: envs.NANGO_TASK_DISPATCH_MAX_AGE_SECONDS * 1000,
+              rateLimitCooldownMaxMs: envs.NANGO_TASK_DISPATCH_RATE_LIMIT_COOLDOWN_MAX_MS
           })
         : undefined;
 

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -61,7 +61,8 @@ try {
               maxAgeMs: envs.NANGO_TASK_DISPATCH_MAX_AGE_SECONDS * 1000,
               rateLimitCooldownMaxMs: envs.NANGO_TASK_DISPATCH_RATE_LIMIT_COOLDOWN_MAX_MS,
               deferJitterRatio: envs.NANGO_TASK_DISPATCH_DEFER_JITTER_RATIO,
-              taskCapDeferMs: envs.NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS
+              taskCapDeferMs: envs.NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS,
+              maxVisibilityExtensionMs: envs.NANGO_TASK_DISPATCH_MAX_VISIBILITY_EXTENSION_MS
           })
         : undefined;
 

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -59,7 +59,10 @@ try {
               waitTimeSeconds: envs.NANGO_TASK_DISPATCH_WAIT_TIME_SECONDS,
               visibilityTimeoutSeconds: envs.NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS,
               maxAgeMs: envs.NANGO_TASK_DISPATCH_MAX_AGE_SECONDS * 1000,
-              rateLimitCooldownMaxMs: envs.NANGO_TASK_DISPATCH_RATE_LIMIT_COOLDOWN_MAX_MS
+              rateLimitCooldownMaxMs: envs.NANGO_TASK_DISPATCH_RATE_LIMIT_COOLDOWN_MAX_MS,
+              deferJitterRatio: envs.NANGO_TASK_DISPATCH_DEFER_JITTER_RATIO,
+              taskCapDeferMs: envs.NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS,
+              maxVisibilityExtensionMs: envs.NANGO_TASK_DISPATCH_MAX_VISIBILITY_EXTENSION_MS
           })
         : undefined;
 

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -61,8 +61,7 @@ try {
               maxAgeMs: envs.NANGO_TASK_DISPATCH_MAX_AGE_SECONDS * 1000,
               rateLimitCooldownMaxMs: envs.NANGO_TASK_DISPATCH_RATE_LIMIT_COOLDOWN_MAX_MS,
               deferJitterRatio: envs.NANGO_TASK_DISPATCH_DEFER_JITTER_RATIO,
-              taskCapDeferMs: envs.NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS,
-              maxVisibilityExtensionMs: envs.NANGO_TASK_DISPATCH_MAX_VISIBILITY_EXTENSION_MS
+              taskCapDeferMs: envs.NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS
           })
         : undefined;
 

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -143,7 +143,7 @@ export class DispatchQueueConsumer {
             tags: { 'webhook.dispatch.received': messages.length }
         });
 
-        return await tracer.scope().activate(span, async () => {
+        return void (await tracer.scope().activate(span, async () => {
             try {
                 const entries = await this.filterMessages(messages);
                 if (entries.length === 0) {
@@ -231,7 +231,7 @@ export class DispatchQueueConsumer {
             } finally {
                 span.finish();
             }
-        });
+        }));
     }
 
     private async filterMessages(messages: Message[]): Promise<ParsedEntry[]> {
@@ -299,11 +299,6 @@ export class DispatchQueueConsumer {
                 continue;
             }
 
-            // Per-entry errors:
-            // - duplicate_task_name: already scheduled, treat as success and delete.
-            // - task_cap_exceeded: the group is saturated, so redelivering won't help, so we drop the message.
-            // - rate_limit_exceeded: the group is over its cap, so cool it down and let SQS redeliver.
-            // - anything else: leave for redelivery (SQS visibility timeout → eventual DLQ).
             if (result.error.name === 'duplicate_task_name') {
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'success', provider, providerConfigKey });
                 await this.deleteGroup(group);
@@ -318,7 +313,6 @@ export class DispatchQueueConsumer {
                 const logCtx = logContextGetter.get({ id: group[0]!.parsed.activityLogId, accountId: group[0]!.parsed.accountId });
                 await logCtx.warn('Webhook execution is delayed: this environment reached its webhook dispatch rate limit');
             } else if (result.error.name === 'task_cap_exceeded') {
-                // Retryable: the group drains, and filterMessages sheds the message once it breaches the age SLO.
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'task_cap_deferred', provider, providerConfigKey });
                 await this.deferGroup(group, this.taskCapDeferMs);
             } else {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -143,7 +143,7 @@ export class DispatchQueueConsumer {
             tags: { 'webhook.dispatch.received': messages.length }
         });
 
-        return void (await tracer.scope().activate(span, async () => {
+        return await tracer.scope().activate(span, async () => {
             try {
                 const entries = await this.filterMessages(messages);
                 if (entries.length === 0) {
@@ -173,8 +173,6 @@ export class DispatchQueueConsumer {
                     }
                     groupedEntries.push(group);
                 }
-                await Promise.all(deferrals);
-
                 metrics.histogram(metrics.Types.WEBHOOK_DISPATCH_BATCH_SIZE, groupedEntries.length);
                 span.setTag('batch_size', groupedEntries.length);
                 span.setTag('received', entries.length);
@@ -182,8 +180,11 @@ export class DispatchQueueConsumer {
 
                 const dispatched = entries.length - coolingDown;
                 if (groupedEntries.length === 0) {
+                    await Promise.all(deferrals);
                     return;
                 }
+
+                void Promise.all(deferrals);
 
                 const propsList: ExecuteWebhookProps[] = groupedEntries.map((group) => {
                     const m = group[0]!.parsed;
@@ -211,7 +212,7 @@ export class DispatchQueueConsumer {
                 try {
                     res = await this.orchestratorClient.executeWebhookBatch(propsList);
                 } finally {
-                    stopKeepingVisible();
+                    await stopKeepingVisible();
                 }
                 if (res.isErr()) {
                     span.setTag('error', true);
@@ -230,7 +231,7 @@ export class DispatchQueueConsumer {
             } finally {
                 span.finish();
             }
-        }));
+        });
     }
 
     private async filterMessages(messages: Message[]): Promise<ParsedEntry[]> {
@@ -310,7 +311,10 @@ export class DispatchQueueConsumer {
                 const groupKey = dispatchGroupKey(group[0]!.parsed);
                 this.cooldowns.start(groupKey, getRetryAfterMs(result.error.payload));
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'rate_limited', provider });
-                await this.deferGroup(group, this.cooldowns.remainingMs(groupKey));
+                const remainingMs = this.cooldowns.remainingMs(groupKey);
+                if (remainingMs > 0) {
+                    await this.deferGroup(group, remainingMs);
+                }
                 const logCtx = logContextGetter.get({ id: group[0]!.parsed.activityLogId, accountId: group[0]!.parsed.accountId });
                 await logCtx.warn('Webhook execution is delayed: this environment reached its webhook dispatch rate limit');
             } else if (result.error.name === 'task_cap_exceeded') {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -7,6 +7,7 @@ import { jsonSchema } from '@nangohq/nango-orchestrator';
 import { Err, getLogger, metrics, Ok, report } from '@nangohq/utils';
 
 import { envs } from '../../env.js';
+import { GroupCooldowns } from './groupCooldown.js';
 
 import type { Message } from '@aws-sdk/client-sqs';
 import type { ExecuteWebhookProps, OrchestratorClient } from '@nangohq/nango-orchestrator';
@@ -44,6 +45,7 @@ export interface DispatchQueueConsumerProps {
     waitTimeSeconds: number;
     visibilityTimeoutSeconds: number;
     maxAgeMs: number;
+    rateLimitCooldownMaxMs: number;
     sqs?: SQSClient;
 }
 
@@ -62,6 +64,7 @@ export class DispatchQueueConsumer {
     private readonly waitTimeSeconds: number;
     private readonly visibilityTimeoutSeconds: number;
     private readonly maxAgeMs: number;
+    private readonly cooldowns: GroupCooldowns;
     private readonly abortController = new AbortController();
     private loopPromises: Promise<void>[] = [];
 
@@ -74,6 +77,7 @@ export class DispatchQueueConsumer {
         this.waitTimeSeconds = props.waitTimeSeconds;
         this.visibilityTimeoutSeconds = props.visibilityTimeoutSeconds;
         this.maxAgeMs = props.maxAgeMs;
+        this.cooldowns = new GroupCooldowns({ maxCooldownMs: props.rateLimitCooldownMaxMs });
         this.sqs = props.sqs ?? new SQSClient(envs.AWS_REGION ? { region: envs.AWS_REGION } : {});
     }
 
@@ -146,17 +150,32 @@ export class DispatchQueueConsumer {
                         groups.set(entry.parsed.taskName, [entry]);
                     }
                 }
-                const groupedEntries = [...groups.values()];
+                const groupedEntries: ParsedEntry[][] = [];
+                let coolingDown = 0;
+                for (const group of groups.values()) {
+                    if (this.cooldowns.isCoolingDown(dispatchGroupKey(group[0]!.parsed))) {
+                        coolingDown += group.length;
+                        this.reportCoolingDown(group);
+                        continue;
+                    }
+                    groupedEntries.push(group);
+                }
 
                 metrics.histogram(metrics.Types.WEBHOOK_DISPATCH_BATCH_SIZE, groupedEntries.length);
                 span.setTag('batch_size', groupedEntries.length);
                 span.setTag('received', entries.length);
+                span.setTag('cooling_down', coolingDown);
+
+                const dispatched = entries.length - coolingDown;
+                if (groupedEntries.length === 0) {
+                    return;
+                }
 
                 const propsList: ExecuteWebhookProps[] = groupedEntries.map((group) => {
                     const m = group[0]!.parsed;
                     return {
                         name: m.taskName,
-                        group: { key: `webhook:environment:${m.connection.environment_id}`, maxConcurrency: this.webhookMaxConcurrency },
+                        group: { key: dispatchGroupKey(m), maxConcurrency: this.webhookMaxConcurrency },
                         args: {
                             webhookName: m.webhookName,
                             parentSyncName: m.parentSyncName,
@@ -176,7 +195,7 @@ export class DispatchQueueConsumer {
                     if (responsePayload) {
                         span.setTag('error.details', responsePayload);
                     }
-                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, entries.length, { result: 'failure' });
+                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, dispatched, { result: 'failure' });
                     report(new Error('webhook dispatch consumer batch failed', { cause: res.error }));
                     return;
                 }
@@ -256,12 +275,13 @@ export class DispatchQueueConsumer {
             // Per-entry errors:
             // - duplicate_task_name: already scheduled, treat as success and delete.
             // - task_cap_exceeded: the group is saturated, so redelivering won't help, so we drop the message.
-            // - rate_limit_exceeded: the environment is over its cap, so redelivery is the backpressure.
+            // - rate_limit_exceeded: the group is over its cap, so cool it down and let SQS redeliver.
             // - anything else: leave for redelivery (SQS visibility timeout → eventual DLQ).
             if (result.error.name === 'duplicate_task_name') {
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'success', provider, providerConfigKey });
                 await this.deleteGroup(group);
             } else if (result.error.name === 'rate_limit_exceeded') {
+                this.cooldowns.start(dispatchGroupKey(group[0]!.parsed), getRetryAfterMs(result.error.payload));
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'rate_limited', provider });
                 const logCtx = logContextGetter.get({ id: group[0]!.parsed.activityLogId, accountId: group[0]!.parsed.accountId });
                 await logCtx.warn('Webhook execution is delayed: this environment reached its webhook dispatch rate limit');
@@ -272,6 +292,15 @@ export class DispatchQueueConsumer {
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'failure', provider, providerConfigKey });
             }
         }
+    }
+
+    private reportCoolingDown(group: ParsedEntry[]): void {
+        const { provider, connection } = group[0]!.parsed;
+        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, group.length, {
+            result: 'cooling_down',
+            provider,
+            providerConfigKey: connection.provider_config_key
+        });
     }
 
     private async deleteGroup(group: ParsedEntry[]): Promise<void> {
@@ -298,6 +327,18 @@ export class DispatchQueueConsumer {
             report(new Error('webhook dispatch consumer delete failed', { cause: err }));
         }
     }
+}
+
+function dispatchGroupKey(message: WebhookDispatchMessage): string {
+    return `webhook:environment:${message.connection.environment_id}`;
+}
+
+function getRetryAfterMs(payload: unknown): number | null {
+    if (!payload || typeof payload !== 'object' || !('retryAfterMs' in payload)) {
+        return null;
+    }
+    const retryAfterMs = payload.retryAfterMs;
+    return typeof retryAfterMs === 'number' ? retryAfterMs : null;
 }
 
 function getClientErrorResponsePayload(err: { payload?: unknown }): string | null {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -8,7 +8,7 @@ import { Err, getLogger, metrics, Ok, report } from '@nangohq/utils';
 
 import { envs } from '../../env.js';
 import { GroupCooldowns } from './groupCooldown.js';
-import { changeVisibility, deferSeconds } from './visibility.js';
+import { changeVisibility, deferSeconds, keepVisible } from './visibility.js';
 
 import type { Message } from '@aws-sdk/client-sqs';
 import type { ExecuteWebhookProps, OrchestratorClient } from '@nangohq/nango-orchestrator';
@@ -49,6 +49,7 @@ export interface DispatchQueueConsumerProps {
     rateLimitCooldownMaxMs: number;
     deferJitterRatio: number;
     taskCapDeferMs: number;
+    maxVisibilityExtensionMs: number;
     sqs?: SQSClient;
 }
 
@@ -70,6 +71,7 @@ export class DispatchQueueConsumer {
     private readonly cooldowns: GroupCooldowns;
     private readonly deferJitterRatio: number;
     private readonly taskCapDeferMs: number;
+    private readonly maxVisibilityExtensionMs: number;
     private readonly abortController = new AbortController();
     private loopPromises: Promise<void>[] = [];
 
@@ -85,6 +87,7 @@ export class DispatchQueueConsumer {
         this.cooldowns = new GroupCooldowns({ maxCooldownMs: props.rateLimitCooldownMaxMs });
         this.deferJitterRatio = props.deferJitterRatio;
         this.taskCapDeferMs = props.taskCapDeferMs;
+        this.maxVisibilityExtensionMs = props.maxVisibilityExtensionMs;
         this.sqs = props.sqs ?? new SQSClient(envs.AWS_REGION ? { region: envs.AWS_REGION } : {});
     }
 
@@ -140,7 +143,7 @@ export class DispatchQueueConsumer {
             tags: { 'webhook.dispatch.received': messages.length }
         });
 
-        return void (await tracer.scope().activate(span, async () => {
+        return await tracer.scope().activate(span, async () => {
             try {
                 const entries = await this.filterMessages(messages);
                 if (entries.length === 0) {
@@ -199,7 +202,19 @@ export class DispatchQueueConsumer {
                 });
 
                 try {
-                    const res = await this.orchestratorClient.executeWebhookBatch(propsList);
+                    const stopKeepingVisible = keepVisible({
+                        sqs: this.sqs,
+                        queueUrl: this.queueUrl,
+                        receiptHandles: groupedEntries.flatMap((group) => group.map((entry) => entry.msg.ReceiptHandle!)),
+                        visibilityTimeoutSeconds: this.visibilityTimeoutSeconds,
+                        maxExtensionMs: this.maxVisibilityExtensionMs
+                    });
+                    let res;
+                    try {
+                        res = await this.orchestratorClient.executeWebhookBatch(propsList);
+                    } finally {
+                        await stopKeepingVisible();
+                    }
                     if (res.isErr()) {
                         span.setTag('error', true);
                         span.setTag('error.type', res.error.name);
@@ -220,7 +235,7 @@ export class DispatchQueueConsumer {
             } finally {
                 span.finish();
             }
-        }));
+        });
     }
 
     private async filterMessages(messages: Message[]): Promise<ParsedEntry[]> {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -145,7 +145,7 @@ export class DispatchQueueConsumer {
             tags: { 'webhook.dispatch.received': messages.length }
         });
 
-        return await tracer.scope().activate(span, async () => {
+        return void (await tracer.scope().activate(span, async () => {
             try {
                 const entries = await this.filterMessages(messages);
                 if (entries.length === 0) {
@@ -233,7 +233,7 @@ export class DispatchQueueConsumer {
             } finally {
                 span.finish();
             }
-        });
+        }));
     }
 
     private async filterMessages(messages: Message[]): Promise<ParsedEntry[]> {
@@ -301,6 +301,11 @@ export class DispatchQueueConsumer {
                 continue;
             }
 
+            // Per-entry errors:
+            // - duplicate_task_name: already scheduled, treat as success and delete.
+            // - task_cap_exceeded: the group is saturated, defer and retry as it drains.
+            // - rate_limit_exceeded: the group is over its cap, cool it down and defer until the cooldown expires.
+            // - anything else: leave for redelivery (SQS visibility timeout → eventual DLQ).
             if (result.error.name === 'duplicate_task_name') {
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'success', provider, providerConfigKey });
                 await this.deleteGroup(group);

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -8,6 +8,7 @@ import { Err, getLogger, metrics, Ok, report } from '@nangohq/utils';
 
 import { envs } from '../../env.js';
 import { GroupCooldowns } from './groupCooldown.js';
+import { changeVisibility, deferSeconds, keepVisible } from './visibility.js';
 
 import type { Message } from '@aws-sdk/client-sqs';
 import type { ExecuteWebhookProps, OrchestratorClient } from '@nangohq/nango-orchestrator';
@@ -46,6 +47,9 @@ export interface DispatchQueueConsumerProps {
     visibilityTimeoutSeconds: number;
     maxAgeMs: number;
     rateLimitCooldownMaxMs: number;
+    deferJitterRatio: number;
+    taskCapDeferMs: number;
+    maxVisibilityExtensionMs: number;
     sqs?: SQSClient;
 }
 
@@ -65,6 +69,9 @@ export class DispatchQueueConsumer {
     private readonly visibilityTimeoutSeconds: number;
     private readonly maxAgeMs: number;
     private readonly cooldowns: GroupCooldowns;
+    private readonly deferJitterRatio: number;
+    private readonly taskCapDeferMs: number;
+    private readonly maxVisibilityExtensionMs: number;
     private readonly abortController = new AbortController();
     private loopPromises: Promise<void>[] = [];
 
@@ -78,6 +85,9 @@ export class DispatchQueueConsumer {
         this.visibilityTimeoutSeconds = props.visibilityTimeoutSeconds;
         this.maxAgeMs = props.maxAgeMs;
         this.cooldowns = new GroupCooldowns({ maxCooldownMs: props.rateLimitCooldownMaxMs });
+        this.deferJitterRatio = props.deferJitterRatio;
+        this.taskCapDeferMs = props.taskCapDeferMs;
+        this.maxVisibilityExtensionMs = props.maxVisibilityExtensionMs;
         this.sqs = props.sqs ?? new SQSClient(envs.AWS_REGION ? { region: envs.AWS_REGION } : {});
     }
 
@@ -151,15 +161,19 @@ export class DispatchQueueConsumer {
                     }
                 }
                 const groupedEntries: ParsedEntry[][] = [];
+                const deferrals: Promise<void>[] = [];
                 let coolingDown = 0;
                 for (const group of groups.values()) {
-                    if (this.cooldowns.isCoolingDown(dispatchGroupKey(group[0]!.parsed))) {
+                    const remainingMs = this.cooldowns.remainingMs(dispatchGroupKey(group[0]!.parsed));
+                    if (remainingMs > 0) {
                         coolingDown += group.length;
                         this.reportCoolingDown(group);
+                        deferrals.push(this.deferGroup(group, remainingMs));
                         continue;
                     }
                     groupedEntries.push(group);
                 }
+                await Promise.all(deferrals);
 
                 metrics.histogram(metrics.Types.WEBHOOK_DISPATCH_BATCH_SIZE, groupedEntries.length);
                 span.setTag('batch_size', groupedEntries.length);
@@ -186,7 +200,19 @@ export class DispatchQueueConsumer {
                     };
                 });
 
-                const res = await this.orchestratorClient.executeWebhookBatch(propsList);
+                const stopKeepingVisible = keepVisible({
+                    sqs: this.sqs,
+                    queueUrl: this.queueUrl,
+                    receiptHandles: groupedEntries.flatMap((group) => group.map((entry) => entry.msg.ReceiptHandle!)),
+                    visibilityTimeoutSeconds: this.visibilityTimeoutSeconds,
+                    maxExtensionMs: this.maxVisibilityExtensionMs
+                });
+                let res;
+                try {
+                    res = await this.orchestratorClient.executeWebhookBatch(propsList);
+                } finally {
+                    stopKeepingVisible();
+                }
                 if (res.isErr()) {
                     span.setTag('error', true);
                     span.setTag('error.type', res.error.name);
@@ -281,13 +307,16 @@ export class DispatchQueueConsumer {
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'success', provider, providerConfigKey });
                 await this.deleteGroup(group);
             } else if (result.error.name === 'rate_limit_exceeded') {
-                this.cooldowns.start(dispatchGroupKey(group[0]!.parsed), getRetryAfterMs(result.error.payload));
+                const groupKey = dispatchGroupKey(group[0]!.parsed);
+                this.cooldowns.start(groupKey, getRetryAfterMs(result.error.payload));
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'rate_limited', provider });
+                await this.deferGroup(group, this.cooldowns.remainingMs(groupKey));
                 const logCtx = logContextGetter.get({ id: group[0]!.parsed.activityLogId, accountId: group[0]!.parsed.accountId });
                 await logCtx.warn('Webhook execution is delayed: this environment reached its webhook dispatch rate limit');
             } else if (result.error.name === 'task_cap_exceeded') {
-                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_DROPPED, count, { reason: 'task_cap', provider, providerConfigKey });
-                await this.deleteGroup(group);
+                // Retryable: the group drains, and filterMessages sheds the message once it breaches the age SLO.
+                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'task_cap_deferred', provider, providerConfigKey });
+                await this.deferGroup(group, this.taskCapDeferMs);
             } else {
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'failure', provider, providerConfigKey });
             }
@@ -301,6 +330,20 @@ export class DispatchQueueConsumer {
             provider,
             providerConfigKey: connection.provider_config_key
         });
+    }
+
+    private async deferGroup(group: ParsedEntry[], delayMs: number): Promise<void> {
+        try {
+            await changeVisibility({
+                sqs: this.sqs,
+                queueUrl: this.queueUrl,
+                receiptHandles: group.map((entry) => entry.msg.ReceiptHandle!),
+                visibilityTimeoutSeconds: deferSeconds(delayMs, this.deferJitterRatio)
+            });
+        } catch (err) {
+            // Redelivery on the normal visibility timeout is the fallback, so this is not fatal.
+            report(new Error('webhook dispatch consumer defer failed', { cause: err }));
+        }
     }
 
     private async deleteGroup(group: ParsedEntry[]): Promise<void> {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -73,6 +73,7 @@ export class DispatchQueueConsumer {
     private readonly taskCapDeferMs: number;
     private readonly maxVisibilityExtensionMs: number;
     private readonly abortController = new AbortController();
+    private readonly inFlightDeferrals = new Set<Promise<void>>();
     private loopPromises: Promise<void>[] = [];
 
     constructor(props: DispatchQueueConsumerProps) {
@@ -105,6 +106,7 @@ export class DispatchQueueConsumer {
             await Promise.allSettled(this.loopPromises);
             this.loopPromises = [];
         }
+        await Promise.allSettled(this.inFlightDeferrals);
         this.sqs.destroy();
     }
 
@@ -143,7 +145,7 @@ export class DispatchQueueConsumer {
             tags: { 'webhook.dispatch.received': messages.length }
         });
 
-        return void (await tracer.scope().activate(span, async () => {
+        return await tracer.scope().activate(span, async () => {
             try {
                 const entries = await this.filterMessages(messages);
                 if (entries.length === 0) {
@@ -184,7 +186,7 @@ export class DispatchQueueConsumer {
                     return;
                 }
 
-                void Promise.all(deferrals);
+                this.trackDeferrals(deferrals);
 
                 const propsList: ExecuteWebhookProps[] = groupedEntries.map((group) => {
                     const m = group[0]!.parsed;
@@ -231,7 +233,7 @@ export class DispatchQueueConsumer {
             } finally {
                 span.finish();
             }
-        }));
+        });
     }
 
     private async filterMessages(messages: Message[]): Promise<ParsedEntry[]> {
@@ -342,6 +344,19 @@ export class DispatchQueueConsumer {
             // Redelivery on the normal visibility timeout is the fallback, so this is not fatal.
             report(new Error('webhook dispatch consumer defer failed', { cause: err }));
         }
+    }
+
+    private trackDeferrals(deferrals: Promise<void>[]): void {
+        if (deferrals.length === 0) {
+            return;
+        }
+
+        const pending = Promise.all(deferrals).then(() => undefined);
+        this.inFlightDeferrals.add(pending);
+        void pending.then(
+            () => this.inFlightDeferrals.delete(pending),
+            () => this.inFlightDeferrals.delete(pending)
+        );
     }
 
     private async deleteGroup(group: ParsedEntry[]): Promise<void> {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -145,7 +145,7 @@ export class DispatchQueueConsumer {
             tags: { 'webhook.dispatch.received': messages.length }
         });
 
-        return void (await tracer.scope().activate(span, async () => {
+        return await tracer.scope().activate(span, async () => {
             try {
                 const entries = await this.filterMessages(messages);
                 if (entries.length === 0) {
@@ -233,7 +233,7 @@ export class DispatchQueueConsumer {
             } finally {
                 span.finish();
             }
-        }));
+        });
     }
 
     private async filterMessages(messages: Message[]): Promise<ParsedEntry[]> {
@@ -303,7 +303,7 @@ export class DispatchQueueConsumer {
 
             // Per-entry errors:
             // - duplicate_task_name: already scheduled, treat as success and delete.
-            // - task_cap_exceeded: the group is saturated, defer and retry as it drains.
+            // - task_cap_exceeded: the group is saturated, leave it for retry as it drains.
             // - rate_limit_exceeded: the group is over its cap, cool it down and defer until the cooldown expires.
             // - anything else: leave for redelivery (SQS visibility timeout → eventual DLQ).
             if (result.error.name === 'duplicate_task_name') {
@@ -321,7 +321,9 @@ export class DispatchQueueConsumer {
                 await logCtx.warn('Webhook execution is delayed: this environment reached its webhook dispatch rate limit');
             } else if (result.error.name === 'task_cap_exceeded') {
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'task_cap_deferred', provider, providerConfigKey });
-                await this.deferGroup(group, this.taskCapDeferMs);
+                if (this.taskCapDeferMs > 0) {
+                    await this.deferGroup(group, this.taskCapDeferMs);
+                }
             } else {
                 metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'failure', provider, providerConfigKey });
             }

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -8,7 +8,7 @@ import { Err, getLogger, metrics, Ok, report } from '@nangohq/utils';
 
 import { envs } from '../../env.js';
 import { GroupCooldowns } from './groupCooldown.js';
-import { changeVisibility, deferSeconds, keepVisible } from './visibility.js';
+import { changeVisibility, deferSeconds } from './visibility.js';
 
 import type { Message } from '@aws-sdk/client-sqs';
 import type { ExecuteWebhookProps, OrchestratorClient } from '@nangohq/nango-orchestrator';
@@ -49,7 +49,6 @@ export interface DispatchQueueConsumerProps {
     rateLimitCooldownMaxMs: number;
     deferJitterRatio: number;
     taskCapDeferMs: number;
-    maxVisibilityExtensionMs: number;
     sqs?: SQSClient;
 }
 
@@ -71,9 +70,7 @@ export class DispatchQueueConsumer {
     private readonly cooldowns: GroupCooldowns;
     private readonly deferJitterRatio: number;
     private readonly taskCapDeferMs: number;
-    private readonly maxVisibilityExtensionMs: number;
     private readonly abortController = new AbortController();
-    private readonly inFlightDeferrals = new Set<Promise<void>>();
     private loopPromises: Promise<void>[] = [];
 
     constructor(props: DispatchQueueConsumerProps) {
@@ -88,7 +85,6 @@ export class DispatchQueueConsumer {
         this.cooldowns = new GroupCooldowns({ maxCooldownMs: props.rateLimitCooldownMaxMs });
         this.deferJitterRatio = props.deferJitterRatio;
         this.taskCapDeferMs = props.taskCapDeferMs;
-        this.maxVisibilityExtensionMs = props.maxVisibilityExtensionMs;
         this.sqs = props.sqs ?? new SQSClient(envs.AWS_REGION ? { region: envs.AWS_REGION } : {});
     }
 
@@ -106,7 +102,6 @@ export class DispatchQueueConsumer {
             await Promise.allSettled(this.loopPromises);
             this.loopPromises = [];
         }
-        await Promise.allSettled(this.inFlightDeferrals);
         this.sqs.destroy();
     }
 
@@ -145,7 +140,7 @@ export class DispatchQueueConsumer {
             tags: { 'webhook.dispatch.received': messages.length }
         });
 
-        return await tracer.scope().activate(span, async () => {
+        return void (await tracer.scope().activate(span, async () => {
             try {
                 const entries = await this.filterMessages(messages);
                 if (entries.length === 0) {
@@ -186,7 +181,7 @@ export class DispatchQueueConsumer {
                     return;
                 }
 
-                this.trackDeferrals(deferrals);
+                const deferralsDone = Promise.all(deferrals);
 
                 const propsList: ExecuteWebhookProps[] = groupedEntries.map((group) => {
                     const m = group[0]!.parsed;
@@ -203,37 +198,29 @@ export class DispatchQueueConsumer {
                     };
                 });
 
-                const stopKeepingVisible = keepVisible({
-                    sqs: this.sqs,
-                    queueUrl: this.queueUrl,
-                    receiptHandles: groupedEntries.flatMap((group) => group.map((entry) => entry.msg.ReceiptHandle!)),
-                    visibilityTimeoutSeconds: this.visibilityTimeoutSeconds,
-                    maxExtensionMs: this.maxVisibilityExtensionMs
-                });
-                let res;
                 try {
-                    res = await this.orchestratorClient.executeWebhookBatch(propsList);
-                } finally {
-                    await stopKeepingVisible();
-                }
-                if (res.isErr()) {
-                    span.setTag('error', true);
-                    span.setTag('error.type', res.error.name);
-                    span.setTag('error.message', res.error.message);
-                    const responsePayload = getClientErrorResponsePayload(res.error);
-                    if (responsePayload) {
-                        span.setTag('error.details', responsePayload);
+                    const res = await this.orchestratorClient.executeWebhookBatch(propsList);
+                    if (res.isErr()) {
+                        span.setTag('error', true);
+                        span.setTag('error.type', res.error.name);
+                        span.setTag('error.message', res.error.message);
+                        const responsePayload = getClientErrorResponsePayload(res.error);
+                        if (responsePayload) {
+                            span.setTag('error.details', responsePayload);
+                        }
+                        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, dispatched, { result: 'failure' });
+                        report(new Error('webhook dispatch consumer batch failed', { cause: res.error }));
+                        return;
                     }
-                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, dispatched, { result: 'failure' });
-                    report(new Error('webhook dispatch consumer batch failed', { cause: res.error }));
-                    return;
-                }
 
-                await this.handleBatchResult(groupedEntries, res.value);
+                    await this.handleBatchResult(groupedEntries, res.value);
+                } finally {
+                    await deferralsDone;
+                }
             } finally {
                 span.finish();
             }
-        });
+        }));
     }
 
     private async filterMessages(messages: Message[]): Promise<ParsedEntry[]> {
@@ -351,19 +338,6 @@ export class DispatchQueueConsumer {
             // Redelivery on the normal visibility timeout is the fallback, so this is not fatal.
             report(new Error('webhook dispatch consumer defer failed', { cause: err }));
         }
-    }
-
-    private trackDeferrals(deferrals: Promise<void>[]): void {
-        if (deferrals.length === 0) {
-            return;
-        }
-
-        const pending = Promise.all(deferrals).then(() => undefined);
-        this.inFlightDeferrals.add(pending);
-        void pending.then(
-            () => this.inFlightDeferrals.delete(pending),
-            () => this.inFlightDeferrals.delete(pending)
-        );
     }
 
     private async deleteGroup(group: ParsedEntry[]): Promise<void> {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -70,6 +70,7 @@ function makeHarness(
         rateLimitCooldownMaxMs?: number;
         deferJitterRatio?: number;
         taskCapDeferMs?: number;
+        maxVisibilityExtensionMs?: number;
         sqsSend?: Mock<SqsSendFn>;
     } = {}
 ): Harness {
@@ -117,7 +118,8 @@ function makeHarness(
         maxAgeMs: opts.maxAgeMs ?? 0,
         rateLimitCooldownMaxMs: opts.rateLimitCooldownMaxMs ?? 0,
         deferJitterRatio: opts.deferJitterRatio ?? 0,
-        taskCapDeferMs: opts.taskCapDeferMs ?? 15_000
+        taskCapDeferMs: opts.taskCapDeferMs ?? 15_000,
+        maxVisibilityExtensionMs: opts.maxVisibilityExtensionMs ?? 0
     });
 
     return { consumer, sqsSend, sqsDestroy, orchestratorExecuteWebhookBatch };

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -70,7 +70,6 @@ function makeHarness(
         rateLimitCooldownMaxMs?: number;
         deferJitterRatio?: number;
         taskCapDeferMs?: number;
-        maxVisibilityExtensionMs?: number;
         sqsSend?: Mock<SqsSendFn>;
     } = {}
 ): Harness {
@@ -118,8 +117,7 @@ function makeHarness(
         maxAgeMs: opts.maxAgeMs ?? 0,
         rateLimitCooldownMaxMs: opts.rateLimitCooldownMaxMs ?? 0,
         deferJitterRatio: opts.deferJitterRatio ?? 0,
-        taskCapDeferMs: opts.taskCapDeferMs ?? 15_000,
-        maxVisibilityExtensionMs: opts.maxVisibilityExtensionMs ?? 0
+        taskCapDeferMs: opts.taskCapDeferMs ?? 15_000
     });
 
     return { consumer, sqsSend, sqsDestroy, orchestratorExecuteWebhookBatch };

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -1,7 +1,7 @@
 import { DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Err, Ok } from '@nangohq/utils';
+import { Err, metrics, Ok } from '@nangohq/utils';
 
 import { DispatchQueueConsumer } from './consumer.js';
 
@@ -67,6 +67,7 @@ function makeHarness(
         badBody?: string;
         consumerConcurrency?: number;
         maxAgeMs?: number;
+        rateLimitCooldownMaxMs?: number;
         sqsSend?: Mock<SqsSendFn>;
     } = {}
 ): Harness {
@@ -111,7 +112,8 @@ function makeHarness(
         maxMessages: 10,
         waitTimeSeconds: 0,
         visibilityTimeoutSeconds: 30,
-        maxAgeMs: opts.maxAgeMs ?? 0
+        maxAgeMs: opts.maxAgeMs ?? 0,
+        rateLimitCooldownMaxMs: opts.rateLimitCooldownMaxMs ?? 0
     });
 
     return { consumer, sqsSend, sqsDestroy, orchestratorExecuteWebhookBatch };
@@ -119,6 +121,12 @@ function makeHarness(
 
 function getDeleteCalls(h: Harness) {
     return h.sqsSend.mock.calls.filter((c) => c[0] instanceof DeleteMessageCommand);
+}
+
+function getDeletedHandles(h: Harness) {
+    return getDeleteCalls(h)
+        .map((c) => (c[0] as DeleteMessageCommand).input.ReceiptHandle)
+        .sort();
 }
 
 async function runOnce(h: Harness, waitFor: () => void | Promise<void>): Promise<void> {
@@ -215,6 +223,107 @@ describe('DispatchQueueConsumer', () => {
         // The environment is over its cap, so the throttled message is left for redelivery.
         // Only the successful entry is deleted.
         expect(getDeleteCalls(h)).toHaveLength(1);
+    });
+
+    it('cools down only the throttled group and keeps the other groups flowing', async () => {
+        const noisy = (n: number) =>
+            buildMessage({
+                taskName: `webhook:noisy:${n}`,
+                connection: { id: 42, connection_id: 'noisy-1', provider_config_key: 'github-noisy', environment_id: 2 }
+            });
+        const quiet = (n: number) =>
+            buildMessage({
+                taskName: `webhook:quiet:${n}`,
+                connection: { id: 43, connection_id: 'quiet-1', provider_config_key: 'github-quiet', environment_id: 3 }
+            });
+
+        const rounds = [
+            [noisy(1), quiet(1)],
+            [noisy(2), quiet(2)]
+        ];
+        const sqsSend = vi.fn<SqsSendFn>(async (command: unknown) => {
+            await new Promise((resolve) => setImmediate(resolve));
+            if (command instanceof ReceiveMessageCommand) {
+                const round = rounds.shift() ?? [];
+                return {
+                    Messages: round.map((m) => ({
+                        Body: JSON.stringify(m),
+                        ReceiptHandle: `rh-${m.taskName}`,
+                        Attributes: { SentTimestamp: String(Date.now()) }
+                    }))
+                };
+            }
+            if (command instanceof DeleteMessageCommand) {
+                return {};
+            }
+            throw new Error(`unexpected command ${String(command)}`);
+        });
+
+        const h = makeHarness({ sqsSend, rateLimitCooldownMaxMs: 60_000 });
+        h.orchestratorExecuteWebhookBatch.mockImplementation((props: unknown[]) =>
+            Promise.resolve(
+                Ok(
+                    (props as { name: string }[]).map((p) =>
+                        p.name.startsWith('webhook:noisy')
+                            ? Err({ name: 'rate_limit_exceeded', message: 'Rate limit exceeded', payload: { retryAfterMs: 30_000 } })
+                            : Ok({ taskId: p.name, retryKey: 'rk' })
+                    )
+                )
+            )
+        );
+
+        await runOnce(h, () => {
+            expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(2);
+        });
+
+        // The quiet group is dispatched right away instead of waiting out the noisy group's 30s.
+        const secondBatch = h.orchestratorExecuteWebhookBatch.mock.calls[1]?.[0] as { name: string }[];
+        expect(secondBatch.map((p) => p.name)).toEqual(['webhook:quiet:2']);
+
+        expect(getDeletedHandles(h)).toEqual(['rh-webhook:quiet:1', 'rh-webhook:quiet:2']);
+    });
+
+    it('counts only the dispatched messages when the whole batch call fails', async () => {
+        const cooling = buildMessage({
+            taskName: 'webhook:cooling',
+            connection: { id: 42, connection_id: 'noisy-1', provider_config_key: 'github-noisy', environment_id: 2 }
+        });
+        const active = buildMessage({
+            taskName: 'webhook:active',
+            connection: { id: 43, connection_id: 'quiet-1', provider_config_key: 'github-quiet', environment_id: 3 }
+        });
+
+        const rounds = [[cooling], [cooling, active]];
+        const sqsSend = vi.fn<SqsSendFn>(async (command: unknown) => {
+            await new Promise((resolve) => setImmediate(resolve));
+            if (command instanceof ReceiveMessageCommand) {
+                const round = rounds.shift() ?? [];
+                return {
+                    Messages: round.map((m) => ({
+                        Body: JSON.stringify(m),
+                        ReceiptHandle: `rh-${m.taskName}`,
+                        Attributes: { SentTimestamp: String(Date.now()) }
+                    }))
+                };
+            }
+            return {};
+        });
+
+        const h = makeHarness({ sqsSend, rateLimitCooldownMaxMs: 60_000 });
+        h.orchestratorExecuteWebhookBatch
+            .mockResolvedValueOnce(Ok([Err({ name: 'rate_limit_exceeded', message: 'Rate limit exceeded', payload: { retryAfterMs: 30_000 } })]))
+            .mockResolvedValueOnce(Err({ name: 'immediate_batch_failed', message: 'boom', payload: {} }));
+        const increment = vi.spyOn(metrics, 'increment');
+
+        await runOnce(h, () => {
+            expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(2);
+        });
+
+        // Round two carried one cooling-down message and one dispatched message. Only the
+        // dispatched one can have failed, the other was never submitted.
+        const failures = increment.mock.calls.filter((c) => c[2]?.['result'] === 'failure');
+        expect(failures).toHaveLength(1);
+        expect(failures[0]?.[1]).toBe(1);
     });
 
     it('does not delete messages whose per-entry result is a generic error', async () => {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -236,6 +236,7 @@ describe('DispatchQueueConsumer', () => {
         // The environment is over its cap, so the throttled message is left for redelivery.
         // Only the successful entry is deleted.
         expect(getDeleteCalls(h)).toHaveLength(1);
+        expect(getVisibilityCalls(h)).toHaveLength(0);
     });
 
     it('defers rate limited messages to the end of the group cooldown', async () => {
@@ -315,6 +316,59 @@ describe('DispatchQueueConsumer', () => {
         // Both noisy messages are held back, the first by its own throttle and the second by
         // the cooldown that throttle opened, so neither burns a receive attempt on the way back.
         expect(getVisibilityCalls(h).map((e) => e.ReceiptHandle)).toEqual(['rh-webhook:noisy:1', 'rh-webhook:noisy:2']);
+    });
+
+    it('does not wait for cooling-group deferrals before dispatching active groups', async () => {
+        const noisy = (n: number) =>
+            buildMessage({
+                taskName: `webhook:noisy:${n}`,
+                connection: { id: 42, connection_id: 'noisy-1', provider_config_key: 'github-noisy', environment_id: 2 }
+            });
+        const quiet = buildMessage({
+            taskName: 'webhook:quiet',
+            connection: { id: 43, connection_id: 'quiet-1', provider_config_key: 'github-quiet', environment_id: 3 }
+        });
+        const rounds = [[noisy(1)], [noisy(2), quiet]];
+        const deferral = deferred<undefined>();
+        const deferralStarted = deferred<undefined>();
+        const sqsSend = vi.fn<SqsSendFn>(async (command: unknown) => {
+            await new Promise((resolve) => setImmediate(resolve));
+            if (command instanceof ReceiveMessageCommand) {
+                const round = rounds.shift() ?? [];
+                return {
+                    Messages: round.map((message) => ({
+                        Body: JSON.stringify(message),
+                        ReceiptHandle: `rh-${message.taskName}`,
+                        Attributes: { SentTimestamp: String(Date.now()) }
+                    }))
+                };
+            }
+            if (command instanceof ChangeMessageVisibilityBatchCommand) {
+                const handles = command.input.Entries?.map((entry) => entry.ReceiptHandle) ?? [];
+                if (handles.includes('rh-webhook:noisy:2')) {
+                    deferralStarted.resolve(undefined);
+                    await deferral.promise;
+                }
+                return {};
+            }
+            if (command instanceof DeleteMessageCommand) {
+                return {};
+            }
+            throw new Error(`unexpected command ${String(command)}`);
+        });
+
+        const h = makeHarness({ sqsSend, rateLimitCooldownMaxMs: 60_000 });
+        h.orchestratorExecuteWebhookBatch
+            .mockResolvedValueOnce(Ok([Err({ name: 'rate_limit_exceeded', message: 'Rate limit exceeded', payload: { retryAfterMs: 30_000 } })]))
+            .mockResolvedValueOnce(Ok([Ok({ taskId: 'quiet', retryKey: 'quiet' })]));
+
+        h.consumer.start();
+        await deferralStarted.promise;
+        await vi.waitFor(() => {
+            expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(2);
+        });
+        deferral.resolve(undefined);
+        await h.consumer.stop();
     });
 
     it('counts only the dispatched messages when the whole batch call fails', async () => {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -1,4 +1,4 @@
-import { DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
+import { ChangeMessageVisibilityBatchCommand, DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Err, metrics, Ok } from '@nangohq/utils';
@@ -68,6 +68,9 @@ function makeHarness(
         consumerConcurrency?: number;
         maxAgeMs?: number;
         rateLimitCooldownMaxMs?: number;
+        deferJitterRatio?: number;
+        taskCapDeferMs?: number;
+        maxVisibilityExtensionMs?: number;
         sqsSend?: Mock<SqsSendFn>;
     } = {}
 ): Harness {
@@ -88,7 +91,7 @@ function makeHarness(
                 const messages = bodyQueue.splice(0, bodyQueue.length);
                 return { Messages: messages };
             }
-            if (command instanceof DeleteMessageCommand) {
+            if (command instanceof DeleteMessageCommand || command instanceof ChangeMessageVisibilityBatchCommand) {
                 return {};
             }
             throw new Error(`unexpected command ${String(command)}`);
@@ -113,10 +116,19 @@ function makeHarness(
         waitTimeSeconds: 0,
         visibilityTimeoutSeconds: 30,
         maxAgeMs: opts.maxAgeMs ?? 0,
-        rateLimitCooldownMaxMs: opts.rateLimitCooldownMaxMs ?? 0
+        rateLimitCooldownMaxMs: opts.rateLimitCooldownMaxMs ?? 0,
+        deferJitterRatio: opts.deferJitterRatio ?? 0,
+        taskCapDeferMs: opts.taskCapDeferMs ?? 30_000,
+        maxVisibilityExtensionMs: opts.maxVisibilityExtensionMs ?? 0
     });
 
     return { consumer, sqsSend, sqsDestroy, orchestratorExecuteWebhookBatch };
+}
+
+function getVisibilityCalls(h: Harness) {
+    return h.sqsSend.mock.calls
+        .filter((c) => c[0] instanceof ChangeMessageVisibilityBatchCommand)
+        .flatMap((c) => (c[0] as ChangeMessageVisibilityBatchCommand).input.Entries ?? []);
 }
 
 function getDeleteCalls(h: Harness) {
@@ -193,9 +205,9 @@ describe('DispatchQueueConsumer', () => {
         expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(1);
     });
 
-    it('drops (deletes) messages whose per-entry result is task_cap_exceeded', async () => {
+    it('defers rather than drops messages whose per-entry result is task_cap_exceeded', async () => {
         const msgs = [buildMessage({ taskName: 'webhook:1' }), buildMessage({ taskName: 'webhook:2' })];
-        const h = makeHarness({ messages: msgs });
+        const h = makeHarness({ messages: msgs, taskCapDeferMs: 30_000 });
         h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(
             Ok([Ok({ taskId: 't1', retryKey: 'r1' }), Err({ name: 'task_cap_exceeded', message: 'cap', payload: {} })])
         );
@@ -204,9 +216,10 @@ describe('DispatchQueueConsumer', () => {
             expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(1);
         });
 
-        // A saturated group can't accept the task, so the message is shed (deleted) rather than
-        // redelivered — both the successful entry and the capped one get deleted.
-        expect(getDeleteCalls(h)).toHaveLength(2);
+        // The group drains eventually, so the capped message is held back instead of thrown away.
+        // Only the successful entry is deleted, and filterMessages sheds the other once it ages out.
+        expect(getDeleteCalls(h)).toHaveLength(1);
+        expect(getVisibilityCalls(h)).toEqual([{ Id: '0', ReceiptHandle: 'rh-1', VisibilityTimeout: 30 }]);
     });
 
     it('keeps messages whose per-entry result is rate_limit_exceeded for redelivery', async () => {
@@ -223,6 +236,23 @@ describe('DispatchQueueConsumer', () => {
         // The environment is over its cap, so the throttled message is left for redelivery.
         // Only the successful entry is deleted.
         expect(getDeleteCalls(h)).toHaveLength(1);
+    });
+
+    it('defers rate limited messages to the end of the group cooldown', async () => {
+        const msgs = [buildMessage({ taskName: 'webhook:1' })];
+        const h = makeHarness({ messages: msgs, rateLimitCooldownMaxMs: 60_000 });
+        h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(
+            Ok([Err({ name: 'rate_limit_exceeded', message: 'Rate limit exceeded', payload: { retryAfterMs: 30_000 } })])
+        );
+
+        await runOnce(h, () => {
+            expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(1);
+        });
+
+        // Held for the cooldown instead of coming back on the 30s visibility timeout and
+        // burning a receive attempt for nothing.
+        expect(getVisibilityCalls(h)).toEqual([{ Id: '0', ReceiptHandle: 'rh-0', VisibilityTimeout: 30 }]);
+        expect(getDeleteCalls(h)).toHaveLength(0);
     });
 
     it('cools down only the throttled group and keeps the other groups flowing', async () => {
@@ -253,7 +283,7 @@ describe('DispatchQueueConsumer', () => {
                     }))
                 };
             }
-            if (command instanceof DeleteMessageCommand) {
+            if (command instanceof DeleteMessageCommand || command instanceof ChangeMessageVisibilityBatchCommand) {
                 return {};
             }
             throw new Error(`unexpected command ${String(command)}`);
@@ -281,6 +311,10 @@ describe('DispatchQueueConsumer', () => {
         expect(secondBatch.map((p) => p.name)).toEqual(['webhook:quiet:2']);
 
         expect(getDeletedHandles(h)).toEqual(['rh-webhook:quiet:1', 'rh-webhook:quiet:2']);
+
+        // Both noisy messages are held back, the first by its own throttle and the second by
+        // the cooldown that throttle opened, so neither burns a receive attempt on the way back.
+        expect(getVisibilityCalls(h).map((e) => e.ReceiptHandle)).toEqual(['rh-webhook:noisy:1', 'rh-webhook:noisy:2']);
     });
 
     it('counts only the dispatched messages when the whole batch call fails', async () => {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -118,7 +118,7 @@ function makeHarness(
         maxAgeMs: opts.maxAgeMs ?? 0,
         rateLimitCooldownMaxMs: opts.rateLimitCooldownMaxMs ?? 0,
         deferJitterRatio: opts.deferJitterRatio ?? 0,
-        taskCapDeferMs: opts.taskCapDeferMs ?? 30_000,
+        taskCapDeferMs: opts.taskCapDeferMs ?? 15_000,
         maxVisibilityExtensionMs: opts.maxVisibilityExtensionMs ?? 0
     });
 
@@ -207,7 +207,7 @@ describe('DispatchQueueConsumer', () => {
 
     it('defers rather than drops messages whose per-entry result is task_cap_exceeded', async () => {
         const msgs = [buildMessage({ taskName: 'webhook:1' }), buildMessage({ taskName: 'webhook:2' })];
-        const h = makeHarness({ messages: msgs, taskCapDeferMs: 30_000 });
+        const h = makeHarness({ messages: msgs });
         h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(
             Ok([Ok({ taskId: 't1', retryKey: 'r1' }), Err({ name: 'task_cap_exceeded', message: 'cap', payload: {} })])
         );
@@ -217,7 +217,19 @@ describe('DispatchQueueConsumer', () => {
         });
 
         expect(getDeleteCalls(h)).toHaveLength(1);
-        expect(getVisibilityCalls(h)).toEqual([{ Id: '0', ReceiptHandle: 'rh-1', VisibilityTimeout: 30 }]);
+        expect(getVisibilityCalls(h)).toEqual([{ Id: '0', ReceiptHandle: 'rh-1', VisibilityTimeout: 15 }]);
+    });
+
+    it('leaves task-cap messages on their current visibility timeout when deferral is disabled', async () => {
+        const h = makeHarness({ messages: [buildMessage()], taskCapDeferMs: 0 });
+        h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(Ok([Err({ name: 'task_cap_exceeded', message: 'cap', payload: {} })]));
+
+        await runOnce(h, () => {
+            expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(1);
+        });
+
+        expect(getVisibilityCalls(h)).toHaveLength(0);
+        expect(getDeleteCalls(h)).toHaveLength(0);
     });
 
     it('keeps messages whose per-entry result is rate_limit_exceeded for redelivery', async () => {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -216,8 +216,6 @@ describe('DispatchQueueConsumer', () => {
             expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(1);
         });
 
-        // The group drains eventually, so the capped message is held back instead of thrown away.
-        // Only the successful entry is deleted, and filterMessages sheds the other once it ages out.
         expect(getDeleteCalls(h)).toHaveLength(1);
         expect(getVisibilityCalls(h)).toEqual([{ Id: '0', ReceiptHandle: 'rh-1', VisibilityTimeout: 30 }]);
     });
@@ -250,8 +248,6 @@ describe('DispatchQueueConsumer', () => {
             expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(1);
         });
 
-        // Held for the cooldown instead of coming back on the 30s visibility timeout and
-        // burning a receive attempt for nothing.
         expect(getVisibilityCalls(h)).toEqual([{ Id: '0', ReceiptHandle: 'rh-0', VisibilityTimeout: 30 }]);
         expect(getDeleteCalls(h)).toHaveLength(0);
     });
@@ -313,8 +309,6 @@ describe('DispatchQueueConsumer', () => {
 
         expect(getDeletedHandles(h)).toEqual(['rh-webhook:quiet:1', 'rh-webhook:quiet:2']);
 
-        // Both noisy messages are held back, the first by its own throttle and the second by
-        // the cooldown that throttle opened, so neither burns a receive attempt on the way back.
         expect(getVisibilityCalls(h).map((e) => e.ReceiptHandle)).toEqual(['rh-webhook:noisy:1', 'rh-webhook:noisy:2']);
     });
 

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -312,7 +312,7 @@ describe('DispatchQueueConsumer', () => {
         expect(getVisibilityCalls(h).map((e) => e.ReceiptHandle)).toEqual(['rh-webhook:noisy:1', 'rh-webhook:noisy:2']);
     });
 
-    it('does not wait for cooling-group deferrals before dispatching active groups', async () => {
+    it('dispatches active groups before cooling deferrals finish and drains them on shutdown', async () => {
         const noisy = (n: number) =>
             buildMessage({
                 taskName: `webhook:noisy:${n}`,
@@ -324,7 +324,6 @@ describe('DispatchQueueConsumer', () => {
         });
         const rounds = [[noisy(1)], [noisy(2), quiet]];
         const deferral = deferred<undefined>();
-        const deferralStarted = deferred<undefined>();
         const sqsSend = vi.fn<SqsSendFn>(async (command: unknown) => {
             await new Promise((resolve) => setImmediate(resolve));
             if (command instanceof ReceiveMessageCommand) {
@@ -340,7 +339,6 @@ describe('DispatchQueueConsumer', () => {
             if (command instanceof ChangeMessageVisibilityBatchCommand) {
                 const handles = command.input.Entries?.map((entry) => entry.ReceiptHandle) ?? [];
                 if (handles.includes('rh-webhook:noisy:2')) {
-                    deferralStarted.resolve(undefined);
                     await deferral.promise;
                 }
                 return {};
@@ -357,12 +355,24 @@ describe('DispatchQueueConsumer', () => {
             .mockResolvedValueOnce(Ok([Ok({ taskId: 'quiet', retryKey: 'quiet' })]));
 
         h.consumer.start();
-        await deferralStarted.promise;
+        await vi.waitFor(() => {
+            expect(getVisibilityCalls(h).some((entry) => entry.ReceiptHandle === 'rh-webhook:noisy:2')).toBe(true);
+        });
         await vi.waitFor(() => {
             expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(2);
         });
+
+        let stopped = false;
+        const stopPromise = h.consumer.stop().then(() => {
+            stopped = true;
+        });
+        await Promise.resolve();
+        expect(stopped).toBe(false);
+        expect(h.sqsDestroy).not.toHaveBeenCalled();
+
         deferral.resolve(undefined);
-        await h.consumer.stop();
+        await stopPromise;
+        expect(h.sqsDestroy).toHaveBeenCalledOnce();
     });
 
     it('counts only the dispatched messages when the whole batch call fails', async () => {

--- a/packages/jobs/lib/webhook/dispatch-queue/groupCooldown.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/groupCooldown.ts
@@ -1,0 +1,38 @@
+import { metrics, TTLFixedSizeMap } from '@nangohq/utils';
+
+const FALLBACK_COOLDOWN_MS = 1000;
+const MAX_TRACKED_GROUPS = 10_000;
+const NANOSECONDS_PER_MILLISECOND = 1_000_000n;
+
+export class GroupCooldowns {
+    private readonly maxCooldownMs: number;
+    private readonly throttledGroups: TTLFixedSizeMap<string, bigint>;
+
+    constructor({ maxCooldownMs }: { maxCooldownMs: number }) {
+        if (!Number.isFinite(maxCooldownMs) || maxCooldownMs < 0) {
+            throw new RangeError('maxCooldownMs must be a finite, non-negative number');
+        }
+        this.maxCooldownMs = Math.ceil(maxCooldownMs);
+        this.throttledGroups = new TTLFixedSizeMap(MAX_TRACKED_GROUPS, this.maxCooldownMs);
+    }
+
+    start(groupKey: string, retryAfterMs: number | null): void {
+        const suggested = retryAfterMs !== null && Number.isFinite(retryAfterMs) && retryAfterMs > 0 ? retryAfterMs : FALLBACK_COOLDOWN_MS;
+        const cooldownMs = Math.min(Math.ceil(suggested), this.maxCooldownMs);
+        if (cooldownMs <= 0) {
+            return;
+        }
+
+        const now = process.hrtime.bigint();
+        const proposedUntil = now + BigInt(cooldownMs) * NANOSECONDS_PER_MILLISECOND;
+        const previousUntil = this.throttledGroups.get(groupKey) ?? 0n;
+        const until = previousUntil > proposedUntil ? previousUntil : proposedUntil;
+        this.throttledGroups.set(groupKey, until);
+        metrics.duration(metrics.Types.WEBHOOK_DISPATCH_COOLDOWN_MS, Number(until - now) / Number(NANOSECONDS_PER_MILLISECOND));
+    }
+
+    isCoolingDown(groupKey: string): boolean {
+        const until = this.throttledGroups.get(groupKey);
+        return until !== undefined && until > process.hrtime.bigint();
+    }
+}

--- a/packages/jobs/lib/webhook/dispatch-queue/groupCooldown.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/groupCooldown.ts
@@ -32,7 +32,15 @@ export class GroupCooldowns {
     }
 
     isCoolingDown(groupKey: string): boolean {
+        return this.remainingMs(groupKey) > 0;
+    }
+
+    remainingMs(groupKey: string): number {
         const until = this.throttledGroups.get(groupKey);
-        return until !== undefined && until > process.hrtime.bigint();
+        if (until === undefined) {
+            return 0;
+        }
+        const remaining = until - process.hrtime.bigint();
+        return remaining > 0n ? Number(remaining / NANOSECONDS_PER_MILLISECOND) : 0;
     }
 }

--- a/packages/jobs/lib/webhook/dispatch-queue/groupCooldown.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/groupCooldown.unit.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { metrics } from '@nangohq/utils';
+
+import { GroupCooldowns } from './groupCooldown.js';
+
+const GROUP = 'webhook:environment:2';
+const OTHER_GROUP = 'webhook:environment:3';
+
+describe('GroupCooldowns', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout', 'hrtime'] });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('cools down only the group it was given', () => {
+        const cooldowns = new GroupCooldowns({ maxCooldownMs: 60_000 });
+        cooldowns.start(GROUP, 5_000);
+
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(true);
+        expect(cooldowns.isCoolingDown(OTHER_GROUP)).toBe(false);
+    });
+
+    it('expires after the suggested delay', () => {
+        const cooldowns = new GroupCooldowns({ maxCooldownMs: 60_000 });
+        cooldowns.start(GROUP, 5_000);
+
+        vi.advanceTimersByTime(4_999);
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(true);
+
+        vi.advanceTimersByTime(1);
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(false);
+    });
+
+    it('does not expire early when the wall clock jumps forward', () => {
+        const cooldowns = new GroupCooldowns({ maxCooldownMs: 60_000 });
+        cooldowns.start(GROUP, 5_000);
+
+        vi.setSystemTime(Date.now() + 60_000);
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(true);
+
+        vi.advanceTimersByTime(5_000);
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(false);
+    });
+
+    it('clamps the suggested delay to the maximum', () => {
+        const cooldowns = new GroupCooldowns({ maxCooldownMs: 10_000 });
+        cooldowns.start(GROUP, 90_000);
+
+        vi.advanceTimersByTime(10_000);
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(false);
+    });
+
+    it('falls back to a cooldown when the orchestrator sends no delay', () => {
+        const cooldowns = new GroupCooldowns({ maxCooldownMs: 60_000 });
+        cooldowns.start(GROUP, null);
+
+        vi.advanceTimersByTime(999);
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(true);
+
+        vi.advanceTimersByTime(1);
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(false);
+    });
+
+    it('keeps the furthest deadline', () => {
+        const durationSpy = vi.spyOn(metrics, 'duration');
+        const cooldowns = new GroupCooldowns({ maxCooldownMs: 60_000 });
+        cooldowns.start(GROUP, 5_000);
+        vi.advanceTimersByTime(1_000);
+        cooldowns.start(GROUP, 1_000);
+
+        expect(durationSpy).toHaveBeenLastCalledWith(metrics.Types.WEBHOOK_DISPATCH_COOLDOWN_MS, 4_000);
+
+        vi.advanceTimersByTime(3_999);
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(true);
+    });
+
+    it('rounds a fractional maximum up so the deadline is not evicted early', () => {
+        const cooldowns = new GroupCooldowns({ maxCooldownMs: 0.5 });
+        cooldowns.start(GROUP, 5_000);
+
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(true);
+        vi.advanceTimersByTime(1);
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(false);
+    });
+
+    it('does nothing when the maximum is zero', () => {
+        const cooldowns = new GroupCooldowns({ maxCooldownMs: 0 });
+        cooldowns.start(GROUP, 5_000);
+
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(false);
+    });
+
+    it('evicts groups whose cooldown has passed', () => {
+        const cooldowns = new GroupCooldowns({ maxCooldownMs: 60_000 });
+        cooldowns.start(GROUP, 1_000);
+        expect(cooldowns).toHaveProperty('throttledGroups.size', 1);
+
+        vi.advanceTimersByTime(60_000);
+        expect(cooldowns.isCoolingDown(GROUP)).toBe(false);
+        expect(cooldowns).toHaveProperty('throttledGroups.size', 0);
+    });
+});

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
@@ -1,5 +1,7 @@
 import { ChangeMessageVisibilityBatchCommand } from '@aws-sdk/client-sqs';
 
+import { report } from '@nangohq/utils';
+
 import type { SQSClient } from '@aws-sdk/client-sqs';
 
 const SQS_BATCH_LIMIT = 10;
@@ -34,4 +36,50 @@ export async function changeVisibility({ sqs, queueUrl, receiptHandles, visibili
             throw new Error('webhook dispatch visibility batch partially failed', { cause: response.Failed });
         }
     }
+}
+
+/** Keeps messages invisible while dispatch is in flight and returns an async stop function. */
+export function keepVisible(props: VisibilityProps & { maxExtensionMs: number }): () => Promise<void> {
+    if (props.receiptHandles.length === 0 || props.visibilityTimeoutSeconds <= 0 || props.maxExtensionMs <= 0) {
+        return () => Promise.resolve();
+    }
+
+    // Extend visibility after the message consumes a third of its SQS timeout.
+    const intervalMs = Math.max(100, Math.floor((props.visibilityTimeoutSeconds * 1000) / 3));
+    const deadline = Date.now() + props.maxExtensionMs;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let inFlight: Promise<void> | undefined;
+
+    const schedule = () => {
+        timer = setTimeout(run, Math.min(intervalMs, deadline - Date.now()));
+        timer.unref();
+    };
+
+    const run = () => {
+        timer = undefined;
+        if (stopped || Date.now() >= deadline) {
+            return;
+        }
+        inFlight = changeVisibility(props)
+            .catch((err: unknown) => {
+                report(new Error('webhook dispatch consumer visibility extension failed', { cause: err }));
+            })
+            .finally(() => {
+                inFlight = undefined;
+                if (!stopped && Date.now() < deadline) {
+                    schedule();
+                }
+            });
+    };
+
+    schedule();
+
+    return async () => {
+        stopped = true;
+        if (timer) {
+            clearTimeout(timer);
+        }
+        await inFlight;
+    };
 }

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
@@ -14,7 +14,6 @@ interface VisibilityProps {
     visibilityTimeoutSeconds: number;
 }
 
-/** Jitter is additive so a deferral never lands before the delay it was asked for. */
 export function deferSeconds(delayMs: number, jitterRatio: number): number {
     const jittered = delayMs * (1 + Math.random() * jitterRatio);
     return Math.min(Math.max(1, Math.ceil(jittered / 1000)), SQS_MAX_VISIBILITY_SECONDS);
@@ -39,12 +38,13 @@ export async function changeVisibility({ sqs, queueUrl, receiptHandles, visibili
     }
 }
 
-/** Stopping waits for an in-flight update so it cannot overwrite a subsequent visibility change. */
+/** Keeps messages invisible while dispatch is in flight and returns an async stop function. */
 export function keepVisible(props: VisibilityProps & { maxExtensionMs: number }): () => Promise<void> {
     if (props.receiptHandles.length === 0 || props.visibilityTimeoutSeconds <= 0 || props.maxExtensionMs <= 0) {
         return () => Promise.resolve();
     }
 
+    // Extend visibility after the message consumes a third of its SQS timeout.
     const intervalMs = Math.max(100, Math.floor((props.visibilityTimeoutSeconds * 1000) / 3));
     const deadline = Date.now() + props.maxExtensionMs;
     let stopped = false;

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
@@ -23,7 +23,7 @@ export function deferSeconds(delayMs: number, jitterRatio: number): number {
 export async function changeVisibility({ sqs, queueUrl, receiptHandles, visibilityTimeoutSeconds }: VisibilityProps): Promise<void> {
     for (let i = 0; i < receiptHandles.length; i += SQS_BATCH_LIMIT) {
         const chunk = receiptHandles.slice(i, i + SQS_BATCH_LIMIT);
-        await sqs.send(
+        const response = await sqs.send(
             new ChangeMessageVisibilityBatchCommand({
                 QueueUrl: queueUrl,
                 Entries: chunk.map((receiptHandle, index) => ({
@@ -33,6 +33,9 @@ export async function changeVisibility({ sqs, queueUrl, receiptHandles, visibili
                 }))
             })
         );
+        if (response.Failed?.length) {
+            throw new Error('webhook dispatch visibility batch partially failed', { cause: response.Failed });
+        }
     }
 }
 
@@ -40,29 +43,46 @@ export async function changeVisibility({ sqs, queueUrl, receiptHandles, visibili
  * Holds messages invisible while a dispatch call is in flight, so a slow orchestrator
  * cannot let them return to the queue mid-call. Returns a function that stops it.
  */
-export function keepVisible(props: VisibilityProps & { maxExtensionMs: number }): () => void {
+export function keepVisible(props: VisibilityProps & { maxExtensionMs: number }): () => Promise<void> {
     if (props.receiptHandles.length === 0 || props.visibilityTimeoutSeconds <= 0 || props.maxExtensionMs <= 0) {
-        return () => undefined;
+        return () => Promise.resolve();
     }
 
-    const intervalMs = Math.max(1000, Math.floor((props.visibilityTimeoutSeconds * 1000) / 3));
+    const intervalMs = Math.max(100, Math.floor((props.visibilityTimeoutSeconds * 1000) / 3));
     const deadline = Date.now() + props.maxExtensionMs;
-    let extending = false;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let inFlight: Promise<void> | undefined;
 
-    const timer = setInterval(() => {
-        if (extending || Date.now() >= deadline) {
+    const schedule = () => {
+        timer = setTimeout(run, Math.min(intervalMs, deadline - Date.now()));
+        timer.unref();
+    };
+
+    const run = () => {
+        timer = undefined;
+        if (stopped || Date.now() >= deadline) {
             return;
         }
-        extending = true;
-        changeVisibility(props)
+        inFlight = changeVisibility(props)
             .catch((err: unknown) => {
                 report(new Error('webhook dispatch consumer visibility extension failed', { cause: err }));
             })
             .finally(() => {
-                extending = false;
+                inFlight = undefined;
+                if (!stopped && Date.now() < deadline) {
+                    schedule();
+                }
             });
-    }, intervalMs);
-    timer.unref();
+    };
 
-    return () => clearInterval(timer);
+    schedule();
+
+    return async () => {
+        stopped = true;
+        if (timer) {
+            clearTimeout(timer);
+        }
+        await inFlight;
+    };
 }

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
@@ -1,0 +1,68 @@
+import { ChangeMessageVisibilityBatchCommand } from '@aws-sdk/client-sqs';
+
+import { report } from '@nangohq/utils';
+
+import type { SQSClient } from '@aws-sdk/client-sqs';
+
+const SQS_BATCH_LIMIT = 10;
+const SQS_MAX_VISIBILITY_SECONDS = 43_200;
+
+interface VisibilityProps {
+    sqs: SQSClient;
+    queueUrl: string;
+    receiptHandles: string[];
+    visibilityTimeoutSeconds: number;
+}
+
+/** Jitter is additive so a deferral never lands before the delay it was asked for. */
+export function deferSeconds(delayMs: number, jitterRatio: number): number {
+    const jittered = delayMs * (1 + Math.random() * jitterRatio);
+    return Math.min(Math.max(1, Math.ceil(jittered / 1000)), SQS_MAX_VISIBILITY_SECONDS);
+}
+
+export async function changeVisibility({ sqs, queueUrl, receiptHandles, visibilityTimeoutSeconds }: VisibilityProps): Promise<void> {
+    for (let i = 0; i < receiptHandles.length; i += SQS_BATCH_LIMIT) {
+        const chunk = receiptHandles.slice(i, i + SQS_BATCH_LIMIT);
+        await sqs.send(
+            new ChangeMessageVisibilityBatchCommand({
+                QueueUrl: queueUrl,
+                Entries: chunk.map((receiptHandle, index) => ({
+                    Id: String(i + index),
+                    ReceiptHandle: receiptHandle,
+                    VisibilityTimeout: visibilityTimeoutSeconds
+                }))
+            })
+        );
+    }
+}
+
+/**
+ * Holds messages invisible while a dispatch call is in flight, so a slow orchestrator
+ * cannot let them return to the queue mid-call. Returns a function that stops it.
+ */
+export function keepVisible(props: VisibilityProps & { maxExtensionMs: number }): () => void {
+    if (props.receiptHandles.length === 0 || props.visibilityTimeoutSeconds <= 0 || props.maxExtensionMs <= 0) {
+        return () => undefined;
+    }
+
+    const intervalMs = Math.max(1000, Math.floor((props.visibilityTimeoutSeconds * 1000) / 3));
+    const deadline = Date.now() + props.maxExtensionMs;
+    let extending = false;
+
+    const timer = setInterval(() => {
+        if (extending || Date.now() >= deadline) {
+            return;
+        }
+        extending = true;
+        changeVisibility(props)
+            .catch((err: unknown) => {
+                report(new Error('webhook dispatch consumer visibility extension failed', { cause: err }));
+            })
+            .finally(() => {
+                extending = false;
+            });
+    }, intervalMs);
+    timer.unref();
+
+    return () => clearInterval(timer);
+}

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
@@ -1,7 +1,5 @@
 import { ChangeMessageVisibilityBatchCommand } from '@aws-sdk/client-sqs';
 
-import { report } from '@nangohq/utils';
-
 import type { SQSClient } from '@aws-sdk/client-sqs';
 
 const SQS_BATCH_LIMIT = 10;
@@ -36,50 +34,4 @@ export async function changeVisibility({ sqs, queueUrl, receiptHandles, visibili
             throw new Error('webhook dispatch visibility batch partially failed', { cause: response.Failed });
         }
     }
-}
-
-/** Keeps messages invisible while dispatch is in flight and returns an async stop function. */
-export function keepVisible(props: VisibilityProps & { maxExtensionMs: number }): () => Promise<void> {
-    if (props.receiptHandles.length === 0 || props.visibilityTimeoutSeconds <= 0 || props.maxExtensionMs <= 0) {
-        return () => Promise.resolve();
-    }
-
-    // Extend visibility after the message consumes a third of its SQS timeout.
-    const intervalMs = Math.max(100, Math.floor((props.visibilityTimeoutSeconds * 1000) / 3));
-    const deadline = Date.now() + props.maxExtensionMs;
-    let stopped = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    let inFlight: Promise<void> | undefined;
-
-    const schedule = () => {
-        timer = setTimeout(run, Math.min(intervalMs, deadline - Date.now()));
-        timer.unref();
-    };
-
-    const run = () => {
-        timer = undefined;
-        if (stopped || Date.now() >= deadline) {
-            return;
-        }
-        inFlight = changeVisibility(props)
-            .catch((err: unknown) => {
-                report(new Error('webhook dispatch consumer visibility extension failed', { cause: err }));
-            })
-            .finally(() => {
-                inFlight = undefined;
-                if (!stopped && Date.now() < deadline) {
-                    schedule();
-                }
-            });
-    };
-
-    schedule();
-
-    return async () => {
-        stopped = true;
-        if (timer) {
-            clearTimeout(timer);
-        }
-        await inFlight;
-    };
 }

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.ts
@@ -39,10 +39,7 @@ export async function changeVisibility({ sqs, queueUrl, receiptHandles, visibili
     }
 }
 
-/**
- * Holds messages invisible while a dispatch call is in flight, so a slow orchestrator
- * cannot let them return to the queue mid-call. Returns a function that stops it.
- */
+/** Stopping waits for an in-flight update so it cannot overwrite a subsequent visibility change. */
 export function keepVisible(props: VisibilityProps & { maxExtensionMs: number }): () => Promise<void> {
     if (props.receiptHandles.length === 0 || props.visibilityTimeoutSeconds <= 0 || props.maxExtensionMs <= 0) {
         return () => Promise.resolve();

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.unit.test.ts
@@ -1,17 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { changeVisibility, deferSeconds, keepVisible } from './visibility.js';
+import { changeVisibility, deferSeconds } from './visibility.js';
 
 import type { ChangeMessageVisibilityBatchCommand, SQSClient } from '@aws-sdk/client-sqs';
 import type { Mock } from 'vitest';
-
-function deferred<T>() {
-    let resolve!: (value: T | PromiseLike<T>) => void;
-    const promise = new Promise<T>((res) => {
-        resolve = res;
-    });
-    return { promise, resolve };
-}
 
 function makeSqs(): { sqs: SQSClient; send: Mock<(command: unknown) => Promise<unknown>> } {
     const send = vi.fn<(command: unknown) => Promise<unknown>>().mockResolvedValue({});
@@ -87,101 +79,5 @@ describe('changeVisibility', () => {
         await expect(changeVisibility({ sqs, queueUrl: 'http://queue', receiptHandles: ['a'], visibilityTimeoutSeconds: 30 })).rejects.toThrow(
             'webhook dispatch visibility batch partially failed'
         );
-    });
-});
-
-describe('keepVisible', () => {
-    beforeEach(() => {
-        vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-        vi.useRealTimers();
-    });
-
-    const props = (sqs: SQSClient) => ({
-        sqs,
-        queueUrl: 'http://queue',
-        receiptHandles: ['a'],
-        visibilityTimeoutSeconds: 30,
-        maxExtensionMs: 300_000
-    });
-
-    it('extends on a third of the visibility window', async () => {
-        const { sqs, send } = makeSqs();
-        const stop = keepVisible(props(sqs));
-
-        await vi.advanceTimersByTimeAsync(9_999);
-        expect(send).not.toHaveBeenCalled();
-
-        await vi.advanceTimersByTimeAsync(1);
-        expect(send).toHaveBeenCalledTimes(1);
-
-        await vi.advanceTimersByTimeAsync(10_000);
-        expect(send).toHaveBeenCalledTimes(2);
-        await stop();
-    });
-
-    it('stops extending once stopped', async () => {
-        const { sqs, send } = makeSqs();
-        const stop = keepVisible(props(sqs));
-
-        await vi.advanceTimersByTimeAsync(10_000);
-        await stop();
-        await vi.advanceTimersByTimeAsync(60_000);
-
-        expect(send).toHaveBeenCalledTimes(1);
-    });
-
-    it('gives up after the maximum extension so a hung call cannot hold a message forever', async () => {
-        const { sqs, send } = makeSqs();
-        const stop = keepVisible({ ...props(sqs), maxExtensionMs: 25_000 });
-
-        await vi.advanceTimersByTimeAsync(20_000);
-        expect(send).toHaveBeenCalledTimes(2);
-
-        await vi.advanceTimersByTimeAsync(60_000);
-        expect(send).toHaveBeenCalledTimes(2);
-        expect(vi.getTimerCount()).toBe(0);
-        await stop();
-    });
-
-    it('is a no-op when there is nothing to keep visible', async () => {
-        const { sqs, send } = makeSqs();
-        keepVisible({ ...props(sqs), receiptHandles: [] });
-
-        await vi.advanceTimersByTimeAsync(60_000);
-        expect(send).not.toHaveBeenCalled();
-    });
-
-    it('extends before a one-second visibility timeout expires', async () => {
-        const { sqs, send } = makeSqs();
-        const stop = keepVisible({ ...props(sqs), visibilityTimeoutSeconds: 1 });
-
-        await vi.advanceTimersByTimeAsync(332);
-        expect(send).not.toHaveBeenCalled();
-
-        await vi.advanceTimersByTimeAsync(1);
-        expect(send).toHaveBeenCalledTimes(1);
-        await stop();
-    });
-
-    it('waits for an in-flight extension when stopped', async () => {
-        const { sqs, send } = makeSqs();
-        const extension = deferred<Record<string, never>>();
-        send.mockReturnValueOnce(extension.promise);
-        const stop = keepVisible(props(sqs));
-
-        await vi.advanceTimersByTimeAsync(10_000);
-        let stopped = false;
-        const stopPromise = stop().then(() => {
-            stopped = true;
-        });
-        await Promise.resolve();
-        expect(stopped).toBe(false);
-
-        extension.resolve({});
-        await stopPromise;
-        expect(stopped).toBe(true);
     });
 });

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.unit.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { changeVisibility, deferSeconds, keepVisible } from './visibility.js';
+
+import type { ChangeMessageVisibilityBatchCommand, SQSClient } from '@aws-sdk/client-sqs';
+import type { Mock } from 'vitest';
+
+function makeSqs(): { sqs: SQSClient; send: Mock<(command: unknown) => Promise<unknown>> } {
+    const send = vi.fn<(command: unknown) => Promise<unknown>>().mockResolvedValue({});
+    return { sqs: { send } as unknown as SQSClient, send };
+}
+
+function entriesOf(send: Mock<(command: unknown) => Promise<unknown>>) {
+    return send.mock.calls.map((c) => (c[0] as ChangeMessageVisibilityBatchCommand).input.Entries);
+}
+
+describe('deferSeconds', () => {
+    it('rounds up to whole seconds', () => {
+        expect(deferSeconds(30_000, 0)).toBe(30);
+        expect(deferSeconds(1_001, 0)).toBe(2);
+    });
+
+    it('never returns less than one second', () => {
+        expect(deferSeconds(0, 0)).toBe(1);
+        expect(deferSeconds(10, 0)).toBe(1);
+    });
+
+    it('only ever jitters upward, so a deferral never lands early', () => {
+        for (let i = 0; i < 100; i++) {
+            const seconds = deferSeconds(30_000, 0.2);
+            expect(seconds).toBeGreaterThanOrEqual(30);
+            expect(seconds).toBeLessThanOrEqual(36);
+        }
+    });
+
+    it('clamps to the SQS maximum', () => {
+        expect(deferSeconds(99_999_999, 0)).toBe(43_200);
+    });
+});
+
+describe('changeVisibility', () => {
+    it('sends one entry per receipt handle', async () => {
+        const { sqs, send } = makeSqs();
+        await changeVisibility({ sqs, queueUrl: 'http://queue', receiptHandles: ['a', 'b'], visibilityTimeoutSeconds: 30 });
+
+        expect(entriesOf(send)).toEqual([
+            [
+                { Id: '0', ReceiptHandle: 'a', VisibilityTimeout: 30 },
+                { Id: '1', ReceiptHandle: 'b', VisibilityTimeout: 30 }
+            ]
+        ]);
+    });
+
+    it('splits into chunks of ten, which is the SQS batch limit', async () => {
+        const { sqs, send } = makeSqs();
+        const receiptHandles = Array.from({ length: 12 }, (_, i) => `rh-${i}`);
+        await changeVisibility({ sqs, queueUrl: 'http://queue', receiptHandles, visibilityTimeoutSeconds: 5 });
+
+        const batches = entriesOf(send);
+        expect(batches).toHaveLength(2);
+        expect(batches[0]).toHaveLength(10);
+        expect(batches[1]).toEqual([
+            { Id: '10', ReceiptHandle: 'rh-10', VisibilityTimeout: 5 },
+            { Id: '11', ReceiptHandle: 'rh-11', VisibilityTimeout: 5 }
+        ]);
+    });
+
+    it('does nothing without receipt handles', async () => {
+        const { sqs, send } = makeSqs();
+        await changeVisibility({ sqs, queueUrl: 'http://queue', receiptHandles: [], visibilityTimeoutSeconds: 30 });
+
+        expect(send).not.toHaveBeenCalled();
+    });
+});
+
+describe('keepVisible', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const props = (sqs: SQSClient) => ({
+        sqs,
+        queueUrl: 'http://queue',
+        receiptHandles: ['a'],
+        visibilityTimeoutSeconds: 30,
+        maxExtensionMs: 300_000
+    });
+
+    it('extends on a third of the visibility window', async () => {
+        const { sqs, send } = makeSqs();
+        const stop = keepVisible(props(sqs));
+
+        await vi.advanceTimersByTimeAsync(9_999);
+        expect(send).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(send).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(send).toHaveBeenCalledTimes(2);
+        stop();
+    });
+
+    it('stops extending once stopped', async () => {
+        const { sqs, send } = makeSqs();
+        const stop = keepVisible(props(sqs));
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        stop();
+        await vi.advanceTimersByTimeAsync(60_000);
+
+        expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up after the maximum extension so a hung call cannot hold a message forever', async () => {
+        const { sqs, send } = makeSqs();
+        const stop = keepVisible({ ...props(sqs), maxExtensionMs: 25_000 });
+
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(send).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(send).toHaveBeenCalledTimes(2);
+        stop();
+    });
+
+    it('is a no-op when there is nothing to keep visible', async () => {
+        const { sqs, send } = makeSqs();
+        keepVisible({ ...props(sqs), receiptHandles: [] });
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(send).not.toHaveBeenCalled();
+    });
+});

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.unit.test.ts
@@ -5,6 +5,14 @@ import { changeVisibility, deferSeconds, keepVisible } from './visibility.js';
 import type { ChangeMessageVisibilityBatchCommand, SQSClient } from '@aws-sdk/client-sqs';
 import type { Mock } from 'vitest';
 
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
 function makeSqs(): { sqs: SQSClient; send: Mock<(command: unknown) => Promise<unknown>> } {
     const send = vi.fn<(command: unknown) => Promise<unknown>>().mockResolvedValue({});
     return { sqs: { send } as unknown as SQSClient, send };
@@ -71,6 +79,15 @@ describe('changeVisibility', () => {
 
         expect(send).not.toHaveBeenCalled();
     });
+
+    it('rejects per-entry failures returned by SQS', async () => {
+        const { sqs, send } = makeSqs();
+        send.mockResolvedValueOnce({ Failed: [{ Id: '0', Code: 'ReceiptHandleIsInvalid', Message: 'invalid handle' }] });
+
+        await expect(changeVisibility({ sqs, queueUrl: 'http://queue', receiptHandles: ['a'], visibilityTimeoutSeconds: 30 })).rejects.toThrow(
+            'webhook dispatch visibility batch partially failed'
+        );
+    });
 });
 
 describe('keepVisible', () => {
@@ -102,7 +119,7 @@ describe('keepVisible', () => {
 
         await vi.advanceTimersByTimeAsync(10_000);
         expect(send).toHaveBeenCalledTimes(2);
-        stop();
+        await stop();
     });
 
     it('stops extending once stopped', async () => {
@@ -110,7 +127,7 @@ describe('keepVisible', () => {
         const stop = keepVisible(props(sqs));
 
         await vi.advanceTimersByTimeAsync(10_000);
-        stop();
+        await stop();
         await vi.advanceTimersByTimeAsync(60_000);
 
         expect(send).toHaveBeenCalledTimes(1);
@@ -125,7 +142,8 @@ describe('keepVisible', () => {
 
         await vi.advanceTimersByTimeAsync(60_000);
         expect(send).toHaveBeenCalledTimes(2);
-        stop();
+        expect(vi.getTimerCount()).toBe(0);
+        await stop();
     });
 
     it('is a no-op when there is nothing to keep visible', async () => {
@@ -134,5 +152,36 @@ describe('keepVisible', () => {
 
         await vi.advanceTimersByTimeAsync(60_000);
         expect(send).not.toHaveBeenCalled();
+    });
+
+    it('extends before a one-second visibility timeout expires', async () => {
+        const { sqs, send } = makeSqs();
+        const stop = keepVisible({ ...props(sqs), visibilityTimeoutSeconds: 1 });
+
+        await vi.advanceTimersByTimeAsync(332);
+        expect(send).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(send).toHaveBeenCalledTimes(1);
+        await stop();
+    });
+
+    it('waits for an in-flight extension when stopped', async () => {
+        const { sqs, send } = makeSqs();
+        const extension = deferred<undefined>();
+        send.mockReturnValueOnce(extension.promise);
+        const stop = keepVisible(props(sqs));
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        let stopped = false;
+        const stopPromise = stop().then(() => {
+            stopped = true;
+        });
+        await Promise.resolve();
+        expect(stopped).toBe(false);
+
+        extension.resolve(undefined);
+        await stopPromise;
+        expect(stopped).toBe(true);
     });
 });

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.unit.test.ts
@@ -168,7 +168,7 @@ describe('keepVisible', () => {
 
     it('waits for an in-flight extension when stopped', async () => {
         const { sqs, send } = makeSqs();
-        const extension = deferred<undefined>();
+        const extension = deferred<Record<string, never>>();
         send.mockReturnValueOnce(extension.promise);
         const stop = keepVisible(props(sqs));
 
@@ -180,7 +180,7 @@ describe('keepVisible', () => {
         await Promise.resolve();
         expect(stopped).toBe(false);
 
-        extension.resolve(undefined);
+        extension.resolve({});
         await stopPromise;
         expect(stopped).toBe(true);
     });

--- a/packages/jobs/lib/webhook/dispatch-queue/visibility.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/visibility.unit.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { changeVisibility, deferSeconds } from './visibility.js';
+import { changeVisibility, deferSeconds, keepVisible } from './visibility.js';
 
 import type { ChangeMessageVisibilityBatchCommand, SQSClient } from '@aws-sdk/client-sqs';
 import type { Mock } from 'vitest';
+
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
 
 function makeSqs(): { sqs: SQSClient; send: Mock<(command: unknown) => Promise<unknown>> } {
     const send = vi.fn<(command: unknown) => Promise<unknown>>().mockResolvedValue({});
@@ -79,5 +87,101 @@ describe('changeVisibility', () => {
         await expect(changeVisibility({ sqs, queueUrl: 'http://queue', receiptHandles: ['a'], visibilityTimeoutSeconds: 30 })).rejects.toThrow(
             'webhook dispatch visibility batch partially failed'
         );
+    });
+});
+
+describe('keepVisible', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const props = (sqs: SQSClient) => ({
+        sqs,
+        queueUrl: 'http://queue',
+        receiptHandles: ['a'],
+        visibilityTimeoutSeconds: 30,
+        maxExtensionMs: 300_000
+    });
+
+    it('extends on a third of the visibility window', async () => {
+        const { sqs, send } = makeSqs();
+        const stop = keepVisible(props(sqs));
+
+        await vi.advanceTimersByTimeAsync(9_999);
+        expect(send).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(send).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(send).toHaveBeenCalledTimes(2);
+        await stop();
+    });
+
+    it('stops extending once stopped', async () => {
+        const { sqs, send } = makeSqs();
+        const stop = keepVisible(props(sqs));
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        await stop();
+        await vi.advanceTimersByTimeAsync(60_000);
+
+        expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up after the maximum extension so a hung call cannot hold a message forever', async () => {
+        const { sqs, send } = makeSqs();
+        const stop = keepVisible({ ...props(sqs), maxExtensionMs: 25_000 });
+
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(send).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(vi.getTimerCount()).toBe(0);
+        await stop();
+    });
+
+    it('is a no-op when there is nothing to keep visible', async () => {
+        const { sqs, send } = makeSqs();
+        keepVisible({ ...props(sqs), receiptHandles: [] });
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(send).not.toHaveBeenCalled();
+    });
+
+    it('extends before a one-second visibility timeout expires', async () => {
+        const { sqs, send } = makeSqs();
+        const stop = keepVisible({ ...props(sqs), visibilityTimeoutSeconds: 1 });
+
+        await vi.advanceTimersByTimeAsync(332);
+        expect(send).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(send).toHaveBeenCalledTimes(1);
+        await stop();
+    });
+
+    it('waits for an in-flight extension when stopped', async () => {
+        const { sqs, send } = makeSqs();
+        const extension = deferred<Record<string, never>>();
+        send.mockReturnValueOnce(extension.promise);
+        const stop = keepVisible(props(sqs));
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        let stopped = false;
+        const stopPromise = stop().then(() => {
+            stopped = true;
+        });
+        await Promise.resolve();
+        expect(stopped).toBe(false);
+
+        extension.resolve({});
+        await stopPromise;
+        expect(stopped).toBe(true);
     });
 });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -920,7 +920,6 @@ const ENVS_SHAPE = z.object({
     NANGO_TASK_DISPATCH_RATE_LIMIT_COOLDOWN_MAX_MS: z.coerce.number().min(0).optional().default(60_000),
     NANGO_TASK_DISPATCH_DEFER_JITTER_RATIO: z.coerce.number().min(0).max(1).optional().default(0.2),
     NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS: z.coerce.number().min(0).optional().default(15_000),
-    NANGO_TASK_DISPATCH_MAX_VISIBILITY_EXTENSION_MS: z.coerce.number().min(0).optional().default(300_000),
 
     // Sandboxes
     SANDBOX_PROVIDER: z.enum(['e2b', 'docker', 'agentcore']).optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -919,7 +919,7 @@ const ENVS_SHAPE = z.object({
     NANGO_TASK_DISPATCH_MAX_AGE_SECONDS: z.coerce.number().min(0).optional().default(7200),
     NANGO_TASK_DISPATCH_RATE_LIMIT_COOLDOWN_MAX_MS: z.coerce.number().min(0).optional().default(60_000),
     NANGO_TASK_DISPATCH_DEFER_JITTER_RATIO: z.coerce.number().min(0).max(1).optional().default(0.2),
-    NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS: z.coerce.number().min(0).optional().default(30_000),
+    NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS: z.coerce.number().min(0).optional().default(15_000),
     NANGO_TASK_DISPATCH_MAX_VISIBILITY_EXTENSION_MS: z.coerce.number().min(0).optional().default(300_000),
 
     // Sandboxes

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -920,6 +920,7 @@ const ENVS_SHAPE = z.object({
     NANGO_TASK_DISPATCH_RATE_LIMIT_COOLDOWN_MAX_MS: z.coerce.number().min(0).optional().default(60_000),
     NANGO_TASK_DISPATCH_DEFER_JITTER_RATIO: z.coerce.number().min(0).max(1).optional().default(0.2),
     NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS: z.coerce.number().min(0).optional().default(15_000),
+    NANGO_TASK_DISPATCH_MAX_VISIBILITY_EXTENSION_MS: z.coerce.number().min(0).optional().default(300_000),
 
     // Sandboxes
     SANDBOX_PROVIDER: z.enum(['e2b', 'docker', 'agentcore']).optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -917,6 +917,7 @@ const ENVS_SHAPE = z.object({
     NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: z.coerce.number().min(1).max(10).optional().default(10),
     NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: z.coerce.number().min(1).optional().default(10),
     NANGO_TASK_DISPATCH_MAX_AGE_SECONDS: z.coerce.number().min(0).optional().default(7200),
+    NANGO_TASK_DISPATCH_RATE_LIMIT_COOLDOWN_MAX_MS: z.coerce.number().min(0).optional().default(60_000),
 
     // Sandboxes
     SANDBOX_PROVIDER: z.enum(['e2b', 'docker', 'agentcore']).optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -918,6 +918,9 @@ const ENVS_SHAPE = z.object({
     NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: z.coerce.number().min(1).optional().default(10),
     NANGO_TASK_DISPATCH_MAX_AGE_SECONDS: z.coerce.number().min(0).optional().default(7200),
     NANGO_TASK_DISPATCH_RATE_LIMIT_COOLDOWN_MAX_MS: z.coerce.number().min(0).optional().default(60_000),
+    NANGO_TASK_DISPATCH_DEFER_JITTER_RATIO: z.coerce.number().min(0).max(1).optional().default(0.2),
+    NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS: z.coerce.number().min(0).optional().default(30_000),
+    NANGO_TASK_DISPATCH_MAX_VISIBILITY_EXTENSION_MS: z.coerce.number().min(0).optional().default(300_000),
 
     // Sandboxes
     SANDBOX_PROVIDER: z.enum(['e2b', 'docker', 'agentcore']).optional(),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -599,7 +599,8 @@ describe('parse', () => {
                 NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS: 30,
                 NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY: 5,
                 NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: 10,
-                NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: 10
+                NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: 10,
+                NANGO_TASK_DISPATCH_TASK_CAP_DEFER_MS: 15_000
             });
             expect(res.NANGO_TASK_DISPATCH_QUEUE_URL).toBeUndefined();
             expect(res.NANGO_TASK_DISPATCH_DLQ_URL).toBeUndefined();

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -87,9 +87,9 @@ export enum Types {
     WEBHOOK_DISPATCH_PUBLISH_FAILURE = 'nango.webhook.dispatch_queue.publish.failure',
     WEBHOOK_DISPATCH_BYPASS_OVERSIZE = 'nango.webhook.dispatch_queue.bypass_oversize',
     WEBHOOK_DISPATCH_LARGE_FANOUT = 'nango.webhook.dispatch_queue.large_fanout',
-    // Consume outcome, tagged result=success|failure|rate_limited|cooling_down.
+    // Consume outcome, tagged result=success|failure|rate_limited|cooling_down|task_cap_deferred.
     WEBHOOK_DISPATCH_CONSUME = 'nango.webhook.dispatch_queue.consume',
-    // Messages dropped without being scheduled, tagged reason=poison_pill|stale|task_cap.
+    // Messages dropped without being scheduled, tagged reason=poison_pill|stale.
     WEBHOOK_DISPATCH_DROPPED = 'nango.webhook.dispatch_queue.dropped',
     WEBHOOK_DISPATCH_DWELL_MS = 'nango.webhook.dispatch_queue.dwell_ms',
     WEBHOOK_DISPATCH_BATCH_SIZE = 'nango.webhook.dispatch_queue.batch_size',

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -87,12 +87,13 @@ export enum Types {
     WEBHOOK_DISPATCH_PUBLISH_FAILURE = 'nango.webhook.dispatch_queue.publish.failure',
     WEBHOOK_DISPATCH_BYPASS_OVERSIZE = 'nango.webhook.dispatch_queue.bypass_oversize',
     WEBHOOK_DISPATCH_LARGE_FANOUT = 'nango.webhook.dispatch_queue.large_fanout',
-    // Consume outcome, tagged result=success|failure.
+    // Consume outcome, tagged result=success|failure|rate_limited|cooling_down.
     WEBHOOK_DISPATCH_CONSUME = 'nango.webhook.dispatch_queue.consume',
     // Messages dropped without being scheduled, tagged reason=poison_pill|stale|task_cap.
     WEBHOOK_DISPATCH_DROPPED = 'nango.webhook.dispatch_queue.dropped',
     WEBHOOK_DISPATCH_DWELL_MS = 'nango.webhook.dispatch_queue.dwell_ms',
     WEBHOOK_DISPATCH_BATCH_SIZE = 'nango.webhook.dispatch_queue.batch_size',
+    WEBHOOK_DISPATCH_COOLDOWN_MS = 'nango.webhook.dispatch_queue.cooldown_ms',
 
     ORCH_TASKS_CREATED = 'nango.orch.tasks.created',
     ORCH_TASKS_DROPPED = 'nango.orch.tasks.dropped',


### PR DESCRIPTION
Stacked on #7334; review and merge that PR first.

A webhook dispatch message can become visible again when an orchestrator batch call runs longer than the SQS visibility timeout. This adds a bounded heartbeat that refreshes visibility while the orchestrator call is in flight.

- refreshes visibility after one third of the configured visibility window
- stops after `NANGO_TASK_DISPATCH_MAX_VISIBILITY_EXTENSION_MS` (default: 5 minutes)
- waits for an in-flight visibility update before processing the orchestrator result
- reports heartbeat failures and falls back to normal SQS redelivery

The heartbeat is isolated here so #7334 remains focused on deferring saturated groups.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

