### PR TITLE
feat(api): add public environment list endpoint

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -813,6 +813,7 @@
                       {
                         "group": "Environments",
                         "pages": [
+                          "reference/backend/http-api/environments/list",
                           "reference/backend/http-api/environments/create",
                           "reference/backend/http-api/environments/delete",
                           "reference/backend/http-api/environments/create-api-key",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9589,6 +9589,7 @@ curl --request POST \
 
 ### Account-level APIs
 
+- [List environments](/reference/backend/http-api/environments/list)
 - [Create an environment](/reference/backend/http-api/environments/create)
 - [Delete an environment](/reference/backend/http-api/environments/delete)
 - [Create an environment API key](/reference/backend/http-api/environments/create-api-key)
@@ -9621,6 +9622,29 @@ Those headers are sent back with every API response:
 - `X-RateLimit-Reset` provides a Unix timestamp representing the time at which the current rate limit window resets, and the remaining request count is replenished.
 
 If a client exceeds the rate limit, the API will respond with a 429 `Too Many Requests` status code. In this case, the `Retry-After` header is included, indicating the number of seconds the client should wait before making another request to avoid being rate-limited.
+
+## List environments
+
+Source: https://nango.dev/docs/reference/backend/http-api/environments/list.md
+
+<Info>
+  Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys) with the `account:environments:list` scope.
+</Info>
+
+<ResponseExample>
+```json Example Response
+{
+  "data": [
+    {
+      "id": 123,
+      "uuid": "123e4567-e89b-12d3-a456-426614174000",
+      "name": "staging",
+      "is_production": false
+    }
+  ]
+}
+```
+</ResponseExample>
 
 ## Create an environment
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -72,6 +72,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 - [Backend: HTTP API: API keys](https://nango.dev/docs/reference/backend/http-api/api-keys.md): Manage Environment and Account API keys with scoped permissions for Nango.
 - [Backend: HTTP API: Authentication](https://nango.dev/docs/reference/backend/http-api/authentication.md)
 - [Backend: HTTP API: Rate limits](https://nango.dev/docs/reference/backend/http-api/rate-limits.md)
+- [Backend: HTTP API: Environments: List environments](https://nango.dev/docs/reference/backend/http-api/environments/list.md)
 - [Backend: HTTP API: Environments: Create an environment](https://nango.dev/docs/reference/backend/http-api/environments/create.md)
 - [Backend: HTTP API: Environments: Delete an environment](https://nango.dev/docs/reference/backend/http-api/environments/delete.md)
 - [Backend: HTTP API: Environments: Create an environment API key](https://nango.dev/docs/reference/backend/http-api/environments/create-api-key.md)

--- a/docs/reference/backend/http-api/api-keys.mdx
+++ b/docs/reference/backend/http-api/api-keys.mdx
@@ -276,6 +276,7 @@ curl --request POST \
 
 ### Account-level APIs
 
+- [List environments](/reference/backend/http-api/environments/list)
 - [Create an environment](/reference/backend/http-api/environments/create)
 - [Delete an environment](/reference/backend/http-api/environments/delete)
 - [Create an environment API key](/reference/backend/http-api/environments/create-api-key)

--- a/docs/reference/backend/http-api/environments/list.mdx
+++ b/docs/reference/backend/http-api/environments/list.mdx
@@ -1,0 +1,23 @@
+---
+title: 'List environments'
+openapi: 'GET /environments'
+---
+
+<Info>
+  Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys) with the `account:environments:list` scope.
+</Info>
+
+<ResponseExample>
+```json Example Response
+{
+  "data": [
+    {
+      "id": 123,
+      "uuid": "123e4567-e89b-12d3-a456-426614174000",
+      "name": "staging",
+      "is_production": false
+    }
+  ]
+}
+```
+</ResponseExample>

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2788,6 +2788,61 @@ paths:
                                                 type: object
 
     /environments:
+        get:
+            summary: List environments
+            description: List environments in the authenticated account. Optionally filter by an exact environment name.
+            parameters:
+                - name: name
+                  in: query
+                  required: false
+                  description: Exact environment name to find.
+                  schema:
+                      type: string
+                      pattern: '^[a-z0-9_-]+$'
+                      maxLength: 255
+                  example: staging
+            responses:
+                '200':
+                    description: Successfully listed environments
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                properties:
+                                    data:
+                                        type: array
+                                        items:
+                                            type: object
+                                            required:
+                                                - id
+                                                - uuid
+                                                - name
+                                                - is_production
+                                            properties:
+                                                id:
+                                                    type: integer
+                                                    description: Numeric environment ID.
+                                                    example: 123
+                                                uuid:
+                                                    type: string
+                                                    format: uuid
+                                                    description: Environment UUID. Use this in account-level API calls for this environment.
+                                                    example: 123e4567-e89b-12d3-a456-426614174000
+                                                name:
+                                                    type: string
+                                                    description: The environment name.
+                                                    example: staging
+                                                is_production:
+                                                    type: boolean
+                                                    description: Whether the environment is production.
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
         post:
             summary: Create an environment
             description: Create a new environment

--- a/packages/authz/lib/scopes.ts
+++ b/packages/authz/lib/scopes.ts
@@ -65,6 +65,7 @@ true satisfies [Exclude<ConcreteApiKeyScope, (typeof PUBLIC_ENVIRONMENT_SCOPES)[
  */
 export const PUBLIC_ACCOUNT_SCOPES = [
     // Environments
+    'account:environments:list',
     'account:environments:create', // any environment
     'account:environments:delete',
     'account:environments:set_production',

--- a/packages/server/lib/controllers/environment/environmentManagement.integration.test.ts
+++ b/packages/server/lib/controllers/environment/environmentManagement.integration.test.ts
@@ -35,6 +35,113 @@ describe('Public environment management', () => {
         api.server.close();
     });
 
+    describe('GET /environments', () => {
+        it('should be protected', async () => {
+            const res = await api.fetch('/environments', { method: 'GET', query: {} });
+
+            shouldBeProtected(res);
+        });
+
+        it('should deny environment API keys', async () => {
+            const { apiKey } = await seedAccount();
+
+            const res = await api.fetch('/environments', { method: 'GET', token: apiKey.secret, query: {} });
+
+            expect(res.res.status).toBe(403);
+            isError(res.json);
+            expect(res.json.error).toEqual({
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: account:environments:list'
+            });
+        });
+
+        it('should deny Account API keys without the read scope', async () => {
+            const { account } = await seedAccount();
+            const accountKey = await createAccountKey(account.id, ['account:environments:create']);
+
+            const res = await api.fetch('/environments', { method: 'GET', token: accountKey.secret, query: {} });
+
+            expect(res.res.status).toBe(403);
+            isError(res.json);
+            expect(res.json.error).toEqual({
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: account:environments:list'
+            });
+        });
+
+        it('should list secret-free environments with the read scope', async () => {
+            const { account } = await seedAccount();
+            const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'readable-environment' })).unwrap();
+            const accountKey = await createAccountKey(account.id, ['account:environments:list']);
+
+            const res = await api.fetch('/environments', {
+                method: 'GET',
+                token: accountKey.secret,
+                query: { name: environment.name }
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json).toStrictEqual({
+                data: [{ id: environment.id, uuid: environment.uuid, name: environment.name, is_production: false }]
+            });
+        });
+
+        it('should filter by an exact name and return an empty list when there is no match', async () => {
+            const { account } = await seedAccount();
+            const accountKey = await createAccountKey(account.id, ['account:environments:list']);
+
+            const res = await api.fetch('/environments', {
+                method: 'GET',
+                token: accountKey.secret,
+                query: { name: 'does-not-exist' }
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json).toStrictEqual({ data: [] });
+        });
+
+        it('should reject invalid query parameters', async () => {
+            const { account } = await seedAccount();
+            const accountKey = await createAccountKey(account.id, ['account:environments:list']);
+
+            const unknown = await api.fetch('/environments', {
+                method: 'GET',
+                token: accountKey.secret,
+                // @ts-expect-error on purpose
+                query: { unknown: 'value' }
+            });
+            expect(unknown.res.status).toBe(400);
+
+            const invalidName = await api.fetch('/environments', {
+                method: 'GET',
+                token: accountKey.secret,
+                query: { name: '' }
+            });
+            expect(invalidName.res.status).toBe(400);
+        });
+
+        it('should support account:* and isolate environments by account', async () => {
+            const first = await seedAccount();
+            const second = await seedAccount();
+            const firstKey = await createAccountKey(first.account.id, ['account:*']);
+            const secondEnvironment = (
+                await environmentService.createEnvironment(db.knex, { accountId: second.account.id, name: 'other-account-environment' })
+            ).unwrap();
+
+            const res = await api.fetch('/environments', {
+                method: 'GET',
+                token: firstKey.secret,
+                query: { name: secondEnvironment.name }
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json).toStrictEqual({ data: [] });
+        });
+    });
+
     describe('POST /environments', () => {
         it('should be protected', async () => {
             const res = await api.fetch('/environments', {

--- a/packages/server/lib/controllers/environment/getEnvironments.ts
+++ b/packages/server/lib/controllers/environment/getEnvironments.ts
@@ -1,0 +1,31 @@
+import * as z from 'zod';
+
+import { environmentService } from '@nangohq/shared';
+import { zodErrorToHTTP } from '@nangohq/utils';
+
+import { envSchema } from '../../helpers/validation.js';
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+
+import type { GetPublicEnvironments } from '@nangohq/types';
+
+const validationQuery = z.object({ name: envSchema.optional() }).strict();
+
+export const getPublicEnvironments = asyncWrapper<GetPublicEnvironments>(async (req, res) => {
+    const query = validationQuery.safeParse(req.query);
+    if (!query.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(query.error) } });
+        return;
+    }
+
+    const account = res.locals.account;
+    if (!account) {
+        res.status(500).send({ error: { code: 'server_error', message: 'Account context is required' } });
+        return;
+    }
+
+    const environments = await environmentService.getEnvironmentsByAccountId(account.id, query.data.name);
+
+    res.status(200).send({
+        data: environments.map(({ id, uuid, name, is_production }) => ({ id, uuid, name, is_production }))
+    });
+});

--- a/packages/server/lib/controllers/environment/getEnvironments.ts
+++ b/packages/server/lib/controllers/environment/getEnvironments.ts
@@ -23,7 +23,7 @@ export const getPublicEnvironments = asyncWrapper<GetPublicEnvironments>(async (
         return;
     }
 
-    const environments = await environmentService.getEnvironmentsByAccountId(account.id, query.data.name);
+    const environments = await environmentService.getEnvironmentsByAccountId(account.id, { name: query.data.name });
 
     res.status(200).send({
         data: environments.map(({ id, uuid, name, is_production }) => ({ id, uuid, name, is_production }))

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -40,6 +40,7 @@ import { getPublicConnections } from './controllers/connection/getConnections.js
 import { postPublicConnection } from './controllers/connection/postConnection.js';
 import { deletePublicEnvironmentApiKey } from './controllers/environment/deleteApiKey.js';
 import { deletePublicEnvironment } from './controllers/environment/deleteEnvironment.js';
+import { getPublicEnvironments } from './controllers/environment/getEnvironments.js';
 import { getPublicEnvironmentVariables } from './controllers/environment/getVariables.js';
 import { postPublicEnvironmentApiKey } from './controllers/environment/postApiKey.js';
 import { postPublicEnvironment } from './controllers/environment/postEnvironment.js';
@@ -247,6 +248,7 @@ publicAPI.route('/providers/:provider').get(connectSessionOrApiAuth, withEnviron
 publicAPI.route('/providers/:provider/templates').get(apiAuth, withEnvironmentTarget, getPublicProviderTemplates);
 
 publicAPI.use('/environments', jsonContentTypeMiddleware);
+publicAPI.route('/environments').get(apiAuth, withScope('account:environments:list'), getPublicEnvironments);
 publicAPI.route('/environments').post(apiAuth, auditPublicEnvironmentCreated, withScope('account:environments:create'), postPublicEnvironment);
 publicAPI
     .route('/environments/:environmentUuid')

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -78,12 +78,17 @@ class EnvironmentService {
         return Ok(name === PROD_ENVIRONMENT_NAME ? true : (isProduction ?? false));
     }
 
-    async getEnvironmentsByAccountId(account_id: number): Promise<Pick<DBEnvironment, 'id' | 'name' | 'is_production'>[]> {
+    async getEnvironmentsByAccountId(account_id: number, name?: string): Promise<Pick<DBEnvironment, 'id' | 'uuid' | 'name' | 'is_production'>[]> {
         try {
             const result = await db.knex
-                .select<Pick<DBEnvironment, 'name' | 'id' | 'is_production'>[]>('id', 'name', 'is_production')
+                .select<Pick<DBEnvironment, 'id' | 'uuid' | 'name' | 'is_production'>[]>('id', 'uuid', 'name', 'is_production')
                 .from<DBEnvironment>(TABLE)
                 .where({ account_id, deleted: false })
+                .modify((query) => {
+                    if (name !== undefined) {
+                        query.where({ name });
+                    }
+                })
                 .orderBy('name', 'asc');
 
             if (result == null || result.length == 0) {

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -78,15 +78,18 @@ class EnvironmentService {
         return Ok(name === PROD_ENVIRONMENT_NAME ? true : (isProduction ?? false));
     }
 
-    async getEnvironmentsByAccountId(account_id: number, name?: string): Promise<Pick<DBEnvironment, 'id' | 'uuid' | 'name' | 'is_production'>[]> {
+    async getEnvironmentsByAccountId(
+        account_id: number,
+        filter: { name?: string | undefined } = {}
+    ): Promise<Pick<DBEnvironment, 'id' | 'uuid' | 'name' | 'is_production'>[]> {
         try {
             const result = await db.knex
                 .select<Pick<DBEnvironment, 'id' | 'uuid' | 'name' | 'is_production'>[]>('id', 'uuid', 'name', 'is_production')
                 .from<DBEnvironment>(TABLE)
                 .where({ account_id, deleted: false })
                 .modify((query) => {
-                    if (name !== undefined) {
-                        query.where({ name });
+                    if (filter.name !== undefined) {
+                        query.where({ name: filter.name });
                     }
                 })
                 .orderBy('name', 'asc');

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -62,6 +62,7 @@ export type ApiKeyScope = ConcreteApiKeyScope | WildcardsFor<'environment'>;
 
 export const ACCOUNT_API_KEY_SCOPES = [
     // Environments
+    'account:environments:list',
     'account:environments:create',
     'account:environments:delete',
     'account:environments:set_production',

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -69,6 +69,7 @@ import type {
     DeletePublicEnvironment,
     GetEnvironment,
     GetEnvironments,
+    GetPublicEnvironments,
     ListApiKeys,
     PatchApiKey,
     PatchEnvironment,
@@ -225,6 +226,7 @@ export type PublicApiEndpoints =
     | AllPublicProxy
     | PostPublicEnvironment
     | DeletePublicEnvironment
+    | GetPublicEnvironments
     | PostPublicApiKey
     | DeletePublicApiKey;
 

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -19,6 +19,16 @@ export type GetEnvironments = ApiEndpoint<{
     };
 }>;
 
+export type GetPublicEnvironments = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
+    Method: 'GET';
+    Path: '/environments';
+    Querystring: { name?: string | undefined };
+    Success: {
+        data: Pick<DBEnvironment, 'id' | 'uuid' | 'name' | 'is_production'>[];
+    };
+}>;
+
 export type PostEnvironment = ApiEndpoint<{
     Audit: AuditPolicy<'environment', 'created', 'account'>;
     Method: 'POST';


### PR DESCRIPTION
Adds `GET /environments` for Account API keys.

- Introduces the `account:environments:list` scope.
- Supports optional exact-name filtering with `?name=`.
- Documents the endpoint in OpenAPI, HTTP API docs, and LLM docs.
- Adds integration coverage for authentication, scopes, filtering, validation, wildcard access, and isolation.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

