### PR TITLE
feat(api): list environment API keys

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -816,6 +816,7 @@
                           "reference/backend/http-api/environments/list",
                           "reference/backend/http-api/environments/create",
                           "reference/backend/http-api/environments/delete",
+                          "reference/backend/http-api/environments/list-api-keys",
                           "reference/backend/http-api/environments/create-api-key",
                           "reference/backend/http-api/environments/delete-api-key"
                         ]

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9592,6 +9592,7 @@ curl --request POST \
 - [List environments](/reference/backend/http-api/environments/list)
 - [Create an environment](/reference/backend/http-api/environments/create)
 - [Delete an environment](/reference/backend/http-api/environments/delete)
+- [List environment API keys](/reference/backend/http-api/environments/list-api-keys)
 - [Create an environment API key](/reference/backend/http-api/environments/create-api-key)
 - [Delete an environment API key](/reference/backend/http-api/environments/delete-api-key)
 
@@ -9683,6 +9684,31 @@ Source: https://nango.dev/docs/reference/backend/http-api/environments/delete.md
 Deletes an environment. `environmentUuid` is the UUID returned when the environment was [created](/reference/backend/http-api/environments/create).
 
 The reserved `prod` environment cannot be deleted.
+
+## List environment API keys
+
+Source: https://nango.dev/docs/reference/backend/http-api/environments/list-api-keys.md
+
+<Info>
+  Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys) with the `account:environments:api_keys:list` scope.
+</Info>
+
+<ResponseExample>
+```json Example Response
+{
+  "data": [
+    {
+      "id": 456,
+      "uuid": "123e4567-e89b-12d3-a456-426614174001",
+      "display_name": "provisioned-ci",
+      "scopes": ["environment:*"],
+      "last_used_at": null,
+      "created_at": "2026-08-18T12:00:00.000Z"
+    }
+  ]
+}
+```
+</ResponseExample>
 
 ## Create an environment API key
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -75,6 +75,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 - [Backend: HTTP API: Environments: List environments](https://nango.dev/docs/reference/backend/http-api/environments/list.md)
 - [Backend: HTTP API: Environments: Create an environment](https://nango.dev/docs/reference/backend/http-api/environments/create.md)
 - [Backend: HTTP API: Environments: Delete an environment](https://nango.dev/docs/reference/backend/http-api/environments/delete.md)
+- [Backend: HTTP API: Environments: List environment API keys](https://nango.dev/docs/reference/backend/http-api/environments/list-api-keys.md)
 - [Backend: HTTP API: Environments: Create an environment API key](https://nango.dev/docs/reference/backend/http-api/environments/create-api-key.md)
 - [Backend: HTTP API: Environments: Delete an environment API key](https://nango.dev/docs/reference/backend/http-api/environments/delete-api-key.md)
 - [Backend: HTTP API: Integrations: List all integrations](https://nango.dev/docs/reference/backend/http-api/integration/list.md)

--- a/docs/reference/backend/http-api/api-keys.mdx
+++ b/docs/reference/backend/http-api/api-keys.mdx
@@ -279,5 +279,6 @@ curl --request POST \
 - [List environments](/reference/backend/http-api/environments/list)
 - [Create an environment](/reference/backend/http-api/environments/create)
 - [Delete an environment](/reference/backend/http-api/environments/delete)
+- [List environment API keys](/reference/backend/http-api/environments/list-api-keys)
 - [Create an environment API key](/reference/backend/http-api/environments/create-api-key)
 - [Delete an environment API key](/reference/backend/http-api/environments/delete-api-key)

--- a/docs/reference/backend/http-api/environments/list-api-keys.mdx
+++ b/docs/reference/backend/http-api/environments/list-api-keys.mdx
@@ -1,0 +1,25 @@
+---
+title: 'List environment API keys'
+openapi: 'GET /environments/{environmentUuid}/api-keys'
+---
+
+<Info>
+  Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys) with the `account:environments:api_keys:list` scope.
+</Info>
+
+<ResponseExample>
+```json Example Response
+{
+  "data": [
+    {
+      "id": 456,
+      "uuid": "123e4567-e89b-12d3-a456-426614174001",
+      "display_name": "provisioned-ci",
+      "scopes": ["environment:*"],
+      "last_used_at": null,
+      "created_at": "2026-08-18T12:00:00.000Z"
+    }
+  ]
+}
+```
+</ResponseExample>

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -2973,6 +2973,81 @@ paths:
                 '404':
                     $ref: '#/components/responses/NotFound'
     /environments/{environmentUuid}/api-keys:
+        get:
+            summary: List environment API keys
+            description: Returns a list of Environment API keys in an environment.
+            parameters:
+                - name: environmentUuid
+                  in: path
+                  required: true
+                  description: Environment UUID that owns the keys.
+                  schema:
+                      type: string
+                      format: uuid
+                  example: 123e4567-e89b-12d3-a456-426614174000
+                - name: display_name
+                  in: query
+                  required: false
+                  description: Exact API-key display name to find.
+                  schema:
+                      type: string
+                      minLength: 1
+                      maxLength: 255
+                  example: provisioned-ci
+            responses:
+                '200':
+                    description: Successfully listed Environment API keys
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                properties:
+                                    data:
+                                        type: array
+                                        items:
+                                            type: object
+                                            required:
+                                                - id
+                                                - uuid
+                                                - display_name
+                                                - scopes
+                                                - last_used_at
+                                                - created_at
+                                            properties:
+                                                id:
+                                                    type: integer
+                                                    description: Numeric API-key ID.
+                                                    example: 456
+                                                uuid:
+                                                    type: string
+                                                    format: uuid
+                                                    description: API-key UUID.
+                                                    example: 123e4567-e89b-12d3-a456-426614174001
+                                                display_name:
+                                                    type: string
+                                                    example: provisioned-ci
+                                                scopes:
+                                                    type: array
+                                                    items:
+                                                        type: string
+                                                last_used_at:
+                                                    type: [string, 'null']
+                                                    format: date-time
+                                                created_at:
+                                                    type: string
+                                                    format: date-time
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+                '500':
+                    $ref: '#/components/responses/ServerError'
         post:
             summary: Create an environment API key
             description: Create a new environment API key

--- a/packages/authz/lib/scopes.ts
+++ b/packages/authz/lib/scopes.ts
@@ -69,6 +69,7 @@ export const PUBLIC_ACCOUNT_SCOPES = [
     'account:environments:create', // any environment
     'account:environments:delete',
     'account:environments:set_production',
+    'account:environments:api_keys:list',
     'account:environments:api_keys:create',
     'account:environments:api_keys:delete'
 ] as const satisfies readonly AccountApiKeyScope[];

--- a/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
@@ -33,6 +33,149 @@ describe('Public environment API key management', () => {
         api.server.close();
     });
 
+    describe('GET /environments/:environmentUuid/api-keys', () => {
+        it('should be protected', async () => {
+            const res = await api.fetch('/environments/:environmentUuid/api-keys', {
+                method: 'GET',
+                params: { environmentUuid: '123e4567-e89b-12d3-a456-426614174000' },
+                query: {}
+            });
+
+            shouldBeProtected(res);
+        });
+
+        it('should deny environment API keys', async () => {
+            const { env, apiKey } = await seedAccount();
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys', {
+                method: 'GET',
+                token: apiKey.secret,
+                params: { environmentUuid: env.uuid },
+                query: {}
+            });
+
+            expect(res.res.status).toBe(403);
+            isError(res.json);
+            expect(res.json.error).toEqual({
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: account:environments:api_keys:list'
+            });
+        });
+
+        it('should deny Account API keys without the list scope', async () => {
+            const { account, env } = await seedAccount();
+            const accountKey = await createAccountKey(account.id, ['account:environments:api_keys:create']);
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: env.uuid },
+                query: {}
+            });
+
+            expect(res.res.status).toBe(403);
+            isError(res.json);
+            expect(res.json.error).toEqual({
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: account:environments:api_keys:list'
+            });
+        });
+
+        it('should list keys without their secrets and filter by exact display name', async () => {
+            const { account, env } = await seedAccount();
+            const apiKey = (
+                await customerKeyService.createApiKey(db.knex, {
+                    accountId: account.id,
+                    environmentId: env.id,
+                    displayName: 'readable-key'
+                })
+            ).unwrap();
+            const accountKey = await createAccountKey(account.id, ['account:environments:api_keys:list']);
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: env.uuid },
+                query: { display_name: apiKey.display_name }
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json).toStrictEqual({
+                data: [
+                    {
+                        id: apiKey.id,
+                        uuid: apiKey.uuid,
+                        display_name: apiKey.display_name,
+                        scopes: ['environment:*'],
+                        last_used_at: null,
+                        created_at: apiKey.created_at.toISOString()
+                    }
+                ]
+            });
+        });
+
+        it('should return an empty list for no match and reject invalid parameters', async () => {
+            const { account, env } = await seedAccount();
+            const accountKey = await createAccountKey(account.id, ['account:environments:api_keys:list']);
+
+            const noMatch = await api.fetch('/environments/:environmentUuid/api-keys', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: env.uuid },
+                query: { display_name: 'does-not-exist' }
+            });
+            expect(noMatch.res.status).toBe(200);
+            isSuccess(noMatch.json);
+            expect(noMatch.json).toStrictEqual({ data: [] });
+
+            const invalid = await api.fetch('/environments/:environmentUuid/api-keys', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: 'not-a-uuid' },
+                query: {}
+            });
+            expect(invalid.res.status).toBe(400);
+
+            const unknownQuery = await api.fetch('/environments/:environmentUuid/api-keys', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: env.uuid },
+                // @ts-expect-error on purpose
+                query: { unknown: 'value' }
+            });
+            expect(unknownQuery.res.status).toBe(400);
+        });
+
+        it('should support account:* and isolate keys by account', async () => {
+            const first = await seedAccount();
+            const second = await seedAccount();
+            const accountKey = await createAccountKey(first.account.id, ['account:*']);
+
+            const own = await api.fetch('/environments/:environmentUuid/api-keys', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: first.env.uuid },
+                query: {}
+            });
+
+            expect(own.res.status).toBe(200);
+            isSuccess(own.json);
+            expect(own.json.data).toContainEqual(expect.objectContaining({ uuid: first.apiKey.uuid }));
+
+            const otherAccount = await api.fetch('/environments/:environmentUuid/api-keys', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: second.env.uuid },
+                query: {}
+            });
+
+            expect(otherAccount.res.status).toBe(404);
+            isError(otherAccount.json);
+            expect(otherAccount.json.error).toEqual({ code: 'not_found', message: 'Environment not found' });
+        });
+    });
+
     describe('POST /environments/:environmentUuid/api-keys', () => {
         it('should be protected', async () => {
             const res = await api.fetch('/environments/:environmentUuid/api-keys', {

--- a/packages/server/lib/controllers/environment/getApiKeys.ts
+++ b/packages/server/lib/controllers/environment/getApiKeys.ts
@@ -1,0 +1,56 @@
+import * as z from 'zod';
+
+import db from '@nangohq/database';
+import { customerKeyService, environmentService } from '@nangohq/shared';
+import { report, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+
+import type { ApiKeyScope, GetPublicApiKeys } from '@nangohq/types';
+
+const validationParams = z.object({ environmentUuid: z.uuid() }).strict();
+const validationQuery = z.object({ display_name: z.string().min(1).max(255).optional() }).strict();
+
+export const getPublicEnvironmentApiKeys = asyncWrapper<GetPublicApiKeys>(async (req, res) => {
+    const params = validationParams.safeParse(req.params);
+    if (!params.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(params.error) } });
+        return;
+    }
+
+    const query = validationQuery.safeParse(req.query);
+    if (!query.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(query.error) } });
+        return;
+    }
+
+    const account = res.locals.account;
+    if (!account) {
+        res.status(500).send({ error: { code: 'server_error', message: 'Account context is required' } });
+        return;
+    }
+
+    const environment = await environmentService.getByUuidWithoutSecrets(params.data.environmentUuid, account.id);
+    if (!environment) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Environment not found' } });
+        return;
+    }
+
+    const keys = await customerKeyService.getApiKeysByEnvWithoutSecrets(db.knex, environment.id, query.data.display_name);
+    if (keys.isErr()) {
+        report(keys.error, { accountId: account.id, environmentId: environment.id });
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to retrieve API keys' } });
+        return;
+    }
+
+    res.status(200).send({
+        data: keys.value.map((key) => ({
+            id: key.id,
+            uuid: key.uuid,
+            display_name: key.display_name,
+            scopes: (key.scopes ?? []) as ApiKeyScope[],
+            last_used_at: key.last_used_at?.toISOString() ?? null,
+            created_at: key.created_at.toISOString()
+        }))
+    });
+});

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -40,6 +40,7 @@ import { getPublicConnections } from './controllers/connection/getConnections.js
 import { postPublicConnection } from './controllers/connection/postConnection.js';
 import { deletePublicEnvironmentApiKey } from './controllers/environment/deleteApiKey.js';
 import { deletePublicEnvironment } from './controllers/environment/deleteEnvironment.js';
