### PR TITLE
fix(security): require encryption key and fail fast on plaintext

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,12 @@
 #
 # Configuration
 #
-# - To enable database credentials encryption, uncomment with a base64-encoded 256-bit key (warning: you cannot change this key once set).
+# REQUIRED: base64-encoded 256-bit key for encrypting credentials (connections, provider configs, secrets).
+# Without it the server will fail to start rather than store credentials in plaintext.
 # - To generate a key: `openssl rand -base64 32`
-# - This key is also required for Connect UI functionality, as it is needed to generate Connect UI sessions.
+# - This key is also required for Connect UI functionality.
+# - Alternative: NANGO_ENCRYPTION_KEY_WRAPPED + NANGO_KMS_KEY_ARN (or NANGO_GCP_KMS_KEY_NAME) for KMS-wrapped DEK.
+# - Warning: you cannot change this key once set without re-encrypting the database.
 #
 # NANGO_ENCRYPTION_KEY=<ADD-BASE64-256BIT-KEY>
 #

--- a/packages/keystore/lib/utils/env.ts
+++ b/packages/keystore/lib/utils/env.ts
@@ -3,7 +3,7 @@ import { ENVS, parseEnvs } from '@nangohq/utils';
 
 export const envs = parseEnvs(ENVS);
 
-if (!envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED) {
+if (!envs.VITEST && envs.NODE_ENV !== 'test' && !envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED) {
     throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)');
 }
 

--- a/packages/keystore/lib/utils/env.ts
+++ b/packages/keystore/lib/utils/env.ts
@@ -3,4 +3,8 @@ import { ENVS, parseEnvs } from '@nangohq/utils';
 
 export const envs = parseEnvs(ENVS);
 
+if (!envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED) {
+    throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)');
+}
+
 export const dek = await DekRegistry.create(envs);

--- a/packages/persist/lib/env.ts
+++ b/packages/persist/lib/env.ts
@@ -6,5 +6,5 @@ export const envs = parseEnvs(ENVS);
 // Encryption key is required for persist to store/retrieve records
 const dek = await DekRegistry.create(envs);
 if (!dek.get()) {
-    throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required');
+    throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)');
 }

--- a/packages/records/lib/env.ts
+++ b/packages/records/lib/env.ts
@@ -3,7 +3,7 @@ import { ENVS, parseEnvs } from '@nangohq/utils';
 
 export const envs = parseEnvs(ENVS);
 
-if (!envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED) {
+if (!envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED && !envs.VITEST && envs.NODE_ENV !== 'test') {
     throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)');
 }
 

--- a/packages/records/lib/env.ts
+++ b/packages/records/lib/env.ts
@@ -3,4 +3,8 @@ import { ENVS, parseEnvs } from '@nangohq/utils';
 
 export const envs = parseEnvs(ENVS);
 
+if (!envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED) {
+    throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)');
+}
+
 export const dek = await DekRegistry.create(envs);

--- a/packages/server/lib/env.ts
+++ b/packages/server/lib/env.ts
@@ -1,3 +1,7 @@
 import { ENVS, parseEnvs } from '@nangohq/utils';
 
 export const envs = parseEnvs(ENVS);
+
+if (!envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED) {
+    throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)');
+}

--- a/packages/server/lib/env.ts
+++ b/packages/server/lib/env.ts
@@ -2,6 +2,6 @@ import { ENVS, parseEnvs } from '@nangohq/utils';
 
 export const envs = parseEnvs(ENVS);
 
-if (!envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED) {
+if (!envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED && !envs.VITEST && envs.NODE_ENV !== 'test') {
     throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)');
 }

--- a/packages/shared/lib/env.ts
+++ b/packages/shared/lib/env.ts
@@ -3,7 +3,7 @@ import { ENVS, parseEnvs } from '@nangohq/utils';
 
 export const envs = parseEnvs(ENVS);
 
-if (!envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED) {
+if (!envs.VITEST && envs.NODE_ENV !== 'test' && !envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED) {
     throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)');
 }
 

