### PR TITLE
feat(integrations): add Discogs OAuth1 and personal token providers

### DIFF
--- a/docs/api-catalog.txt
+++ b/docs/api-catalog.txt
@@ -2,7 +2,7 @@
 
 > Compact provider slug catalog for agents. Use the slug to reconstruct provider-specific docs URLs only when needed.
 
-Provider count: 987
+Provider count: 989
 
 URL patterns:
 - Main provider page: https://nango.dev/docs/integrations/all/{slug}.md or https://nango.dev/docs/api-integrations/{slug}.md
@@ -243,6 +243,8 @@ URL patterns:
 | `digitalocean` | DigitalOcean | OAUTH2 | [docs](https://nango.dev/docs/integrations/all/digitalocean.md) |  |  | dev-tools |
 | `digits` | Digits | OAUTH2 | [docs](https://nango.dev/docs/api-integrations/digits.md) |  | [setup](https://nango.dev/docs/api-integrations/digits/how-to-register-your-own-digits-api-oauth-app.md) | accounting |
 | `digits-mcp` | Digits (MCP) | MCP_OAUTH2 | [docs](https://nango.dev/docs/api-integrations/digits-mcp.md) |  |  | accounting, mcp |
+| `discogs` | Discogs | OAUTH1 | [docs](https://nango.dev/docs/integrations/all/discogs.md) | [connect](https://nango.dev/docs/integrations/all/discogs/connect.md) | [setup](https://nango.dev/docs/integrations/all/discogs/how-to-register-your-own-discogs-api-oauth-app.md) | e-commerce, other |
+| `discogs-token` | Discogs (Personal Access Token) | API_KEY | [docs](https://nango.dev/docs/integrations/all/discogs-token.md) | [connect](https://nango.dev/docs/integrations/all/discogs-token/connect.md) |  | e-commerce, other |
 | `discolike` | DiscoLike | API_KEY | [docs](https://nango.dev/docs/api-integrations/discolike.md) | [connect](https://nango.dev/docs/api-integrations/discolike/connect.md) |  | marketing |
 | `discord` | Discord | OAUTH2 | [docs](https://nango.dev/docs/api-integrations/discord.md) |  | [setup](https://nango.dev/docs/api-integrations/discord/how-to-register-your-own-discord-api-oauth-app.md) | gaming, social |
 | `discourse` | Discourse | API_KEY | [docs](https://nango.dev/docs/integrations/all/discourse.md) |  |  | communication |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1184,6 +1184,8 @@
               "integrations/all/digitalocean",
               "api-integrations/digits",
               "api-integrations/digits-mcp",
+              "integrations/all/discogs",
+              "integrations/all/discogs-token",
               "api-integrations/discolike",
               "api-integrations/discord",
               "integrations/all/discourse",

--- a/docs/integrations/all/discogs-token.mdx
+++ b/docs/integrations/all/discogs-token.mdx
@@ -1,0 +1,57 @@
+---
+title: Discogs (Personal Access Token)
+sidebarTitle: Discogs (Personal Access Token)
+---
+
+import Overview from "/snippets/overview.mdx"
+import PreBuiltTooling from "/snippets/generated/discogs-token/PreBuiltTooling.mdx"
+import PreBuiltUseCases from "/snippets/generated/discogs-token/PreBuiltUseCases.mdx"
+
+<Overview />
+<PreBuiltTooling />
+<PreBuiltUseCases />
+
+## Access requirements
+| Pre-Requisites | Status | Comment|
+| - | - | - |
+| Paid dev account | ✅ Not required | Free Discogs account required. |
+| Paid test account | ✅ Not required | Use your own Discogs account for testing. |
+| Partnership | ✅ Not required | |
+| App review | ✅ Not required | |
+| Security audit | ✅ Not required | |
+
+
+## Setup guide
+
+_No setup guide yet._
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+<Note>Contribute improvements to the setup guide by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/discogs-token.mdx)</Note>
+
+
+## Useful links
+
+| Topic | Links |
+| - | - |
+| General | [Discogs website](https://www.discogs.com/) |
+| Developer | [Discogs API documentation](https://www.discogs.com/developers) |
+| | [Authentication](https://www.discogs.com/developers/#page:authentication,header:authentication-discogs-auth-flow) |
+| | [Developer settings](https://www.discogs.com/settings/developers) |
+
+<Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/discogs-token.mdx)</Note>
+
+## API gotchas
+
+- Discogs **requires a unique `User-Agent` header** on every API request. Nango sets this automatically for proxy requests.
+- Personal access tokens are sent as `Authorization: Discogs token=<token>`.
+- Personal access tokens are tied to your Discogs user account and are best suited for scripts or single-user integrations.
+- For multi-user integrations, use [Discogs OAuth](/integrations/all/discogs) instead.
+
+<Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/discogs-token.mdx)</Note>
+
+## Going further
+
+<Card title="Connect to Discogs (Personal Access Token)" icon="link" href="/integrations/all/discogs-token/connect" horizontal>
+  Guide to connect to Discogs (Personal Access Token) using Connect UI
+</Card>

--- a/docs/integrations/all/discogs-token/connect.mdx
+++ b/docs/integrations/all/discogs-token/connect.mdx
@@ -1,0 +1,34 @@
+---
+title: Discogs (Personal Access Token) - How do I link my account?
+sidebarTitle: Discogs (Personal Access Token)
+---
+
+## Overview
+
+To authenticate with Discogs (Personal Access Token), you need:
+1. **Personal Access Token** - A token that grants Nango permission to interact with the Discogs API on your behalf.
+
+This guide walks you through generating your **Personal Access Token** in Discogs.
+
+### Prerequisites
+
+- You must have a registered Discogs account.
+
+### Instructions
+
+#### Step 1: Generating your Personal Access Token
+
+1. Log in to your [Discogs](https://www.discogs.com/) account.
+2. Go to [Developer settings](https://www.discogs.com/settings/developers).
+3. Under **Personal Access Tokens**, click **Generate new token**.
+4. Enter a name for the token and generate it.
+5. Copy the token immediately. Discogs may not show it again.
+
+#### Step 2: Enter credentials in the Connect UI
+
+Once you have your **Personal Access Token**:
+1. Open the form where you need to authenticate with Discogs (Personal Access Token).
+2. Enter your **Personal Access Token** in the designated field.
+3. Submit the form, and you should be successfully authenticated.
+
+You are now connected to Discogs (Personal Access Token).

--- a/docs/integrations/all/discogs.mdx
+++ b/docs/integrations/all/discogs.mdx
@@ -1,0 +1,57 @@
+---
+title: Discogs
+sidebarTitle: Discogs
+---
+
+import Overview from "/snippets/overview.mdx"
+import PreBuiltTooling from "/snippets/generated/discogs/PreBuiltTooling.mdx"
+import PreBuiltUseCases from "/snippets/generated/discogs/PreBuiltUseCases.mdx"
+
+<Overview />
+<PreBuiltTooling />
+<PreBuiltUseCases />
+
+## Access requirements
+| Pre-Requisites | Status | Comment|
+| - | - | - |
+| Paid dev account | ✅ Not required | Free Discogs account required to register a developer application. |
+| Paid test account | ✅ Not required | Use your own Discogs account for testing. |
+| Partnership | ✅ Not required | |
+| App review | ✅ Not required | |
+| Security audit | ✅ Not required | |
+
+
+## Setup guide
+
+Follow the [Discogs OAuth app registration guide](/integrations/all/discogs/how-to-register-your-own-discogs-api-oauth-app) to obtain your consumer key and consumer secret.
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+<Note>Contribute improvements to the setup guide by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/discogs.mdx)</Note>
+
+
+## Useful links
+
+| Topic | Links |
+| - | - |
+| General | [Discogs website](https://www.discogs.com/) |
+| Developer | [Discogs API documentation](https://www.discogs.com/developers) |
+| | [Authentication](https://www.discogs.com/developers/#page:authentication,header:authentication-discogs-auth-flow) |
+| | [Register a developer application](https://www.discogs.com/settings/developers) |
+
+<Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/discogs.mdx)</Note>
+
+## API gotchas
+
+- Discogs **requires a unique `User-Agent` header** on every API request. Nango sets this automatically for proxy requests.
+- Discogs OAuth 1.0a uses the **PLAINTEXT** signature method.
+- OAuth access tokens **do not expire** unless the user revokes access or you generate a new token for the same user.
+- For personal scripts or single-user integrations, consider [Discogs (Personal Access Token)](/integrations/all/discogs-token) instead of OAuth.
+
+<Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/discogs.mdx)</Note>
+
+## Going further
+
+<Card title="Connect to Discogs" icon="link" href="/integrations/all/discogs/connect" horizontal>
+  Guide to connect to Discogs using Connect UI
+</Card>

--- a/docs/integrations/all/discogs/connect.mdx
+++ b/docs/integrations/all/discogs/connect.mdx
@@ -1,0 +1,30 @@
+---
+title: Discogs - How do I link my account?
+sidebarTitle: Discogs
+---
+
+## Overview
+
+To authenticate with Discogs, your application uses **OAuth 1.0a**. End users authorize Nango to access their Discogs account.
+
+### Prerequisites
+
+- A Discogs developer application with consumer key and consumer secret configured in Nango.
+- See the [OAuth app registration guide](/integrations/all/discogs/how-to-register-your-own-discogs-api-oauth-app) if you have not registered an app yet.
+
+### Instructions
+
+#### Step 1: Configure the integration in Nango
+
+1. In Nango, create or open your **Discogs** integration.
+2. Enter your Discogs **Consumer Key** and **Consumer Secret** from the [developer settings](https://www.discogs.com/settings/developers) page.
+3. Save the integration.
+
+#### Step 2: Authorize in the Connect UI
+
+1. Open the form where you need to authenticate with Discogs.
+2. Click **Authorize** (or equivalent) to start the OAuth flow.
+3. Log in to Discogs if prompted and approve access for your application.
+4. After approval, you are redirected back and the connection is created.
+
+You are now connected to Discogs.

--- a/docs/integrations/all/discogs/how-to-register-your-own-discogs-api-oauth-app.mdx
+++ b/docs/integrations/all/discogs/how-to-register-your-own-discogs-api-oauth-app.mdx
@@ -1,0 +1,46 @@
+---
+title: How to register your own Discogs OAuth app
+sidebarTitle: Discogs Setup
+description: Register an OAuth app with Discogs and obtain credentials to connect it to Nango
+---
+
+This guide shows you how to register your own app with Discogs to obtain your OAuth credentials (consumer key and consumer secret). These are required to let your users grant your app access to their Discogs account.
+
+<Steps>
+  <Step title="Create a Discogs account">
+    If you do not already have one, sign up for a free account at [Discogs](https://www.discogs.com/).
+  </Step>
+  <Step title="Open developer settings">
+    Go to [Discogs Developer settings](https://www.discogs.com/settings/developers).
+  </Step>
+  <Step title="Create a new application">
+    1. Click **Create an app** (or **Add new application**).
+    2. Fill in the application name and description.
+    3. Set the callback URL to Nango's OAuth callback:
+
+    ```
+    https://api.nango.dev/oauth/callback
+    ```
+
+    <Tip>For local development, you can also add `http://localhost:3003/oauth/callback`.</Tip>
+  </Step>
+  <Step title="Copy your credentials">
+    After creating the application, copy your **Consumer Key** and **Consumer Secret**. You will enter these when configuring the Discogs integration in Nango.
+
+    <Warning>Keep your consumer secret secure and never share it publicly.</Warning>
+  </Step>
+  <Step title="Add credentials to Nango">
+    In Nango, go to your Discogs integration settings and add:
+    - **Consumer Key**
+    - **Consumer Secret**
+
+    Save your configuration.
+  </Step>
+  <Step title="Next">
+    Follow the [_Quickstart_](/getting-started/quickstart) to connect your first account.
+  </Step>
+</Steps>
+
+For more details, see the [Discogs authentication documentation](https://www.discogs.com/developers/#page:authentication,header:authentication-discogs-auth-flow).
+
+---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -15193,6 +15193,8 @@ Use these slugs to construct provider-specific docs URLs only when needed.
 | `digitalocean` | DigitalOcean | OAUTH2 | [docs](https://nango.dev/docs/integrations/all/digitalocean.md) |  |  | dev-tools |
 | `digits` | Digits | OAUTH2 | [docs](https://nango.dev/docs/api-integrations/digits.md) |  | [setup](https://nango.dev/docs/api-integrations/digits/how-to-register-your-own-digits-api-oauth-app.md) | accounting |
 | `digits-mcp` | Digits (MCP) | MCP_OAUTH2 | [docs](https://nango.dev/docs/api-integrations/digits-mcp.md) |  |  | accounting, mcp |
+| `discogs` | Discogs | OAUTH1 | [docs](https://nango.dev/docs/integrations/all/discogs.md) | [connect](https://nango.dev/docs/integrations/all/discogs/connect.md) | [setup](https://nango.dev/docs/integrations/all/discogs/how-to-register-your-own-discogs-api-oauth-app.md) | e-commerce, other |
+| `discogs-token` | Discogs (Personal Access Token) | API_KEY | [docs](https://nango.dev/docs/integrations/all/discogs-token.md) | [connect](https://nango.dev/docs/integrations/all/discogs-token/connect.md) |  | e-commerce, other |
 | `discolike` | DiscoLike | API_KEY | [docs](https://nango.dev/docs/api-integrations/discolike.md) | [connect](https://nango.dev/docs/api-integrations/discolike/connect.md) |  | marketing |
 | `discord` | Discord | OAUTH2 | [docs](https://nango.dev/docs/api-integrations/discord.md) |  | [setup](https://nango.dev/docs/api-integrations/discord/how-to-register-your-own-discord-api-oauth-app.md) | gaming, social |
 | `discourse` | Discourse | API_KEY | [docs](https://nango.dev/docs/integrations/all/discourse.md) |  |  | communication |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -147,7 +147,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 
 ## APIs and integrations
 
-- [API catalog](https://nango.dev/docs/api-catalog.txt): 987 provider slugs with canonical docs routes, auth modes, setup guides, and connect guides.
+- [API catalog](https://nango.dev/docs/api-catalog.txt): 989 provider slugs with canonical docs routes, auth modes, setup guides, and connect guides.
 - Provider-specific pages are intentionally not expanded here so core Nango guides remain easy for agents to find.
 
 ## Resources

--- a/docs/snippets/generated/discogs-token/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/discogs-token/PreBuiltTooling.mdx
@@ -1,0 +1,40 @@
+## Pre-built tooling
+<AccordionGroup>
+<Accordion title="✅ Authorization">
+| Tools | Status |
+| - | - |
+| Pre-built authorization (API Key) | ✅ |
+| Pre-built authorization UI | ✅ |
+| Custom authorization UI | ✅ |
+| End-user authorization guide | ✅ |
+| Expired credentials detection | ✅ |
+</Accordion>
+<Accordion title="✅ Read & write data">
+| Tools | Status |
+| - | - |
+| Pre-built integrations | 🚫 (time to contribute: &lt;48h) |
+| API unification | ✅ |
+| 2-way sync | ✅ |
+| Webhooks from Nango on data modifications | ✅ |
+| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Proxy requests | ✅ |
+</Accordion>
+<Accordion title="✅ Observability & data quality">
+| Tools | Status |
+| - | - |
+| HTTP request logging | ✅ |
+| End-to-end type safety | ✅ |
+| Data runtime validation | ✅ |
+| OpenTelemetry export | ✅ |
+| Slack alerts on errors | ✅ |
+| Integration status API | ✅ |
+</Accordion>
+<Accordion title="✅ Customization">
+| Tools | Status |
+| - | - |
+| Create or customize use-cases | ✅ |
+| Pre-configured pagination | 🚫 (time to contribute: &lt;48h) |
+| Pre-configured rate-limit handling | 🚫 (time to contribute: &lt;48h) |
+| Per-customer configurations | ✅ |
+</Accordion>
+</AccordionGroup>

--- a/docs/snippets/generated/discogs-token/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/discogs-token/PreBuiltUseCases.mdx
@@ -1,0 +1,3 @@
+_No pre-built syncs or actions available yet._
+
+<Tip>Not seeing the integration you need? [Build your own](/guides/functions/functions-guide) independently.</Tip>

--- a/docs/snippets/generated/discogs/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/discogs/PreBuiltTooling.mdx
@@ -1,0 +1,41 @@
+## Pre-built tooling
+<AccordionGroup>
+<Accordion title="✅ Authorization">
+| Tools | Status |
+| - | - |
+| Pre-built authorization (OAuth) | ✅ |
+| Credentials auto-refresh | ✅ |
+| Pre-built authorization UI | ✅ |
+| Custom authorization UI | ✅ |
+| End-user authorization guide | ✅ |
+| Expired credentials detection | ✅ |
+</Accordion>
+<Accordion title="✅ Read & write data">
+| Tools | Status |
+| - | - |
+| Pre-built integrations | 🚫 (time to contribute: &lt;48h) |
+| API unification | ✅ |
+| 2-way sync | ✅ |
+| Webhooks from Nango on data modifications | ✅ |
+| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Proxy requests | ✅ |
+</Accordion>
+<Accordion title="✅ Observability & data quality">
+| Tools | Status |
+| - | - |
+| HTTP request logging | ✅ |
+| End-to-end type safety | ✅ |
+| Data runtime validation | ✅ |
+| OpenTelemetry export | ✅ |
+| Slack alerts on errors | ✅ |
+| Integration status API | ✅ |
+</Accordion>
+<Accordion title="✅ Customization">
+| Tools | Status |
+| - | - |
+| Create or customize use-cases | ✅ |
+| Pre-configured pagination | 🚫 (time to contribute: &lt;48h) |
+| Pre-configured rate-limit handling | 🚫 (time to contribute: &lt;48h) |
+| Per-customer configurations | ✅ |
+</Accordion>
+</AccordionGroup>

--- a/docs/snippets/generated/discogs/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/discogs/PreBuiltUseCases.mdx
@@ -1,0 +1,3 @@
+_No pre-built syncs or actions available yet._
+
+<Tip>Not seeing the integration you need? [Build your own](/guides/functions/functions-guide) independently.</Tip>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -6740,6 +6740,65 @@ discolike:
             example: 123e4567-e89b-12d3-a456-426614174000
             format: uuid
 
+discogs:
+    display_name: Discogs
+    categories:
+        - e-commerce
+        - other
+    auth_mode: OAUTH1
+    request_url: https://api.discogs.com/oauth/request_token
+    authorization_url: https://www.discogs.com/oauth/authorize
+    token_url: https://api.discogs.com/oauth/access_token
+    signature_method: 'PLAINTEXT'
+    proxy:
+        base_url: https://api.discogs.com
+        headers:
+            user-agent: ${connectionConfig.userAgent} || NangoDiscogsIntegration/1.0 (+https://nango.dev; support@nango.dev)
+        verification:
+            method: GET
+            endpoints:
+                - /oauth/identity
+    docs: https://nango.dev/docs/integrations/all/discogs
+    docs_connect: https://nango.dev/docs/integrations/all/discogs/connect
+    setup_guide_url: https://nango.dev/docs/integrations/all/discogs/how-to-register-your-own-discogs-api-oauth-app
+    connection_config:
+        userAgent:
+            type: string
+            title: ''
+            description: ''
+            automated: true
+
+discogs-token:
+    display_name: Discogs (Personal Access Token)
+    categories:
+        - e-commerce
+        - other
+    auth_mode: API_KEY
+    proxy:
+        base_url: https://api.discogs.com
+        headers:
+            authorization: Discogs token=${apiKey}
+            user-agent: ${connectionConfig.userAgent} || NangoDiscogsIntegration/1.0 (+https://nango.dev; support@nango.dev)
+        verification:
+            method: GET
+            endpoints:
+                - /oauth/identity
+    docs: https://nango.dev/docs/integrations/all/discogs-token
+    docs_connect: https://nango.dev/docs/integrations/all/discogs-token/connect
+    connection_config:
+        userAgent:
+            type: string
+            title: ''
+            description: ''
+            automated: true
+    credentials:
+        apiKey:
+            type: string
+            title: Personal Access Token
+            description: The personal access token for your Discogs account
+            example: 'discoAbcd1234efgh5678ijkl9012mnop3456qrst'
+            doc_section: '#step-1-generating-your-personal-access-token'
+
 discord:
     display_name: Discord
     categories:

--- a/packages/webapp/public/images/template-logos/discogs-token.svg
+++ b/packages/webapp/public/images/template-logos/discogs-token.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="62" height="62" viewBox="0 0 62 62" fill="none">
+  <rect width="62" height="62" rx="31" fill="#333333"/>
+  <circle cx="31" cy="31" r="18" stroke="#ffffff" stroke-width="2" fill="none"/>
+  <circle cx="31" cy="31" r="6" fill="#ffffff"/>
+  <circle cx="31" cy="31" r="2" fill="#333333"/>
+  <rect x="40" y="40" width="14" height="14" rx="2" fill="#ffffff"/>
+  <path d="M43 47h8M47 43v8" stroke="#333333" stroke-width="1.5"/>
+</svg>

--- a/packages/webapp/public/images/template-logos/discogs.svg
+++ b/packages/webapp/public/images/template-logos/discogs.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="62" height="62" viewBox="0 0 62 62" fill="none">
+  <rect width="62" height="62" rx="31" fill="#333333"/>
+  <circle cx="31" cy="31" r="18" stroke="#ffffff" stroke-width="2" fill="none"/>
+  <circle cx="31" cy="31" r="6" fill="#ffffff"/>
+  <circle cx="31" cy="31" r="2" fill="#333333"/>
+</svg>


### PR DESCRIPTION
## Description

Adds Discogs as a new Nango API provider with two auth modes:

- `discogs` — OAuth 1.0a (PLAINTEXT signature) for multi-user connect
- `discogs-token` — personal access token (`Authorization: Discogs token=…`)

## Authentication

- OAuth1: request/authorize/access token endpoints on `api.discogs.com` / `www.discogs.com`
- API key: Discogs personal access token header format
- Mandatory `User-Agent` on proxied requests (Discogs requirement)
- Credential verification via `GET /oauth/identity`

## Testing

- `npx tsx scripts/validation/providers/validate.ts` — JSON schema valid, all providers valid
- Local docker (`nango-server` with mounted `providers.yaml`)
- Created `discogs-token` integration + connection
- Proxied successfully:
  - `GET /oauth/identity` → 200
  - `GET /users/{username}/collection/folders` → 200

## Docs

- Main + connect guides for both providers
- OAuth app registration setup guide for `discogs`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