+import { getPublicEnvironmentApiKeys } from './controllers/environment/getApiKeys.js';
 import { getPublicEnvironments } from './controllers/environment/getEnvironments.js';
 import { getPublicEnvironmentVariables } from './controllers/environment/getVariables.js';
 import { postPublicEnvironmentApiKey } from './controllers/environment/postApiKey.js';
@@ -255,6 +256,7 @@ publicAPI
     .delete(apiAuth, auditPublicEnvironmentDeleted, withScope('account:environments:delete'), deletePublicEnvironment);
 publicAPI
     .route('/environments/:environmentUuid/api-keys')
+    .get(apiAuth, withScope('account:environments:api_keys:list'), getPublicEnvironmentApiKeys)
     .post(apiAuth, auditPublicApiKeyCreated, withScope('account:environments:api_keys:create'), postPublicEnvironmentApiKey);
 publicAPI
     .route('/environments/:environmentUuid/api-keys/:keyUuid')

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -346,14 +346,7 @@ class CustomerKeyService {
 
     public async getApiKeysByEnv(trx: Knex, envId: number): Promise<Result<DBCustomerKey[]>> {
         try {
-            const rows = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
-                .select(`${CUSTOMER_KEYS_TABLE}.*`)
-                .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
-                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
-                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
-                .orderBy(`${CUSTOMER_KEYS_TABLE}.display_name`, 'asc');
+            const rows = await this.apiKeysByEnvironmentQuery(trx, envId).select<DBCustomerKey[]>(`${CUSTOMER_KEYS_TABLE}.*`);
 
             const decrypted = rows.map(
                 (row) => getEncryptionManager().decryptAPISecret(row as Parameters<EncryptionManager['decryptAPISecret']>[0]) as DBCustomerKey
@@ -362,6 +355,44 @@ class CustomerKeyService {
         } catch (err) {
             return Err(err);
         }
+    }
+
+    public async getApiKeysByEnvWithoutSecrets(
+        trx: Knex,
+        envId: number,
+        displayName?: string
+    ): Promise<Result<Pick<DBCustomerKey, 'id' | 'uuid' | 'display_name' | 'scopes' | 'last_used_at' | 'created_at'>[]>> {
+        try {
+            const rows = await this.apiKeysByEnvironmentQuery(trx, envId, { displayName }).select<
+                Pick<DBCustomerKey, 'id' | 'uuid' | 'display_name' | 'scopes' | 'last_used_at' | 'created_at'>[]
+            >(
+                `${CUSTOMER_KEYS_TABLE}.id`,
+                `${CUSTOMER_KEYS_TABLE}.uuid`,
+                `${CUSTOMER_KEYS_TABLE}.display_name`,
+                `${CUSTOMER_KEYS_TABLE}.scopes`,
+                `${CUSTOMER_KEYS_TABLE}.last_used_at`,
+                `${CUSTOMER_KEYS_TABLE}.created_at`
+            );
+
+            return Ok(rows);
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    private apiKeysByEnvironmentQuery(trx: Knex, environmentId: number, { displayName }: { displayName?: string | undefined } = {}) {
+        return trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+            .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
+            .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
+            .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, environmentId)
+            .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+            .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+            .modify((query) => {
+                if (displayName !== undefined) {
+                    query.where(`${CUSTOMER_KEYS_TABLE}.display_name`, displayName);
+                }
+            })
+            .orderBy(`${CUSTOMER_KEYS_TABLE}.display_name`, 'asc');
     }
 
     private webhookSigningKeyForEnv(trx: Knex, envId: number) {

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -66,6 +66,7 @@ export const ACCOUNT_API_KEY_SCOPES = [
     'account:environments:create',
     'account:environments:delete',
     'account:environments:set_production',
+    'account:environments:api_keys:list',
     'account:environments:api_keys:create',
     'account:environments:api_keys:delete'
 ] as const;

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -69,6 +69,7 @@ import type {
     DeletePublicEnvironment,
     GetEnvironment,
     GetEnvironments,
+    GetPublicApiKeys,
     GetPublicEnvironments,
     ListApiKeys,
     PatchApiKey,
@@ -227,6 +228,7 @@ export type PublicApiEndpoints =
     | PostPublicEnvironment
     | DeletePublicEnvironment
     | GetPublicEnvironments
+    | GetPublicApiKeys
     | PostPublicApiKey
     | DeletePublicApiKey;
 

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -203,6 +203,24 @@ export type PostPublicApiKey = ApiEndpoint<{
     Error: ApiError<'conflict' | 'resource_capped'>;
 }>;
 
+export type GetPublicApiKeys = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
+    Method: 'GET';
+    Path: '/environments/:environmentUuid/api-keys';
+    Params: { environmentUuid: string };
+    Querystring: { display_name?: string | undefined };
+    Success: {
+        data: {
+            id: number;
+            uuid: string;
+            display_name: string;
+            scopes: ApiKeyScope[];
+            last_used_at: string | null;
+            created_at: string;
+        }[];
+    };
+}>;
+
 export type DeletePublicApiKey = ApiEndpoint<{
     Audit: AuditPolicy<'api_key', 'deleted', 'environment'>;
     Method: 'DELETE';


### PR DESCRIPTION
Adds `GET /environments/:environmentUuid/api-keys` for Environment API keys.

- Introduces the `account:environments:api_keys:list` scope.
- Supports optional exact `display_name` filtering with `?display_name=`.
- Refactors environment API-key queries to share the base relation/filter query.
- Documents the endpoint in OpenAPI, HTTP API docs, and LLM docs.
- Adds integration coverage for authentication, scopes, filtering, validation, wildcard access, and isolation.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

