### PR TITLE
feat(server): tag internal callers instead of excluding them from deprecated endpoint metric

### DIFF
--- a/packages/server/lib/controllers/connection/connectionId/getConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.ts
@@ -55,9 +55,7 @@ export const getPublicConnection = asyncWrapperWithEnvironment<GetPublicConnecti
 
     const isSync = req.get('Nango-Is-Sync') === 'true';
 
-    if (!isSync) {
-        metrics.increment(metrics.Types.GET_CONNECTION, 1);
-    }
+    metrics.increment(metrics.Types.GET_CONNECTION, 1, { internal: isSync ? 'true' : 'false' });
 
     const includeCredentials = hasAuthorizedScope({ locals: res.locals, requiredScope: 'environment:connections:read_credentials' });
     const requestsCredentialOperation = returnRefreshToken || instantRefresh || refreshGithubAppJwtToken;

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -147,14 +147,15 @@ const sandboxTokenOnly: RequestHandler = (_req, res, next) => {
     next();
 };
 
-function trackDeprecatedPublicEndpoint(endpoint: string, shouldSkip?: (req: Request) => boolean): RequestHandler {
+function trackDeprecatedPublicEndpoint(endpoint: string, isInternal?: (req: Request) => boolean): RequestHandler {
     return (req, res, next) => {
         const { account, environment } = res.locals as RequestLocals;
-        if (environment && !shouldSkip?.(req)) {
+        if (environment) {
             metrics.increment(metrics.Types.DEPRECATED_PUBLIC_ENDPOINT_USED, 1, {
                 accountId: account.id,
                 environmentId: environment.id,
-                endpoint
+                endpoint,
+                internal: isInternal?.(req) ? 'true' : 'false'
             });
         }
         next();

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -155,7 +155,7 @@ function trackDeprecatedPublicEndpoint(endpoint: string, isInternal?: (req: Requ
                 accountId: account.id,
                 environmentId: environment.id,
                 endpoint,
-                internal: isInternal?.(req) ? 'true' : 'false'
+                ...(isInternal && { internal: isInternal(req) ? 'true' : 'false' })
             });
         }
         next();

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -118,6 +118,7 @@ export enum Types {
 
     API_REQUEST_CONTENT_LENGTH = 'nango.api.request.content_length',
     DEPRECATED_V1_ENDPOINT_USED = 'nango.server.deprecated.v1.used',
+
     DEPRECATED_PUBLIC_ENDPOINT_USED = 'nango.server.deprecated.public.used',
 
     AUTH_SUCCESS = 'nango.server.auth.success',


### PR DESCRIPTION
## Describe the problem and your solution

- tag internal get connection callers instead of excluding them from deprecated endpoint metric

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

