### PR TITLE
feat(api): get environment API keys by UUID

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -817,6 +817,7 @@
                           "reference/backend/http-api/environments/create",
                           "reference/backend/http-api/environments/delete",
                           "reference/backend/http-api/environments/list-api-keys",
+                          "reference/backend/http-api/environments/get-api-key",
                           "reference/backend/http-api/environments/create-api-key",
                           "reference/backend/http-api/environments/delete-api-key"
                         ]

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9593,6 +9593,7 @@ curl --request POST \
 - [Create an environment](/reference/backend/http-api/environments/create)
 - [Delete an environment](/reference/backend/http-api/environments/delete)
 - [List environment API keys](/reference/backend/http-api/environments/list-api-keys)
+- [Get an environment API key](/reference/backend/http-api/environments/get-api-key)
 - [Create an environment API key](/reference/backend/http-api/environments/create-api-key)
 - [Delete an environment API key](/reference/backend/http-api/environments/delete-api-key)
 
@@ -9706,6 +9707,32 @@ Source: https://nango.dev/docs/reference/backend/http-api/environments/list-api-
       "created_at": "2026-08-18T12:00:00.000Z"
     }
   ]
+}
+```
+</ResponseExample>
+
+## Get an environment API key
+
+Source: https://nango.dev/docs/reference/backend/http-api/environments/get-api-key.md
+
+<Info>
+  Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys) with the `account:environments:api_keys:read` scope.
+</Info>
+
+Retrieves an Environment API key, including its secret.
+
+<ResponseExample>
+```json Example Response
+{
+  "data": {
+    "id": 456,
+    "uuid": "123e4567-e89b-12d3-a456-426614174001",
+    "display_name": "provisioned-ci",
+    "scopes": ["environment:*"],
+    "secret": "<YOUR-ENVIRONMENT-API-KEY>",
+    "last_used_at": null,
+    "created_at": "2026-08-18T12:00:00.000Z"
+  }
 }
 ```
 </ResponseExample>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -76,6 +76,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 - [Backend: HTTP API: Environments: Create an environment](https://nango.dev/docs/reference/backend/http-api/environments/create.md)
 - [Backend: HTTP API: Environments: Delete an environment](https://nango.dev/docs/reference/backend/http-api/environments/delete.md)
 - [Backend: HTTP API: Environments: List environment API keys](https://nango.dev/docs/reference/backend/http-api/environments/list-api-keys.md)
+- [Backend: HTTP API: Environments: Get an environment API key](https://nango.dev/docs/reference/backend/http-api/environments/get-api-key.md)
 - [Backend: HTTP API: Environments: Create an environment API key](https://nango.dev/docs/reference/backend/http-api/environments/create-api-key.md)
 - [Backend: HTTP API: Environments: Delete an environment API key](https://nango.dev/docs/reference/backend/http-api/environments/delete-api-key.md)
 - [Backend: HTTP API: Integrations: List all integrations](https://nango.dev/docs/reference/backend/http-api/integration/list.md)

--- a/docs/reference/backend/http-api/api-keys.mdx
+++ b/docs/reference/backend/http-api/api-keys.mdx
@@ -280,5 +280,6 @@ curl --request POST \
 - [Create an environment](/reference/backend/http-api/environments/create)
 - [Delete an environment](/reference/backend/http-api/environments/delete)
 - [List environment API keys](/reference/backend/http-api/environments/list-api-keys)
+- [Get an environment API key](/reference/backend/http-api/environments/get-api-key)
 - [Create an environment API key](/reference/backend/http-api/environments/create-api-key)
 - [Delete an environment API key](/reference/backend/http-api/environments/delete-api-key)

--- a/docs/reference/backend/http-api/environments/get-api-key.mdx
+++ b/docs/reference/backend/http-api/environments/get-api-key.mdx
@@ -1,0 +1,26 @@
+---
+title: 'Get an environment API key'
+openapi: 'GET /environments/{environmentUuid}/api-keys/{keyUuid}'
+---
+
+<Info>
+  Requires an [Account API key](/reference/backend/http-api/api-keys#account-api-keys) with the `account:environments:api_keys:read` scope.
+</Info>
+
+Retrieves an Environment API key, including its secret.
+
+<ResponseExample>
+```json Example Response
+{
+  "data": {
+    "id": 456,
+    "uuid": "123e4567-e89b-12d3-a456-426614174001",
+    "display_name": "provisioned-ci",
+    "scopes": ["environment:*"],
+    "secret": "<YOUR-ENVIRONMENT-API-KEY>",
+    "last_used_at": null,
+    "created_at": "2026-08-18T12:00:00.000Z"
+  }
+}
+```
+</ResponseExample>

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -3138,6 +3138,80 @@ paths:
                 '500':
                     $ref: '#/components/responses/ServerError'
     /environments/{environmentUuid}/api-keys/{keyUuid}:
+        get:
+            summary: Get an environment API key
+            description: Retrieve an Environment API key, including its secret.
+            parameters:
+                - name: environmentUuid
+                  in: path
+                  required: true
+                  description: Environment UUID that owns the key.
+                  schema:
+                      type: string
+                      format: uuid
+                  example: 123e4567-e89b-12d3-a456-426614174000
+                - name: keyUuid
+                  in: path
+                  required: true
+                  description: API-key UUID.
+                  schema:
+                      type: string
+                      format: uuid
+                  example: 123e4567-e89b-12d3-a456-426614174001
+            responses:
+                '200':
+                    description: Successfully retrieved the Environment API key
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                properties:
+                                    data:
+                                        type: object
+                                        required:
+                                            - id
+                                            - uuid
+                                            - display_name
+                                            - scopes
+                                            - secret
+                                            - last_used_at
+                                            - created_at
+                                        properties:
+                                            id:
+                                                type: integer
+                                                example: 456
+                                            uuid:
+                                                type: string
+                                                format: uuid
+                                                example: 123e4567-e89b-12d3-a456-426614174001
+                                            display_name:
+                                                type: string
+                                                example: provisioned-ci
+                                            scopes:
+                                                type: array
+                                                items:
+                                                    type: string
+                                            secret:
+                                                type: string
+                                                description: The Environment API-key secret.
+                                            last_used_at:
+                                                type: [string, 'null']
+                                                format: date-time
+                                            created_at:
+                                                type: string
+                                                format: date-time
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+                '500':
+                    $ref: '#/components/responses/ServerError'
         delete:
             summary: Delete an environment API key
             description: Delete an environment API key

--- a/packages/authz/lib/scopes.ts
+++ b/packages/authz/lib/scopes.ts
@@ -70,6 +70,7 @@ export const PUBLIC_ACCOUNT_SCOPES = [
     'account:environments:delete',
     'account:environments:set_production',
     'account:environments:api_keys:list',
+    'account:environments:api_keys:read',
     'account:environments:api_keys:create',
     'account:environments:api_keys:delete'
 ] as const satisfies readonly AccountApiKeyScope[];

--- a/packages/server/lib/controllers/environment/deleteApiKey.ts
+++ b/packages/server/lib/controllers/environment/deleteApiKey.ts
@@ -43,7 +43,7 @@ export const deletePublicEnvironmentApiKey = asyncWrapper<DeletePublicApiKey>(as
         return;
     }
 
-    const key = await customerKeyService.getApiKeyByUuid(db.knex, keyUuid, environment.id, account.id);
+    const key = await customerKeyService.getApiKeyByUuidWithoutSecrets(db.knex, keyUuid, environment.id, account.id);
     if (key.isErr()) {
         report(key.error, { accountId: account.id, environmentId: environment.id });
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to delete API key' } });

--- a/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
@@ -311,6 +311,36 @@ describe('Public environment API key management', () => {
             expect(res.json.error.code).toBe('invalid_uri_params');
         });
 
+        it('should reject an invalid environment UUID', async () => {
+            const { account, apiKey } = await seedAccount();
+            const accountKey = await createAccountKey(account.id, ['account:environments:api_keys:read']);
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: 'not-a-uuid', keyUuid: apiKey.uuid }
+            });
+
+            expect(res.res.status).toBe(400);
+            isError(res.json);
+            expect(res.json.error.code).toBe('invalid_uri_params');
+        });
+
+        it('should return not found for an unknown key in the environment', async () => {
+            const { account, env } = await seedAccount();
+            const accountKey = await createAccountKey(account.id, ['account:environments:api_keys:read']);
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: env.uuid, keyUuid: '123e4567-e89b-12d3-a456-426614174001' }
+            });
+
+            expect(res.res.status).toBe(404);
+            isError(res.json);
+            expect(res.json.error).toEqual({ code: 'not_found', message: 'API key not found' });
+        });
+
         it('should require the read scope', async () => {
             const { account, env } = await seedAccount();
             const apiKey = (

--- a/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
@@ -266,6 +266,140 @@ describe('Public environment API key management', () => {
         });
     });
 
+    describe('GET /environments/:environmentUuid/api-keys/:keyUuid', () => {
+        it('should be protected', async () => {
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
+                method: 'GET',
+                params: {
+                    environmentUuid: '123e4567-e89b-12d3-a456-426614174000',
+                    keyUuid: '123e4567-e89b-12d3-a456-426614174001'
+                }
+            });
+
+            shouldBeProtected(res);
+        });
+
+        it('should deny environment API keys', async () => {
+            const { env, apiKey } = await seedAccount();
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
+                method: 'GET',
+                token: apiKey.secret,
+                params: { environmentUuid: env.uuid, keyUuid: apiKey.uuid }
+            });
+
+            expect(res.res.status).toBe(403);
+            isError(res.json);
+            expect(res.json.error).toEqual({
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: account:environments:api_keys:read'
+            });
+        });
+
+        it('should reject an invalid key UUID', async () => {
+            const { account, env } = await seedAccount();
+            const accountKey = await createAccountKey(account.id, ['account:environments:api_keys:read']);
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: env.uuid, keyUuid: 'not-a-uuid' }
+            });
+
+            expect(res.res.status).toBe(400);
+            isError(res.json);
+            expect(res.json.error.code).toBe('invalid_uri_params');
+        });
+
+        it('should require the read scope', async () => {
+            const { account, env } = await seedAccount();
+            const apiKey = (
+                await customerKeyService.createApiKey(db.knex, {
+                    accountId: account.id,
+                    environmentId: env.id,
+                    displayName: 'read-scope-key'
+                })
+            ).unwrap();
+            const listKey = await createAccountKey(account.id, ['account:environments:api_keys:list']);
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
+                method: 'GET',
+                token: listKey.secret,
+                params: { environmentUuid: env.uuid, keyUuid: apiKey.uuid }
+            });
+
+            expect(res.res.status).toBe(403);
+            isError(res.json);
+            expect(res.json.error).toEqual({
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: account:environments:api_keys:read'
+            });
+        });
+
+        it('should return a key and its secret with the read scope', async () => {
+            const { account, env } = await seedAccount();
+            const apiKey = (
+                await customerKeyService.createApiKey(db.knex, {
+                    accountId: account.id,
+                    environmentId: env.id,
+                    displayName: 'readable-secret-key'
+                })
+            ).unwrap();
+            const accountKey = await createAccountKey(account.id, ['account:environments:api_keys:read']);
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: env.uuid, keyUuid: apiKey.uuid }
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json).toStrictEqual({
+                data: {
+                    id: apiKey.id,
+                    uuid: apiKey.uuid,
+                    display_name: apiKey.display_name,
+                    scopes: ['environment:*'],
+                    secret: apiKey.secret,
+                    last_used_at: null,
+                    created_at: apiKey.created_at.toISOString()
+                }
+            });
+        });
+
+        it('should not reveal a key from another account', async () => {
+            const first = await seedAccount();
+            const second = await seedAccount();
+            const accountKey = await createAccountKey(first.account.id, ['account:environments:api_keys:read']);
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: second.env.uuid, keyUuid: second.apiKey.uuid }
+            });
+
+            expect(res.res.status).toBe(404);
+            isError(res.json);
+            expect(res.json.error).toEqual({ code: 'not_found', message: 'Environment not found' });
+        });
+
+        it('should allow account:*', async () => {
+            const { account, env, apiKey } = await seedAccount();
+            const accountKey = await createAccountKey(account.id, ['account:*']);
+
+            const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {
+                method: 'GET',
+                token: accountKey.secret,
+                params: { environmentUuid: env.uuid, keyUuid: apiKey.uuid }
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json.data.secret).toBe(apiKey.secret);
+        });
+    });
+
     describe('DELETE /environments/:environmentUuid/api-keys/:keyUuid', () => {
         it('should be protected', async () => {
             const res = await api.fetch('/environments/:environmentUuid/api-keys/:keyUuid', {

--- a/packages/server/lib/controllers/environment/getApiKey.ts
+++ b/packages/server/lib/controllers/environment/getApiKey.ts
@@ -1,0 +1,61 @@
+import * as z from 'zod';
+
+import db from '@nangohq/database';
+import { customerKeyService, environmentService } from '@nangohq/shared';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+
+import type { ApiKeyScope, GetPublicApiKey } from '@nangohq/types';
+
+const validationParams = z.object({ environmentUuid: z.uuid(), keyUuid: z.uuid() }).strict();
+
+export const getPublicEnvironmentApiKey = asyncWrapper<GetPublicApiKey>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const params = validationParams.safeParse(req.params);
+    if (!params.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(params.error) } });
+        return;
+    }
+
+    const account = res.locals.account;
+    if (!account) {
+        res.status(500).send({ error: { code: 'server_error', message: 'Account context is required' } });
+        return;
+    }
+
+    const environment = await environmentService.getByUuidWithoutSecrets(params.data.environmentUuid, account.id);
+    if (!environment) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Environment not found' } });
+        return;
+    }
+
+    const key = await customerKeyService.getApiKeyByUuid(db.knex, params.data.keyUuid, environment.id, account.id);
+    if (key.isErr()) {
+        report(key.error, { accountId: account.id, environmentId: environment.id, keyUuid: params.data.keyUuid });
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to retrieve API key' } });
+        return;
+    }
+    if (!key.value) {
+        res.status(404).send({ error: { code: 'not_found', message: 'API key not found' } });
+        return;
+    }
+
+    const { id, uuid, display_name, scopes, secret, last_used_at, created_at } = key.value;
+    res.status(200).send({
+        data: {
+            id,
+            uuid,
+            display_name,
+            scopes: (scopes ?? []) as ApiKeyScope[],
+            secret,
+            last_used_at: last_used_at?.toISOString() ?? null,
+            created_at: created_at.toISOString()
+        }
+    });
+});

--- a/packages/server/lib/middleware/audit/apiKey.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/apiKey.middleware.unit.test.ts
@@ -7,7 +7,7 @@ import {
     fakeReq,
     fakeRes,
     getApiKeyByIdMock,
-    getApiKeyByUuidMock,
+    getApiKeyByUuidWithoutSecretsMock,
     getEnvironmentByIdMock,
     getEnvironmentByUuidMock,
     installAuditMockDefaults,
@@ -27,7 +27,7 @@ describe('apiKey audit middleware (unit)', () => {
         getEnvironmentByIdMock.mockReset().mockResolvedValue({ id: 12, name: 'prod' });
         getEnvironmentByUuidMock.mockReset().mockResolvedValue({ id: 12, uuid: '00000000-0000-4000-8000-000000000012', name: 'prod' });
         getApiKeyByIdMock.mockReset().mockResolvedValue(Ok({ uuid: 'a2f1c0de-0000-4000-8000-000000000001', display_name: 'ci-key' }));
-        getApiKeyByUuidMock.mockReset().mockResolvedValue(Ok({ id: 2551, display_name: 'ci-key' }));
+        getApiKeyByUuidWithoutSecretsMock.mockReset().mockResolvedValue(Ok({ id: 2551, display_name: 'ci-key' }));
     });
 
     afterEach(() => {
@@ -85,8 +85,10 @@ describe('apiKey audit middleware (unit)', () => {
             resource: 'api_key',
             action: 'deleted',
             accountId: 42,
-            environment: { id: '00000000-0000-4000-8000-000000000012', display: 'prod' }
+            environment: { id: '00000000-0000-4000-8000-000000000012', display: 'prod' },
+            targets: [{ type: 'api_key', id: '00000000-0000-4000-8000-000000002551', display: 'ci-key' }]
         });
+        expect(getApiKeyByUuidWithoutSecretsMock).toHaveBeenCalledWith(expect.anything(), '00000000-0000-4000-8000-000000002551', 12, 42);
         expect(accountKey?.environment).toBeNull();
     });
 
@@ -151,7 +153,7 @@ describe('apiKey audit middleware (unit)', () => {
         );
         expect(event).toMatchObject({ resource: 'api_key', action: 'deleted', accountId: 42, environment: null, targets: [] });
         expect(getEnvironmentByUuidMock).not.toHaveBeenCalled();
-        expect(getApiKeyByUuidMock).not.toHaveBeenCalled();
+        expect(getApiKeyByUuidWithoutSecretsMock).not.toHaveBeenCalled();
     });
 
     it("public api key create: another account's environment is never named", async () => {

--- a/packages/server/lib/middleware/audit/lookups.ts
+++ b/packages/server/lib/middleware/audit/lookups.ts
@@ -117,7 +117,7 @@ export function publicEnvApiKeyTarget(keyUuid: unknown, environmentUuid: unknown
         if (!environment) {
             return undefined;
         }
-        const result = await customerKeyService.getApiKeyByUuid(db.knex, id, environment.id, account.id);
+        const result = await customerKeyService.getApiKeyByUuidWithoutSecrets(db.knex, id, environment.id, account.id);
         if (result.isErr()) {
             throw result.error;
         }

--- a/packages/server/lib/middleware/audit/testing.ts
+++ b/packages/server/lib/middleware/audit/testing.ts
@@ -19,7 +19,7 @@ export const getEnvironmentByIdMock: Mock = vi.fn();
 export const getEnvironmentByUuidMock: Mock = vi.fn();
 export const getApiKeyByIdMock: Mock = vi.fn();
 export const getAccountApiKeyByIdMock: Mock = vi.fn();
-export const getApiKeyByUuidMock: Mock = vi.fn();
+export const getApiKeyByUuidWithoutSecretsMock: Mock = vi.fn();
 export const getIntegrationSummaryMock: Mock = vi.fn();
 export const getConnectionByIdMock: Mock = vi.fn();
 export const getUserByIdMock: Mock = vi.fn();
@@ -39,7 +39,7 @@ export async function sharedModuleMock(importOriginal: () => Promise<typeof Nang
             ...actual.customerKeyService,
             getApiKeyById: getApiKeyByIdMock,
             getAccountApiKeyById: getAccountApiKeyByIdMock,
-            getApiKeyByUuid: getApiKeyByUuidMock
+            getApiKeyByUuidWithoutSecrets: getApiKeyByUuidWithoutSecretsMock
         },
         configService: { ...actual.configService, getIntegrationSummary: getIntegrationSummaryMock },
         accountService: { ...actual.accountService, getAccountById: getAccountByIdMock },

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -40,6 +40,7 @@ import { getPublicConnections } from './controllers/connection/getConnections.js
 import { postPublicConnection } from './controllers/connection/postConnection.js';
 import { deletePublicEnvironmentApiKey } from './controllers/environment/deleteApiKey.js';
 import { deletePublicEnvironment } from './controllers/environment/deleteEnvironment.js';
+import { getPublicEnvironmentApiKey } from './controllers/environment/getApiKey.js';
 import { getPublicEnvironmentApiKeys } from './controllers/environment/getApiKeys.js';
 import { getPublicEnvironments } from './controllers/environment/getEnvironments.js';
 import { getPublicEnvironmentVariables } from './controllers/environment/getVariables.js';
@@ -260,6 +261,7 @@ publicAPI
     .post(apiAuth, auditPublicApiKeyCreated, withScope('account:environments:api_keys:create'), postPublicEnvironmentApiKey);
 publicAPI
     .route('/environments/:environmentUuid/api-keys/:keyUuid')
+    .get(apiAuth, withScope('account:environments:api_keys:read'), getPublicEnvironmentApiKey)
     .delete(apiAuth, auditPublicApiKeyDeleted, withScope('account:environments:api_keys:delete'), deletePublicEnvironmentApiKey);
 
 // @deprecated rollbacked for one customer, to delete asap

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -273,7 +273,7 @@ class CustomerKeyService {
         }
     }
 
-    public async getApiKeyByUuid(trx: Knex, keyUuid: string, envId: number, accountId: number): Promise<Result<DBCustomerKey | null>> {
+    public async getApiKeyByUuidWithoutSecrets(trx: Knex, keyUuid: string, envId: number, accountId: number): Promise<Result<DBCustomerKey | null>> {
         try {
             const row = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
                 .select(`${CUSTOMER_KEYS_TABLE}.*`)
@@ -289,6 +289,13 @@ class CustomerKeyService {
         } catch (err) {
             return Err(err);
         }
+    }
+
+    public async getApiKeyByUuid(trx: Knex, keyUuid: string, envId: number, accountId: number): Promise<Result<DBCustomerKey | null>> {
+        const encryptedKey = await this.getApiKeyByUuidWithoutSecrets(trx, keyUuid, envId, accountId);
+        return encryptedKey.map((key) => {
+            return key !== null ? getEncryptionManager().decryptAPISecret(key) : null;
+        });
     }
 
     public async createWebhookSigningKey(

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -67,6 +67,7 @@ export const ACCOUNT_API_KEY_SCOPES = [
     'account:environments:delete',
     'account:environments:set_production',
     'account:environments:api_keys:list',
+    'account:environments:api_keys:read',
     'account:environments:api_keys:create',
     'account:environments:api_keys:delete'
 ] as const;

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -69,6 +69,7 @@ import type {
     DeletePublicEnvironment,
     GetEnvironment,
     GetEnvironments,
+    GetPublicApiKey,
     GetPublicApiKeys,
     GetPublicEnvironments,
     ListApiKeys,
@@ -228,6 +229,7 @@ export type PublicApiEndpoints =
     | PostPublicEnvironment
     | DeletePublicEnvironment
     | GetPublicEnvironments
+    | GetPublicApiKey
     | GetPublicApiKeys
     | PostPublicApiKey
     | DeletePublicApiKey;

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -221,6 +221,24 @@ export type GetPublicApiKeys = ApiEndpoint<{
     };
 }>;
 
+export type GetPublicApiKey = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
+    Method: 'GET';
+    Path: '/environments/:environmentUuid/api-keys/:keyUuid';
+    Params: { environmentUuid: string; keyUuid: string };
+    Success: {
+        data: {
+            id: number;
+            uuid: string;
+            display_name: string;
+            scopes: ApiKeyScope[];
+            secret: string;
+            last_used_at: string | null;
+            created_at: string;
+        };
+    };
+}>;
+
 export type DeletePublicApiKey = ApiEndpoint<{
     Audit: AuditPolicy<'api_key', 'deleted', 'environment'>;
     Method: 'DELETE';


### PR DESCRIPTION
Adds `GET /environments/:environmentUuid/api-keys/:keyUuid`.

- Introduces the `account:environments:api_keys:read` scope.
- Returns an environment API key’s metadata and decrypted secret.
- Adds a shared service method for UUID lookups that decrypts secrets.
- Documents the endpoint in OpenAPI, HTTP API docs, and LLM docs.
- Adds integration coverage for authentication, scopes, filtering, validation, wildcard access, and isolation.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

