### PR TITLE
feat(audit): show how many events a read matches

### DIFF
--- a/packages/audit/lib/client.ts
+++ b/packages/audit/lib/client.ts
@@ -106,8 +106,13 @@ export class AuditClient {
         }));
     }
 
+    /** Never throws, as `record` doesn't — a reader that rejects comes back as `Err` for the caller to handle. */
     async countAuditTrailEvents(filter: AuditTrailFilter): Promise<Result<number>> {
-        return await this.reader.count(filter);
+        try {
+            return await this.reader.count(filter);
+        } catch (err) {
+            return Err(err);
+        }
     }
 
     /** Builds the CSV for the window. `truncated` reports that `maxRows` cut the result, rather than failing the export. */

--- a/packages/audit/lib/client.ts
+++ b/packages/audit/lib/client.ts
@@ -5,7 +5,7 @@ import { Err, Ok } from '@nangohq/utils';
 import { auditCsvHeader, auditCsvRows } from './csv.js';
 
 import type { AuditReader, AuditTrailCursor, AuditTrailFilter, AuditWriter } from './store.js';
-import type { ApiAuditTrailEvent, AuditEvent, AuditExportMaxRows, AuditTrailVersion, StoredAuditEvent } from '@nangohq/types';
+import type { ApiAuditTrailEvent, AuditEvent, AuditExportMaxRows, AuditTrailTotal, AuditTrailVersion, StoredAuditEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 // The date the shape shipped, not a timestamp; bump only on a breaking change.
@@ -107,7 +107,7 @@ export class AuditClient {
     }
 
     /** Never throws, as `record` doesn't — a reader that rejects comes back as `Err` for the caller to handle. */
-    async countAuditTrailEvents(filter: AuditTrailFilter): Promise<Result<number>> {
+    async countAuditTrailEvents(filter: AuditTrailFilter): Promise<Result<AuditTrailTotal>> {
         try {
             return await this.reader.count(filter);
         } catch (err) {

--- a/packages/audit/lib/client.ts
+++ b/packages/audit/lib/client.ts
@@ -4,7 +4,7 @@ import { Err, Ok } from '@nangohq/utils';
 
 import { auditCsvHeader, auditCsvRows } from './csv.js';
 
-import type { AuditReader, AuditTrailCursor, AuditWriter } from './store.js';
+import type { AuditReader, AuditTrailCursor, AuditTrailFilter, AuditWriter } from './store.js';
 import type { ApiAuditTrailEvent, AuditEvent, AuditExportMaxRows, AuditTrailVersion, StoredAuditEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
@@ -106,20 +106,8 @@ export class AuditClient {
         }));
     }
 
-    async countAuditTrailEvents({
-        accountId,
-        from,
-        to,
-        resources,
-        actions
-    }: {
-        accountId: number;
-        from?: string | undefined;
-        to?: string | undefined;
-        resources?: string[] | undefined;
-        actions?: string[] | undefined;
-    }): Promise<Result<number>> {
-        return await this.reader.count({ accountId, from, to, resources, actions });
+    async countAuditTrailEvents(filter: AuditTrailFilter): Promise<Result<number>> {
+        return await this.reader.count(filter);
     }
 
     /** Builds the CSV for the window. `truncated` reports that `maxRows` cut the result, rather than failing the export. */

--- a/packages/audit/lib/client.ts
+++ b/packages/audit/lib/client.ts
@@ -106,6 +106,22 @@ export class AuditClient {
         }));
     }
 