--- a/packages/shared/lib/env.ts
+++ b/packages/shared/lib/env.ts
@@ -3,4 +3,8 @@ import { ENVS, parseEnvs } from '@nangohq/utils';
 
 export const envs = parseEnvs(ENVS);
 
+if (!envs.NANGO_ENCRYPTION_KEY && !envs.NANGO_ENCRYPTION_KEY_WRAPPED) {
+    throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)');
+}
+
 export const dek = await DekRegistry.create(envs);

--- a/packages/shared/lib/utils/encryption.manager.ts
+++ b/packages/shared/lib/utils/encryption.manager.ts
@@ -40,7 +40,7 @@ export class EncryptionManager extends Encryption {
 
     public encryptConnection(connection: Omit<DBConnectionDecrypted, 'end_user_id' | 'credentials_iv' | 'credentials_tag'>): Omit<DBConnection, 'end_user_id'> {
         if (!this.shouldEncrypt()) {
-            return connection as unknown as DBConnection;
+            throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required to encrypt connections');
         }
 
         const [encryptedClientSecret, iv, authTag] = this.encryptSync(JSON.stringify(connection.credentials));
@@ -82,7 +82,7 @@ export class EncryptionManager extends Encryption {
 
     public encryptEnvironmentVariables(environmentVariables: Omit<DBEnvironmentVariable, 'id'>[]): Omit<DBEnvironmentVariable, 'id'>[] {
         if (!this.shouldEncrypt()) {
-            return environmentVariables;
+            throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required to encrypt environment variables');
         }
 
         const encryptedEnvironmentVariables: DBEnvironmentVariable[] = Object.assign([], environmentVariables);
@@ -113,7 +113,7 @@ export class EncryptionManager extends Encryption {
 
     public encryptProviderConfig(config: ProviderConfig): ProviderConfig {
         if (!this.shouldEncrypt()) {
-            return config;
+            throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required to encrypt provider configs');
         }
 
         const encryptedConfig: ProviderConfig = Object.assign({}, config);
@@ -205,7 +205,7 @@ export class EncryptionManager extends Encryption {
         const encryptionKeyHash = this.key ? await this.hashEncryptionKey(this.key, this.keySalt) : null;
 
         if (status === 'disabled') {
-            return;
+            throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (database is not encrypted)');
         }
         if (status === 'done') {
             return;
@@ -319,7 +319,7 @@ export class EncryptionManager extends Encryption {
 
     encryptAPISecret<T extends Pick<DBAPISecret, 'iv' | 'tag' | 'secret'>>(secret: T): T {
         if (!this.shouldEncrypt()) {
-            return secret;
+            throw new Error('NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required to encrypt API secrets');
         }
         if (secret.iv && secret.tag) {
             return secret; // Already encrypted.

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -968,24 +968,6 @@ export const ENVS = ENVS_SHAPE.check((ctx) => {
             input: ctx.value.EMAIL_HTTP_BODY
         });
     }
-    // Encryption key is required to avoid silently storing credentials in plaintext.
-    // Either NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED must be set.
-    // Vitest / NODE_ENV=test are exempt so unit tests can call parseEnvs(ENVS, {}) without bootstrapping a key;
-    // runtime still enforces via encryption.manager throws and DekRegistry, and vite configs inject a test key.
-    if (!ctx.value.NANGO_ENCRYPTION_KEY && !ctx.value.NANGO_ENCRYPTION_KEY_WRAPPED) {
-        // Allow unit tests (which call parseEnvs(ENVS, {})) to pass without a key when the
-        // global process is in test mode. Runtime vite configs already inject a test key for
-        // integration tests; this exemption only covers parseEnvs(ENVS, {}) in parse.unit.test.
-        const isTestProcess = process.env['VITEST'] === 'true' || process.env['NODE_ENV'] === 'test';
-        if (!ctx.value.VITEST && ctx.value.NODE_ENV !== 'test' && !isTestProcess) {
-            ctx.issues.push({
-                code: 'custom',
-                message: 'NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)',
-                path: ['NANGO_ENCRYPTION_KEY'],
-                input: undefined
-            });
-        }
-    }
 });
 
 export function parseEnvs<T extends z.ZodObject<any>>(schema: T, envs: Record<string, unknown> = process.env): z.ZodSafeParseSuccess<z.infer<T>>['data'] {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -968,6 +968,24 @@ export const ENVS = ENVS_SHAPE.check((ctx) => {
             input: ctx.value.EMAIL_HTTP_BODY
         });
     }
+    // Encryption key is required to avoid silently storing credentials in plaintext.
+    // Either NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED must be set.
+    // Vitest / NODE_ENV=test are exempt so unit tests can call parseEnvs(ENVS, {}) without bootstrapping a key;
+    // runtime still enforces via encryption.manager throws and DekRegistry, and vite configs inject a test key.
+    if (!ctx.value.NANGO_ENCRYPTION_KEY && !ctx.value.NANGO_ENCRYPTION_KEY_WRAPPED) {
+        // Allow unit tests (which call parseEnvs(ENVS, {})) to pass without a key when the
+        // global process is in test mode. Runtime vite configs already inject a test key for
+        // integration tests; this exemption only covers parseEnvs(ENVS, {}) in parse.unit.test.
+        const isTestProcess = process.env['VITEST'] === 'true' || process.env['NODE_ENV'] === 'test';
+        if (!ctx.value.VITEST && ctx.value.NODE_ENV !== 'test' && !isTestProcess) {
+            ctx.issues.push({
+                code: 'custom',
+                message: 'NANGO_ENCRYPTION_KEY or NANGO_ENCRYPTION_KEY_WRAPPED is required (generate with: openssl rand -base64 32)',
+                path: ['NANGO_ENCRYPTION_KEY'],
+                input: undefined
+            });
+        }
+    }
 });
 
 export function parseEnvs<T extends z.ZodObject<any>>(schema: T, envs: Record<string, unknown> = process.env): z.ZodSafeParseSuccess<z.infer<T>>['data'] {


### PR DESCRIPTION
### Summary
Encryption was optional. `NANGO_ENCRYPTION_KEY` was `z.string().optional()` in `packages/utils/lib/environment/parse.ts:651` and `EncryptionManager.shouldEncrypt()` at `packages/shared/lib/utils/encryption.manager.ts:21` gated every `encrypt*()` to silently return plaintext when no key was configured. Self-hosted deployments that missed `.env` step stored OAuth tokens/API keys unencrypted indefinitely. `docker-compose.yaml:24` and `.env.example:9` did not enforce, while `packages/persist/lib/env.ts:9` already required the key (inconsistent).

### Changes
- **`packages/utils/lib/environment/parse.ts:959`** – Add `ENVS.check` requiring `NANGO_ENCRYPTION_KEY` or `NANGO_ENCRYPTION_KEY_WRAPPED` (exempt only when `VITEST` or `NODE_ENV=test` so `parseEnvs(ENVS, {})` in unit tests keeps passing; `vite.config.ts:27` and `vite.integration.config.ts:48` already inject a test key for integration tests).
- **`packages/shared/lib/utils/encryption.manager.ts:41,83,114,320,202`** – `encryptConnection`, `encryptProviderConfig`, `encryptEnvironmentVariables`, `encryptAPISecret` now `throw` instead of returning plaintext when `!shouldEncrypt()`. `encryptDatabaseIfNeeded` now throws on `status=disabled` instead of silently returning.
- **`.env.example:5`** – Document key as **REQUIRED** and mention KMS-wrapped alternative.

### Verification
- `npx vitest run packages/utils/lib/environment/parse.unit.test.ts` – 97 passed
- `npx vitest run packages/shared/lib/utils/encryption.manager.unit.test.ts` – 2 passed
- `npx vitest run` – 4247 passed, 1 pre-existing failure in `egress.unit.test.ts` (verified on master)
- Manual checks: `parseEnvs(ENVS, {NODE_ENV:'production'})` throws `NANGO_ENCRYPTION_KEY is required`; `new EncryptionManager('').encryptConnection()` throws; with valid base64 key encrypts and round-trips.
- `npm run lint` and `npm run format:check` pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

