### PR TITLE
feat(webapp): show spend and per-metric charges to all customers

### DIFF
--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -54,12 +54,8 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
     const setOverdueOverride = usePlanOverrideStore((s) => s.setOverdueOverride);
     const usageLimitOverride = usePlanOverrideStore((s) => s.usageLimitOverride);
     const setUsageLimitOverride = usePlanOverrideStore((s) => s.setUsageLimitOverride);
-    const spendHeadlineEnabled = usePlanOverrideStore((s) => s.spendHeadlineEnabled);
-    const setSpendHeadlineEnabled = usePlanOverrideStore((s) => s.setSpendHeadlineEnabled);
     const spendOverride = usePlanOverrideStore((s) => s.spendOverride);
     const setSpendOverride = usePlanOverrideStore((s) => s.setSpendOverride);
-    const metricChargesEnabled = usePlanOverrideStore((s) => s.metricChargesEnabled);
-    const setMetricChargesEnabled = usePlanOverrideStore((s) => s.setMetricChargesEnabled);
     const periodCostsOverride = usePlanOverrideStore((s) => s.periodCostsOverride);
     const setPeriodCostsOverride = usePlanOverrideStore((s) => s.setPeriodCostsOverride);
     const addonState = usePlanOverrideStore((s) => s.addonState);