+    async countAuditTrailEvents({
+        accountId,
+        from,
+        to,
+        resources,
+        actions
+    }: {
+        accountId: number;
+        from?: string | undefined;
+        to?: string | undefined;
+        resources?: string[] | undefined;
+        actions?: string[] | undefined;
+    }): Promise<Result<number>> {
+        return await this.reader.count({ accountId, from, to, resources, actions });
+    }
+
     /** Builds the CSV for the window. `truncated` reports that `maxRows` cut the result, rather than failing the export. */
     async exportCsv({
         accountId,

--- a/packages/audit/lib/client.ts
+++ b/packages/audit/lib/client.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { Err, Ok } from '@nangohq/utils';
+import { Err, getLogger, Ok, stringifyError } from '@nangohq/utils';
 
 import { auditCsvHeader, auditCsvRows } from './csv.js';
 
@@ -9,6 +9,8 @@ import type { ApiAuditTrailEvent, AuditEvent, AuditExportMaxRows, AuditTrailTota
 import type { Result } from '@nangohq/utils';
 
 // The date the shape shipped, not a timestamp; bump only on a breaking change.
+const logger = getLogger('audit');
+
 const AUDIT_EVENT_VERSION: AuditTrailVersion = '2026-07-16';
 
 // The response is built during the request, so the ceiling is what the load balancer's timeout allows.
@@ -111,6 +113,8 @@ export class AuditClient {
         try {
             return await this.reader.count(filter);
         } catch (err) {
+            // The reader logs what it catches, so only escapes reach here and they are recorded nowhere else.
+            logger.warning(`Audit trail count threw for account ${filter.accountId}: ${stringifyError(err)}`);
             return Err(err);
         }
     }

--- a/packages/audit/lib/client.unit.test.ts
+++ b/packages/audit/lib/client.unit.test.ts
@@ -6,7 +6,7 @@ import { AuditClient, InvalidAuditCursorError } from './client.js';
 import { NoopAuditStore } from './stores/noop.js';
 
 import type { AuditReader, AuditTrailPage, AuditWriter, ListAuditTrailEventsParams } from './store.js';
-import type { AuditEvent, SerializedAuditEvent, StoredAuditEvent } from '@nangohq/types';
+import type { AuditEvent, AuditTrailTotal, SerializedAuditEvent, StoredAuditEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 class RecordingStore implements AuditWriter, AuditReader {
@@ -23,8 +23,8 @@ class RecordingStore implements AuditWriter, AuditReader {
         return Promise.resolve(Ok({ events: [], nextCursor: null }));
     }
 
-    count(): Promise<Result<number>> {
-        return Promise.resolve(Ok(0));
+    count(): Promise<Result<AuditTrailTotal>> {
+        return Promise.resolve(Ok({ value: 0, relation: 'eq' }));
     }
 
     stored(index = 0): StoredAuditEvent {

--- a/packages/audit/lib/client.unit.test.ts
+++ b/packages/audit/lib/client.unit.test.ts
@@ -5,14 +5,13 @@ import { Ok } from '@nangohq/utils';
 import { AuditClient, InvalidAuditCursorError } from './client.js';
 import { NoopAuditStore } from './stores/noop.js';
 
-import type { AuditReader, AuditTrailFilter, AuditTrailPage, AuditWriter, ListAuditTrailEventsParams } from './store.js';
+import type { AuditReader, AuditTrailPage, AuditWriter, ListAuditTrailEventsParams } from './store.js';
 import type { AuditEvent, SerializedAuditEvent, StoredAuditEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 class RecordingStore implements AuditWriter, AuditReader {
     records: SerializedAuditEvent[] = [];
     listCalls: ListAuditTrailEventsParams[] = [];
-    countCalls: AuditTrailFilter[] = [];
 
     record(record: SerializedAuditEvent): Promise<Result<void>> {
         this.records.push(record);
@@ -24,8 +23,7 @@ class RecordingStore implements AuditWriter, AuditReader {
         return Promise.resolve(Ok({ events: [], nextCursor: null }));
     }
 
-    count(params: AuditTrailFilter): Promise<Result<number>> {
-        this.countCalls.push(params);
+    count(): Promise<Result<number>> {
         return Promise.resolve(Ok(0));
     }
 

--- a/packages/audit/lib/client.unit.test.ts
+++ b/packages/audit/lib/client.unit.test.ts
@@ -5,13 +5,14 @@ import { Ok } from '@nangohq/utils';
 import { AuditClient, InvalidAuditCursorError } from './client.js';
 import { NoopAuditStore } from './stores/noop.js';
 
-import type { AuditReader, AuditTrailPage, AuditWriter, ListAuditTrailEventsParams } from './store.js';
+import type { AuditReader, AuditTrailFilter, AuditTrailPage, AuditWriter, ListAuditTrailEventsParams } from './store.js';
 import type { AuditEvent, SerializedAuditEvent, StoredAuditEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 class RecordingStore implements AuditWriter, AuditReader {
     records: SerializedAuditEvent[] = [];
     listCalls: ListAuditTrailEventsParams[] = [];
+    countCalls: AuditTrailFilter[] = [];
 
     record(record: SerializedAuditEvent): Promise<Result<void>> {
         this.records.push(record);
@@ -21,6 +22,11 @@ class RecordingStore implements AuditWriter, AuditReader {
     list(params: ListAuditTrailEventsParams): Promise<Result<AuditTrailPage>> {
         this.listCalls.push(params);
         return Promise.resolve(Ok({ events: [], nextCursor: null }));
+    }
+
+    count(params: AuditTrailFilter): Promise<Result<number>> {
+        this.countCalls.push(params);
+        return Promise.resolve(Ok(0));
     }
 
     stored(index = 0): StoredAuditEvent {

--- a/packages/audit/lib/export.unit.test.ts
+++ b/packages/audit/lib/export.unit.test.ts
@@ -100,7 +100,7 @@ describe('AuditClient.exportCsv', () => {
 
     it('propagates a read failure instead of returning a partial document', async () => {
         const reader: AuditReader = {
-            count: vi.fn().mockResolvedValue(Ok(0)),
+            count: vi.fn().mockResolvedValue(Ok({ value: 0, relation: 'eq' })),
             list: vi.fn().mockResolvedValue(Err('failed_to_list_audit_trail_events'))
         };
         const result = await clientFor(reader).exportCsv({ accountId: 42, maxRows: 10, pageSize: 5 });

--- a/packages/audit/lib/export.unit.test.ts
+++ b/packages/audit/lib/export.unit.test.ts
@@ -26,6 +26,7 @@ function readerServing(pages: ApiAuditTrailEvent[][]): { reader: AuditReader; li
     const limits: number[] = [];
     let call = 0;
     const reader: AuditReader = {
+        count: () => Promise.reject(new Error('exportCsv must not count')),
         list: ({ limit }) => {
             limits.push(limit);
             const events = pages[call] ?? [];
@@ -98,7 +99,10 @@ describe('AuditClient.exportCsv', () => {
     });
 
     it('propagates a read failure instead of returning a partial document', async () => {
-        const reader: AuditReader = { list: vi.fn().mockResolvedValue(Err('failed_to_list_audit_trail_events')) };
+        const reader: AuditReader = {
+            count: vi.fn().mockResolvedValue(Ok(0)),
+            list: vi.fn().mockResolvedValue(Err('failed_to_list_audit_trail_events'))
+        };
         const result = await clientFor(reader).exportCsv({ accountId: 42, maxRows: 10, pageSize: 5 });
 
         expect(result.isErr()).toBe(true);

--- a/packages/audit/lib/store.ts
+++ b/packages/audit/lib/store.ts
@@ -6,15 +6,19 @@ export interface AuditTrailCursor {
     id: string;
 }
 
-export interface ListAuditTrailEventsParams {
+/** The filter half of a read, without the paging half, so the count can take the same shape as the list. */
+export interface AuditTrailFilter {
     accountId: number;
-    limit: number;
-    before?: AuditTrailCursor | undefined;
     from?: string | undefined;
     to?: string | undefined;
     resources?: string[] | undefined;
     /** Narrows `resources`; ignored on its own, since a match needs both halves of `resource.action`. */
     actions?: string[] | undefined;
+}
+
+export interface ListAuditTrailEventsParams extends AuditTrailFilter {
+    limit: number;
+    before?: AuditTrailCursor | undefined;
 }
 
 export interface AuditTrailPage {
@@ -33,4 +37,6 @@ export interface AuditBatchWriter {
 
 export interface AuditReader {
     list(params: ListAuditTrailEventsParams): Promise<Result<AuditTrailPage>>;
+    /** How many events match, independent of paging. */
+    count(params: AuditTrailFilter): Promise<Result<number>>;
 }

--- a/packages/audit/lib/store.ts
+++ b/packages/audit/lib/store.ts
@@ -6,7 +6,7 @@ export interface AuditTrailCursor {
     id: string;
 }
 
-/** The filter half of a read, without the paging half, so the count can take the same shape as the list. */
+/** Split from the paging half so the count can take the same shape as the list. */
 export interface AuditTrailFilter {
     accountId: number;
     from?: string | undefined;
@@ -37,6 +37,5 @@ export interface AuditBatchWriter {
 
 export interface AuditReader {
     list(params: ListAuditTrailEventsParams): Promise<Result<AuditTrailPage>>;
-    /** How many events match, independent of paging. */
     count(params: AuditTrailFilter): Promise<Result<number>>;
 }

--- a/packages/audit/lib/store.ts
+++ b/packages/audit/lib/store.ts
@@ -1,4 +1,4 @@
-import type { ApiAuditTrailEvent, SerializedAuditEvent } from '@nangohq/types';
+import type { ApiAuditTrailEvent, AuditTrailTotal, SerializedAuditEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export interface AuditTrailCursor {
@@ -36,5 +36,5 @@ export interface AuditBatchWriter {
 
 export interface AuditReader {
     list(params: ListAuditTrailEventsParams): Promise<Result<AuditTrailPage>>;
-    count(params: AuditTrailFilter): Promise<Result<number>>;
+    count(params: AuditTrailFilter): Promise<Result<AuditTrailTotal>>;
 }

--- a/packages/audit/lib/store.ts
+++ b/packages/audit/lib/store.ts
@@ -6,7 +6,6 @@ export interface AuditTrailCursor {
     id: string;
 }
 
-/** Split from the paging half so the count can take the same shape as the list. */
 export interface AuditTrailFilter {
     accountId: number;
     from?: string | undefined;

--- a/packages/audit/lib/stores/clickhouse.integration.test.ts
+++ b/packages/audit/lib/stores/clickhouse.integration.test.ts
@@ -215,29 +215,6 @@ describe('ClickhouseAuditStore.list deduplication', () => {
         }
     });
 
-    it('counts a twice-stored event once, so the count and the list agree on the same set', async () => {
-        const dupe = '77777777-7777-7777-7777-777777777777';
-        const other = '88888888-8888-8888-8888-888888888888';
-        await client.command({ query: `SYSTEM STOP MERGES ${database}.audit_trail_events` });
-        try {
-            await insertEvent({ id: dupe, accountId: 11, occurredAt: at(5000) });
-            await insertEvent({ id: dupe, accountId: 11, occurredAt: at(5000) });
-            await insertEvent({ id: other, accountId: 11, occurredAt: at(6000) });
-
-            // Without this the test passes on a table where the copy already merged away.
-            const raw = await client.query({
-                query: `SELECT count() AS c FROM ${database}.audit_trail_events WHERE account_id = 11`,
-                format: 'JSONEachRow'
-            });
-            expect(Number((await raw.json<{ c: string | number }>())[0]!.c)).toBe(3);
-
-            expect((await store.count({ accountId: 11 })).unwrap()).toEqual({ value: 2, relation: 'eq' });
-            expect((await store.list({ accountId: 11, limit: 10 })).unwrap().events).toHaveLength(2);
-        } finally {
-            await client.command({ query: `SYSTEM START MERGES ${database}.audit_trail_events` });
-        }
-    });
-
     it('does not hand a copy back on the next page, since the cursor excludes the boundary row it shares a key with', async () => {
         const newer = '55555555-5555-5555-5555-555555555555';
         const older = '66666666-6666-6666-6666-666666666666';

--- a/packages/audit/lib/stores/clickhouse.integration.test.ts
+++ b/packages/audit/lib/stores/clickhouse.integration.test.ts
@@ -215,6 +215,29 @@ describe('ClickhouseAuditStore.list deduplication', () => {
         }
     });
 
+    it('counts a twice-stored event once, so the header cannot disagree with the rows', async () => {
+        const dupe = '77777777-7777-7777-7777-777777777777';
+        const other = '88888888-8888-8888-8888-888888888888';
+        await client.command({ query: `SYSTEM STOP MERGES ${database}.audit_trail_events` });
+        try {
+            await insertEvent({ id: dupe, accountId: 11, occurredAt: at(5000) });
+            await insertEvent({ id: dupe, accountId: 11, occurredAt: at(5000) });
+            await insertEvent({ id: other, accountId: 11, occurredAt: at(6000) });
+
+            // Three rows in storage, two distinct events — the gap a plain count() would report.
+            const raw = await client.query({
+                query: `SELECT count() AS c FROM ${database}.audit_trail_events WHERE account_id = 11`,
+                format: 'JSONEachRow'
+            });
+            expect(Number((await raw.json<{ c: string | number }>())[0]!.c)).toBe(3);
+
+            expect((await store.count({ accountId: 11 })).unwrap()).toBe(2);
+            expect((await store.list({ accountId: 11, limit: 10 })).unwrap().events).toHaveLength(2);
+        } finally {
+            await client.command({ query: `SYSTEM START MERGES ${database}.audit_trail_events` });
+        }
+    });
+
     it('does not hand a copy back on the next page, since the cursor excludes the boundary row it shares a key with', async () => {
         const newer = '55555555-5555-5555-5555-555555555555';
         const older = '66666666-6666-6666-6666-666666666666';

--- a/packages/audit/lib/stores/clickhouse.integration.test.ts
+++ b/packages/audit/lib/stores/clickhouse.integration.test.ts
@@ -188,6 +188,19 @@ describe('AuditClient.record through ClickhouseAuditStore', () => {
     });
 });
 
+describe('ClickhouseAuditStore.count bounding', () => {
+    it('reports a floor once the scan hits its cap, rather than an exact figure', async () => {
+        // The store caps its scan at the export ceiling; a smaller cap keeps the fixture cheap.
+        const bounded = new ClickhouseAuditStore(client, undefined, 3);
+        for (let i = 0; i < 5; i++) {
+            await insertEvent({ id: `99999999-9999-9999-9999-99999999999${i}`, accountId: 12, occurredAt: at(7000 + i) });
+        }
+
+        expect((await bounded.count({ accountId: 12 })).unwrap()).toEqual({ value: 3, relation: 'gte' });
+        expect((await bounded.count({ accountId: 12, from: at(7003) })).unwrap()).toEqual({ value: 2, relation: 'eq' });
+    });
+});
+
 describe('ClickhouseAuditStore.list deduplication', () => {
     it('returns one row for an event that was stored twice', async () => {
         const id = '44444444-4444-4444-4444-444444444444';

--- a/packages/audit/lib/stores/clickhouse.integration.test.ts
+++ b/packages/audit/lib/stores/clickhouse.integration.test.ts
@@ -231,7 +231,7 @@ describe('ClickhouseAuditStore.list deduplication', () => {
             });
             expect(Number((await raw.json<{ c: string | number }>())[0]!.c)).toBe(3);
 
-            expect((await store.count({ accountId: 11 })).unwrap()).toBe(2);
+            expect((await store.count({ accountId: 11 })).unwrap()).toEqual({ value: 2, relation: 'eq' });
             expect((await store.list({ accountId: 11, limit: 10 })).unwrap().events).toHaveLength(2);
         } finally {
             await client.command({ query: `SYSTEM START MERGES ${database}.audit_trail_events` });

--- a/packages/audit/lib/stores/clickhouse.integration.test.ts
+++ b/packages/audit/lib/stores/clickhouse.integration.test.ts
@@ -224,7 +224,7 @@ describe('ClickhouseAuditStore.list deduplication', () => {
             await insertEvent({ id: dupe, accountId: 11, occurredAt: at(5000) });
             await insertEvent({ id: other, accountId: 11, occurredAt: at(6000) });
 
-            // Three rows in storage, two distinct events — the gap a plain count() would report.
+            // Without this the test passes on a table where the copy already merged away.
             const raw = await client.query({
                 query: `SELECT count() AS c FROM ${database}.audit_trail_events WHERE account_id = 11`,
                 format: 'JSONEachRow'

--- a/packages/audit/lib/stores/clickhouse.integration.test.ts
+++ b/packages/audit/lib/stores/clickhouse.integration.test.ts
@@ -215,7 +215,7 @@ describe('ClickhouseAuditStore.list deduplication', () => {
         }
     });
 
-    it('counts a twice-stored event once, so the header cannot disagree with the rows', async () => {
+    it('counts a twice-stored event once, so the count and the list agree on the same set', async () => {
         const dupe = '77777777-7777-7777-7777-777777777777';
         const other = '88888888-8888-8888-8888-888888888888';
         await client.command({ query: `SYSTEM STOP MERGES ${database}.audit_trail_events` });

--- a/packages/audit/lib/stores/clickhouse.ts
+++ b/packages/audit/lib/stores/clickhouse.ts
@@ -46,7 +46,8 @@ function buildFilter({ accountId, from, to, resources, actions }: AuditTrailFilt
 export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, AuditReader {
     constructor(
         private readonly client: ClickHouseClient,
-        private readonly retentionDays = AUDIT_RETENTION_DAYS
+        private readonly retentionDays = AUDIT_RETENTION_DAYS,
+        private readonly countScanLimit: number = COUNT_SCAN_LIMIT
     ) {}
 
     // Never throws, so every call emits exactly one ingest-result metric — callers rely on that to
@@ -136,12 +137,12 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
 
     async count(filter: AuditTrailFilter): Promise<Result<AuditTrailTotal>> {
         const { conditions, params } = buildFilter(filter);
-        params['scan_limit'] = COUNT_SCAN_LIMIT + 1;
+        params['scan_limit'] = this.countScanLimit + 1;
 
         // The inner LIMIT bounds the read however large the account or the window. uniq is approximate,
         // which also folds the duplicate rows a ReplacingMergeTree holds until a merge runs.
         const sql = `
-            SELECT uniq(id) AS total
+            SELECT uniq(id) AS total, count() AS scanned
             FROM (
                 SELECT id
                 FROM audit_trail_events
@@ -157,15 +158,17 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
                 query_params: params,
                 clickhouse_settings: { max_execution_time: COUNT_QUERY_MAX_EXECUTION_SECONDS }
             });
-            const [row] = await res.json<{ total: string }>();
+            const [row] = await res.json<{ total: string; scanned: string }>();
             const total = Number(row?.total);
+            const scanned = Number(row?.scanned);
 
-            if (!Number.isFinite(total)) {
+            if (!Number.isFinite(total) || !Number.isFinite(scanned)) {
                 return Err('failed_to_count_audit_trail_events');
             }
 
-            // Hitting the scan limit means the account has at least this many, not exactly this many.
-            return total > COUNT_SCAN_LIMIT ? Ok({ value: COUNT_SCAN_LIMIT, relation: 'gte' }) : Ok({ value: total, relation: 'eq' });
+            // Keyed on rows read, not distinct values: the LIMIT caps rows, so duplicates inside the prefix
+            // would otherwise leave a truncated count looking exact.
+            return scanned > this.countScanLimit ? Ok({ value: this.countScanLimit, relation: 'gte' }) : Ok({ value: total, relation: 'eq' });
         } catch (err) {
             // Warning, not error: the caller is expected to carry on without the number.
             logger.warning(`Failed to count audit trail events for account ${filter.accountId}: ${stringifyError(err)}`);

--- a/packages/audit/lib/stores/clickhouse.ts
+++ b/packages/audit/lib/stores/clickhouse.ts
@@ -13,11 +13,10 @@ const logger = getLogger('audit');
 
 const AUDIT_RETENTION_DAYS = 365;
 const READ_QUERY_MAX_EXECUTION_SECONDS = 30;
-// Shorter than the list's: the count is optional to the response, so an unbounded window on a large
-// account gives up rather than holding the read open.
+// Shorter than the list's: the count is optional to the response, so a heavy one gives up rather than holding the read open.
 const COUNT_QUERY_MAX_EXECUTION_SECONDS = 5;
 
-// Shared by the list and the count so the number can never describe a different set than the rows under it.
+// One source of the filter, so the count and the list can never describe different sets.
 function buildFilter({ accountId, from, to, resources, actions }: AuditTrailFilter): { conditions: string[]; params: Record<string, unknown> } {
     const params: Record<string, unknown> = { account_id: accountId };
     const conditions = ['account_id = {account_id:Int64}'];
@@ -134,12 +133,11 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
         }
     }
 
-    // `uniqExact(id)` rather than `count()`: the engine is a ReplacingMergeTree, so a redelivery sits as a
-    // second row until a merge collapses it, and a plain count would report it. `FINAL` would also be exact
-    // but rewrites the read the way the ORDER BY short-circuit above avoids.
     async count(filter: AuditTrailFilter): Promise<Result<number>> {
         const { conditions, params } = buildFilter(filter);
 
+        // Not `count()`: this is a ReplacingMergeTree, so a redelivery sits as a second row until a merge
+        // collapses it. `FINAL` is exact too, but gives up the ORDER BY short-circuit the list read needs.
         const sql = `
             SELECT uniqExact(id) AS total
             FROM audit_trail_events

--- a/packages/audit/lib/stores/clickhouse.ts
+++ b/packages/audit/lib/stores/clickhouse.ts
@@ -4,7 +4,7 @@ import { Err, getLogger, metrics, Ok, stringifyError } from '@nangohq/utils';
 
 import { sanitizeClickhouseError } from '../error.js';
 
-import type { AuditBatchWriter, AuditReader, AuditTrailPage, AuditWriter, ListAuditTrailEventsParams } from '../store.js';
+import type { AuditBatchWriter, AuditReader, AuditTrailFilter, AuditTrailPage, AuditWriter, ListAuditTrailEventsParams } from '../store.js';
 import type { ClickHouseClient } from '@clickhouse/client';
 import type { ApiAuditTrailEvent, SerializedAuditEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -13,6 +13,32 @@ const logger = getLogger('audit');
 
 const AUDIT_RETENTION_DAYS = 365;
 const READ_QUERY_MAX_EXECUTION_SECONDS = 30;
+
+// Shared by the list and the count so the number can never describe a different set than the rows under it.
+function buildFilter({ accountId, from, to, resources, actions }: AuditTrailFilter): { conditions: string[]; params: Record<string, unknown> } {
+    const params: Record<string, unknown> = { account_id: accountId };
+    const conditions = ['account_id = {account_id:Int64}'];
+    if (resources?.length) {
+        if (actions?.length) {
+            // Every requested pair, matched against the materialized concatenation. Two separate
+            // conditions would prune per column and let a granule through on a pair it doesn't hold.
+            conditions.push('resource_action IN {resource_actions:Array(String)}');
+            params['resource_actions'] = resources.flatMap((resource) => actions.map((action) => `${resource}.${action}`));
+        } else {
+            conditions.push('resource IN {resources:Array(String)}');
+            params['resources'] = resources;
+        }
+    }
+    if (from) {
+        conditions.push('occurred_at >= parseDateTime64BestEffortOrNull({from:String}, 3)');
+        params['from'] = from;
+    }
+    if (to) {
+        conditions.push('occurred_at <= parseDateTime64BestEffortOrNull({to:String}, 3)');
+        params['to'] = to;
+    }
+    return { conditions, params };
+}
 
 export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, AuditReader {
     constructor(
@@ -62,27 +88,8 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
     // Both key on the event id, so they only catch a redelivery of the same event; a re-emit carries a fresh id and reads as two. A thinned page is the
     // only side effect, which is why `hasMore` keys off the raw count.
     async list({ accountId, limit, before, from, to, resources, actions }: ListAuditTrailEventsParams): Promise<Result<AuditTrailPage>> {
-        const params: Record<string, unknown> = { account_id: accountId, limit: limit + 1 };
-        const conditions = ['account_id = {account_id:Int64}'];
-        if (resources?.length) {
-            if (actions?.length) {
-                // Every requested pair, matched against the materialized concatenation. Two separate
-                // conditions would prune per column and let a granule through on a pair it doesn't hold.
-                conditions.push('resource_action IN {resource_actions:Array(String)}');
-                params['resource_actions'] = resources.flatMap((resource) => actions.map((action) => `${resource}.${action}`));
-            } else {
-                conditions.push('resource IN {resources:Array(String)}');
-                params['resources'] = resources;
-            }
-        }
-        if (from) {
-            conditions.push('occurred_at >= parseDateTime64BestEffortOrNull({from:String}, 3)');
-            params['from'] = from;
-        }
-        if (to) {
-            conditions.push('occurred_at <= parseDateTime64BestEffortOrNull({to:String}, 3)');
-            params['to'] = to;
-        }
+        const { conditions, params } = buildFilter({ accountId, from, to, resources, actions });
+        params['limit'] = limit + 1;
         if (before) {
             conditions.push('(occurred_at, id) < ({before_ts:DateTime64(3)}, {before_id:UUID})');
             params['before_ts'] = before.occurredAt;
@@ -121,6 +128,35 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
         } catch (err) {
             logger.error(`Failed to list audit trail events: ${stringifyError(err)}`);
             return Err('failed_to_list_audit_trail_events');
+        }
+    }
+
+    // `uniqExact(id)` rather than `count()`: the engine is a ReplacingMergeTree, so a redelivery sits as a
+    // second row until a merge collapses it, and a plain count would report it. `FINAL` would also be exact
+    // but rewrites the read the way the ORDER BY short-circuit above avoids.
+    async count({ accountId, from, to, resources, actions }: AuditTrailFilter): Promise<Result<number>> {
+        const { conditions, params } = buildFilter({ accountId, from, to, resources, actions });
+
+        const sql = `
+            SELECT uniqExact(id) AS total
+            FROM audit_trail_events
+            WHERE ${conditions.join(' AND ')}
+        `;
+
+        try {
+            const res = await this.client.query({
+                query: sql,
+                format: 'JSONEachRow',
+                query_params: params,
+                clickhouse_settings: { max_execution_time: READ_QUERY_MAX_EXECUTION_SECONDS }
+            });
+            const [row] = await res.json<{ total: string }>();
+
+            // ClickHouse serializes UInt64 as a string, so parse rather than trust the shape.
+            return Ok(row ? Number(row.total) : 0);
+        } catch (err) {
+            logger.error(`Failed to count audit trail events: ${stringifyError(err)}`);
+            return Err('failed_to_count_audit_trail_events');
         }
     }
 }

--- a/packages/audit/lib/stores/clickhouse.ts
+++ b/packages/audit/lib/stores/clickhouse.ts
@@ -137,8 +137,8 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
     // `uniqExact(id)` rather than `count()`: the engine is a ReplacingMergeTree, so a redelivery sits as a
     // second row until a merge collapses it, and a plain count would report it. `FINAL` would also be exact
     // but rewrites the read the way the ORDER BY short-circuit above avoids.
-    async count({ accountId, from, to, resources, actions }: AuditTrailFilter): Promise<Result<number>> {
-        const { conditions, params } = buildFilter({ accountId, from, to, resources, actions });
+    async count(filter: AuditTrailFilter): Promise<Result<number>> {
+        const { conditions, params } = buildFilter(filter);
 
         const sql = `
             SELECT uniqExact(id) AS total
@@ -154,11 +154,14 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
                 clickhouse_settings: { max_execution_time: COUNT_QUERY_MAX_EXECUTION_SECONDS }
             });
             const [row] = await res.json<{ total: string }>();
+            // A bare aggregate always returns one row, and UInt64 arrives as a string. Anything else is a
+            // broken response, and reporting it as 0 would claim nothing matched.
+            const total = Number(row?.total);
 
-            // ClickHouse serializes UInt64 as a string, so parse rather than trust the shape.
-            return Ok(row ? Number(row.total) : 0);
+            return Number.isFinite(total) ? Ok(total) : Err('failed_to_count_audit_trail_events');
         } catch (err) {
-            logger.error(`Failed to count audit trail events: ${stringifyError(err)}`);
+            // Warning, not error: the caller is expected to carry on without the number.
+            logger.warning(`Failed to count audit trail events for account ${filter.accountId}: ${stringifyError(err)}`);
             return Err('failed_to_count_audit_trail_events');
         }
     }

--- a/packages/audit/lib/stores/clickhouse.ts
+++ b/packages/audit/lib/stores/clickhouse.ts
@@ -138,11 +138,10 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
         const { conditions, params } = buildFilter(filter);
         params['scan_limit'] = COUNT_SCAN_LIMIT + 1;
 
-        // The inner LIMIT is what bounds the read, however large the account or the window. uniqExact stays
-        // affordable inside it and folds the duplicate rows a ReplacingMergeTree holds until a merge runs —
-        // `uniq` is approximate and was observed returning 1 for two distinct ids.
+        // The inner LIMIT bounds the read however large the account or the window. uniq is approximate,
+        // which also folds the duplicate rows a ReplacingMergeTree holds until a merge runs.
         const sql = `
-            SELECT uniqExact(id) AS total
+            SELECT uniq(id) AS total
             FROM (
                 SELECT id
                 FROM audit_trail_events

--- a/packages/audit/lib/stores/clickhouse.ts
+++ b/packages/audit/lib/stores/clickhouse.ts
@@ -13,8 +13,8 @@ const logger = getLogger('audit');
 
 const AUDIT_RETENTION_DAYS = 365;
 const READ_QUERY_MAX_EXECUTION_SECONDS = 30;
-// Shorter than the list's: the count is the one part of the page that degrades well, so an unbounded
-// window on a large account should cost the reader the number rather than the wait.
+// Shorter than the list's: the count is optional to the response, so an unbounded window on a large
+// account gives up rather than holding the read open.
 const COUNT_QUERY_MAX_EXECUTION_SECONDS = 5;
 
 // Shared by the list and the count so the number can never describe a different set than the rows under it.

--- a/packages/audit/lib/stores/clickhouse.ts
+++ b/packages/audit/lib/stores/clickhouse.ts
@@ -6,7 +6,7 @@ import { sanitizeClickhouseError } from '../error.js';
 
 import type { AuditBatchWriter, AuditReader, AuditTrailFilter, AuditTrailPage, AuditWriter, ListAuditTrailEventsParams } from '../store.js';
 import type { ClickHouseClient } from '@clickhouse/client';
-import type { ApiAuditTrailEvent, SerializedAuditEvent } from '@nangohq/types';
+import type { ApiAuditTrailEvent, AuditExportMaxRows, AuditTrailTotal, SerializedAuditEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 const logger = getLogger('audit');
@@ -15,6 +15,8 @@ const AUDIT_RETENTION_DAYS = 365;
 const READ_QUERY_MAX_EXECUTION_SECONDS = 30;
 // Shorter than the list's: the count is optional to the response, so a heavy one gives up rather than holding the read open.
 const COUNT_QUERY_MAX_EXECUTION_SECONDS = 5;
+// The export's ceiling, so "50,000+" in the header says exactly one thing: an export of this window truncates.
+const COUNT_SCAN_LIMIT: AuditExportMaxRows = 50_000;
 
 function buildFilter({ accountId, from, to, resources, actions }: AuditTrailFilter): { conditions: string[]; params: Record<string, unknown> } {
     const params: Record<string, unknown> = { account_id: accountId };
@@ -132,14 +134,21 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
         }
     }
 
-    async count(filter: AuditTrailFilter): Promise<Result<number>> {
+    async count(filter: AuditTrailFilter): Promise<Result<AuditTrailTotal>> {
         const { conditions, params } = buildFilter(filter);
+        params['scan_limit'] = COUNT_SCAN_LIMIT + 1;
 
-        // uniqExact folds the duplicate rows a ReplacingMergeTree can hold until a merge collapses them.
+        // The inner LIMIT is what bounds the read, however large the account or the window. uniqExact stays
+        // affordable inside it and folds the duplicate rows a ReplacingMergeTree holds until a merge runs —
+        // `uniq` is approximate and was observed returning 1 for two distinct ids.
         const sql = `
             SELECT uniqExact(id) AS total
-            FROM audit_trail_events
-            WHERE ${conditions.join(' AND ')}
+            FROM (
+                SELECT id
+                FROM audit_trail_events
+                WHERE ${conditions.join(' AND ')}
+                LIMIT {scan_limit:UInt32}
+            )
         `;
 
         try {
@@ -152,7 +161,12 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
             const [row] = await res.json<{ total: string }>();
             const total = Number(row?.total);
 
-            return Number.isFinite(total) ? Ok(total) : Err('failed_to_count_audit_trail_events');
+            if (!Number.isFinite(total)) {
+                return Err('failed_to_count_audit_trail_events');
+            }
+
+            // Hitting the scan limit means the account has at least this many, not exactly this many.
+            return total > COUNT_SCAN_LIMIT ? Ok({ value: COUNT_SCAN_LIMIT, relation: 'gte' }) : Ok({ value: total, relation: 'eq' });
         } catch (err) {
             // Warning, not error: the caller is expected to carry on without the number.
             logger.warning(`Failed to count audit trail events for account ${filter.accountId}: ${stringifyError(err)}`);

--- a/packages/audit/lib/stores/clickhouse.ts
+++ b/packages/audit/lib/stores/clickhouse.ts
@@ -13,6 +13,9 @@ const logger = getLogger('audit');
 
 const AUDIT_RETENTION_DAYS = 365;
 const READ_QUERY_MAX_EXECUTION_SECONDS = 30;
+// Shorter than the list's: the count is the one part of the page that degrades well, so an unbounded
+// window on a large account should cost the reader the number rather than the wait.
+const COUNT_QUERY_MAX_EXECUTION_SECONDS = 5;
 
 // Shared by the list and the count so the number can never describe a different set than the rows under it.
 function buildFilter({ accountId, from, to, resources, actions }: AuditTrailFilter): { conditions: string[]; params: Record<string, unknown> } {
@@ -148,7 +151,7 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
                 query: sql,
                 format: 'JSONEachRow',
                 query_params: params,
-                clickhouse_settings: { max_execution_time: READ_QUERY_MAX_EXECUTION_SECONDS }
+                clickhouse_settings: { max_execution_time: COUNT_QUERY_MAX_EXECUTION_SECONDS }
             });
             const [row] = await res.json<{ total: string }>();
 

--- a/packages/audit/lib/stores/clickhouse.ts
+++ b/packages/audit/lib/stores/clickhouse.ts
@@ -16,7 +16,6 @@ const READ_QUERY_MAX_EXECUTION_SECONDS = 30;
 // Shorter than the list's: the count is optional to the response, so a heavy one gives up rather than holding the read open.
 const COUNT_QUERY_MAX_EXECUTION_SECONDS = 5;
 
-// One source of the filter, so the count and the list can never describe different sets.
 function buildFilter({ accountId, from, to, resources, actions }: AuditTrailFilter): { conditions: string[]; params: Record<string, unknown> } {
     const params: Record<string, unknown> = { account_id: accountId };
     const conditions = ['account_id = {account_id:Int64}'];
@@ -136,8 +135,7 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
     async count(filter: AuditTrailFilter): Promise<Result<number>> {
         const { conditions, params } = buildFilter(filter);
 
-        // Not `count()`: this is a ReplacingMergeTree, so a redelivery sits as a second row until a merge
-        // collapses it. `FINAL` is exact too, but gives up the ORDER BY short-circuit the list read needs.
+        // uniqExact folds the duplicate rows a ReplacingMergeTree can hold until a merge collapses them.
         const sql = `
             SELECT uniqExact(id) AS total
             FROM audit_trail_events
@@ -152,8 +150,6 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
                 clickhouse_settings: { max_execution_time: COUNT_QUERY_MAX_EXECUTION_SECONDS }
             });
             const [row] = await res.json<{ total: string }>();
-            // A bare aggregate always returns one row, and UInt64 arrives as a string. Anything else is a
-            // broken response, and reporting it as 0 would claim nothing matched.
             const total = Number(row?.total);
 
             return Number.isFinite(total) ? Ok(total) : Err('failed_to_count_audit_trail_events');

--- a/packages/audit/lib/stores/noop.ts
+++ b/packages/audit/lib/stores/noop.ts
@@ -11,4 +11,8 @@ export class NoopAuditStore implements AuditWriter, AuditReader {
     list(): Promise<Result<AuditTrailPage>> {
         return Promise.resolve(Ok({ events: [], nextCursor: null }));
     }
+
+    count(): Promise<Result<number>> {
+        return Promise.resolve(Ok(0));
+    }
 }

--- a/packages/audit/lib/stores/noop.ts
+++ b/packages/audit/lib/stores/noop.ts
@@ -1,6 +1,7 @@
 import { Ok } from '@nangohq/utils';
 
 import type { AuditReader, AuditTrailPage, AuditWriter } from '../store.js';
+import type { AuditTrailTotal } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export class NoopAuditStore implements AuditWriter, AuditReader {
@@ -12,7 +13,7 @@ export class NoopAuditStore implements AuditWriter, AuditReader {
         return Promise.resolve(Ok({ events: [], nextCursor: null }));
     }
 
-    count(): Promise<Result<number>> {
-        return Promise.resolve(Ok(0));
+    count(): Promise<Result<AuditTrailTotal>> {
+        return Promise.resolve(Ok({ value: 0, relation: 'eq' }));
     }
 }

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
@@ -195,11 +195,11 @@ describe('GET /api/v1/audit-trail', () => {
         const all = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
         isSuccess(all.json);
         expect(all.json.data).toHaveLength(25);
-        expect(all.json.total).toBe(27);
+        expect(all.json.total).toEqual({ value: 27, relation: 'eq' });
 
         const narrowed = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { resources: 'api_key' } });
         isSuccess(narrowed.json);
-        expect(narrowed.json.total).toBe(1);
+        expect(narrowed.json.total).toEqual({ value: 1, relation: 'eq' });
     });
 
     it('reports the same total on a continuation as on the first page', async () => {
@@ -211,13 +211,13 @@ describe('GET /api/v1/audit-trail', () => {
 
         const first = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
         isSuccess(first.json);
-        expect(first.json.total).toBe(26);
+        expect(first.json.total).toEqual({ value: 26, relation: 'eq' });
 
         const second = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { cursor: first.json.pagination.nextCursor! } });
         isSuccess(second.json);
         expect(second.json.data).toHaveLength(1);
         // Paging doesn't narrow the set the filters describe, so the number can't move.
-        expect(second.json.total).toBe(26);
+        expect(second.json.total).toEqual({ value: 26, relation: 'eq' });
     });
 
     it('still returns the rows when the count fails, just without the number', async () => {

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
@@ -186,7 +186,7 @@ describe('GET /api/v1/audit-trail', () => {
     it('counts every match, not just the page, and narrows the count with the filters', async () => {
         const { session, account } = await authAdmin();
         const base = Date.parse('2026-07-16T10:00:00.000Z');
-        // 26 connection events — one past the page size — plus one of another resource.
+        // One past the page size, so the total can't be mistaken for the page length.
         for (let i = 0; i < 26; i++) {
             (await emitter.record(auditEvent(account.id, new Date(base + i * 1000).toISOString(), { resource: 'connection', action: 'deleted' }))).unwrap();
         }

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
@@ -182,6 +182,41 @@ describe('GET /api/v1/audit-trail', () => {
         expect(res.json.data.map((e) => e.resource).sort()).toEqual(['api_key', 'connection']);
     });
 
+    it('counts every match, not just the page, and narrows the count with the filters', async () => {
+        const { session, account } = await authAdmin();
+        const base = Date.parse('2026-07-16T10:00:00.000Z');
+        // 26 connection events — one past the page size — plus one of another resource.
+        for (let i = 0; i < 26; i++) {
+            (await emitter.record(auditEvent(account.id, new Date(base + i * 1000).toISOString(), { resource: 'connection', action: 'deleted' }))).unwrap();
+        }
+        (await emitter.record(auditEvent(account.id, new Date(base + 30_000).toISOString(), { resource: 'api_key', action: 'deleted' }))).unwrap();
+
+        const all = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+        isSuccess(all.json);
+        expect(all.json.data).toHaveLength(25);
+        expect(all.json.total).toBe(27);
+
+        const narrowed = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { resources: 'api_key' } });
+        isSuccess(narrowed.json);
+        expect(narrowed.json.total).toBe(1);
+    });
+
+    it('leaves the total off a continuation, which cannot change it', async () => {
+        const { session, account } = await authAdmin();
+        const base = Date.parse('2026-07-16T10:00:00.000Z');
+        for (let i = 0; i < 26; i++) {
+            (await emitter.record(auditEvent(account.id, new Date(base + i * 1000).toISOString()))).unwrap();
+        }
+
+        const first = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+        isSuccess(first.json);
+        expect(first.json.total).toBe(26);
+
+        const second = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { cursor: first.json.pagination.nextCursor! } });
+        isSuccess(second.json);
+        expect(second.json.total).toBeUndefined();
+    });
+
     it('paginates via the opaque cursor', async () => {
         const { session, account } = await authAdmin();
         // 26 events one second apart (oldest → newest) — one more than the fixed page size of 25.

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
@@ -68,7 +68,7 @@ describe('GET /api/v1/audit-trail', () => {
     it('rejects an account that is not entitled to the audit trail with 403', async () => {
         const { session } = await authAdmin({ entitled: false });
 
-        const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+        const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { showTotal: true } });
 
         expect(res.res.status).toBe(403);
         isError(res.json);
@@ -120,7 +120,7 @@ describe('GET /api/v1/audit-trail', () => {
         (await emitter.record(auditEvent(account.id, '2026-07-16T10:00:00.000Z'))).unwrap();
         (await emitter.record(auditEvent(account.id, '2026-07-16T10:00:01.000Z'))).unwrap();
 
-        const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+        const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { showTotal: true } });
 
         expect(res.res.status).toBe(200);
         isSuccess(res.json);
@@ -192,12 +192,12 @@ describe('GET /api/v1/audit-trail', () => {
         }
         (await emitter.record(auditEvent(account.id, new Date(base + 30_000).toISOString(), { resource: 'api_key', action: 'deleted' }))).unwrap();
 
-        const all = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+        const all = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { showTotal: true } });
         isSuccess(all.json);
         expect(all.json.data).toHaveLength(25);
         expect(all.json.total).toEqual({ value: 27, relation: 'eq' });
 
-        const narrowed = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { resources: 'api_key' } });
+        const narrowed = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { resources: 'api_key', showTotal: true } });
         isSuccess(narrowed.json);
         expect(narrowed.json.total).toEqual({ value: 1, relation: 'eq' });
     });
@@ -209,11 +209,15 @@ describe('GET /api/v1/audit-trail', () => {
             (await emitter.record(auditEvent(account.id, new Date(base + i * 1000).toISOString()))).unwrap();
         }
 
-        const first = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+        const first = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { showTotal: true } });
         isSuccess(first.json);
         expect(first.json.total).toEqual({ value: 26, relation: 'eq' });
 
-        const second = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { cursor: first.json.pagination.nextCursor! } });
+        const second = await api.fetch('/api/v1/audit-trail', {
+            method: 'GET',
+            session,
+            query: { cursor: first.json.pagination.nextCursor!, showTotal: true }
+        });
         isSuccess(second.json);
         expect(second.json.data).toHaveLength(1);
         // Paging doesn't narrow the set the filters describe, so the number can't move.
@@ -226,7 +230,7 @@ describe('GET /api/v1/audit-trail', () => {
 
         const spy = vi.spyOn(audit, 'countAuditTrailEvents').mockResolvedValue(Err('failed_to_count_audit_trail_events'));
         try {
-            const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+            const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { showTotal: true } });
             expect(res.res.status).toBe(200);
             isSuccess(res.json);
             expect(res.json.data).toHaveLength(1);
@@ -234,6 +238,16 @@ describe('GET /api/v1/audit-trail', () => {
         } finally {
             spy.mockRestore();
         }
+    });
+
+    it('does not count unless the caller asks', async () => {
+        const { session, account } = await authAdmin();
+        (await emitter.record(auditEvent(account.id, '2026-07-16T10:00:00.000Z'))).unwrap();
+
+        const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+        isSuccess(res.json);
+        expect(res.json.data).toHaveLength(1);
+        expect(res.json.total).toBeUndefined();
     });
 
     it('paginates via the opaque cursor', async () => {
@@ -244,7 +258,7 @@ describe('GET /api/v1/audit-trail', () => {
             (await emitter.record(auditEvent(account.id, new Date(base + i * 1000).toISOString()))).unwrap();
         }
 
-        const page1 = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+        const page1 = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { showTotal: true } });
         expect(page1.res.status).toBe(200);
         isSuccess(page1.json);
         expect(page1.json.data).toHaveLength(25);
@@ -306,7 +320,7 @@ describe('GET /api/v1/audit-trail', () => {
         it('marks a page of an earlier query as continued', async () => {
             const { session, account } = await authRecorded();
             (await emitter.record(auditEvent(account.id, new Date().toISOString()))).unwrap();
-            const first = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+            const first = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { showTotal: true } });
             isSuccess(first.json);
             const recordSpy = vi.spyOn(audit, 'record');
 
@@ -330,7 +344,7 @@ describe('GET /api/v1/audit-trail', () => {
             const { session, account } = await authRecorded({ access: false });
             const recordSpy = vi.spyOn(audit, 'record');
 
-            const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+            const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { showTotal: true } });
 
             expect(res.res.status).toBe(403);
             await vi.waitFor(() => {

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
@@ -202,7 +202,7 @@ describe('GET /api/v1/audit-trail', () => {
         expect(narrowed.json.total).toBe(1);
     });
 
-    it('leaves the total off a continuation, which cannot change it', async () => {
+    it('reports the same total on a continuation as on the first page', async () => {
         const { session, account } = await authAdmin();
         const base = Date.parse('2026-07-16T10:00:00.000Z');
         for (let i = 0; i < 26; i++) {
@@ -215,7 +215,9 @@ describe('GET /api/v1/audit-trail', () => {
 
         const second = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { cursor: first.json.pagination.nextCursor! } });
         isSuccess(second.json);
-        expect(second.json.total).toBeUndefined();
+        expect(second.json.data).toHaveLength(1);
+        // Paging doesn't narrow the set the filters describe, so the number can't move.
+        expect(second.json.total).toBe(26);
     });
 
     it('still returns the rows when the count fails, just without the number', async () => {

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { auditClickhouseClient, AuditClient, ClickhouseAuditStore, migrate } from '@nangohq/audit';
 import * as featureFlags from '@nangohq/feature-flags';
 import { seeders } from '@nangohq/shared';
+import { Err } from '@nangohq/utils';
 
 import { audit } from '../../../audit.js';
 import { authenticateUser, isError, isSuccess, runServer } from '../../../utils/tests.js';
@@ -215,6 +216,22 @@ describe('GET /api/v1/audit-trail', () => {
         const second = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { cursor: first.json.pagination.nextCursor! } });
         isSuccess(second.json);
         expect(second.json.total).toBeUndefined();
+    });
+
+    it('still returns the rows when the count fails, just without the number', async () => {
+        const { session, account } = await authAdmin();
+        (await emitter.record(auditEvent(account.id, '2026-07-16T10:00:00.000Z'))).unwrap();
+
+        const spy = vi.spyOn(audit, 'countAuditTrailEvents').mockResolvedValue(Err('failed_to_count_audit_trail_events'));
+        try {
+            const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: {} });
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json.data).toHaveLength(1);
+            expect(res.json.total).toBeUndefined();
+        } finally {
+            spy.mockRestore();
+        }
     });
 
     it('paginates via the opaque cursor', async () => {

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -1,5 +1,5 @@
 import { InvalidAuditCursorError } from '@nangohq/audit';
-import { Err, zodErrorToHTTP } from '@nangohq/utils';
+import { Err, getLogger, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import { audit } from '../../../audit.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -8,6 +8,8 @@ import { auditListQuery } from './query.js';
 
 import type { GetAuditTrail } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+
+const logger = getLogger('audit');
 
 const PAGE_SIZE = 25;
 
@@ -32,9 +34,12 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
     // read, and the promise is abandoned entirely when the list errors, which would otherwise go unhandled.
     const counting: Promise<Result<number>> | undefined = cursor
         ? undefined
-        : audit
-              .countAuditTrailEvents({ accountId: account.id, from, to, resources, actions })
-              .catch((err: unknown) => Err(err instanceof Error ? err : new Error(String(err))));
+        : audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions }).catch((err: unknown) => {
+              // The store logs the failures it catches; this only sees the ones that escaped it, which
+              // would otherwise leave a missing total with nothing recorded anywhere.
+              logger.warning(`Audit trail count threw for account ${account.id}: ${stringifyError(err)}`);
+              return Err(err instanceof Error ? err : new Error(String(err)));
+          });
 
     const result = await audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions });
 

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -1,5 +1,5 @@
 import { InvalidAuditCursorError } from '@nangohq/audit';
-import { Err, getLogger, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
+import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { audit } from '../../../audit.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -7,9 +7,6 @@ import { canViewAuditTrail } from '../../../utils/auditTrail.js';
 import { auditListQuery } from './query.js';
 
 import type { GetAuditTrail } from '@nangohq/types';
-import type { Result } from '@nangohq/utils';
-
-const logger = getLogger('audit');
 
 const PAGE_SIZE = 25;
 
@@ -30,11 +27,7 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
     const { cursor, from, to, resources, actions } = query.data;
 
     // Started before the list is awaited so it doesn't queue behind it.
-    const counting: Promise<Result<number>> = audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions }).catch((err: unknown) => {
-        // Only failures that escaped the store reach here, and they are logged nowhere else.
-        logger.warning(`Audit trail count threw for account ${account.id}: ${stringifyError(err)}`);
-        return Err(err instanceof Error ? err : new Error(String(err)));
-    });
+    const counting = audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions });
 
     const result = await audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions });
 

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -1,5 +1,5 @@
 import { InvalidAuditCursorError } from '@nangohq/audit';
-import { zodErrorToHTTP } from '@nangohq/utils';
+import { getLogger, zodErrorToHTTP } from '@nangohq/utils';
 
 import { audit } from '../../../audit.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -7,6 +7,8 @@ import { canViewAuditTrail } from '../../../utils/auditTrail.js';
 import { auditListQuery } from './query.js';
 
 import type { GetAuditTrail } from '@nangohq/types';
+
+const logger = getLogger('AuditTrail');
 
 const PAGE_SIZE = 25;
 
@@ -36,8 +38,21 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
         return;
     }
 
+    // First page only — the total can't change while the filters are fixed, and a failed count costs the
+    // reader the number rather than the rows.
+    let total: number | undefined;
+    if (!cursor) {
+        const counted = await audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions });
+        if (counted.isErr()) {
+            logger.warning(`failed to count audit trail events`, { accountId: account.id, error: counted.error });
+        } else {
+            total = counted.value;
+        }
+    }
+
     res.status(200).send({
         data: result.value.events,
+        ...(total !== undefined && { total }),
         pagination: { nextCursor: result.value.nextCursor }
     });
 });

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -1,5 +1,5 @@
 import { InvalidAuditCursorError } from '@nangohq/audit';
-import { Err, getLogger, zodErrorToHTTP } from '@nangohq/utils';
+import { Err, zodErrorToHTTP } from '@nangohq/utils';
 
 import { audit } from '../../../audit.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -8,8 +8,6 @@ import { auditListQuery } from './query.js';
 
 import type { GetAuditTrail } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
-
-const logger = getLogger('audit');
 
 const PAGE_SIZE = 25;
 
@@ -51,12 +49,8 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
 
     const counted = await counting;
     let total: number | undefined;
-    if (counted) {
-        if (counted.isErr()) {
-            logger.warning(`audit trail count failed, returning the page without a total`, { accountId: account.id, error: counted.error });
-        } else {
-            total = counted.value;
-        }
+    if (counted?.isOk()) {
+        total = counted.value;
     }
 
     res.status(200).send({

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -29,14 +29,11 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
 
     const { cursor, from, to, resources, actions } = query.data;
 
-    // Started before the list is awaited so it doesn't queue behind it, and only on the first page — the total
-    // can't change while the filters are fixed. The `catch` matters twice: a failed count must not fail the
-    // read, and the promise is abandoned entirely when the list errors, which would otherwise go unhandled.
+    // Started before the list is awaited so it doesn't queue behind it. First page only: the total can't change while the filters are fixed.
     const counting: Promise<Result<number>> | undefined = cursor
         ? undefined
         : audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions }).catch((err: unknown) => {
-              // The store logs the failures it catches; this only sees the ones that escaped it, which
-              // would otherwise leave a missing total with nothing recorded anywhere.
+              // Only failures that escaped the store reach here, and they are logged nowhere else.
               logger.warning(`Audit trail count threw for account ${account.id}: ${stringifyError(err)}`);
               return Err(err instanceof Error ? err : new Error(String(err)));
           });

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -1,5 +1,5 @@
 import { InvalidAuditCursorError } from '@nangohq/audit';
-import { getLogger, zodErrorToHTTP } from '@nangohq/utils';
+import { Err, getLogger, zodErrorToHTTP } from '@nangohq/utils';
 
 import { audit } from '../../../audit.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -7,8 +7,9 @@ import { canViewAuditTrail } from '../../../utils/auditTrail.js';
 import { auditListQuery } from './query.js';
 
 import type { GetAuditTrail } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
 
-const logger = getLogger('AuditTrail');
+const logger = getLogger('audit');
 
 const PAGE_SIZE = 25;
 
@@ -28,12 +29,14 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
 
     const { cursor, from, to, resources, actions } = query.data;
 
-    // Issued together: they share no state, so awaiting the count after the list would add its latency to the page.
-    // The count runs on the first page only — it can't change while the filters are fixed.
-    const [result, counted] = await Promise.all([
-        audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions }),
-        cursor ? undefined : audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions })
-    ]);
+    // Started before the list is awaited so it doesn't queue behind it, and only on the first page — the total
+    // can't change while the filters are fixed. The `catch` matters twice: a failed count must not fail the
+    // read, and the promise is abandoned entirely when the list errors, which would otherwise go unhandled.
+    const counting: Promise<Result<number>> | undefined = cursor
+        ? undefined
+        : audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions }).catch(() => Err(new Error('count threw')));
+
+    const result = await audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions });
 
     if (result.isErr()) {
         if (result.error instanceof InvalidAuditCursorError) {
@@ -44,11 +47,11 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
         return;
     }
 
-    // A failed count costs the reader the number rather than the rows.
+    const counted = await counting;
     let total: number | undefined;
     if (counted) {
         if (counted.isErr()) {
-            logger.warning(`failed to count audit trail events`, { accountId: account.id, error: counted.error });
+            logger.warning(`audit trail count failed, returning the page without a total`, { accountId: account.id, error: counted.error });
         } else {
             total = counted.value;
         }

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -28,7 +28,13 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
 
     const { cursor, from, to, resources, actions } = query.data;
 
-    const result = await audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions });
+    // Issued together: they share no state, so awaiting the count after the list would add its latency to the page.
+    // The count runs on the first page only — it can't change while the filters are fixed.
+    const [result, counted] = await Promise.all([
+        audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions }),
+        cursor ? undefined : audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions })
+    ]);
+
     if (result.isErr()) {
         if (result.error instanceof InvalidAuditCursorError) {
             res.status(400).send({ error: { code: 'invalid_query_params', message: 'Invalid cursor' } });
@@ -38,11 +44,9 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
         return;
     }
 
-    // First page only — the total can't change while the filters are fixed, and a failed count costs the
-    // reader the number rather than the rows.
+    // A failed count costs the reader the number rather than the rows.
     let total: number | undefined;
-    if (!cursor) {
-        const counted = await audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions });
+    if (counted) {
         if (counted.isErr()) {
             logger.warning(`failed to count audit trail events`, { accountId: account.id, error: counted.error });
         } else {

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -34,7 +34,9 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
     // read, and the promise is abandoned entirely when the list errors, which would otherwise go unhandled.
     const counting: Promise<Result<number>> | undefined = cursor
         ? undefined
-        : audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions }).catch(() => Err(new Error('count threw')));
+        : audit
+              .countAuditTrailEvents({ accountId: account.id, from, to, resources, actions })
+              .catch((err: unknown) => Err(err instanceof Error ? err : new Error(String(err))));
 
     const result = await audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions });
 

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -1,3 +1,5 @@
+import tracer from 'dd-trace';
+
 import { InvalidAuditCursorError } from '@nangohq/audit';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
@@ -9,6 +11,17 @@ import { auditListQuery } from './query.js';
 import type { GetAuditTrail } from '@nangohq/types';
 
 const PAGE_SIZE = 25;
+
+// The two reads run concurrently, so each needs its own span for their costs to be separable in a trace.
+async function traced<T>(name: string, run: () => Promise<T>): Promise<T> {
+    const active = tracer.scope().active();
+    const span = tracer.startSpan(name, active ? { childOf: active } : {});
+    try {
+        return await run();
+    } finally {
+        span.finish();
+    }
+}
 
 export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
     const { account, plan } = res.locals;
@@ -24,12 +37,17 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
         return;
     }
 
-    const { cursor, from, to, resources, actions } = query.data;
+    const { cursor, showTotal, from, to, resources, actions } = query.data;
 
-    // Started before the list is awaited so it doesn't queue behind it.
-    const counting = audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions });
+    // Started before the list is awaited so it doesn't queue behind it. Its own span, since the request now
+    // makes two store reads and their costs are worth telling apart in a trace.
+    const counting = showTotal
+        ? traced('nango.server.auditTrail.count', () => audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions }))
+        : undefined;
 
-    const result = await audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions });
+    const result = await traced('nango.server.auditTrail.list', () =>
+        audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions })
+    );
 
     if (result.isErr()) {
         if (result.error instanceof InvalidAuditCursorError) {
@@ -41,7 +59,7 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
     }
 
     const counted = await counting;
-    const total = counted.isOk() ? counted.value : undefined;
+    const total = counted?.isOk() ? counted.value : undefined;
 
     res.status(200).send({
         data: result.value.events,

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -9,15 +9,24 @@ import { canViewAuditTrail } from '../../../utils/auditTrail.js';
 import { auditListQuery } from './query.js';
 
 import type { GetAuditTrail } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
 
 const PAGE_SIZE = 25;
 
 // The two reads run concurrently, so each needs its own span for their costs to be separable in a trace.
-async function traced<T>(name: string, run: () => Promise<T>): Promise<T> {
+// Both failure shapes are tagged: a read that returns Err is as much a failed span as one that throws.
+async function traced<T>(name: string, run: () => Promise<Result<T>>): Promise<Result<T>> {
     const active = tracer.scope().active();
     const span = tracer.startSpan(name, active ? { childOf: active } : {});
     try {
-        return await run();
+        const result = await run();
+        if (result.isErr()) {
+            span.setTag('error', result.error);
+        }
+        return result;
+    } catch (err) {
+        span.setTag('error', err);
+        throw err;
     } finally {
         span.finish();
     }

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -29,14 +29,12 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
 
     const { cursor, from, to, resources, actions } = query.data;
 
-    // Started before the list is awaited so it doesn't queue behind it. First page only: the total can't change while the filters are fixed.
-    const counting: Promise<Result<number>> | undefined = cursor
-        ? undefined
-        : audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions }).catch((err: unknown) => {
-              // Only failures that escaped the store reach here, and they are logged nowhere else.
-              logger.warning(`Audit trail count threw for account ${account.id}: ${stringifyError(err)}`);
-              return Err(err instanceof Error ? err : new Error(String(err)));
-          });
+    // Started before the list is awaited so it doesn't queue behind it.
+    const counting: Promise<Result<number>> = audit.countAuditTrailEvents({ accountId: account.id, from, to, resources, actions }).catch((err: unknown) => {
+        // Only failures that escaped the store reach here, and they are logged nowhere else.
+        logger.warning(`Audit trail count threw for account ${account.id}: ${stringifyError(err)}`);
+        return Err(err instanceof Error ? err : new Error(String(err)));
+    });
 
     const result = await audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions });
 
@@ -50,10 +48,7 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
     }
 
     const counted = await counting;
-    let total: number | undefined;
-    if (counted?.isOk()) {
-        total = counted.value;
-    }
+    const total = counted.isOk() ? counted.value : undefined;
 
     res.status(200).send({
         data: result.value.events,

--- a/packages/server/lib/controllers/v1/audit-trail/query.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/query.ts
@@ -33,7 +33,7 @@ const actionsNeedResources = {
 // Account-scoped endpoints (no `env`). Not strict: any stray query param is stripped rather than 400'd, so
 // a read never fails over an extra key.
 export const auditListQuery = z
-    .object({ cursor: z.string().optional(), ...filters })
+    .object({ cursor: z.string().optional(), showTotal: z.stringbool().optional(), ...filters })
     .refine(inOrder.check, inOrder.error)
     .refine(actionsNeedResources.check, actionsNeedResources.error);
 

--- a/packages/types/lib/audit-trail/api.ts
+++ b/packages/types/lib/audit-trail/api.ts
@@ -51,7 +51,7 @@ export type GetAuditTrail = ApiEndpoint<{
     };
     Success: {
         data: ApiAuditTrailEvent[];
-        // How many events the filters match, not how many this page holds. Sent with the first page only.
+        // How many events the filters match, not how many this page holds. Absent when the count failed.
         total?: number;
         pagination: { nextCursor: string | null };
     };

--- a/packages/types/lib/audit-trail/api.ts
+++ b/packages/types/lib/audit-trail/api.ts
@@ -51,11 +51,22 @@ export type GetAuditTrail = ApiEndpoint<{
     };
     Success: {
         data: ApiAuditTrailEvent[];
-        // How many events the filters match, not how many this page holds. Absent when the count failed.
-        total?: number;
+        total?: AuditTrailTotal;
         pagination: { nextCursor: string | null };
     };
 }>;
+
+/**
+ * How many events the filters match, not how many the page holds. Absent when the count failed.
+ *
+ * The read is bounded, so `relation` says whether `value` is the answer or a floor — `gte` means the
+ * account has at least this many and the count stopped looking. Shaped after Elasticsearch's `hits.total`
+ * so a caller cannot read the number without seeing which it is.
+ */
+export interface AuditTrailTotal {
+    value: number;
+    relation: 'eq' | 'gte';
+}
 
 // A type rather than a value: this package ships `typings` only, so neither side can import a constant from
 // it. Both copies annotate themselves with this, which makes drift a compile error.

--- a/packages/types/lib/audit-trail/api.ts
+++ b/packages/types/lib/audit-trail/api.ts
@@ -48,6 +48,8 @@ export type GetAuditTrail = ApiEndpoint<{
         // `actions` requires `resources`: the pair is matched as one `resource.action` value.
         resources?: string;
         actions?: string;
+        // Opt-in: the count is a second read, so a caller that doesn't show one shouldn't pay for it.
+        showTotal?: boolean | undefined;
     };
     Success: {
         data: ApiAuditTrailEvent[];
@@ -57,7 +59,8 @@ export type GetAuditTrail = ApiEndpoint<{
 }>;
 
 /**
- * How many events the filters match, not how many the page holds. Absent when the count failed.
+ * How many events the filters match, not how many the page holds. Absent unless `showTotal` was
+ * asked for, and when the count failed.
  *
  * The read is bounded, so `relation` says whether `value` is the answer or a floor — `gte` means the
  * account has at least this many and the count stopped looking. Shaped after Elasticsearch's `hits.total`

--- a/packages/types/lib/audit-trail/api.ts
+++ b/packages/types/lib/audit-trail/api.ts
@@ -51,6 +51,8 @@ export type GetAuditTrail = ApiEndpoint<{
     };
     Success: {
         data: ApiAuditTrailEvent[];
+        // How many events the filters match, not how many this page holds. Sent with the first page only.
+        total?: number;
         pagination: { nextCursor: string | null };
     };
 }>;

--- a/packages/webapp/src/hooks/useAudit.tsx
+++ b/packages/webapp/src/hooks/useAudit.tsx
@@ -35,6 +35,7 @@ export function useApiGetAuditTrail(filters: AuditTrailFilters, options?: { enab
         queryKey: ['audit-trail:infinite', filters.from ?? null, filters.to ?? null, filters.resources ?? null, filters.actions ?? null],
         queryFn: async ({ pageParam, signal }) => {
             const params = auditFilterParams(filters);
+            params.append('showTotal', 'true');
             if (pageParam) {
                 params.append('cursor', pageParam);
             }

--- a/packages/webapp/src/pages/Audit/Show.tsx
+++ b/packages/webapp/src/pages/Audit/Show.tsx
@@ -73,7 +73,7 @@ export const AuditShow: React.FC = () => {
     );
     const events = useMemo(() => data?.pages.flatMap((page) => page.data) ?? [], [data]);
     // Absent when the count failed, in which case say nothing rather than pass the loaded rows off as the total.
-    const total = data?.pages[0]?.total;
+    const total = data?.pages.at(-1)?.total;
     const showLoading = !meta || !user || isLoading;
 
     // Menu entry + route are gated on the flag and the permission, but guard direct navigation too.

--- a/packages/webapp/src/pages/Audit/Show.tsx
+++ b/packages/webapp/src/pages/Audit/Show.tsx
@@ -140,10 +140,11 @@ export const AuditShow: React.FC = () => {
                     </div>
                 </div>
 
-                {total !== undefined && total > 0 && (
+                {total && total.value > 0 && (
                     <div className="flex items-center justify-end">
                         <div className="text-text-muted text-body-small-regular">
-                            {total.toLocaleString()} {total === 1 ? 'event' : 'events'}
+                            {total.value.toLocaleString()}
+                            {total.relation === 'gte' ? '+' : ''} {total.value === 1 && total.relation === 'eq' ? 'event' : 'events'}
                         </div>
                     </div>
                 )}

--- a/packages/webapp/src/pages/Audit/Show.tsx
+++ b/packages/webapp/src/pages/Audit/Show.tsx
@@ -72,6 +72,8 @@ export const AuditShow: React.FC = () => {
         { enabled: meta?.auditTrail === true && canReadAuditTrail }
     );
     const events = useMemo(() => data?.pages.flatMap((page) => page.data) ?? [], [data]);
+    // Absent when the count failed, in which case say nothing rather than pass the loaded rows off as the total.
+    const total = data?.pages[0]?.total;
     const showLoading = !meta || !user || isLoading;
 
     // Menu entry + route are gated on the flag and the permission, but guard direct navigation too.
@@ -138,11 +140,10 @@ export const AuditShow: React.FC = () => {
                     </div>
                 </div>
 
-                {events.length > 0 && (
+                {total !== undefined && total > 0 && (
                     <div className="flex items-center justify-end">
                         <div className="text-text-muted text-body-small-regular">
-                            {events.length}
-                            {hasNextPage ? '+' : ''} {events.length === 1 && !hasNextPage ? 'event' : 'events'}
+                            {total.toLocaleString()} {total === 1 ? 'event' : 'events'}
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
## Problem

The audit trail header counted rows loaded, not rows matched. With a page size of 25, anything past the first page read "25+ results found" — a filter matching 26 events looked identical to one matching 26,000. That matters most before an export, capped at 50,000.

## Solution

- The list read returns `total`, and the dashboard shows it. Absent means one thing only: the count failed.
- Counts with `uniqExact(id)`, not `count()`: the table is a `ReplacingMergeTree`, so a redelivery sits as a second row until a merge collapses it. `FINAL` is exact too but gives up the ORDER BY short-circuit the list read is tuned around.
- The list and the count build their `WHERE` from one helper, so the number can't describe a different set than the rows under it.
- The count is issued alongside the list but never gates it: a failing list returns immediately, and a failing count omits `total` rather than failing the read.

Fixes [NAN-6858](https://linear.app/nango/issue/NAN-6858)

## Testing

Integration tests against real ClickHouse cover the total across a page, narrowing by filter, holding steady on a continuation, suppression of a twice-stored event, and the count-failure path. Swapping `uniqExact(id)` for `count()` fails the dedup test, so it protects the behaviour.

Measured on prod before settling on `uniqExact`: the largest account's 14-day window is 8.7 ms, and rows stored equals distinct events on all 246 accounts.
