### PR TITLE
fix(audit): let the auth type name the connect session, not the end user

### DIFF
--- a/packages/server/lib/hooks/auditConnection.ts
+++ b/packages/server/lib/hooks/auditConnection.ts
@@ -31,6 +31,10 @@ export function connectionCreatedActor(
     if (authType === 'publicKey') {
         return PUBLIC_KEY_ACTOR;
     }
+    // The hook-side emitter has no OAuth session to report an auth type from.
+    if (endUser) {
+        return connectSessionActor(endUser);
+    }
     return UNKNOWN_ACTOR;
 }
 

--- a/packages/server/lib/hooks/auditConnection.ts
+++ b/packages/server/lib/hooks/auditConnection.ts
@@ -15,8 +15,8 @@ export function oauthAuthType(session: Pick<OAuthSession, 'connectSessionId'>): 
     return session.connectSessionId ? 'connectSession' : 'publicKey';
 }
 
-// `resolveActor` only reports what a request proves, so both the connect session's end user and how the flow
-// started reach us from the OAuth session instead.
+// `resolveActor` only reports what a request proves, so the auth type the OAuth session recorded is what
+// names the actor here. The end user only fills in the id, and a connect session does not have to carry one.
 export function connectionCreatedActor(
     actor: AuditActor | undefined,
     endUser: InternalEndUser | null | undefined,
@@ -25,7 +25,7 @@ export function connectionCreatedActor(
     if (actor && actor.type !== 'unknown') {
         return actor;
     }
-    if (endUser) {
+    if (authType === 'connectSession') {
         return connectSessionActor(endUser);
     }
     if (authType === 'publicKey') {

--- a/packages/server/lib/hooks/auditConnection.unit.test.ts
+++ b/packages/server/lib/hooks/auditConnection.unit.test.ts
@@ -160,16 +160,24 @@ describe('connectionCreatedActor', () => {
     const unknown = { type: 'unknown', id: 'unknown', display: 'unknown' } as const;
     const endUser = { endUserId: 'customer-user-1', email: 'buyer@customer.com', tags: null };
 
-    it('names the public key when that is all the flow was started with', () => {
-        expect(connectionCreatedActor(unknown, undefined, 'publicKey')).toEqual({ type: 'public_key', id: 'unknown' });
-    });
-
-    it('keeps the end user over the public key that started the flow', () => {
-        expect(connectionCreatedActor(unknown, endUser, 'publicKey')).toEqual({
+    it('names the connect session and the end user it carries', () => {
+        expect(connectionCreatedActor(unknown, endUser, 'connectSession')).toEqual({
             type: 'connect_session',
             id: 'customer-user-1',
             display: 'buyer@customer.com'
         });
+    });
+
+    it('names the connect session even when it carries no end user', () => {
+        expect(connectionCreatedActor(unknown, null, 'connectSession')).toEqual({ type: 'connect_session', id: 'unknown' });
+    });
+
+    it('names the public key when the flow started with one', () => {
+        expect(connectionCreatedActor(unknown, undefined, 'publicKey')).toEqual({ type: 'public_key', id: 'unknown' });
+    });
+
+    it('names nobody when no oauth session was behind the creation', () => {
+        expect(connectionCreatedActor(unknown, undefined, undefined)).toEqual({ type: 'unknown', id: 'unknown', display: 'unknown' });
     });
 });
 


### PR DESCRIPTION
`connection.created` from a hosted OAuth flow still recorded an `unknown` actor whenever the connect session carried no end user. The end user is optional — `ConnectSession.endUser` is nullable and `connectSessionActor` is written for that case — but the resolver was gating on it, so a session that names nobody fell through to `unknown` even though the OAuth session had already recorded which credential started the flow. The auth type now selects the actor and the end user only fills in the id, which is what every authenticated route already records for the same situation.

Measured on cloud after [#7329 — feat(audit): attribute public-key OAuth callbacks](https://github.com/NangoHQ/nango/pull/7329) deployed: 61 events in 3.5 hours, ~400 a day, all `outcome: success` browser callbacks across nine accounts — eight of which never produce a `connect_session` actor at all, i.e. integrators who never pass `end_user`.

## Test plan

- [x] Resolver cases rewritten: a connect session with and without an end user, a public key start, and no OAuth session at all
- [ ] CI (a fresh worktree cannot run the suite without a full `ts-build`)
- [ ] After deploy: those ~400/day should reappear as `connect_session` / `unknown`, and `unknown` should fall to provider-webhook volume only

One old case was dropped rather than updated: it asserted `authType: 'publicKey'` together with an end user, which cannot occur — `oauthAuthType` only returns `publicKey` when there is no `connectSessionId`, and the end user only exists when there is one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