@@ -221,58 +217,46 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
 
                     {leadsWithSpend && (
                         <>
-                            <Row label="Spend headline" hint="Unverified against real Orb invoices, so customers do not see it yet.">
-                                <RowSwitch checked={spendHeadlineEnabled} onCheckedChange={setSpendHeadlineEnabled} />
+                            <Row label="Spend">
+                                <Select
+                                    value={spendOverride === null ? REAL_SPEND_VALUE : String(spendOverride)}
+                                    onValueChange={(value) =>
+                                        setSpendOverride(
+                                            value === REAL_SPEND_VALUE
+                                                ? null
+                                                : value === UNAVAILABLE_SPEND_VALUE
+                                                  ? UNAVAILABLE_SPEND_VALUE
+                                                  : (Number(value) as SpendOverride)
+                                        )
+                                    }
+                                >
+                                    <RowTrigger placeholder="Real" />
+                                    <SelectContent>
+                                        <SelectItem value={REAL_SPEND_VALUE}>Real</SelectItem>
+                                        {SPEND_PRESETS_IN_CENTS.map((cents) => (
+                                            <SelectItem key={cents} value={String(cents)}>
+                                                {(cents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
+                                            </SelectItem>
+                                        ))}
+                                        <SelectItem value={UNAVAILABLE_SPEND_VALUE}>Unavailable</SelectItem>
+                                    </SelectContent>
+                                </Select>
                             </Row>
-                            {spendHeadlineEnabled && (
-                                <Row label="Spend" indent>
-                                    <Select
-                                        value={spendOverride === null ? REAL_SPEND_VALUE : String(spendOverride)}
-                                        onValueChange={(value) =>
-                                            setSpendOverride(
-                                                value === REAL_SPEND_VALUE
-                                                    ? null
-                                                    : value === UNAVAILABLE_SPEND_VALUE
-                                                      ? UNAVAILABLE_SPEND_VALUE
-                                                      : (Number(value) as SpendOverride)
-                                            )
-                                        }
-                                    >
-                                        <RowTrigger placeholder="Real" />
-                                        <SelectContent>
-                                            <SelectItem value={REAL_SPEND_VALUE}>Real</SelectItem>
-                                            {SPEND_PRESETS_IN_CENTS.map((cents) => (
-                                                <SelectItem key={cents} value={String(cents)}>
-                                                    {(cents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
-                                                </SelectItem>
-                                            ))}
-                                            <SelectItem value={UNAVAILABLE_SPEND_VALUE}>Unavailable</SelectItem>
-                                        </SelectContent>
-                                    </Select>
-                                </Row>
-                            )}
 
-                            <Row label="Charges column" hint="Unverified against real Orb invoices, so customers do not see it yet.">
-                                <RowSwitch checked={metricChargesEnabled} onCheckedChange={setMetricChargesEnabled} />
+                            <Row label="Charges">
+                                <Select
+                                    value={periodCostsOverride ?? REAL_PERIOD_COSTS_VALUE}
+                                    onValueChange={(value) => setPeriodCostsOverride(value === REAL_PERIOD_COSTS_VALUE ? null : (value as PeriodCostsOverride))}
+                                >
+                                    <RowTrigger placeholder="Real" />
+                                    <SelectContent>
+                                        <SelectItem value={REAL_PERIOD_COSTS_VALUE}>Real</SelectItem>
+                                        <SelectItem value="populated">Some metrics</SelectItem>
+                                        <SelectItem value="zero">$0.00 on all</SelectItem>
+                                        <SelectItem value="unavailable">Unavailable</SelectItem>
+                                    </SelectContent>
+                                </Select>
                             </Row>
-                            {metricChargesEnabled && (
-                                <Row label="Charges" indent>
-                                    <Select
-                                        value={periodCostsOverride ?? REAL_PERIOD_COSTS_VALUE}
-                                        onValueChange={(value) =>
-                                            setPeriodCostsOverride(value === REAL_PERIOD_COSTS_VALUE ? null : (value as PeriodCostsOverride))
-                                        }
-                                    >
-                                        <RowTrigger placeholder="Real" />
-                                        <SelectContent>
-                                            <SelectItem value={REAL_PERIOD_COSTS_VALUE}>Real</SelectItem>
-                                            <SelectItem value="populated">Some metrics</SelectItem>
-                                            <SelectItem value="zero">$0.00 on all</SelectItem>
-                                            <SelectItem value="unavailable">Unavailable</SelectItem>
-                                        </SelectContent>
-                                    </Select>
-                                </Row>
-                            )}
                         </>
                     )}
                 </Section>

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -23,14 +23,7 @@ interface PlanOverrideState {
     overdueOverride: boolean;
     /** Plan-limit state to simulate, or `null` to use real usage. Free plan only. */
     usageLimitOverride: UsageLimitOverride | null;
-    /**
-     * Reveals the current-period spend headline. Off until the figure is verified against real Orb
-     * invoices; delete this flag once it ships to everyone.
-     */
-    spendHeadlineEnabled: boolean;
-    /** Spend to simulate. Only meaningful with the flag on. */
     spendOverride: SpendOverride | null;
-    metricChargesEnabled: boolean;
     periodCostsOverride: PeriodCostsOverride | null;
     addonState: GrowthAddonState | null;
     paymentMethodOverride: boolean;
@@ -38,9 +31,7 @@ interface PlanOverrideState {
     setScheduledTarget: (code: PlanDefinition['code'] | null) => void;
     setOverdueOverride: (override: boolean) => void;
     setUsageLimitOverride: (override: UsageLimitOverride | null) => void;
-    setSpendHeadlineEnabled: (enabled: boolean) => void;
     setSpendOverride: (override: SpendOverride | null) => void;
-    setMetricChargesEnabled: (enabled: boolean) => void;
     setPeriodCostsOverride: (override: PeriodCostsOverride | null) => void;
     setAddonState: (state: GrowthAddonState | null) => void;
     setPaymentMethodOverride: (override: boolean) => void;
@@ -52,9 +43,7 @@ export const DEFAULTS = {
     scheduledTargetCode: null,
     overdueOverride: false,
     usageLimitOverride: null,
-    spendHeadlineEnabled: false,
     spendOverride: null,
-    metricChargesEnabled: false,
     periodCostsOverride: null,
     addonState: null,
     paymentMethodOverride: false
@@ -64,8 +53,7 @@ export const usePlanOverrideStore = create<PlanOverrideState>()(
     persist(
         (set) => ({
             ...DEFAULTS,
-            // Switching plan clears the states picked against the old one. `spendHeadlineEnabled`
-            // survives here — a rollout flag, not a simulated state — though Reset still clears it.
+            // Switching plan clears the states picked against the old one.
             setOverride: (overrideCode) =>
                 set({
                     overrideCode,
@@ -79,9 +67,7 @@ export const usePlanOverrideStore = create<PlanOverrideState>()(
             setScheduledTarget: (scheduledTargetCode) => set({ scheduledTargetCode }),
             setOverdueOverride: (overdueOverride) => set({ overdueOverride }),
             setUsageLimitOverride: (usageLimitOverride) => set({ usageLimitOverride }),
-            setSpendHeadlineEnabled: (spendHeadlineEnabled) => set({ spendHeadlineEnabled }),
             setSpendOverride: (spendOverride) => set({ spendOverride }),
-            setMetricChargesEnabled: (metricChargesEnabled) => set({ metricChargesEnabled }),
             setPeriodCostsOverride: (periodCostsOverride) => set({ periodCostsOverride }),
             setAddonState: (addonState) => set({ addonState }),
             setPaymentMethodOverride: (paymentMethodOverride) => set({ paymentMethodOverride }),

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 
 import { IconButton } from '@nangohq/design-system';
 
-import { usePlanOverrideStore } from '@/features/planOverride';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useApiGetPlans, useApiGetUpcomingInvoice, useCurrentPlan } from '@/hooks/usePlan';
 import { useStripePaymentMethods } from '@/hooks/useStripe';
@@ -31,9 +30,7 @@ export const Summary: React.FC = () => {
     const transition = usePlanTransition();
     const paymentMethod = paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
 
-    // Behind a dev-tool flag until the figure is reconciled against real Orb invoices (NAN-6246).
-    const spendHeadlineEnabled = usePlanOverrideStore((s) => s.spendHeadlineEnabled);
-    const spendEnabled = spendHeadlineEnabled && hasMonthlySpend(plan);
+    const spendEnabled = hasMonthlySpend(plan);
     const { data: upcoming, isPending: isSpendPending, isError: didSpendFail } = useApiGetUpcomingInvoice(env, plan, { enabled: spendEnabled });
     const spend = useMemo(() => {
         if (!spendEnabled) {

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react';
 import { Alert, AlertActions, AlertDescription, AlertTitle, Button } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
-import { usePlanOverrideStore } from '@/features/planOverride';
 import { useApiGetBillingPeriodCosts, useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
@@ -43,9 +42,8 @@ export const Usage: React.FC = () => {
     // billing running-average, matching what each row's drill-in chart also requests.
     const { data: usage, isLoading, error: usageError } = useApiGetBillingUsage(env, timeframe, { avgPerDay: true, enabled: plan != null && !isFree });
 
-    const metricChargesEnabled = usePlanOverrideStore((s) => s.metricChargesEnabled);
     // Orb only holds costs for the period in progress, so a past month has no charge to state.
-    const chargesEnabled = metricChargesEnabled && isCurrentMonth && hasMonthlySpend(plan);
+    const chargesEnabled = isCurrentMonth && hasMonthlySpend(plan);
     const { data: periodCosts, isPending: costsPending, isError: costsError } = useApiGetBillingPeriodCosts(env, plan, { enabled: chargesEnabled });
     const charges = buildUsageRowCharges({ enabled: chargesEnabled, isPending: costsPending, isError: costsError, data: periodCosts });
 


### PR DESCRIPTION
## Problem

The summary strip's current-period spend headline (NAN-6246) and the usage table's Charges column (NAN-6220) both shipped behind dev-tool-only flags, so customers never saw either one. Both have now been checked against real Orb invoices.

## Solution

- Remove the `spendHeadlineEnabled` and `metricChargesEnabled` dev-tool flags — both surfaces now render for every plan billed monthly, which already includes `pay-as-you-go`
- Keep the simulate-spend and simulate-charges overrides: the noop billing client returns nothing locally, so they're the only way to preview populated states without an Orb key
- The two overrides move up to top-level rows in Billing Overrides now that there's no toggle to nest under

## Testing

- Verified on the dev API with a fresh browser profile (empty `localStorage`, so no flag could be set): strip shows `CURRENT PERIOD SPEND`, usage table shows `CHARGES`, no console errors
- Confirmed the Billing Overrides panel still renders and that selecting a simulated spend preset still drives the headline
- `ts-build`, oxlint and the webapp unit tests (393) all pass

## Follow-ups

- Charges lag ~24h by design — canonical Orb events come from the daily ClickHouse→S3 export of yesterday, so the 1st of a month reads $0.00 until the 2nd. Known and accepted; the improvement direction is more frequent exports.
- [NAN-6755](https://linear.app/nango/issue/NAN-6755/move-the-orb-billable-metric-mapping-out-of-code) — move the Orb billable-metric id mapping out of code
