### PR TITLE
fix(billing): read Orb subtotal for metric charges

### DIFF
--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -99,7 +99,7 @@ interface OrbCostBucket {
     timeframe_end: string;
     per_price_costs: {
         price_id: string;
-        total: string;
+        subtotal: string;
         price: { price_type: string; name: string; currency?: string | null; billable_metric?: { id: string } | null };
     }[];
 }
@@ -134,7 +134,9 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date):
 
         const metric = price.billable_metric ? (orbBillableMetricToUsageMetric[price.billable_metric.id] ?? null) : null;
         const priceCurrency = normalizeIsoCurrency(price.currency);
-        const amountInCents = orbAmountToCents(priceCost.total);
+        // `total` also carries the price's share of any plan-level minimum or discount — a $50 minimum
+        // lands as $16.67 on each of three unused metrics — so only `subtotal` is attributable to usage.
+        const amountInCents = orbAmountToCents(priceCost.subtotal);
         const readable = priceCurrency !== null && (currency === null || priceCurrency === currency) && amountInCents !== null;
 
         if (!readable) {

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -475,9 +475,10 @@ const COMPUTE_HOURS_PROD = 'ZrAoynYimCwtmFSP';
 const DATA_TRANSFER_PROD = 'RNskBsYUvTYLsjV2';
 const CONNECTIONS_PROD = '8aAyMTG6HafmZpqJ';
 
-function usagePrice(metricId: string | null, total: string, name = 'Some price', priceId = 'price_1') {
+function usagePrice(metricId: string | null, subtotal: string, name = 'Some price', priceId = 'price_1', total = subtotal) {
     return {
         price_id: priceId,
+        subtotal,
         total,
         price: { price_type: 'usage_price', currency: 'USD', name, billable_metric: metricId ? { id: metricId } : null }
     };
@@ -488,6 +489,27 @@ function bucket(perPriceCosts: ReturnType<typeof usagePrice>[], timeframeEnd = '
 }
 
 describe('fromOrbPeriodCosts', () => {
+    it('reads the usage cost, not the total with a plan minimum folded in', () => {
+        const minimumShare = '16.111111111111111111111';
+        const costs = {
+            data: [
+                bucket([
+                    usagePrice(CONNECTIONS_PROD, '0.00', 'Connections', 'price_1', minimumShare),
+                    usagePrice(COMPUTE_HOURS_PROD, '0.00', 'Function compute time (h)', 'price_2', minimumShare),
+                    usagePrice(DATA_TRANSFER_PROD, '0.00', 'Data transfer (GB)', 'price_3', minimumShare)
+                ])
+            ]
+        };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ connections: 0, function_duration_seconds: 0, data_transfer: 0 });
+    });
+
+    it('keeps a used metric at its own cost when the minimum tops it up', () => {
+        const costs = { data: [bucket([usagePrice(CONNECTIONS_PROD, '0.29', 'Connections', 'price_1', '16.86')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ connections: 29 });
+    });
+
     it('maps a price to its metric and converts the amount to cents', () => {
         const costs = { data: [bucket([usagePrice(RECORDS_PROD, '23.17', 'Sync records')])] };
 
@@ -564,7 +586,12 @@ describe('fromOrbPeriodCosts', () => {
             data: [
                 bucket([
                     usagePrice(RECORDS_PROD, '23.17'),
-                    { price_id: 'price_fixed', total: '500.00', price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null } }
+                    {
+                        price_id: 'price_fixed',
+                        subtotal: '500.00',
+                        total: '500.00',
+                        price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null }
+                    }
                 ])
             ]
         };
@@ -642,6 +669,7 @@ describe('fromOrbPeriodCosts', () => {
         const costs = { data: [bucket([usagePrice(RECORDS_PROD, '1.00')])] };
         costs.data[0]!.per_price_costs.push({
             price_id: 'price_2',
+            subtotal: '1.00',
             total: '1.00',
             price: { price_type: 'usage_price', currency: 'EUR', name: 'Proxy requests', billable_metric: { id: WEBHOOKS_PROD } }
         });
@@ -676,7 +704,12 @@ describe('fromOrbPeriodCosts', () => {
         const costs = {
             data: [
                 bucket([
-                    { price_id: 'price_fixed', total: '500.00', price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null } }
+                    {
+                        price_id: 'price_fixed',
+                        subtotal: '500.00',
+                        total: '500.00',
+                        price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null }
+                    }
                 ])
             ]
         };

--- a/packages/billing/lib/clients/orb/client.unit.test.ts
+++ b/packages/billing/lib/clients/orb/client.unit.test.ts
@@ -141,7 +141,7 @@ describe('OrbClient.getPeriodCosts', () => {
                     per_price_costs: [
                         {
                             price_id: 'price_1',
-                            total: 'n/a',
+                            subtotal: 'n/a',
                             price: { price_type: 'usage_price', currency: 'USD', name: 'Sync records', billable_metric: { id: 'AinLoHESvrXqhEig' } }
                         }
                     ]
@@ -162,12 +162,12 @@ describe('OrbClient.getPeriodCosts', () => {
                     per_price_costs: [
                         {
                             price_id: 'price_1',
-                            total: 'n/a',
+                            subtotal: 'n/a',
                             price: { price_type: 'usage_price', currency: 'USD', name: 'Sync records', billable_metric: { id: 'AinLoHESvrXqhEig' } }
                         },
                         {
                             price_id: 'price_2',
-                            total: '2.24',
+                            subtotal: '2.24',
                             price: { price_type: 'usage_price', currency: 'USD', name: 'Webhook forwards', billable_metric: { id: 'j46jUSMMya8jqhkR' } }
                         }
                     ]


### PR DESCRIPTION
## Problem

On pay-as-you-go the Charges column showed money against metrics with zero usage: every one of the 8 prod accounts read $16.11 per metric. The adapter reads each price's `total`, which Orb documents as *including* minimums and discounts. An invoice-level minimum is split evenly across the prices it covers, so on a plan whose whole bill is the $50 minimum each unused metric gets a share. One growth-v2 account (Linksquares, $1,100 minimum) showed $75 per metric the same way.

## Solution

- Read `subtotal` instead of `total` in `fromOrbPeriodCosts` — the price's own usage cost, so an unused metric reads $0.00.
- Add regression tests with the real pay-as-you-go shape (three prices, $0 usage, $16.11 each in `total`) and the used-metric case.

No UI or endpoint change. The $50 minimum stays explained by the spend headline's tooltip; the column deliberately shows usage cost, not the invoice split. A sweep of all 657 prod spend-plan subscriptions confirmed negotiated rates are modelled as price overrides (already inside `subtotal`), and no adjustment-style discount is active — details and the account list are on the ticket and in the new Notion DB [Non-standard Orb setups (prod)](https://app.notion.com/p/c16ed6ae6c7341248039d57bea52fb56).

Fixes [NAN-6874](https://linear.app/nango/issue/NAN-6874)

## Testing

- Unit tests for the adapter and Orb client (88 passing), type-check and lint clean.
- Verified against live prod Orb data: for all 9 accounts with an active minimum, `subtotal` matches the metric's usage and `total` carries the minimum share.
