### PR TITLE
fix(dockerfile): fix vulns in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,11 +90,15 @@ FROM node:22.22.2-bookworm-slim AS web
 RUN npm install -g npm@11.10.1
 
 # - Bash is just to be able to log inside the image and have a decent shell
+# - apt upgrade pulls Debian security updates (libgnutls30 / DSA-6281)
+# - perl-base has unfixed CRITICAL/HIGH CVEs on bookworm and is unused at runtime
 RUN true \
-  && apt update && apt-get install -y bash ca-certificates \
+  && apt-get update \
+  && apt-get upgrade -y --no-install-recommends \
+  && apt-get install -y --no-install-recommends bash ca-certificates \
   && update-ca-certificates \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+  && apt-get purge -y --auto-remove --allow-remove-essential -o APT::AutoRemove::RecommendsImportant=false perl-base \
+  && rm -rf /var/lib/apt/lists/*
 
 # Do not use root to run the app
 # BUT it does not work with secret mount (could not find a solution yet)


### PR DESCRIPTION
## Summary
- Upgrade Debian packages in the final image so `libgnutls30` picks up DSA-6281 (`3.7.9-2+deb12u7`).
- Purge `perl-base` after apt work. Bookworm has no fix for the scanner-flagged CRITICAL/HIGH perl CVEs, and the Node runtime never uses Perl.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

