### PR TITLE
fix(ci): give the Clickhouse test container a 120s startup budget

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -118,6 +118,7 @@ export async function setupClickhouse() {
         .withExposedPorts(8123)
         .withName(`clickhouse-test-${randomUUID()}`)
         .withEnvironment({ CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: '1', ALLOW_EMPTY_PASSWORD: 'yes' })
+        .withStartupTimeout(120_000)
         .withWaitStrategy(Wait.forHttp('/ping', 8123))
         .start();
     containers.push(clickhouse);


### PR DESCRIPTION
- Raise the Clickhouse test container's startup budget from testcontainers' default 60s to 120s, matching the budget Elasticsearch already carries in the same file. Clickhouse was the last container still on the default, so it is the first thing to break when container startup slows down — and when it breaks it throws from vitest's `globalSetup`, taking the whole shard down before a single test runs.

## Root cause of today's CI outage

Not this repo, and not the Clickhouse image — Blacksmith's docker cache reports the same image hash in the last green run and in every red one, and no pull happens. It is an upstream Blacksmith incident: [Service degradation in upstream GHCR registries](https://status.blacksmith.sh/cmtk69nmb002c13pmm1yfslre), `DEGRADEDPERFORMANCE`, started 2026-09-02T14:09:09Z. That straddles our last green run (13:43 UTC) and the first red one (13:57 UTC), and it explains why only the two largest images are affected.

Clickhouse startup time over the day: 11s (11:38) to 46s (13:24) to 45s (13:43) to over 60s (13:57) to about 122s (15:44).

This PR does not fix the outage and cannot — while the incident is degrading, both heavy images can exceed any budget worth setting. It removes a real asymmetry that made us fail earlier and more confusingly than we had to. Deliberately not chasing the incident with larger numbers: a 300s budget would make every shard spend five minutes booting containers long after the incident clears, and would mask genuine hangs.

## Test plan

- [x] Verified `withStartupTimeout` actually drives `HttpWaitStrategy`'s budget despite being chained before `withWaitStrategy`: with a 7s budget and a path that never returns 200, the failure message becomes `URL /nope not accessible after 7000ms` instead of the 60000ms default.
- [x] Verified the new budget takes effect in CI: shard 4 of the first run on this branch brought Clickhouse up at 122s, which the old 60s budget would have killed. (That shard still failed, on Elasticsearch's own 120s budget.)
- [ ] All 4 integration shards green once the Blacksmith incident clears.