### PR TITLE
fix(server): validate google incoming webhooks

### DIFF
--- a/docs/api-integrations/google-calendar/webhooks.mdx
+++ b/docs/api-integrations/google-calendar/webhooks.mdx
@@ -25,7 +25,17 @@ Watching **additional calendars** uses a different metadata-based step; see [Con
 
 Copy the webhook URL from your Google Calendar integration page in the Nango dashboard, under the **Webhook URL** section. This is the HTTPS URL you will use as the channel `address` when creating notification channels.
 
-### 2. Create a notification channel (watch a resource)
+### 2. Set a webhook secret in Nango
+
+Google Calendar push notifications have no HMAC. The `token` you set on the channel is echoed back as `X-Goog-Channel-Token` and is the only way Nango can authenticate the request.
+
+1. In the Nango dashboard, open your Google Calendar integration and go to the **Settings** tab
+2. Under **Webhook Configuration**, enter a secret string in the **Webhook Secret** field
+3. Click **Save**. You will pass this same value as `token` when creating channels.
+
+Once a secret is saved, Nango rejects notifications that omit `X-Goog-Channel-Token` or send a different value. Existing channels created without `token` must be recreated.
+
+### 3. Create a notification channel (watch a resource)
 
 Create a notification channel for the calendar you want to watch by sending a `POST` request to the appropriate `watch` endpoint. See the [API reference](https://developers.google.com/workspace/calendar/api/guides/push#create-notification-channels) for the exact URI.
 
@@ -53,6 +63,10 @@ export default createOnEvent({
         const channelId = randomUUID();
         const expiration = Date.now() + 7 * 24 * 60 * 60 * 1000; // 7 days in ms
         const webhookUrl = await nango.getWebhookURL();
+        const integration = await nango.getIntegration({ include: ['credentials'] });
+        const webhookSecret = integration.credentials && 'webhook_secret' in integration.credentials
+            ? integration.credentials.webhook_secret
+            : undefined;
 
         const config: ProxyConfiguration = {
             baseUrlOverride: 'https://www.googleapis.com/calendar',
@@ -63,12 +77,13 @@ export default createOnEvent({
                 // Webhook URL can be found on https://app.nango.dev/dev/integrations/google-calendar (your integration settings page)
                 address: webhookUrl,
                 expiration: expiration,
+                ...(webhookSecret && { token: webhookSecret }),
             },
         };
 
         const response = await nango.post(config);
 
-        // Store channel info so it can be used to stop notifications later (step 4)
+        // Store channel info so it can be used to stop notifications later (step 5)
         await nango.updateMetadata({
             googleCalendarChannelId: channelId,
             googleCalendarResourceId: response.data.resourceId,
@@ -88,6 +103,7 @@ curl -X POST "https://www.googleapis.com/calendar/v3/calendars/<CALENDAR_ID>/eve
     "id": "01234567-89ab-cdef-0123456789ab",
     "type": "web_hook",
     "address": "<REPLACE_WITH_NANGO_WEBHOOK_URL>",
+    "token": "<YOUR-WEBHOOK-SECRET>",
     "expiration": <EXPIRATION>
   }'
 ```
@@ -98,9 +114,10 @@ Replace:
 - **&lt;AUTH_TOKEN&gt;** — A valid OAuth 2.0 access token for the user who owns or has access to the calendar.
 - **address** — Your Nango webhook URL from the dashboard.
 - **id** — A unique string (e.g. UUID) identifying this channel; max 64 characters. It is echoed in `X-Goog-Channel-ID` on every notification.
+- **token** — The webhook secret from [step 2](#2-set-a-webhook-secret-in-nango). Google echoes it as `X-Goog-Channel-Token`. Required once a secret is saved on the integration.
 - **expiration** — (Optional) Unix timestamp in **milliseconds** when the channel should stop sending notifications. If omitted, Google applies a default; channels must be renewed before they expire.
 
-### 3. Renew the notification channel
+### 4. Renew the notification channel
 
 Google does **not** renew channels automatically. When a channel is close to its expiration, you must create a new channel by calling the `watch` endpoint again with a **new** unique `id`. After the new channel is created successfully, stop the old channel so only one remains active. See [Renew notification channels](https://developers.google.com/workspace/calendar/api/guides/push#renew-notification-channels).
 
@@ -135,6 +152,10 @@ export default createSync({
         const channelId = randomUUID();
         const expiration = Date.now() + 7 * 24 * 60 * 60 * 1000; // 7 days in ms
         const webhookUrl = await nango.getWebhookURL();
+        const integration = await nango.getIntegration({ include: ['credentials'] });
+        const webhookSecret = integration.credentials && 'webhook_secret' in integration.credentials
+            ? integration.credentials.webhook_secret
+            : undefined;
 
         const config: ProxyConfiguration = {
             baseUrlOverride: 'https://www.googleapis.com/calendar',
@@ -145,6 +166,7 @@ export default createSync({
                 // Webhook URL can be found on https://app.nango.dev/dev/integrations/google-calendar (your integration settings page)
                 address: webhookUrl,
                 expiration: expiration,
+                ...(webhookSecret && { token: webhookSecret }),
             },
         };
 
@@ -163,7 +185,7 @@ export default createSync({
             }
         }
 
-        // Update stored channel info for use in stop notifications (step 4)
+        // Update stored channel info for use in stop notifications (step 5)
         await nango.updateMetadata({
             googleCalendarChannelId: channelId,
             googleCalendarResourceId: response.data.resourceId,
@@ -172,11 +194,11 @@ export default createSync({
 });
 ```
 
-### 4. Stop notifications on connection deletion
+### 5. Stop notifications on connection deletion
 
 If a connection is deleted in Nango but the channel remains active, Google may continue sending notifications until the channel expires. To stop notifications immediately for a deleted connection, call `channels.stop` before deletion.
 
-You can automate this with a `pre-connection-deletion` lifecycle event. This uses the `googleCalendarChannelId` and `googleCalendarResourceId` stored in metadata during channel creation (step 2) and renewal (step 3):
+You can automate this with a `pre-connection-deletion` lifecycle event. This uses the `googleCalendarChannelId` and `googleCalendarResourceId` stored in metadata during channel creation (step 3) and renewal (step 4):
 
 ```typescript
 import { createOnEvent, ProxyConfiguration } from 'nango';
@@ -212,7 +234,7 @@ export default createOnEvent({
 });
 ```
 
-### 5. Handle forwarded webhooks
+### 6. Handle forwarded webhooks
 
 When a Calendar notification arrives, Nango matches it to the correct connection and forwards it to your system. Notification messages have **no body**; Google sends only HTTP headers. Nango forwards those headers in the payload. Example structure:
 
@@ -223,6 +245,7 @@ When a Calendar notification arrives, Nango matches it to the correct connection
   "type": "forward",
   "payload": {
     "x-goog-channel-id": "01234567-89ab-cdef-0123456789ab",
+    "x-goog-channel-token": "your-webhook-secret",
     "x-goog-resource-id": "o3hgv1538sdjfh",
     "x-goog-resource-uri": "https://www.googleapis.com/calendar/v3/calendars/user@example.com/events",
     "x-goog-resource-state": "exists",
@@ -239,6 +262,7 @@ Relevant headers (see [Google's documentation](https://developers.google.com/wor
 | `x-goog-resource-state` | `sync` = channel created; `exists` = resource changed (create/update/delete). |
 | `x-goog-resource-uri` | The watched resource (e.g. which calendar's events). |
 | `x-goog-channel-id` | The channel `id` you sent when creating the channel. |
+| `x-goog-channel-token` | The `token` you set when creating the channel. Nango verifies this against the integration webhook secret when one is configured. |
 | `x-goog-message-number` | Incrementing message number for this channel. |
 
 Notifications do **not** include the changed events themselves—you must call the Calendar API (e.g. list events or get event) to fetch the updates. After receiving the webhook, trigger your sync or API calls for that connection:

--- a/docs/api-integrations/google-drive/webhooks.mdx
+++ b/docs/api-integrations/google-drive/webhooks.mdx
@@ -11,7 +11,7 @@ This guide shows you how to receive real-time Google Drive webhooks in Nango usi
 The Google Drive API supports two kinds of notification channels:
 
 - **`changes.watch`** — watches every change across the user's Drive (or one shared drive). This is the recommended approach.
-- **`files.watch`** — watches a single file for changes. Use this when you only care about one specific file; see the note at the end of [step 2](#2-create-a-notification-channel-watch-the-drive).
+- **`files.watch`** — watches a single file for changes. Use this when you only care about one specific file; see the note at the end of [step 3](#3-create-a-notification-channel-watch-the-drive).
 
 The flow:
 
@@ -28,7 +28,17 @@ Drive has no built-in identifier Nango can derive automatically — you must sto
 
 Copy the webhook URL from your Google Drive integration page in the Nango dashboard, under the **Webhook URL** section. This is the HTTPS URL you will use as the channel `address` when creating notification channels.
 
-### 2. Create a notification channel (watch the Drive)
+### 2. Set a webhook secret in Nango
+
+Google Drive push notifications have no HMAC. The `token` you set on the channel is echoed back as `X-Goog-Channel-Token` and is the only way Nango can authenticate the request.
+
+1. In the Nango dashboard, open your Google Drive integration and go to the **Settings** tab
+2. Under **Webhook Configuration**, enter a secret string in the **Webhook Secret** field
+3. Click **Save**. You will pass this same value as `token` when creating channels.
+
+Once a secret is saved, Nango rejects notifications that omit `X-Goog-Channel-Token` or send a different value. Existing channels created without `token` must be recreated.
+
+### 3. Create a notification channel (watch the Drive)
 
 You can automate creating the channel for new connections with a [post-connection-creation script](/implementation-guides/use-cases/implement-event-handler):
 
@@ -51,6 +61,10 @@ export default createOnEvent({
 
         try {
             const webhookUrl = await nango.getWebhookURL();
+            const integration = await nango.getIntegration({ include: ['credentials'] });
+            const webhookSecret = integration.credentials && 'webhook_secret' in integration.credentials
+                ? integration.credentials.webhook_secret
+                : undefined;
 
             const startPageTokenResponse = await nango.get({
                 endpoint: '/drive/v3/changes/startPageToken',
@@ -69,14 +83,15 @@ export default createOnEvent({
                     // Webhook URL can be found on https://app.nango.dev/dev/integrations/google-drive (your integration settings page)
                     address: webhookUrl,
                     expiration: expiration,
+                    ...(webhookSecret && { token: webhookSecret }),
                 },
             };
 
             const response = await nango.post(config);
 
-            // Store the channel info so it can be used to stop notifications later (step 4) and to
+            // Store the channel info so it can be used to stop notifications later (step 5) and to
             // route incoming notifications to this connection (see "Connection matching" below).
-            // Persisting driveId ensures the renewal sync (step 3) keeps watching the same shared drive.
+            // Persisting driveId ensures the renewal sync (step 4) keeps watching the same shared drive.
             await nango.updateMetadata({
                 googleDriveChannelId: channelId,
                 googleDriveWatchResourceIds: [response.data.resourceId],
@@ -95,6 +110,7 @@ Replace:
 
 - **address** — Your Nango webhook URL from the dashboard.
 - **id** — A unique string (e.g. UUID) identifying this channel; max 64 characters. It is echoed in `X-Goog-Channel-ID` on every notification.
+- **token** — The webhook secret from [step 2](#2-set-a-webhook-secret-in-nango). Google echoes it as `X-Goog-Channel-Token`. Required once a secret is saved on the integration.
 - **expiration** — (Optional) Unix timestamp in **milliseconds** when the channel should stop sending notifications. Drive's own maximum is 7 days for `changes.watch`; if you request longer, Google caps it. If omitted, the default is 1 hour after the current time.
 
 See the [API reference](https://developers.google.com/workspace/drive/api/reference/rest/v3/changes/watch) for the exact request shape.
@@ -103,7 +119,7 @@ See the [API reference](https://developers.google.com/workspace/drive/api/refere
 To watch a single file instead of the whole Drive, call `files.watch` instead: drop the `pageToken` param and `startPageToken` call, and set `endpoint: "/drive/v3/files/${fileId}/watch"` (24h max expiration instead of 7 days).
 </Note>
 
-### 3. Renew the notification channel
+### 4. Renew the notification channel
 
 Google does **not** renew channels automatically. When a channel is close to its expiration, you must create a new channel by calling `changes.watch` again with a **new** unique `id` and a fresh `pageToken`. After the new channel is created successfully, stop the old channel so only one remains active. See [Renew notification channels](https://developers.google.com/workspace/drive/api/guides/push#renew-notification-channels).
 
@@ -132,6 +148,10 @@ export default createSync({
         const channelId = randomUUID();
         const expiration = Date.now() + 7 * 24 * 60 * 60 * 1000; // 7 days in ms
         const webhookUrl = await nango.getWebhookURL();
+        const integration = await nango.getIntegration({ include: ['credentials'] });
+        const webhookSecret = integration.credentials && 'webhook_secret' in integration.credentials
+            ? integration.credentials.webhook_secret
+            : undefined;
 
         const startPageTokenResponse = await nango.get({
             endpoint: '/drive/v3/changes/startPageToken',
@@ -149,6 +169,7 @@ export default createSync({
                 type: 'web_hook',
                 address: webhookUrl,
                 expiration: expiration,
+                ...(webhookSecret && { token: webhookSecret }),
             },
         };
 
@@ -166,7 +187,7 @@ export default createSync({
             }
         }
 
-        // Update stored channel info for use in stop notifications (step 4) and connection matching
+        // Update stored channel info for use in stop notifications (step 5) and connection matching
         await nango.updateConnectionConfig({
             googleDriveChannelId: channelId,
             googleDriveWatchResourceIds: [response.data.resourceId],
@@ -176,11 +197,11 @@ export default createSync({
 });
 ```
 
-### 4. Stop notifications on connection deletion
+### 5. Stop notifications on connection deletion
 
 If a connection is deleted in Nango but the channel remains active, Google may continue sending notifications until the channel expires. To stop notifications immediately for a deleted connection, call `channels.stop` before deletion.
 
-You can automate this with a `pre-connection-deletion` lifecycle event. This uses the `googleDriveChannelId` and `googleDriveWatchResourceIds` stored in metadata during channel creation (step 2) and renewal (step 3):
+You can automate this with a `pre-connection-deletion` lifecycle event. This uses the `googleDriveChannelId` and `googleDriveWatchResourceIds` stored in metadata during channel creation (step 3) and renewal (step 4):
 
 ```typescript
 import { createOnEvent, ProxyConfiguration } from 'nango';
@@ -215,7 +236,7 @@ export default createOnEvent({
 });
 ```
 
-### 5. Handle forwarded webhooks
+### 6. Handle forwarded webhooks
 
 When a Drive notification arrives, Nango matches it to the correct connection and forwards it to your system. Notification messages have **no body**; Google sends only HTTP headers. Nango forwards those headers in the payload. Example structure:
 
@@ -226,6 +247,7 @@ When a Drive notification arrives, Nango matches it to the correct connection an
   "type": "forward",
   "payload": {
     "x-goog-channel-id": "01234567-89ab-cdef-0123456789ab",
+    "x-goog-channel-token": "your-webhook-secret",
     "x-goog-resource-id": "ret08u3rv24htgh289g",
     "x-goog-resource-uri": "https://www.googleapis.com/drive/v3/changes",
     "x-goog-resource-state": "change",
@@ -244,6 +266,7 @@ Relevant headers (see [Google's documentation](https://developers.google.com/wor
 | `x-goog-resource-uri` | The watched resource. Identical across every connection watching the same target (e.g. every "My Drive" watch), so it can't be used to identify a connection. |
 | `x-goog-resource-id` | Stable identifier for the watched resource, unique per watched Drive/shared drive. Nango matches on this — see [Connection matching](#connection-matching). |
 | `x-goog-channel-id` | The channel `id` you sent when creating the channel. |
+| `x-goog-channel-token` | The `token` you set when creating the channel. Nango verifies this against the integration webhook secret when one is configured. |
 | `x-goog-message-number` | Incrementing message number for this channel. |
 
 Notifications do **not** include the changed files themselves — call `changes.list` with a stored `pageToken` to fetch what changed since your last check, then save the `newStartPageToken` it returns for the next call. After receiving the webhook, trigger your sync or API calls for that connection:
@@ -270,12 +293,12 @@ See: [Real-time syncs](/implementation-guides/use-cases/syncs/realtime-syncs)
 
 ## Connection matching
 
-Google Drive has no built-in identifier Nango can derive automatically, so you must always register the watched resource yourself. Nango matches incoming Drive notifications by resource ID, against **`metadata.googleDriveWatchResourceIds`** — the value you store via `nango.updateMetadata()` in your post-connection-creation script (step 2) and renewal sync (step 3).
+Google Drive has no built-in identifier Nango can derive automatically, so you must always register the watched resource yourself. Nango matches incoming Drive notifications by resource ID, against **`metadata.googleDriveWatchResourceIds`** — the value you store via `nango.updateMetadata()` in your post-connection-creation script (step 3) and renewal sync (step 4).
 
 - The value must be a JSON **`string[]`**. Store the **`X-Goog-Resource-ID` string exactly as Google sends it**.
 - Update metadata from your own Nango functions via `nango.updateMetadata()`, or manually via the [update metadata API](/reference/api/connection/update-metadata).
 
-If you use the post-connection-creation script from [step 2](#2-create-a-notification-channel-watch-the-drive), this is already handled for you.
+If you use the post-connection-creation script from [step 3](#3-create-a-notification-channel-watch-the-drive), this is already handled for you.
 
 **Duplicates:** If more than one connection stores the **same** value in `googleDriveWatchResourceIds` (e.g. two connections watching the same shared drive), **every** matching connection is included. Nango forwards the webhook **once per matching connection**, with the appropriate `connectionId`.
 

--- a/docs/api-integrations/google-mail/webhooks.mdx
+++ b/docs/api-integrations/google-mail/webhooks.mdx
@@ -53,7 +53,7 @@ Click on the default subscription for your topic (if one was created) or create 
 
 1. **Delivery type**: Set as push
 2. **Endpoint URL**: Copy the webhook URL from your Gmail integration page in the Nango dashboard, under the **Webhook URL** section.
-3. **Authentication** (recommended): Enable authentication and configure a service account for added security.
+3. **Authentication** (required): Enable authentication and configure a service account. Set the audience to your Nango webhook URL from the previous step. Nango verifies the Google-signed OIDC JWT on every push and rejects requests without a valid `Authorization` header.
 4. **Save the changes**
 
 ### 4. Activate the watch subscription

--- a/docs/api-integrations/google-mail/webhooks.mdx
+++ b/docs/api-integrations/google-mail/webhooks.mdx
@@ -53,7 +53,7 @@ Click on the default subscription for your topic (if one was created) or create 
 
 1. **Delivery type**: Set as push
 2. **Endpoint URL**: Copy the webhook URL from your Gmail integration page in the Nango dashboard, under the **Webhook URL** section.
-3. **Authentication** (required): Enable authentication and configure a service account. Set the audience to your Nango webhook URL from the previous step. Nango verifies the Google-signed OIDC JWT on every push and rejects requests without a valid `Authorization` header.
+3. **Authentication** (recommended): Enable authentication and configure a service account. Set the audience to your Nango webhook URL from the previous step. When the header is present, Nango verifies the Google-signed OIDC JWT.
 4. **Save the changes**
 
 ### 4. Activate the watch subscription

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -10096,7 +10096,6 @@ google-mail:
     proxy:
         base_url: https://gmail.googleapis.com
     webhook_routing_script: gmailWebhookRouting
-    webhook_user_defined_secret: true
     post_connection_script: googleMailPostConnection
     docs: https://nango.dev/docs/api-integrations/google-mail
     setup_guide_url: https://nango.dev/docs/api-integrations/google-mail/how-to-register-your-own-gmail-api-oauth-app

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -10038,6 +10038,7 @@ google-calendar:
                 - '401'
                 - '429'
     webhook_routing_script: googleCalendarWebhookRouting
+    webhook_user_defined_secret: true
     post_connection_script: googleCalendarPostConnection
     docs: https://nango.dev/docs/api-integrations/google-calendar
     setup_guide_url: https://nango.dev/docs/api-integrations/google-calendar/how-to-register-your-own-google-calendar-api-oauth-app
@@ -10158,6 +10159,7 @@ google-drive:
         - storage
     alias: google
     webhook_routing_script: googleDriveWebhookRouting
+    webhook_user_defined_secret: true
     docs: https://nango.dev/docs/api-integrations/google-drive
     setup_guide_url: https://nango.dev/docs/api-integrations/google-drive/how-to-register-your-own-google-drive-api-oauth-app
 

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -10096,7 +10096,7 @@ google-mail:
     proxy:
         base_url: https://gmail.googleapis.com
     webhook_routing_script: gmailWebhookRouting
-    webhook_user_defined_secret: false
+    webhook_user_defined_secret: true
     post_connection_script: googleMailPostConnection
     docs: https://nango.dev/docs/api-integrations/google-mail
     setup_guide_url: https://nango.dev/docs/api-integrations/google-mail/how-to-register-your-own-gmail-api-oauth-app

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -9997,6 +9997,7 @@ google:
     docs: https://nango.dev/docs/api-integrations/google
     setup_guide_url: https://nango.dev/docs/api-integrations/google/how-to-register-your-own-google-api-oauth-app
     webhook_routing_script: googleWebhookRouting
+    webhook_user_defined_secret: true
 
 google-analytics:
     display_name: Google Analytics
@@ -10094,6 +10095,7 @@ google-mail:
     proxy:
         base_url: https://gmail.googleapis.com
     webhook_routing_script: gmailWebhookRouting
+    webhook_user_defined_secret: false
     post_connection_script: googleMailPostConnection
     docs: https://nango.dev/docs/api-integrations/google-mail
     setup_guide_url: https://nango.dev/docs/api-integrations/google-mail/how-to-register-your-own-gmail-api-oauth-app

--- a/packages/server/lib/webhook/gmail-webhook-routing.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.ts
@@ -66,10 +66,12 @@ export async function validate(integration: IntegrationConfig, headers: Record<s
         }
 
         const environment = await environmentService.getById(integration.environment_id);
-        const webhookUrl = `${getGlobalWebhookReceiveUrl()}/${environment?.uuid}/${integration.unique_key}`;
+        const webhookBase = `${getGlobalWebhookReceiveUrl()}/${environment?.uuid}`;
+        const encodedWebhookUrl = `${webhookBase}/${encodeURIComponent(integration.unique_key)}`;
+        const rawWebhookUrl = `${webhookBase}/${integration.unique_key}`;
 
-        if (payload.aud !== webhookUrl) {
-            logger.warning(`Invalid audience. Expected ${webhookUrl}, got ${payload.aud}`);
+        if (payload.aud !== encodedWebhookUrl && payload.aud !== rawWebhookUrl) {
+            logger.warning(`Invalid audience. Expected ${encodedWebhookUrl}, got ${payload.aud}`);
             return false;
         }
 

--- a/packages/server/lib/webhook/gmail-webhook-routing.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.ts
@@ -94,8 +94,6 @@ const route: WebhookHandler = async (nango, headers, body) => {
     if (!authHeader) {
         metrics.increment(metrics.Types.WEBHOOK_INCOMING_UNVERIFIED, 1, {
             accountId: nango.team.id,
-            environmentId: nango.environment.id,
-            provider: nango.integration.provider,
             reason: 'gmail_missing_authorization'
         });
     }

--- a/packages/server/lib/webhook/gmail-webhook-routing.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.ts
@@ -20,10 +20,6 @@ export async function validate(integration: IntegrationConfig, headers: Record<s
     try {
         const authHeader: string | undefined = headers['authorization'];
 
-        if (!authHeader) {
-            return true;
-        }
-
         if (!authHeader?.startsWith('Bearer ')) {
             return false;
         }
@@ -66,7 +62,7 @@ export async function validate(integration: IntegrationConfig, headers: Record<s
         }
 
         const environment = await environmentService.getById(integration.environment_id);
-        const webhookUrl = `${getGlobalWebhookReceiveUrl()}/${environment?.uuid}/${integration.provider}`;
+        const webhookUrl = `${getGlobalWebhookReceiveUrl()}/${environment?.uuid}/${integration.unique_key}`;
 
         if (payload.aud !== webhookUrl) {
             logger.warning(`Invalid audience. Expected ${webhookUrl}, got ${payload.aud}`);
@@ -87,14 +83,11 @@ export async function validate(integration: IntegrationConfig, headers: Record<s
 
 const route: WebhookHandler = async (nango, headers, body) => {
     const authHeader = headers['authorization'];
+    const valid = await validate(nango.integration, headers);
 
-    if (authHeader) {
-        const valid = await validate(nango.integration, headers);
-
-        if (!valid) {
-            logger.error('webhook signature invalid');
-            return Err(new NangoError('webhook_invalid_signature'));
-        }
+    if (!valid) {
+        logger.error(authHeader ? 'webhook signature invalid' : 'webhook signature missing');
+        return Err(new NangoError(authHeader ? 'webhook_invalid_signature' : 'webhook_missing_signature'));
     }
 
     let decodedBody: DecodedDataObject | null = null;

--- a/packages/server/lib/webhook/gmail-webhook-routing.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.ts
@@ -71,7 +71,8 @@ export async function validate(integration: IntegrationConfig, headers: Record<s
         const rawWebhookUrl = `${webhookBase}/${integration.unique_key}`;
 
         if (payload.aud !== encodedWebhookUrl && payload.aud !== rawWebhookUrl) {
-            logger.warning(`Invalid audience. Expected ${encodedWebhookUrl}, got ${payload.aud}`);
+            const expected = encodedWebhookUrl === rawWebhookUrl ? encodedWebhookUrl : `${encodedWebhookUrl} or ${rawWebhookUrl}`;
+            logger.warning(`Invalid audience. Expected ${expected}, got ${payload.aud}`);
             return false;
         }
 

--- a/packages/server/lib/webhook/gmail-webhook-routing.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 
 import { environmentService, getGlobalWebhookReceiveUrl, NangoError } from '@nangohq/shared';
-import { Err, getLogger, Ok, report } from '@nangohq/utils';
+import { Err, getLogger, metrics, Ok, report } from '@nangohq/utils';
 
 import { hashEmailAddress } from '../utils/pii.js';
 import { getGoogleJWKS } from './cache.js';
@@ -20,7 +20,11 @@ export async function validate(integration: IntegrationConfig, headers: Record<s
     try {
         const authHeader: string | undefined = headers['authorization'];
 
-        if (!authHeader?.startsWith('Bearer ')) {
+        if (!authHeader) {
+            return true;
+        }
+
+        if (!authHeader.startsWith('Bearer ')) {
             return false;
         }
 
@@ -83,11 +87,21 @@ export async function validate(integration: IntegrationConfig, headers: Record<s
 
 const route: WebhookHandler = async (nango, headers, body) => {
     const authHeader = headers['authorization'];
+
+    if (!authHeader) {
+        metrics.increment(metrics.Types.WEBHOOK_INCOMING_UNVERIFIED, 1, {
+            accountId: nango.team.id,
+            environmentId: nango.environment.id,
+            provider: nango.integration.provider,
+            reason: 'gmail_missing_authorization'
+        });
+    }
+
     const valid = await validate(nango.integration, headers);
 
     if (!valid) {
-        logger.error(authHeader ? 'webhook signature invalid' : 'webhook signature missing');
-        return Err(new NangoError(authHeader ? 'webhook_invalid_signature' : 'webhook_missing_signature'));
+        logger.error('webhook signature invalid');
+        return Err(new NangoError('webhook_invalid_signature'));
     }
 
     let decodedBody: DecodedDataObject | null = null;

--- a/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { logContextGetter } from '@nangohq/logs';
 import { environmentService, getGlobalWebhookReceiveUrl, NangoError, seeders } from '@nangohq/shared';
 import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
-import { metrics } from '@nangohq/utils';
 
 import { hashEmailAddress } from '../utils/pii.js';
 import * as GmailWebhookRouting from './gmail-webhook-routing.js';
@@ -126,27 +125,6 @@ describe('gmailWebhookRouting', () => {
         expect(execute).toHaveBeenNthCalledWith(1, expect.objectContaining({ propName: 'emailAddressHash' }));
         expect(execute).toHaveBeenNthCalledWith(2, expect.objectContaining({ propName: 'metadata.emailAddress' }));
         expect(execute).toHaveBeenNthCalledWith(3, expect.objectContaining({ propName: 'metadata.email' }));
-    });
-
-    it('accepts a request with no Authorization header and records a metric', async () => {
-        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'google-mail' });
-        const { nango, execute } = getNangoMock(integration);
-        const increment = vi.spyOn(metrics, 'increment');
-
-        const result = await GmailWebhookRouting.default(nango, {}, gmailBody() as any, '');
-
-        expect(result.isOk()).toBe(true);
-        expect(execute).toHaveBeenCalledTimes(1);
-        expect(increment).toHaveBeenCalledWith(
-            metrics.Types.WEBHOOK_INCOMING_UNVERIFIED,
-            1,
-            expect.objectContaining({
-                accountId: nango.team.id,
-                environmentId: nango.environment.id,
-                provider: 'google-mail',
-                reason: 'gmail_missing_authorization'
-            })
-        );
     });
 
     it('rejects an invalid JWT', async () => {

--- a/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
@@ -1,35 +1,90 @@
-import { describe, expect, it, vi } from 'vitest';
+import crypto from 'node:crypto';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { logContextGetter } from '@nangohq/logs';
-import { seeders } from '@nangohq/shared';
+import { environmentService, getGlobalWebhookReceiveUrl, NangoError, seeders } from '@nangohq/shared';
 import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
 
 import { hashEmailAddress } from '../utils/pii.js';
 import * as GmailWebhookRouting from './gmail-webhook-routing.js';
 import { InternalNango } from './internal-nango.js';
 
+import type { IntegrationConfig } from '@nangohq/types';
+
+vi.mock('./cache.js', () => ({
+    getGoogleJWKS: vi.fn()
+}));
+
+const { getGoogleJWKS } = await import('./cache.js');
+const getGoogleJWKSMock = vi.mocked(getGoogleJWKS);
+
+const environment = seeders.getTestEnvironment();
+
+function gmailBody() {
+    const payload = { emailAddress: 'user@example.com', historyId: '1' };
+    return { message: { data: Buffer.from(JSON.stringify(payload)).toString('base64') } };
+}
+
+function createSignedJwt({
+    integration,
+    iss = 'https://accounts.google.com',
+    exp = Math.floor(Date.now() / 1000) + 3600,
+    aud
+}: {
+    integration: IntegrationConfig;
+    iss?: string;
+    exp?: number;
+    aud?: string;
+}) {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const kid = 'test-kid';
+    const header = { alg: 'RS256', typ: 'JWT', kid };
+    const expectedAud = `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${integration.unique_key}`;
+    const payload = { iss, aud: aud ?? expectedAud, exp };
+    const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+    const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    const signedData = `${headerB64}.${payloadB64}`;
+    const signature = crypto.sign('RSA-SHA256', Buffer.from(signedData), privateKey);
+
+    return {
+        token: `${signedData}.${signature.toString('base64url')}`,
+        jwk: { ...publicKey.export({ format: 'jwk' }), kid }
+    };
+}
+
+function getNangoMock(integration: IntegrationConfig) {
+    const nango = new InternalNango({
+        team: seeders.getTestTeam(),
+        environment,
+        plan: seeders.getTestPlan(),
+        integration,
+        logContextGetter
+    });
+    const execute = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'], connectionMetadata: {} });
+    nango.executeScriptForWebhooks = execute;
+    return { nango, execute };
+}
+
 describe('gmailWebhookRouting', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        getGoogleJWKSMock.mockReset();
+        vi.spyOn(environmentService, 'getById').mockResolvedValue(environment);
+    });
+
     it('routes by connection_config.emailAddressHash first', async () => {
-        const integration = getTestConfig({ provider: 'google-mail' });
+        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'google-mail' });
+        const { token, jwk } = createSignedJwt({ integration });
+        getGoogleJWKSMock.mockResolvedValue([jwk as Record<string, string>]);
 
-        const mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'], connectionMetadata: {} });
+        const { nango, execute } = getNangoMock(integration);
+        const body = gmailBody();
 
-        const nangoMock = new InternalNango({
-            team: seeders.getTestTeam(),
-            environment: seeders.getTestEnvironment(),
-            plan: seeders.getTestPlan(),
-            integration,
-            logContextGetter
-        });
-        nangoMock.executeScriptForWebhooks = mock;
+        await GmailWebhookRouting.default(nango, { authorization: `Bearer ${token}` }, body as any, '');
 
-        const payload = { emailAddress: 'user@example.com', historyId: '1' };
-        const body = { message: { data: Buffer.from(JSON.stringify(payload)).toString('base64') } };
-
-        await GmailWebhookRouting.default(nangoMock as unknown as InternalNango, {}, body as any, '');
-
-        expect(mock).toHaveBeenCalledTimes(1);
-        expect(mock).toHaveBeenCalledWith(
+        expect(execute).toHaveBeenCalledTimes(1);
+        expect(execute).toHaveBeenCalledWith(
             expect.objectContaining({
                 propName: 'emailAddressHash',
                 webhookType: 'type',
@@ -44,32 +99,86 @@ describe('gmailWebhookRouting', () => {
     });
 
     it('falls back to legacy config then metadata', async () => {
-        const integration = getTestConfig({ provider: 'google-mail' });
+        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'google-mail' });
+        const { token, jwk } = createSignedJwt({ integration });
+        getGoogleJWKSMock.mockResolvedValue([jwk as Record<string, string>]);
 
-        const mock = vi
+        const execute = vi
             .fn()
             .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
             .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
             .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
             .mockResolvedValueOnce({ connectionIds: ['conn-2'], connectionMetadata: {} });
 
-        const nangoMock = new InternalNango({
+        const nango = new InternalNango({
             team: seeders.getTestTeam(),
-            environment: seeders.getTestEnvironment(),
+            environment,
             plan: seeders.getTestPlan(),
             integration,
             logContextGetter
         });
-        nangoMock.executeScriptForWebhooks = mock;
+        nango.executeScriptForWebhooks = execute;
 
-        const payload = { emailAddress: 'user@example.com', historyId: '1' };
-        const body = { message: { data: Buffer.from(JSON.stringify(payload)).toString('base64') } };
+        await GmailWebhookRouting.default(nango, { authorization: `Bearer ${token}` }, gmailBody() as any, '');
 
-        await GmailWebhookRouting.default(nangoMock as unknown as InternalNango, {}, body as any, '');
+        expect(execute).toHaveBeenCalledTimes(3);
+        expect(execute).toHaveBeenNthCalledWith(1, expect.objectContaining({ propName: 'emailAddressHash' }));
+        expect(execute).toHaveBeenNthCalledWith(2, expect.objectContaining({ propName: 'metadata.emailAddress' }));
+        expect(execute).toHaveBeenNthCalledWith(3, expect.objectContaining({ propName: 'metadata.email' }));
+    });
 
-        expect(mock).toHaveBeenCalledTimes(3);
-        expect(mock).toHaveBeenNthCalledWith(1, expect.objectContaining({ propName: 'emailAddressHash' }));
-        expect(mock).toHaveBeenNthCalledWith(2, expect.objectContaining({ propName: 'metadata.emailAddress' }));
-        expect(mock).toHaveBeenNthCalledWith(3, expect.objectContaining({ propName: 'metadata.email' }));
+    it('rejects a request with no Authorization header', async () => {
+        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'google-mail' });
+        const { nango, execute } = getNangoMock(integration);
+
+        const result = await GmailWebhookRouting.default(nango, {}, gmailBody() as any, '');
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(NangoError);
+            expect((result.error as NangoError).type).toBe('webhook_missing_signature');
+        }
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid JWT', async () => {
+        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'google-mail' });
+        const { nango, execute } = getNangoMock(integration);
+
+        const result = await GmailWebhookRouting.default(nango, { authorization: 'Bearer not-a-jwt' }, gmailBody() as any, '');
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(NangoError);
+            expect((result.error as NangoError).type).toBe('webhook_invalid_signature');
+        }
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('accepts a valid Google JWT and routes the webhook', async () => {
+        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'gmail-prod' });
+        const { token, jwk } = createSignedJwt({ integration });
+        getGoogleJWKSMock.mockResolvedValue([jwk as Record<string, string>]);
+
+        const { nango, execute } = getNangoMock(integration);
+        const result = await GmailWebhookRouting.default(nango, { authorization: `Bearer ${token}` }, gmailBody() as any, '');
+
+        expect(result.isOk()).toBe(true);
+        expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a JWT whose audience uses provider instead of unique_key', async () => {
+        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'gmail-prod' });
+        const { token, jwk } = createSignedJwt({
+            integration,
+            aud: `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${integration.provider}`
+        });
+        getGoogleJWKSMock.mockResolvedValue([jwk as Record<string, string>]);
+
+        const { nango, execute } = getNangoMock(integration);
+        const result = await GmailWebhookRouting.default(nango, { authorization: `Bearer ${token}` }, gmailBody() as any, '');
+
+        expect(result.isErr()).toBe(true);
+        expect(execute).not.toHaveBeenCalled();
     });
 });

--- a/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { logContextGetter } from '@nangohq/logs';
 import { environmentService, getGlobalWebhookReceiveUrl, NangoError, seeders } from '@nangohq/shared';
 import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
+import { metrics } from '@nangohq/utils';
 
 import { hashEmailAddress } from '../utils/pii.js';
 import * as GmailWebhookRouting from './gmail-webhook-routing.js';
@@ -127,18 +128,25 @@ describe('gmailWebhookRouting', () => {
         expect(execute).toHaveBeenNthCalledWith(3, expect.objectContaining({ propName: 'metadata.email' }));
     });
 
-    it('rejects a request with no Authorization header', async () => {
+    it('accepts a request with no Authorization header and records a metric', async () => {
         const integration = getTestConfig({ provider: 'google-mail', unique_key: 'google-mail' });
         const { nango, execute } = getNangoMock(integration);
+        const increment = vi.spyOn(metrics, 'increment');
 
         const result = await GmailWebhookRouting.default(nango, {}, gmailBody() as any, '');
 
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
-            expect(result.error).toBeInstanceOf(NangoError);
-            expect((result.error as NangoError).type).toBe('webhook_missing_signature');
-        }
-        expect(execute).not.toHaveBeenCalled();
+        expect(result.isOk()).toBe(true);
+        expect(execute).toHaveBeenCalledTimes(1);
+        expect(increment).toHaveBeenCalledWith(
+            metrics.Types.WEBHOOK_INCOMING_UNVERIFIED,
+            1,
+            expect.objectContaining({
+                accountId: nango.team.id,
+                environmentId: nango.environment.id,
+                provider: 'google-mail',
+                reason: 'gmail_missing_authorization'
+            })
+        );
     });
 
     it('rejects an invalid JWT', async () => {

--- a/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
@@ -41,7 +41,7 @@ function createSignedJwt({
     const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
     const kid = 'test-kid';
     const header = { alg: 'RS256', typ: 'JWT', kid };
-    const expectedAud = `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${integration.unique_key}`;
+    const expectedAud = `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${encodeURIComponent(integration.unique_key)}`;
     const payload = { iss, aud: aud ?? expectedAud, exp };
     const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
     const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
@@ -188,5 +188,54 @@ describe('gmailWebhookRouting', () => {
 
         expect(result.isErr()).toBe(true);
         expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('rejects an expired JWT', async () => {
+        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'google-mail' });
+        const { token, jwk } = createSignedJwt({ integration, exp: Math.floor(Date.now() / 1000) - 60 });
+        getGoogleJWKSMock.mockResolvedValue([jwk as Record<string, string>]);
+
+        const { nango, execute } = getNangoMock(integration);
+        const result = await GmailWebhookRouting.default(nango, { authorization: `Bearer ${token}` }, gmailBody() as any, '');
+
+        expect(result.isErr()).toBe(true);
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('rejects a JWT with the wrong issuer', async () => {
+        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'google-mail' });
+        const { token, jwk } = createSignedJwt({ integration, iss: 'https://example.com' });
+        getGoogleJWKSMock.mockResolvedValue([jwk as Record<string, string>]);
+
+        const { nango, execute } = getNangoMock(integration);
+        const result = await GmailWebhookRouting.default(nango, { authorization: `Bearer ${token}` }, gmailBody() as any, '');
+
+        expect(result.isErr()).toBe(true);
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('rejects a JWT signed with a different key than JWKS', async () => {
+        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'google-mail' });
+        const signed = createSignedJwt({ integration });
+        const other = createSignedJwt({ integration });
+        getGoogleJWKSMock.mockResolvedValue([other.jwk as Record<string, string>]);
+
+        const { nango, execute } = getNangoMock(integration);
+        const result = await GmailWebhookRouting.default(nango, { authorization: `Bearer ${signed.token}` }, gmailBody() as any, '');
+
+        expect(result.isErr()).toBe(true);
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('accepts a JWT whose audience encodes reserved characters in unique_key', async () => {
+        const integration = getTestConfig({ provider: 'google-mail', unique_key: 'gmail:prod' });
+        const { token, jwk } = createSignedJwt({ integration });
+        getGoogleJWKSMock.mockResolvedValue([jwk as Record<string, string>]);
+
+        const { nango, execute } = getNangoMock(integration);
+        const result = await GmailWebhookRouting.default(nango, { authorization: `Bearer ${token}` }, gmailBody() as any, '');
+
+        expect(result.isOk()).toBe(true);
+        expect(execute).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.ts
@@ -1,10 +1,16 @@
-import { Ok } from '@nangohq/utils';
+import { Err, Ok } from '@nangohq/utils';
 
 import { hashEmailAddress } from '../utils/pii.js';
+import { validateGoogleChannelToken } from './google-channel-token.js';
 
 import type { WebhookHandler } from './types.js';
 
 const route: WebhookHandler = async (nango, headers) => {
+    const tokenResult = validateGoogleChannelToken(nango.integration, headers);
+    if (tokenResult.isErr()) {
+        return Err(tokenResult.error);
+    }
+
     // https://developers.google.com/workspace/calendar/api/guides/push
     // we will need to just forward the headers since the body is empty
     const resourceUri = headers['x-goog-resource-uri'];

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.unit.test.ts
@@ -126,4 +126,80 @@ describe('googleCalendarWebhookRouting', () => {
         }
         expect(mock).not.toHaveBeenCalled();
     });
+
+    it('rejects a missing channel token when a webhook secret is configured', async () => {
+        const integration = getTestConfig({ provider: 'google-calendar', custom: { webhookSecret: 'channel-secret' } });
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const result = await GoogleCalendarWebhookRouting.default(
+            nangoMock as unknown as InternalNango,
+            { 'x-goog-resource-uri': EXAMPLE_RESOURCE_URI } as any,
+            {},
+            ''
+        );
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a mismatched channel token when a webhook secret is configured', async () => {
+        const integration = getTestConfig({ provider: 'google-calendar', custom: { webhookSecret: 'channel-secret' } });
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const result = await GoogleCalendarWebhookRouting.default(
+            nangoMock as unknown as InternalNango,
+            {
+                'x-goog-resource-uri': EXAMPLE_RESOURCE_URI,
+                'x-goog-channel-token': 'wrong'
+            } as any,
+            {},
+            ''
+        );
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('routes when the channel token matches the webhook secret', async () => {
+        const integration = getTestConfig({ provider: 'google-calendar', custom: { webhookSecret: 'channel-secret' } });
+        const mock = vi.fn().mockResolvedValueOnce({ connectionIds: ['conn-1'], connectionMetadata: {} });
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const result = await GoogleCalendarWebhookRouting.default(
+            nangoMock as unknown as InternalNango,
+            {
+                'x-goog-resource-uri': EXAMPLE_RESOURCE_URI,
+                'x-goog-channel-token': 'channel-secret',
+                'x-goog-resource-state': 'exists'
+            } as any,
+            {},
+            ''
+        );
+
+        expect(result.isOk()).toBe(true);
+        expect(mock).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/server/lib/webhook/google-channel-token.ts
+++ b/packages/server/lib/webhook/google-channel-token.ts
@@ -1,0 +1,37 @@
+import crypto from 'node:crypto';
+
+import { NangoError } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import type { IntegrationConfig } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+function safeCompare(expected: string, received: string): boolean {
+    const expectedBuffer = Buffer.from(expected);
+    const receivedBuffer = Buffer.from(received);
+
+    return expectedBuffer.length === receivedBuffer.length && crypto.timingSafeEqual(expectedBuffer, receivedBuffer);
+}
+
+/**
+ * Google push notifications have no HMAC. Authenticity is the `token` set at
+ * watch registration and echoed as `X-Goog-Channel-Token`.
+ * Verification runs only when the integration has a webhook secret.
+ */
+export function validateGoogleChannelToken(integration: IntegrationConfig, headers: Record<string, any>): Result<void> {
+    const expected = integration.custom?.['webhookSecret'];
+    if (!expected || typeof expected !== 'string') {
+        return Ok(undefined);
+    }
+
+    const received = headers['x-goog-channel-token'];
+    if (!received || typeof received !== 'string') {
+        return Err(new NangoError('webhook_missing_token'));
+    }
+
+    if (!safeCompare(expected, received)) {
+        return Err(new NangoError('webhook_invalid_signature'));
+    }
+
+    return Ok(undefined);
+}

--- a/packages/server/lib/webhook/google-channel-token.ts
+++ b/packages/server/lib/webhook/google-channel-token.ts
@@ -1,16 +1,28 @@
 import crypto from 'node:crypto';
 
 import { NangoError } from '@nangohq/shared';
-import { Err, Ok } from '@nangohq/utils';
+import { Err, getLogger, metrics, Ok } from '@nangohq/utils';
 
 import type { IntegrationConfig } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+
+const logger = getLogger('Webhook.GoogleChannelToken');
 
 function safeCompare(expected: string, received: string): boolean {
     const expectedBuffer = Buffer.from(expected);
     const receivedBuffer = Buffer.from(received);
 
     return expectedBuffer.length === receivedBuffer.length && crypto.timingSafeEqual(expectedBuffer, receivedBuffer);
+}
+
+function reject(integration: IntegrationConfig, reason: string, errorType: 'webhook_missing_token' | 'webhook_invalid_signature'): Result<void> {
+    logger.error(reason, { configId: integration.id, provider: integration.provider, environmentId: integration.environment_id });
+    metrics.increment(metrics.Types.WEBHOOK_INCOMING_UNVERIFIED, 1, {
+        environmentId: integration.environment_id,
+        provider: integration.provider,
+        reason
+    });
+    return Err(new NangoError(errorType));
 }
 
 /**
@@ -20,17 +32,20 @@ function safeCompare(expected: string, received: string): boolean {
  */
 export function validateGoogleChannelToken(integration: IntegrationConfig, headers: Record<string, any>): Result<void> {
     const expected = integration.custom?.['webhookSecret'];
-    if (!expected || typeof expected !== 'string') {
+    if (expected == null || expected === '') {
         return Ok(undefined);
+    }
+    if (typeof expected !== 'string') {
+        return reject(integration, 'google_malformed_webhook_secret', 'webhook_invalid_signature');
     }
 
     const received = headers['x-goog-channel-token'];
     if (!received || typeof received !== 'string') {
-        return Err(new NangoError('webhook_missing_token'));
+        return reject(integration, 'google_missing_channel_token', 'webhook_missing_token');
     }
 
     if (!safeCompare(expected, received)) {
-        return Err(new NangoError('webhook_invalid_signature'));
+        return reject(integration, 'google_invalid_channel_token', 'webhook_invalid_signature');
     }
 
     return Ok(undefined);

--- a/packages/server/lib/webhook/google-channel-token.unit.test.ts
+++ b/packages/server/lib/webhook/google-channel-token.unit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { NangoError } from '@nangohq/shared';
+import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
+
+import { validateGoogleChannelToken } from './google-channel-token.js';
+
+describe('validateGoogleChannelToken', () => {
+    it('skips verification when no webhook secret is configured', () => {
+        const integration = getTestConfig({ provider: 'google-drive' });
+
+        const result = validateGoogleChannelToken(integration, {});
+
+        expect(result.isOk()).toBe(true);
+    });
+
+    it('rejects a missing token when a webhook secret is configured', () => {
+        const integration = getTestConfig({ provider: 'google-drive', custom: { webhookSecret: 'channel-secret' } });
+
+        const result = validateGoogleChannelToken(integration, {});
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(NangoError);
+            expect(result.error.type).toBe('webhook_missing_token');
+        }
+    });
+
+    it('rejects a mismatched token', () => {
+        const integration = getTestConfig({ provider: 'google-drive', custom: { webhookSecret: 'channel-secret' } });
+
+        const result = validateGoogleChannelToken(integration, { 'x-goog-channel-token': 'wrong' });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(NangoError);
+            expect(result.error.type).toBe('webhook_invalid_signature');
+        }
+    });
+
+    it('accepts a matching token', () => {
+        const integration = getTestConfig({ provider: 'google-drive', custom: { webhookSecret: 'channel-secret' } });
+
+        const result = validateGoogleChannelToken(integration, { 'x-goog-channel-token': 'channel-secret' });
+
+        expect(result.isOk()).toBe(true);
+    });
+});

--- a/packages/server/lib/webhook/google-channel-token.unit.test.ts
+++ b/packages/server/lib/webhook/google-channel-token.unit.test.ts
@@ -45,4 +45,19 @@ describe('validateGoogleChannelToken', () => {
 
         expect(result.isOk()).toBe(true);
     });
+
+    it('rejects a truthy non-string webhook secret', () => {
+        const integration = getTestConfig({
+            provider: 'google-drive',
+            custom: { webhookSecret: 1 as unknown as string }
+        });
+
+        const result = validateGoogleChannelToken(integration, { 'x-goog-channel-token': 'channel-secret' });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(NangoError);
+            expect((result.error as NangoError).type).toBe('webhook_invalid_signature');
+        }
+    });
 });

--- a/packages/server/lib/webhook/google-channel-token.unit.test.ts
+++ b/packages/server/lib/webhook/google-channel-token.unit.test.ts
@@ -22,7 +22,7 @@ describe('validateGoogleChannelToken', () => {
         expect(result.isErr()).toBe(true);
         if (result.isErr()) {
             expect(result.error).toBeInstanceOf(NangoError);
-            expect(result.error.type).toBe('webhook_missing_token');
+            expect((result.error as NangoError).type).toBe('webhook_missing_token');
         }
     });
 
@@ -34,7 +34,7 @@ describe('validateGoogleChannelToken', () => {
         expect(result.isErr()).toBe(true);
         if (result.isErr()) {
             expect(result.error).toBeInstanceOf(NangoError);
-            expect(result.error.type).toBe('webhook_invalid_signature');
+            expect((result.error as NangoError).type).toBe('webhook_invalid_signature');
         }
     });
 

--- a/packages/server/lib/webhook/google-drive-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-drive-webhook-routing.ts
@@ -1,9 +1,16 @@
-import { Ok } from '@nangohq/utils';
+import { Err, Ok } from '@nangohq/utils';
+
+import { validateGoogleChannelToken } from './google-channel-token.js';
 
 import type { WebhookHandler } from './types.js';
 
 // https://developers.google.com/workspace/drive/api/guides/push
 const route: WebhookHandler = async (nango, headers) => {
+    const tokenResult = validateGoogleChannelToken(nango.integration, headers);
+    if (tokenResult.isErr()) {
+        return Err(tokenResult.error);
+    }
+
     const resourceId = headers['x-goog-resource-id'];
     const resourceUri = headers['x-goog-resource-uri'];
 

--- a/packages/server/lib/webhook/google-drive-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/google-drive-webhook-routing.unit.test.ts
@@ -145,4 +145,80 @@ describe('googleDriveWebhookRouting', () => {
         }
         expect(mock).not.toHaveBeenCalled();
     });
+
+    it('rejects a missing channel token when a webhook secret is configured', async () => {
+        const integration = getTestConfig({ provider: 'google-drive', custom: { webhookSecret: 'channel-secret' } });
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const result = await GoogleDriveWebhookRouting.default(
+            nangoMock as unknown as InternalNango,
+            { 'x-goog-resource-id': EXAMPLE_RESOURCE_ID } as any,
+            {},
+            ''
+        );
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a mismatched channel token when a webhook secret is configured', async () => {
+        const integration = getTestConfig({ provider: 'google-drive', custom: { webhookSecret: 'channel-secret' } });
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const result = await GoogleDriveWebhookRouting.default(
+            nangoMock as unknown as InternalNango,
+            {
+                'x-goog-resource-id': EXAMPLE_RESOURCE_ID,
+                'x-goog-channel-token': 'wrong'
+            } as any,
+            {},
+            ''
+        );
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('routes when the channel token matches the webhook secret', async () => {
+        const integration = getTestConfig({ provider: 'google-drive', custom: { webhookSecret: 'channel-secret' } });
+        const mock = vi.fn().mockResolvedValueOnce({ connectionIds: ['conn-1'], connectionMetadata: {} });
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const result = await GoogleDriveWebhookRouting.default(
+            nangoMock as unknown as InternalNango,
+            {
+                'x-goog-resource-id': EXAMPLE_RESOURCE_ID,
+                'x-goog-channel-token': 'channel-secret',
+                'x-goog-resource-state': 'change'
+            } as any,
+            {},
+            ''
+        );
+
+        expect(result.isOk()).toBe(true);
+        expect(mock).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/server/lib/webhook/google-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-webhook-routing.ts
@@ -1,4 +1,6 @@
-import { Ok } from '@nangohq/utils';
+import { Err, Ok } from '@nangohq/utils';
+
+import { validateGoogleChannelToken } from './google-channel-token.js';
 
 import type { WebhookHandler } from './types.js';
 
@@ -7,6 +9,11 @@ import type { WebhookHandler } from './types.js';
  * (no email / emailAddressHash fallbacks).
  */
 const route: WebhookHandler = async (nango, headers) => {
+    const tokenResult = validateGoogleChannelToken(nango.integration, headers);
+    if (tokenResult.isErr()) {
+        return Err(tokenResult.error);
+    }
+
     const resourceUri = headers['x-goog-resource-uri'];
 
     const baseArgs = {

--- a/packages/server/lib/webhook/google-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/google-webhook-routing.unit.test.ts
@@ -88,4 +88,80 @@ describe('googleWebhookRouting', () => {
             })
         );
     });
+
+    it('rejects a missing channel token when a webhook secret is configured', async () => {
+        const integration = getTestConfig({ provider: 'google', custom: { webhookSecret: 'channel-secret' } });
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const result = await GoogleWebhookRouting.default(
+            nangoMock as unknown as InternalNango,
+            { 'x-goog-resource-uri': EXAMPLE_RESOURCE_URI } as any,
+            {},
+            ''
+        );
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a mismatched channel token when a webhook secret is configured', async () => {
+        const integration = getTestConfig({ provider: 'google', custom: { webhookSecret: 'channel-secret' } });
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const result = await GoogleWebhookRouting.default(
+            nangoMock as unknown as InternalNango,
+            {
+                'x-goog-resource-uri': EXAMPLE_RESOURCE_URI,
+                'x-goog-channel-token': 'wrong'
+            } as any,
+            {},
+            ''
+        );
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('routes when the channel token matches the webhook secret', async () => {
+        const integration = getTestConfig({ provider: 'google', custom: { webhookSecret: 'channel-secret' } });
+        const mock = vi.fn().mockResolvedValueOnce({ connectionIds: ['conn-1'], connectionMetadata: {} });
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const result = await GoogleWebhookRouting.default(
+            nangoMock as unknown as InternalNango,
+            {
+                'x-goog-resource-uri': EXAMPLE_RESOURCE_URI,
+                'x-goog-channel-token': 'channel-secret',
+                'x-goog-resource-state': 'exists'
+            } as any,
+            {},
+            ''
+        );
+
+        expect(result.isOk()).toBe(true);
+        expect(mock).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -72,6 +72,7 @@ export enum Types {
     WEBHOOK_INCOMING_RECEIVED = 'nango.webhook.incoming.received',
     WEBHOOK_INCOMING_RATE_LIMITED = 'nango.webhook.incoming.rateLimited',
     WEBHOOK_INCOMING_SKIPPED = 'nango.webhook.incoming.skipped',
+    WEBHOOK_INCOMING_UNVERIFIED = 'nango.webhook.incoming.unverified',
     WEBHOOK_INCOMING_FORWARDED_SUCCESS = 'nango.webhook.incoming.forwarded.success',
     WEBHOOK_INCOMING_FORWARDED_FAILED = 'nango.webhook.incoming.forwarded.failed',
     WEBHOOK_OUTGOING_SUCCESS = 'nango.webhook.outgoing.success',


### PR DESCRIPTION
## Summary

- **Gmail:** When Pub/Sub sends an `Authorization` header, Nango verifies the Google OIDC JWT (issuer, expiry, signature, audience). Audience is the integration webhook URL (`unique_key`, encoded or raw). Requests with no header are still accepted so existing unauthenticated subscriptions keep working; they increment `nango.webhook.incoming.unverified` (`reason: gmail_missing_authorization`). Invalid tokens return `401` and are not forwarded.
- **Google Drive, Calendar, and base Google:** If a webhook secret is saved on the integration, Nango checks `X-Goog-Channel-Token` against it. No secret means no change. A malformed stored secret fails closed. Rejections are logged (no token values) and metriced.
- Dashboard: webhook secret field enabled for Drive / Calendar / Google; Gmail stays JWT-only.
- Docs updated for recommended Gmail Pub/Sub auth and optional Drive/Calendar channel tokens.

## Compatibility

Gmail subscriptions without authentication continue to work. Invalid JWTs are rejected.

Drive / Calendar only enforce the channel token after a webhook secret is saved. Existing channels without `token` keep working until then; recreate them with `token` once you set a secret.