### PR TITLE
feat(server): return a specific error for oversized request bodies

### DIFF
--- a/packages/server/lib/routes.integration.test.ts
+++ b/packages/server/lib/routes.integration.test.ts
@@ -78,6 +78,45 @@ describe('route', () => {
                 }
             });
         });
+
+        it('should handle a body over the size limit', async () => {
+            const { apiKey } = await seeders.seedAccountEnvAndUser();
+            const oversizedBody = JSON.stringify({ padding: 'a'.repeat(2 * 1024 * 1024) }); // over the 1mb limit on this router
+            const res = await fetch(`${api.url}/api/v1/environment/callback`, {
+                method: 'POST',
+                body: oversizedBody,
+                headers: { Authorization: `Bearer ${apiKey.secret}`, 'content-type': 'application/json' }
+            });
+
+            expect(res.status).toBe(413);
+            expect(await res.json()).toStrictEqual({
+                error: {
+                    code: 'request_too_large',
+                    message: expect.stringContaining('Request entity too large')
+                }
+            });
+        });
+    });
+
+    describe('POST /internal/shared-credentials', () => {
+        it('should report a sub-mb limit in kb, not as a rounded-to-zero mb value', async () => {
+            // The internal API's body limit (100kb) is below 1mb, so a naive bytes/1024/1024
+            // rounded to the nearest mb would report "0mb" here instead of a useful number.
+            const oversizedBody = JSON.stringify({ padding: 'a'.repeat(200 * 1024) }); // over the 100kb limit on this router
+            const res = await fetch(`${api.url}/internal/shared-credentials`, {
+                method: 'POST',
+                body: oversizedBody,
+                headers: { 'content-type': 'application/json' }
+            });
+
+            expect(res.status).toBe(413);
+            expect(await res.json()).toStrictEqual({
+                error: {
+                    code: 'request_too_large',
+                    message: 'Request entity too large (limit: 100kb)'
+                }
+            });
+        });
     });
 
     describe('Authenticated endpoints', () => {

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -18,6 +18,13 @@ import { dirname } from './utils/utils.js';
 import type { ApiError } from '@nangohq/types';
 import type { Request, Response } from 'express';
 
+function formatByteLimit(bytes: number): string {
+    if (bytes < 1024 * 1024) {
+        return `${Math.round(bytes / 1024)}kb`;
+    }
+    return `${Math.round(bytes / (1024 * 1024))}mb`;
+}
+
 export const router = express.Router();
 
 router.use(...securityMiddlewares());
@@ -52,9 +59,15 @@ router.use(staticSite);
 
 // -------
 // Error handling.
-router.use((err: any, req: Request, res: Response<ApiError<'invalid_json'>>, _: any) => {
+router.use((err: any, req: Request, res: Response<ApiError<'invalid_json'> | ApiError<'request_too_large'>>, _: any) => {
     if (err instanceof SyntaxError && 'body' in err && 'type' in err && err.type === 'entity.parse.failed') {
         res.status(400).send({ error: { code: 'invalid_json', message: err.message } });
+        return;
+    }
+
+    if (err instanceof Error && 'type' in err && err.type === 'entity.too.large') {
+        const limit = 'limit' in err && typeof err.limit === 'number' ? formatByteLimit(err.limit) : undefined;
+        res.status(413).send({ error: { code: 'request_too_large', message: `Request entity too large${limit ? ` (limit: ${limit})` : ''}` } });
         return;
     }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

- return a specific error for oversized request bodies, which was causing a generic error to be returned when customers were deploying huge functions 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

