### PR TITLE
fix(connect): allow previews at the connection cap

### DIFF
--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -1,6 +1,15 @@
 import db from '@nangohq/database';
 import { logContextGetter } from '@nangohq/logs';
-import { accountService, configService, connectionService, errorManager, getProvider, githubAppClient, syncEndUserToConnection } from '@nangohq/shared';
+import {
+    accountService,
+    configService,
+    ConnectionCreationCappedError,
+    connectionService,
+    errorManager,
+    getProvider,
+    githubAppClient,
+    syncEndUserToConnection
+} from '@nangohq/shared';
 import { report, stringifyError } from '@nangohq/utils';
 
 import publisher from '../clients/publisher.client.js';
@@ -229,6 +238,30 @@ class AppAuthController {
             });
             return;
         } catch (err) {
+            if (err instanceof ConnectionCreationCappedError) {
+                void logCtx.error(err.message);
+                await logCtx.failed();
+                void connectionCreationFailedHook(
+                    {
+                        connection: {
+                            connection_id: receivedConnectionId,
+                            provider_config_key: providerConfigKey,
+                            webhook_url_override: resolvedWebhookUrlOverride
+                        },
+                        environment,
+                        account,
+                        auth_mode: 'APP',
+                        error: {
+                            type: 'resource_capped',
+                            description: err.message
+                        },
+                        operation: 'unknown'
+                    },
+                    account
+                );
+                return publisher.notifyErr(res, wsClientId, providerConfigKey, receivedConnectionId, WSErrBuilder.ResourceCapped());
+            }
+
             const prettyError = stringifyError(err, { pretty: true });
 
             const error = WSErrBuilder.UnknownError();

--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -259,7 +259,7 @@ class AppAuthController {
                     },
                     account
                 );
-                return publisher.notifyErr(res, wsClientId, providerConfigKey, receivedConnectionId, WSErrBuilder.ResourceCapped());
+                return publisher.notifyErr(res, wsClientId, providerConfigKey, receivedConnectionId, WSErrBuilder.ResourceCapped(err.message));
             }
 
             const prettyError = stringifyError(err, { pretty: true });

--- a/packages/server/lib/controllers/appAuth.controller.unit.test.ts
+++ b/packages/server/lib/controllers/appAuth.controller.unit.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ConnectionCreationCappedError } from '@nangohq/shared';
 import { Ok } from '@nangohq/utils';
 
 import appAuthController from './appAuth.controller.js';
@@ -185,6 +186,35 @@ describe('AppAuthController.connect', () => {
                 connection: expect.objectContaining({
                     webhook_url_override: 'https://override.example.com/hook'
                 })
+            }),
+            expect.anything()
+        );
+    });
+
+    it('triggers the creation-failure hook when connection creation is capped', async () => {
+        mockUpsertConnection.mockRejectedValue(new ConnectionCreationCappedError());
+
+        const req = {
+            query: { installation_id: 'install-1', state: 'session-id' },
+            ip: '203.0.113.7',
+            get: vi.fn(() => 'vitest')
+        } as unknown as Request;
+        const res = {
+            locals: {},
+            redirect: vi.fn(),
+            sendStatus: vi.fn(),
+            status: vi.fn().mockReturnThis(),
+            send: vi.fn().mockReturnThis()
+        } as unknown as Response;
+
+        await appAuthController.connect(req, res, vi.fn());
+
+        expect(mockConnectionCreationFailed).toHaveBeenCalledWith(
+            expect.objectContaining({
+                error: {
+                    type: 'resource_capped',
+                    description: 'Reached maximum number of allowed connections. Upgrade your plan to get rid of connection limits.'
+                }
             }),
             expect.anything()
         );

--- a/packages/server/lib/controllers/auth/postApiKey.ts
+++ b/packages/server/lib/controllers/auth/postApiKey.ts
@@ -2,7 +2,16 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import { configService, connectionService, errorManager, ErrorSourceEnum, getProvider, LogActionEnum, syncEndUserToConnection } from '@nangohq/shared';
+import {
+    configService,
+    ConnectionCreationCappedError,
+    connectionService,
+    errorManager,
+    ErrorSourceEnum,
+    getProvider,
+    LogActionEnum,
+    syncEndUserToConnection
+} from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import {
@@ -280,6 +289,10 @@ export const postPublicApiKeyAuthorization = asyncWrapperWithEnvironment<PostPub
             ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
         });
 
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return;
+        }
         next(err);
     }
 });

--- a/packages/server/lib/controllers/auth/postAwsSigV4.ts
+++ b/packages/server/lib/controllers/auth/postAwsSigV4.ts
@@ -6,6 +6,7 @@ import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@na
 import {
     awsSigV4Client,
     configService,
+    ConnectionCreationCappedError,
     connectionService,
     errorManager,
     ErrorSourceEnum,
@@ -372,6 +373,10 @@ export const postPublicAwsSigV4Authorization = asyncWrapperWithEnvironment<PostP
             auth_mode: 'AWS_SIGV4',
             ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
         });
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return;
+        }
         next(err);
     }
 });

--- a/packages/server/lib/controllers/auth/postBasic.ts
+++ b/packages/server/lib/controllers/auth/postBasic.ts
@@ -2,7 +2,16 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import { configService, connectionService, errorManager, ErrorSourceEnum, getProvider, LogActionEnum, syncEndUserToConnection } from '@nangohq/shared';
+import {
+    configService,
+    ConnectionCreationCappedError,
+    connectionService,
+    errorManager,
+    ErrorSourceEnum,
+    getProvider,
+    LogActionEnum,
+    syncEndUserToConnection
+} from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import {
@@ -279,6 +288,10 @@ export const postPublicBasicAuthorization = asyncWrapperWithEnvironment<PostPubl
             ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
         });
 
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return;
+        }
         next(err);
     }
 });

--- a/packages/server/lib/controllers/auth/postBill.ts
+++ b/packages/server/lib/controllers/auth/postBill.ts
@@ -5,6 +5,7 @@ import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@na
 import {
     billClient,
     configService,
+    ConnectionCreationCappedError,
     connectionService,
     errorManager,
     ErrorSourceEnum,
@@ -282,6 +283,10 @@ export const postPublicBillAuthorization = asyncWrapperWithEnvironment<PostPubli
             ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
         });
 
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return;
+        }
         next(err);
     }
 });

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -4,6 +4,7 @@ import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
 import {
     configService,
+    ConnectionCreationCappedError,
     connectionService,
     errorManager,
     ErrorSourceEnum,
@@ -296,6 +297,10 @@ export const postPublicJwtAuthorization = asyncWrapperWithEnvironment<PostPublic
             ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
         });
 
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return;
+        }
         next(err);
     }
 });

--- a/packages/server/lib/controllers/auth/postOauthOutbound.ts
+++ b/packages/server/lib/controllers/auth/postOauthOutbound.ts
@@ -2,7 +2,16 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import { configService, connectionService, errorManager, ErrorSourceEnum, getProvider, LogActionEnum, syncEndUserToConnection } from '@nangohq/shared';
+import {
+    configService,
+    ConnectionCreationCappedError,
+    connectionService,
+    errorManager,
+    ErrorSourceEnum,
+    getProvider,
+    LogActionEnum,
+    syncEndUserToConnection
+} from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
@@ -254,6 +263,10 @@ export const postPublicOauthOutboundAuthorization = asyncWrapperWithEnvironment<
             ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
         });
 
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return;
+        }
         next(err);
     }
 });

--- a/packages/server/lib/controllers/auth/postSignature.ts
+++ b/packages/server/lib/controllers/auth/postSignature.ts
@@ -4,6 +4,7 @@ import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
 import {
     configService,
+    ConnectionCreationCappedError,
     connectionService,
     errorManager,
     ErrorSourceEnum,
@@ -297,6 +298,10 @@ export const postPublicSignatureAuthorization = asyncWrapperWithEnvironment<Post
             ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
         });
 
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return;
+        }
         next(err);
     }
 });

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -2,7 +2,16 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import { configService, connectionService, errorManager, ErrorSourceEnum, getProvider, LogActionEnum, syncEndUserToConnection } from '@nangohq/shared';
+import {
+    configService,
+    ConnectionCreationCappedError,
+    connectionService,
+    errorManager,
+    ErrorSourceEnum,
+    getProvider,
+    LogActionEnum,
+    syncEndUserToConnection
+} from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
@@ -313,6 +322,10 @@ export const postPublicTbaAuthorization = asyncWrapperWithEnvironment<PostPublic
             ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
         });
 
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return;
+        }
         next(err);
     }
 });

--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -4,6 +4,7 @@ import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
 import {
     configService,
+    ConnectionCreationCappedError,
     connectionService,
     errorManager,
     ErrorSourceEnum,
@@ -291,6 +292,10 @@ export const postPublicTwoStepAuthorization = asyncWrapperWithEnvironment<PostPu
             ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
         });
 
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return;
+        }
         next(err);
     }
 });

--- a/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
@@ -41,6 +41,35 @@ describe(`GET ${endpoint}`, () => {
         });
     });
 
+    it('should reject creating a new connection at the connection cap', async () => {
+        const { env, apiKey, plan } = await seeders.seedAccountEnvAndUser();
+        const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+
+        const session = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: { end_user: { id: 'capped-user', email: 'capped@example.com' } }
+        });
+        isSuccess(session.json);
+
+        await db.knex('plans').where({ id: plan.id }).update({ connections_max: 0 });
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { connect_session_token: session.json.data.token },
+            params: { providerConfigKey: config.unique_key }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'resource_capped',
+                message: 'Reached maximum number of allowed connections. Upgrade your plan to get rid of connection limits.'
+            }
+        });
+    });
+
     // webhook_url is privileged: an untrusted client must not be able to redirect a connection's webhooks
     // by passing it as a param. It is silently dropped and never persisted from this path.
     it('ignores a client-supplied webhook_url param and does not store it', async () => {
@@ -181,7 +210,7 @@ describe(`GET ${endpoint}`, () => {
     });
 
     it('should be allowed to reconnect', async () => {
-        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const { env, apiKey, plan } = await seeders.seedAccountEnvAndUser();
         const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
 
         // Initial session token
@@ -199,6 +228,8 @@ describe(`GET ${endpoint}`, () => {
             params: { providerConfigKey: config.unique_key }
         });
         isSuccess(resConnect.json);
+
+        await db.knex('plans').where({ id: plan.id }).update({ connections_max: 1 });
 
         const connectionBefore = await connectionService.checkIfConnectionExists(db.knex, {
             connectionId: resConnect.json.connectionId,

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import { configService, connectionService, errorManager, getProvider, syncEndUserToConnection } from '@nangohq/shared';
+import { configService, ConnectionCreationCappedError, connectionService, getProvider, syncEndUserToConnection } from '@nangohq/shared';
 import { metrics, requireEmptyBody, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
@@ -29,7 +29,7 @@ const paramValidation = z
     })
     .strict();
 
-export const postPublicUnauthenticated = asyncWrapperWithEnvironment<PostPublicUnauthenticatedAuthorization>(async (req, res) => {
+export const postPublicUnauthenticated = asyncWrapperWithEnvironment<PostPublicUnauthenticatedAuthorization>(async (req, res, next) => {
     const valBody = requireEmptyBody(req);
     if (valBody) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
@@ -236,6 +236,10 @@ export const postPublicUnauthenticated = asyncWrapperWithEnvironment<PostPublicU
             ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
         });
 
-        errorManager.handleGenericError(err, req, res);
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return;
+        }
+        next(err);
     }
 });

--- a/packages/server/lib/controllers/connect/postSessions.integration.test.ts
+++ b/packages/server/lib/controllers/connect/postSessions.integration.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import db from '@nangohq/database';
 import { seeders } from '@nangohq/shared';
 
-import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
+import { authenticateUser, isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
 
 import type { DBConnectSession } from '../../services/connectSession.service.js';
 import type { DBCustomerKey, DBEndUser, DBEnvironment, DBPlan, DBTeam, DBUser } from '@nangohq/types';
@@ -35,6 +35,31 @@ describe(`POST ${endpoint}`, () => {
         });
 
         shouldBeProtected(res);
+    });
+
+    it('should enforce the connection cap for normal sessions but not preview sessions', async () => {
+        const { env, apiKey, plan, user } = await seeders.seedAccountEnvAndUser();
+        await db.knex('plans').where({ id: plan.id }).update({ connections_max: 0 });
+
+        const normalSession = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: { end_user: { id: 'capped-user', email: 'capped@example.com' } }
+        });
+        isError(normalSession.json);
+        expect(normalSession.json.error.code).toBe('resource_capped');
+
+        const dashboardSession = await authenticateUser(api, user);
+        const previewSession = await api.fetch('/api/v1/connect/sessions', {
+            method: 'POST',
+            query: { env: env.name },
+            session: dashboardSession,
+            body: {
+                is_preview: true,
+                end_user: { id: 'preview-user', email: 'preview@nango.dev' }
+            }
+        });
+        isSuccess(previewSession.json);
     });
 
     it('should fail if no endUser', async () => {

--- a/packages/server/lib/controllers/connect/postSessions.ts
+++ b/packages/server/lib/controllers/connect/postSessions.ts
@@ -129,7 +129,12 @@ export function checkIntegrationsExist(
     return errors.length > 0 ? errors : false;
 }
 
-export async function generateSession(res: Response<any, RequestLocalsWithEnvironment>, body: PostConnectSessions['Body'], plan?: DBPlan | null) {
+export async function generateSession(
+    res: Response<any, RequestLocalsWithEnvironment>,
+    body: PostConnectSessions['Body'],
+    plan?: DBPlan | null,
+    isPreview = false
+) {
     const mapped = mapDeprecatedConnectionConfigWebhookUrl(body);
     if (!mapped.ok) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP({ issues: mapped.issues }) } });
@@ -156,6 +161,7 @@ export async function generateSession(res: Response<any, RequestLocalsWithEnviro
         account,
         environment,
         plan: plan ?? null,
+        isPreview,
         endUser,
         tags: body.tags,
         allowedIntegrations: body.allowed_integrations,

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -3,6 +3,7 @@ import { envs, logContextGetter } from '@nangohq/logs';
 import {
     accountService,
     configService,
+    ConnectionCreationCappedError,
     connectionService,
     errorManager,
     generateSlackConnectionId,
@@ -15,11 +16,7 @@ import { flags, zodErrorToHTTP } from '@nangohq/utils';
 import { webhookUrlSchema } from '../helpers/validation.js';
 import { noteConnectionUpsert } from '../hooks/auditConnection.js';
 import { preConnectionDeletion } from '../hooks/connection/on/pre-connection-deletion.js';
-import {
-    connectionCreated as connectionCreatedHook,
-    connectionCreationStartCapCheck as connectionCreationStartCapCheckHook,
-    connectionRefreshSuccess
-} from '../hooks/hooks.js';
+import { connectionCreated as connectionCreatedHook, connectionRefreshSuccess } from '../hooks/hooks.js';
 import { slackService } from '../services/slack.js';
 import { requireEnvironment } from '../utils/asyncWrapper.js';
 import { getOrchestrator } from '../utils/utils.js';
@@ -184,7 +181,7 @@ class ConnectionController {
 
     async createConnection(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         try {
-            const { account, plan } = res.locals;
+            const { account } = res.locals;
             const environment = requireEnvironment(req, res);
             if (!environment) {
                 return;
@@ -215,23 +212,6 @@ class ConnectionController {
             }
 
             const providerName = integration.provider;
-
-            if (plan) {
-                const isCapped = await connectionCreationStartCapCheckHook({
-                    creationType: 'import',
-                    team: account,
-                    plan
-                });
-                if (isCapped.capped) {
-                    res.status(400).send({
-                        error: {
-                            code: 'resource_capped',
-                            message: 'Reached maximum number of allowed connections. Upgrade your plan to get rid of connection limits.'
-                        }
-                    });
-                    return;
-                }
-            }
 
             const provider = getProvider(providerName);
             if (!provider) {
@@ -718,6 +698,10 @@ class ConnectionController {
                 connection_id: connectionId
             });
         } catch (err) {
+            if (err instanceof ConnectionCreationCappedError) {
+                res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+                return;
+            }
             next(err);
         }
     }

--- a/packages/server/lib/controllers/connection/postConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/postConnection.integration.test.ts
@@ -26,6 +26,26 @@ describe(`POST ${endpoint}`, () => {
         shouldBeProtected(res);
     });
 
+    it('should return a resource capped error when creating a connection at the cap', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser({ plan: { connections_max: 0 } });
+        const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: { provider_config_key: config.unique_key, credentials: { type: 'NONE' } }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'resource_capped',
+                message: 'Reached maximum number of allowed connections. Upgrade your plan to get rid of connection limits.'
+            }
+        });
+    });
+
     it('should validate oauth2 credentials', async () => {
         const { apiKey } = await seeders.seedAccountEnvAndUser();
         const res = await api.fetch(endpoint, {

--- a/packages/server/lib/controllers/connection/postConnection.ts
+++ b/packages/server/lib/controllers/connection/postConnection.ts
@@ -5,6 +5,7 @@ import { defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
 import {
     buildTagsFromEndUser,
     configService,
+    ConnectionCreationCappedError,
     connectionService,
     EndUserMapper,
     getEncryptionManager,
@@ -30,10 +31,11 @@ import {
 } from '../../helpers/validation.js';
 import { noteConnectionUpsert } from '../../hooks/auditConnection.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
-import { connectionCreated, connectionCreationStartCapCheck, connectionRefreshSuccess, testConnectionCredentials } from '../../hooks/hooks.js';
+import { connectionCreated, connectionRefreshSuccess, testConnectionCredentials } from '../../hooks/hooks.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 
 import type { AuthOperationType, ConnectionConfig, ConnectionUpsertResponse, EndUser, PostPublicConnection, ProviderGithubApp } from '@nangohq/types';
+import type { Response } from 'express';
 
 const schemaBody = z.strictObject({
     provider_config_key: z.string(),
@@ -96,6 +98,18 @@ const schemaBody = z.strictObject({
     tags: connectionTagsSchema.optional()
 });
 
+async function handleConnectionCreation<T>(res: Response, creation: Promise<T>): Promise<T | null> {
+    try {
+        return await creation;
+    } catch (err) {
+        if (err instanceof ConnectionCreationCappedError) {
+            res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+            return null;
+        }
+        throw err;
+    }
+}
+
 export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnection>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
@@ -109,7 +123,7 @@ export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnec
         return;
     }
 
-    const { environment, account, plan } = res.locals;
+    const { environment, account } = res.locals;
     const body: PostPublicConnection['Body'] = valBody.data;
     const webhookUrlOverride = body.webhook_url_override ?? null;
 
@@ -120,20 +134,6 @@ export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnec
     }
 
     const providerName = integration.provider;
-
-    if (plan) {
-        const isCapped = await connectionCreationStartCapCheck({
-            creationType: 'import',
-            team: account,
-            plan
-        });
-        if (isCapped.capped) {
-            res.status(400).send({
-                error: { code: 'resource_capped', message: 'Reached maximum number of allowed connections. Upgrade your plan to get rid of connection limits.' }
-            });
-            return;
-        }
-    }
 
     const provider = getProvider(providerName);
     if (!provider) {
@@ -185,17 +185,24 @@ export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnec
         case 'OAUTH2':
         case 'OAUTH2_CC':
         case 'OAUTH1': {
-            const [imported] = await connectionService.importOAuthConnection({
-                connectionId,
-                providerConfigKey: body.provider_config_key,
-                metadata: body.metadata || {},
-                environment,
-                connectionConfig: body.connection_config || {},
-                webhookUrlOverride,
-                parsedRawCredentials: { ...body.credentials, raw: body.credentials },
-                connectionCreatedHook: connCreatedHook,
-                tags: mergedTags
-            });
+            const creation = await handleConnectionCreation(
+                res,
+                connectionService.importOAuthConnection({
+                    connectionId,
+                    providerConfigKey: body.provider_config_key,
+                    metadata: body.metadata || {},
+                    environment,
+                    connectionConfig: body.connection_config || {},
+                    webhookUrlOverride,
+                    parsedRawCredentials: { ...body.credentials, raw: body.credentials },
+                    connectionCreatedHook: connCreatedHook,
+                    tags: mergedTags
+                })
+            );
+            if (!creation) {
+                return;
+            }
+            const [imported] = creation;
 
             if (imported) {
                 updatedConnection = imported;
@@ -225,17 +232,24 @@ export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnec
                 return;
             }
 
-            const [imported] = await connectionService.importApiAuthConnection({
-                connectionId,
-                providerConfigKey: body.provider_config_key,
-                metadata: body.metadata || {},
-                environment,
-                credentials: body.credentials,
-                connectionConfig,
-                webhookUrlOverride,
-                connectionCreatedHook: connCreatedHook,
-                tags: mergedTags
-            });
+            const creation = await handleConnectionCreation(
+                res,
+                connectionService.importApiAuthConnection({
+                    connectionId,
+                    providerConfigKey: body.provider_config_key,
+                    metadata: body.metadata || {},
+                    environment,
+                    credentials: body.credentials,
+                    connectionConfig,
+                    webhookUrlOverride,
+                    connectionCreatedHook: connCreatedHook,
+                    tags: mergedTags
+                })
+            );
+            if (!creation) {
+                return;
+            }
+            const [imported] = creation;
 
             if (imported) {
                 updatedConnection = imported;
@@ -263,16 +277,23 @@ export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnec
                 return;
             }
 
-            const [imported] = await connectionService.upsertConnection({
-                connectionId,
-                providerConfigKey: body.provider_config_key,
-                parsedRawCredentials: credentialsRes.value,
-                connectionConfig: body.connection_config || {},
-                webhookUrlOverride,
-                environmentId: environment.id,
-                metadata: body.metadata || {},
-                tags: mergedTags
-            });
+            const creation = await handleConnectionCreation(
+                res,
+                connectionService.upsertConnection({
+                    connectionId,
+                    providerConfigKey: body.provider_config_key,
+                    parsedRawCredentials: credentialsRes.value,
+                    connectionConfig: body.connection_config || {},
+                    webhookUrlOverride,
+                    environmentId: environment.id,
+                    metadata: body.metadata || {},
+                    tags: mergedTags
+                })
+            );
+            if (!creation) {
+                return;
+            }
+            const [imported] = creation;
 
             if (imported) {
                 updatedConnection = imported;
@@ -302,16 +323,23 @@ export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnec
                 return;
             }
 
-            const [imported] = await connectionService.upsertConnection({
-                connectionId,
-                providerConfigKey: body.provider_config_key,
-                parsedRawCredentials: credentialsRes.value,
-                connectionConfig: body.connection_config || {},
-                webhookUrlOverride,
-                environmentId: environment.id,
-                metadata: body.metadata || {},
-                tags: mergedTags
-            });
+            const creation = await handleConnectionCreation(
+                res,
+                connectionService.upsertConnection({
+                    connectionId,
+                    providerConfigKey: body.provider_config_key,
+                    parsedRawCredentials: credentialsRes.value,
+                    connectionConfig: body.connection_config || {},
+                    webhookUrlOverride,
+                    environmentId: environment.id,
+                    metadata: body.metadata || {},
+                    tags: mergedTags
+                })
+            );
+            if (!creation) {
+                return;
+            }
+            const [imported] = creation;
 
             if (imported) {
                 updatedConnection = imported;
@@ -349,21 +377,28 @@ export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnec
                 return;
             }
 
-            const [imported] = await connectionService.upsertAuthConnection({
-                connectionId,
-                providerConfigKey: body.provider_config_key,
-                credentials: body.credentials,
-                connectionConfig: {
-                    ...body.connection_config,
-                    oauth_client_id: integration.oauth_client_id,
-                    oauth_client_secret: integration.oauth_client_secret
-                },
-                webhookUrlOverride,
-                metadata: body.metadata || {},
-                config: integration,
-                environment,
-                tags: mergedTags
-            });
+            const creation = await handleConnectionCreation(
+                res,
+                connectionService.upsertAuthConnection({
+                    connectionId,
+                    providerConfigKey: body.provider_config_key,
+                    credentials: body.credentials,
+                    connectionConfig: {
+                        ...body.connection_config,
+                        oauth_client_id: integration.oauth_client_id,
+                        oauth_client_secret: integration.oauth_client_secret
+                    },
+                    webhookUrlOverride,
+                    metadata: body.metadata || {},
+                    config: integration,
+                    environment,
+                    tags: mergedTags
+                })
+            );
+            if (!creation) {
+                return;
+            }
+            const [imported] = creation;
 
             if (imported) {
                 updatedConnection = imported;
@@ -372,15 +407,22 @@ export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnec
             break;
         }
         case 'NONE': {
-            const [imported] = await connectionService.upsertUnauthConnection({
-                connectionId,
-                providerConfigKey: body.provider_config_key,
-                environment,
-                metadata: body.metadata || {},
-                connectionConfig: body.connection_config || {},
-                webhookUrlOverride,
-                tags: mergedTags
-            });
+            const creation = await handleConnectionCreation(
+                res,
+                connectionService.upsertUnauthConnection({
+                    connectionId,
+                    providerConfigKey: body.provider_config_key,
+                    environment,
+                    metadata: body.metadata || {},
+                    connectionConfig: body.connection_config || {},
+                    webhookUrlOverride,
+                    tags: mergedTags
+                })
+            );
+            if (!creation) {
+                return;
+            }
+            const [imported] = creation;
 
             if (imported) {
                 updatedConnection = imported;

--- a/packages/server/lib/controllers/oauth.controller.integration.test.ts
+++ b/packages/server/lib/controllers/oauth.controller.integration.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import db from '@nangohq/database';
+import { connectionService, seeders } from '@nangohq/shared';
+
+import { isSuccess, runServer } from '../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe('POST /oauth2/auth/:providerConfigKey', () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('returns a resource capped error when creating an OAuth2 client credentials connection at the cap', async () => {
+        const { env, apiKey, plan } = await seeders.seedAccountEnvAndUser();
+        const config = await seeders.createConfigSeed(env, 'oauth2-client-credentials', '8x8');
+        const session = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: { end_user: { id: 'capped-oauth2-cc-user', email: 'capped-oauth2-cc@example.com' } }
+        });
+        isSuccess(session.json);
+
+        vi.spyOn(connectionService, 'getOauthClientCredentials').mockResolvedValue({
+            success: true,
+            error: null,
+            response: {
+                type: 'OAUTH2_CC',
+                token: 'token',
+                client_id: 'client-id',
+                client_secret: 'client-secret',
+                raw: {}
+            }
+        });
+        await db.knex('plans').where({ id: plan.id }).update({ connections_max: 0 });
+
+        const url = new URL(`/oauth2/auth/${config.unique_key}`, api.url);
+        url.searchParams.set('connect_session_token', session.json.data.token);
+        const res = await fetch(url, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ client_id: 'client-id', client_secret: 'client-secret' })
+        });
+        const body = (await res.json()) as { error: { code: string; message: string } };
+
+        expect(res.status).toBe(400);
+        expect(body).toStrictEqual<typeof body>({
+            error: {
+                code: 'resource_capped',
+                message: 'Reached maximum number of allowed connections. Upgrade your plan to get rid of connection limits.'
+            }
+        });
+    });
+});

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -657,6 +657,10 @@ class OAuthController {
                 ...(config ? { provider: config.provider, providerConfigKey: config.unique_key } : {})
             });
 
+            if (err instanceof ConnectionCreationCappedError) {
+                res.status(err.status).send({ error: { code: 'resource_capped', message: err.message } });
+                return;
+            }
             next(err);
         }
     }

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -12,6 +12,7 @@ import {
     accountService,
     assertSafeOAuthUrl,
     configService,
+    ConnectionCreationCappedError,
     connectionService,
     environmentService,
     errorManager,
@@ -1256,6 +1257,7 @@ class OAuthController {
         }
 
         let logCtx: LogContext | undefined;
+        let connectionCreationContext: { environment: DBEnvironment; account: DBTeam; config: ProviderConfig } | undefined;
 
         const channel = session.webSocketClientId;
         const providerConfigKey = session.providerConfigKey;
@@ -1285,6 +1287,7 @@ class OAuthController {
             }
 
             const config = (await configService.getProviderConfig(session.providerConfigKey, session.environmentId))!;
+            connectionCreationContext = { environment, account, config };
             await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
 
             const usesStateCookie =
@@ -1352,6 +1355,33 @@ class OAuthController {
             await publisher.notifyErr(res, channel, providerConfigKey, connectionId, error);
             return;
         } catch (err) {
+            if (err instanceof ConnectionCreationCappedError) {
+                void logCtx?.error(err.message);
+                await logCtx?.failed();
+                if (connectionCreationContext) {
+                    void connectionCreationFailedHook(
+                        {
+                            connection: {
+                                connection_id: connectionId,
+                                provider_config_key: providerConfigKey,
+                                webhook_url_override: session.webhookUrlOverride
+                            },
+                            environment: connectionCreationContext.environment,
+                            account: connectionCreationContext.account,
+                            auth_mode: session.authMode,
+                            error: {
+                                type: 'resource_capped',
+                                description: err.message
+                            },
+                            operation: 'unknown'
+                        },
+                        connectionCreationContext.account,
+                        connectionCreationContext.config
+                    );
+                }
+                return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped());
+            }
+
             const prettyError = stringifyError(err, { pretty: true });
 
             errorManager.report(err, { source: ErrorSourceEnum.PLATFORM, operation: LogActionEnum.AUTH, environmentId: session.environmentId });
@@ -2091,6 +2121,30 @@ class OAuthController {
             }
             return;
         } catch (err) {
+            if (err instanceof ConnectionCreationCappedError) {
+                void logCtx.error(err.message);
+                await logCtx.failed();
+                void connectionCreationFailedHook(
+                    {
+                        connection: { connection_id: connectionId, provider_config_key: providerConfigKey, webhook_url_override: session.webhookUrlOverride },
+                        environment,
+                        account,
+                        auth_mode: provider.auth_mode,
+                        error: {
+                            type: 'resource_capped',
+                            description: err.message
+                        },
+                        operation: 'unknown'
+                    },
+                    account,
+                    config
+                );
+                if (res) {
+                    return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped());
+                }
+                throw err;
+            }
+
             const prettyError = stringifyError(err, { pretty: true });
             errorManager.report(err, {
                 source: ErrorSourceEnum.PLATFORM,
@@ -2455,6 +2509,31 @@ class OAuthController {
                 });
             })
             .catch(async (err: unknown) => {
+                if (err instanceof ConnectionCreationCappedError) {
+                    void logCtx.error(err.message);
+                    await logCtx.failed();
+                    void connectionCreationFailedHook(
+                        {
+                            connection: {
+                                connection_id: connectionId,
+                                provider_config_key: providerConfigKey,
+                                webhook_url_override: session.webhookUrlOverride
+                            },
+                            environment,
+                            account,
+                            auth_mode: provider.auth_mode,
+                            error: {
+                                type: 'resource_capped',
+                                description: err.message
+                            },
+                            operation: 'unknown'
+                        },
+                        account,
+                        config
+                    );
+                    return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped());
+                }
+
                 errorManager.report(err, {
                     source: ErrorSourceEnum.PLATFORM,
                     operation: LogActionEnum.AUTH,
@@ -2637,6 +2716,27 @@ class OAuthController {
                 connectionId
             });
         } catch (err) {
+            if (err instanceof ConnectionCreationCappedError) {
+                void logCtx.error(err.message);
+                await logCtx.failed();
+                void connectionCreationFailedHook(
+                    {
+                        connection: { connection_id: connectionId, provider_config_key: providerConfigKey, webhook_url_override: session.webhookUrlOverride },
+                        environment,
+                        account,
+                        auth_mode: provider.auth_mode,
+                        error: {
+                            type: 'resource_capped',
+                            description: err.message
+                        },
+                        operation: 'unknown'
+                    },
+                    account,
+                    config
+                );
+                return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped());
+            }
+
             const prettyError = stringifyError(err, { pretty: true });
 
             errorManager.report(err, {

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1379,7 +1379,7 @@ class OAuthController {
                         connectionCreationContext.config
                     );
                 }
-                return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped());
+                return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped(err.message));
             }
 
             const prettyError = stringifyError(err, { pretty: true });
@@ -2140,7 +2140,7 @@ class OAuthController {
                     config
                 );
                 if (res) {
-                    return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped());
+                    return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped(err.message));
                 }
                 throw err;
             }
@@ -2531,7 +2531,7 @@ class OAuthController {
                         account,
                         config
                     );
-                    return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped());
+                    return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped(err.message));
                 }
 
                 errorManager.report(err, {
@@ -2734,7 +2734,7 @@ class OAuthController {
                     account,
                     config
                 );
-                return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped());
+                return publisher.notifyErr(res, channel, providerConfigKey, connectionId, WSErrBuilder.ResourceCapped(err.message));
             }
 
             const prettyError = stringifyError(err, { pretty: true });

--- a/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
+++ b/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
@@ -15,7 +15,8 @@ const bodySchema = z
         organization: originalBodySchema.shape.organization,
         integrations_config_defaults: originalBodySchema.shape.integrations_config_defaults,
         overrides: originalBodySchema.shape.overrides,
-        webhook_url_override: originalBodySchema.shape.webhook_url_override
+        webhook_url_override: originalBodySchema.shape.webhook_url_override,
+        is_preview: z.boolean().optional()
     })
     .strict();
 
@@ -47,5 +48,5 @@ export const postInternalConnectSessions = asyncWrapperWithEnvironment<PostInter
         tags: endUserTags
     } satisfies PostConnectSessions['Body'];
 
-    await generateSession(res, emulatedBody, res.locals.plan);
+    await generateSession(res, emulatedBody, res.locals.plan, body.is_preview);
 });

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -3,7 +3,6 @@ import tracer from 'dd-trace';
 import db from '@nangohq/database';
 import {
     configService,
-    connectionService,
     customerKeyService,
     errorNotificationService,
     externalWebhookService,
@@ -12,12 +11,11 @@ import {
     getServerOutboundUrlPolicy,
     makeDataTransferEvent,
     NangoError,
-    productTracking,
     ProxyRequest,
     pubsub,
     syncManager
 } from '@nangohq/shared';
-import { Err, getLogger, isHosted, Ok, report } from '@nangohq/utils';
+import { Err, isHosted, Ok, report } from '@nangohq/utils';
 import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
 
 import { slackService } from '../services/slack.js';
@@ -36,7 +34,6 @@ import type {
     DBConnection,
     DBConnectionDecrypted,
     DBEnvironment,
-    DBPlan,
     DBTeam,
     InstallPluginCredentials,
     IntegrationConfig,
@@ -51,42 +48,7 @@ import type {
 import type { Result } from '@nangohq/utils';
 import type { Span } from 'dd-trace';
 
-const logger = getLogger('hooks');
 const orchestrator = getOrchestrator();
-
-export const connectionCreationStartCapCheck = async ({
-    team,
-    plan,
-    creationType
-}: {
-    team: DBTeam;
-    plan: DBPlan;
-    creationType: 'create' | 'import';
-}): Promise<{ capped: boolean }> => {
-    if (plan.connections_max === null) {
-        return { capped: false };
-    }
-
-    const connectionCount = await connectionService.countByAccountId(team.id);
-
-    if (connectionCount >= plan.connections_max) {
-        logger.info(
-            `You reached the maximum number of connections on your plan. Attempts to create new connections will be blocked. Upgrade your account, or delete some connections to add new ones.`,
-            {
-                connectionCount,
-                limit: plan.connections_max
-            }
-        );
-        if (creationType === 'create') {
-            productTracking.track({ name: 'server:resource_capped:connection_creation', team });
-        } else {
-            productTracking.track({ name: 'server:resource_capped:connection_imported', team });
-        }
-        return { capped: true };
-    }
-
-    return { capped: false };
-};
 
 export async function testConnectionCredentials({
     config,

--- a/packages/server/lib/services/connectSession.service.ts
+++ b/packages/server/lib/services/connectSession.service.ts
@@ -1,10 +1,8 @@
 import db from '@nangohq/database';
 import * as keystore from '@nangohq/keystore';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import { buildTagsFromEndUser, configService, connectionTagsSchema } from '@nangohq/shared';
+import { buildTagsFromEndUser, configService, ConnectionCreationCappedError, connectionService, connectionTagsSchema } from '@nangohq/shared';
 import { buildConnectUiSessionLink, Err, Ok } from '@nangohq/utils';
-
-import { connectionCreationStartCapCheck } from '../hooks/hooks.js';
 
 import type { Knex } from '@nangohq/database';
 import type {
@@ -208,6 +206,7 @@ export interface CreateConnectSessionParams {
     account: DBTeam;
     environment: DBEnvironment;
     plan: DBPlan | null;
+    isPreview?: boolean | undefined;
     endUser: InternalEndUser | null;
     tags?: Tags | undefined;
     allowedIntegrations?: string[] | undefined;
@@ -230,16 +229,8 @@ class ConnectSessionTransactionError extends Error {
 
 export async function createConnectSession(params: CreateConnectSessionParams): Promise<Result<CreatedConnectSession, CreateConnectSessionError>> {
     try {
-        if (params.plan) {
-            const cap = await connectionCreationStartCapCheck({ creationType: 'create', team: params.account, plan: params.plan });
-            if (cap.capped) {
-                return Err(
-                    new CreateConnectSessionError({
-                        code: 'resource_capped',
-                        message: 'Reached maximum number of allowed connections. Upgrade your plan to get rid of connection limits.'
-                    })
-                );
-            }
+        if (params.plan && !params.isPreview) {
+            await connectionService.enforceCreationCap(params.environment.id);
         }
 
         // Enforce that integrations in `integrationsConfigDefaults` and `overrides` exist
@@ -328,6 +319,9 @@ export async function createConnectSession(params: CreateConnectSessionParams): 
             return Ok({ token, connectLink: buildConnectUiSessionLink(token), expiresAt: storedPrivateKey.expiresAt });
         });
     } catch (err) {
+        if (err instanceof ConnectionCreationCappedError) {
+            return Err(new CreateConnectSessionError({ code: 'resource_capped', message: err.message, cause: err }));
+        }
         if (err instanceof ConnectSessionTransactionError) {
             return Err(err.serviceError);
         }

--- a/packages/server/lib/services/connectSession.service.unit.test.ts
+++ b/packages/server/lib/services/connectSession.service.unit.test.ts
@@ -3,10 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import db from '@nangohq/database';
 import * as keystore from '@nangohq/keystore';
 import * as logs from '@nangohq/logs';
-import { configService } from '@nangohq/shared';
+import { configService, ConnectionCreationCappedError, connectionService } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
-import * as hooks from '../hooks/hooks.js';
 import { createConnectSession } from './connectSession.service.js';
 
 import type { DBEnvironment, DBPlan, DBTeam, PrivateKey } from '@nangohq/types';
@@ -19,7 +18,7 @@ describe('createConnectSession', () => {
     it('validates, inserts, creates a private key, and returns transport-neutral data', async () => {
         const expiresAt = new Date('2026-01-01T00:30:00.000Z');
         const { trx, insert } = mockTransaction();
-        vi.spyOn(hooks, 'connectionCreationStartCapCheck').mockResolvedValue({ capped: false });
+        vi.spyOn(connectionService, 'enforceCreationCap').mockResolvedValue();
         vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([{ unique_key: 'github' }] as any);
         vi.spyOn(logs.logContextGetter, 'create').mockResolvedValue({ id: 'operation-id' } as any);
         const keySpy = vi.spyOn(keystore, 'createPrivateKey').mockResolvedValue(Ok(['session-token', privateKeyFixture(expiresAt)]));
@@ -106,8 +105,28 @@ describe('createConnectSession', () => {
         expect(transactionSpy).not.toHaveBeenCalled();
     });
 
-    it('enforces connection caps before creating a session', async () => {
-        vi.spyOn(hooks, 'connectionCreationStartCapCheck').mockResolvedValue({ capped: true });
+    it('creates a preview session without enforcing the connection cap', async () => {
+        const expiresAt = new Date('2026-01-01T00:30:00.000Z');
+        mockTransaction();
+        const capCheck = vi.spyOn(connectionService, 'enforceCreationCap').mockRejectedValue(new ConnectionCreationCappedError());
+        vi.spyOn(logs.logContextGetter, 'create').mockResolvedValue({ id: 'operation-id' } as any);
+        vi.spyOn(keystore, 'createPrivateKey').mockResolvedValue(Ok(['session-token', privateKeyFixture(expiresAt)]));
+
+        const result = await createConnectSession({
+            account: accountFixture(),
+            environment: environmentFixture(),
+            plan: planFixture(),
+            isPreview: true,
+            endUser: null,
+            tags: { team: 'platform' }
+        });
+
+        expect(result.isOk()).toBe(true);
+        expect(capCheck).not.toHaveBeenCalled();
+    });
+
+    it('enforces connection caps for normal sessions', async () => {
+        vi.spyOn(connectionService, 'enforceCreationCap').mockRejectedValue(new ConnectionCreationCappedError());
         const transactionSpy = vi.spyOn(db.knex, 'transaction');
 
         const result = await createConnectSession({
@@ -126,7 +145,7 @@ describe('createConnectSession', () => {
     });
 
     it('enforces the docs Connect override plan entitlement', async () => {
-        vi.spyOn(hooks, 'connectionCreationStartCapCheck').mockResolvedValue({ capped: false });
+        vi.spyOn(connectionService, 'enforceCreationCap').mockResolvedValue();
         vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([{ unique_key: 'github' }] as any);
 
         const result = await createConnectSession({

--- a/packages/server/lib/utils/web-socket-error.ts
+++ b/packages/server/lib/utils/web-socket-error.ts
@@ -144,10 +144,10 @@ export function FailedCredentialsCheck(errorMessage: string): WSErr {
     };
 }
 
-export function ResourceCapped(): WSErr {
+export function ResourceCapped(message: string): WSErr {
     return {
         type: 'resource_capped',
-        message: 'Reached maximum number of allowed connections. Upgrade your plan to get rid of connection limits.'
+        message
     };
 }
 

--- a/packages/server/lib/utils/web-socket-error.ts
+++ b/packages/server/lib/utils/web-socket-error.ts
@@ -144,6 +144,13 @@ export function FailedCredentialsCheck(errorMessage: string): WSErr {
     };
 }
 
+export function ResourceCapped(): WSErr {
+    return {
+        type: 'resource_capped',
+        message: 'Reached maximum number of allowed connections. Upgrade your plan to get rid of connection limits.'
+    };
+}
+
 export function UnknownError(errorMessage?: string): WSErr {
     return {
         type: 'unknown_err',

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -57,6 +57,27 @@ describe('Connection service integration tests', () => {
 
             expect(updated?.operation).toBe('override');
         });
+
+        it('does not exceed the cap when connections are created concurrently', async () => {
+            const { account, env } = await seedAccountEnvAndUser({ plan: { connections_max: 1 } });
+            const config = await createConfigSeed(env, `concurrent-${Math.random().toString(36).slice(2, 10)}`, 'unauthenticated');
+
+            const attempts = await Promise.allSettled(
+                Array.from({ length: 5 }, (_, index) =>
+                    connectionService.upsertUnauthConnection({
+                        connectionId: `concurrent-connection-${index}`,
+                        providerConfigKey: config.unique_key,
+                        environment: env
+                    })
+                )
+            );
+
+            expect(attempts.filter((attempt) => attempt.status === 'fulfilled')).toHaveLength(1);
+            expect(
+                attempts.filter((attempt) => attempt.status === 'rejected').every((attempt) => attempt.reason instanceof ConnectionCreationCappedError)
+            ).toBe(true);
+            await expect(connectionService.countByAccountId(account.id)).resolves.toBe(1);
+        });
     });
 
     describe('Metadata simple operations', () => {

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -5,7 +5,9 @@ import db, { multipleMigrations } from '@nangohq/database';
 import { createConfigSeed, createConfigSeeds, createPreprovisionedProviderConfigSeed } from '../seeders/config.seeder.js';
 import { createConnectionSeed, createConnectionSeeds, getTestConnection } from '../seeders/connection.seeder.js';
 import { createEnvironmentSeed } from '../seeders/environment.seeder.js';
+import { seedAccountEnvAndUser } from '../seeders/global.seeder.js';
 import { createSyncSeeds } from '../seeders/sync.seeder.js';
+import { ConnectionCreationCappedError } from '../utils/error.js';
 import connectionService from './connection.service.js';
 import { errorNotificationService } from './notification/error.service.js';
 
@@ -15,6 +17,46 @@ import type { Metadata } from '@nangohq/types';
 describe('Connection service integration tests', () => {
     beforeAll(async () => {
         await multipleMigrations();
+    });
+
+    describe('connection cap', () => {
+        it('rejects inserting a new connection at the cap', async () => {
+            const { env } = await seedAccountEnvAndUser({ plan: { connections_max: 0 } });
+            const config = await createConfigSeed(env, `capped-${Math.random().toString(36).slice(2, 10)}`, 'unauthenticated');
+
+            await expect(
+                connectionService.upsertUnauthConnection({
+                    connectionId: 'new-connection',
+                    providerConfigKey: config.unique_key,
+                    environment: env
+                })
+            ).rejects.toBeInstanceOf(ConnectionCreationCappedError);
+
+            await expect(
+                connectionService.checkIfConnectionExists(db.knex, {
+                    connectionId: 'new-connection',
+                    providerConfigKey: config.unique_key,
+                    environmentId: env.id
+                })
+            ).resolves.toBeNull();
+        });
+
+        it('allows completing an existing staged connection at the cap', async () => {
+            const { env, plan } = await seedAccountEnvAndUser();
+            const config = await createConfigSeed(env, `reconnect-${Math.random().toString(36).slice(2, 10)}`, 'unauthenticated');
+            const existing = await createConnectionSeed({ env, provider: config.unique_key, connectionId: 'existing-connection' });
+            await db.knex('plans').where({ id: plan.id }).update({ connections_max: 1 });
+
+            const [updated] = await connectionService.upsertConnection({
+                connectionId: existing.connection_id,
+                providerConfigKey: config.unique_key,
+                environmentId: env.id,
+                parsedRawCredentials: { type: 'API_KEY', apiKey: 'updated' },
+                connectionConfig: { reconnected: true }
+            });
+
+            expect(updated?.operation).toBe('override');
+        });
     });
 
     describe('Metadata simple operations', () => {

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
 
@@ -77,6 +77,36 @@ describe('Connection service integration tests', () => {
                 attempts.filter((attempt) => attempt.status === 'rejected').every((attempt) => attempt.reason instanceof ConnectionCreationCappedError)
             ).toBe(true);
             await expect(connectionService.countByAccountId(account.id)).resolves.toBe(1);
+        });
+
+        it('does not lock uncapped accounts during connection creation', async () => {
+            const { account, env } = await seedAccountEnvAndUser({ plan: { connections_max: null } });
+            const config = await createConfigSeed(env, `uncapped-${Math.random().toString(36).slice(2, 10)}`, 'unauthenticated');
+            const capCheckStarted = Promise.withResolvers<undefined>();
+            const continueCapCheck = Promise.withResolvers<undefined>();
+            const enforceCreationCap = vi.spyOn(connectionService, 'enforceCreationCap').mockImplementation(async () => {
+                capCheckStarted.resolve(undefined);
+                await continueCapCheck.promise;
+            });
+
+            const connectionCreation = connectionService.upsertUnauthConnection({
+                connectionId: 'uncapped-connection',
+                providerConfigKey: config.unique_key,
+                environment: env
+            });
+
+            try {
+                await capCheckStarted.promise;
+                await db.knex.transaction(async (trx) => {
+                    await trx.raw("SET LOCAL lock_timeout = '1s'");
+                    await trx.from('_nango_accounts').select('id').where({ id: account.id }).forUpdate().first();
+                });
+            } finally {
+                continueCapCheck.resolve(undefined);
+                enforceCreationCap.mockRestore();
+            }
+
+            await expect(connectionCreation).resolves.toHaveLength(1);
         });
     });
 

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -264,9 +264,11 @@ export class ConnectionService {
         await trx
             .from({ account: '_nango_accounts' })
             .join({ environment: '_nango_environments' }, 'environment.account_id', 'account.id')
+            .join({ plan: 'plans' }, 'plan.account_id', 'account.id')
             .select('account.id')
             .where('environment.id', params.environmentId)
-            .forUpdate()
+            .whereNotNull('plan.connections_max')
+            .forNoKeyUpdate('account')
             .first();
 
         return await this.checkIfConnectionExists(trx, params);

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -223,15 +223,15 @@ export class ConnectionService {
         return uuidv4();
     }
 
-    public async enforceCreationCap(environmentId: number): Promise<void> {
-        const cappedPlan = await db.knex
+    public async enforceCreationCap(environmentId: number, database: Knex = db.knex): Promise<void> {
+        const cappedPlan = await database
             .from({ target_environment: '_nango_environments' })
             .join({ plan: 'plans' }, 'plan.account_id', 'target_environment.account_id')
             .leftJoin({ account_environment: '_nango_environments' }, function () {
-                this.on('account_environment.account_id', 'target_environment.account_id').andOn('account_environment.deleted', db.knex.raw('false'));
+                this.on('account_environment.account_id', 'target_environment.account_id').andOn('account_environment.deleted', database.raw('false'));
             })
             .leftJoin({ connection: '_nango_connections' }, function () {
-                this.on('connection.environment_id', 'account_environment.id').andOn('connection.deleted', db.knex.raw('false'));
+                this.on('connection.environment_id', 'account_environment.id').andOn('connection.deleted', database.raw('false'));
             })
             .select({
                 limit: 'plan.connections_max'
@@ -250,6 +250,26 @@ export class ConnectionService {
 
         this.logCreationCapReached({ connectionCount: Number(cappedPlan.connectionCount), limit: cappedPlan.limit });
         throw new ConnectionCreationCappedError();
+    }
+
+    private async findExistingConnectionOrLockCreation(
+        trx: Knex.Transaction,
+        params: { connectionId: string; providerConfigKey: string; environmentId: number }
+    ): Promise<DBConnection | null> {
+        const existing = await this.checkIfConnectionExists(trx, params);
+        if (existing) {
+            return existing;
+        }
+
+        await trx
+            .from({ account: '_nango_accounts' })
+            .join({ environment: '_nango_environments' }, 'environment.account_id', 'account.id')
+            .select('account.id')
+            .where('environment.id', params.environmentId)
+            .forUpdate()
+            .first();
+
+        return await this.checkIfConnectionExists(trx, params);
     }
 
     private logCreationCapReached({ connectionCount, limit }: { connectionCount: number; limit: number }): void {
@@ -278,64 +298,67 @@ export class ConnectionService {
         metadata?: Metadata | null;
         tags?: Tags | undefined;
     }): Promise<ConnectionUpsertResponse[]> {
-        const storedConnection = await this.checkIfConnectionExists(db.knex, { connectionId, providerConfigKey, environmentId });
         const config_id = await configService.getIdByProviderConfigKey(environmentId, providerConfigKey);
 
-        if (storedConnection) {
-            const encryptedConnection = getEncryptionManager().encryptConnection({
-                ...storedConnection,
+        return await db.knex.transaction(async (trx) => {
+            const storedConnection = await this.findExistingConnectionOrLockCreation(trx, { connectionId, providerConfigKey, environmentId });
+
+            if (storedConnection) {
+                const encryptedConnection = getEncryptionManager().encryptConnection({
+                    ...storedConnection,
+                    connection_id: connectionId,
+                    provider_config_key: providerConfigKey,
+                    credentials: parsedRawCredentials,
+                    connection_config: connectionConfig || storedConnection.connection_config,
+                    webhook_url_override: webhookUrlOverride !== undefined ? webhookUrlOverride : (storedConnection.webhook_url_override ?? null),
+                    environment_id: environmentId,
+                    config_id: config_id as number,
+                    metadata: metadata || storedConnection.metadata || null,
+                    credentials_expires_at: getExpiresAtFromCredentials(parsedRawCredentials),
+                    last_refresh_success: new Date(),
+                    last_refresh_failure: null,
+                    refresh_attempts: null,
+                    refresh_exhausted: false,
+                    tags: tags ?? storedConnection.tags
+                });
+
+                const connection = await trx
+                    .from<DBConnection>(`_nango_connections`)
+                    .where({ id: storedConnection.id, deleted: false })
+                    .update(encryptedConnection)
+                    .returning('*');
+
+                return [{ connection: connection[0]!, operation: 'override' }];
+            }
+
+            await this.enforceCreationCap(environmentId, trx);
+
+            const { id, ...data } = getEncryptionManager().encryptConnection({
                 connection_id: connectionId,
                 provider_config_key: providerConfigKey,
-                credentials: parsedRawCredentials,
-                connection_config: connectionConfig || storedConnection.connection_config,
-                webhook_url_override: webhookUrlOverride !== undefined ? webhookUrlOverride : (storedConnection.webhook_url_override ?? null),
-                environment_id: environmentId,
                 config_id: config_id as number,
-                metadata: metadata || storedConnection.metadata || null,
+                credentials: parsedRawCredentials,
+                connection_config: connectionConfig || {},
+                webhook_url_override: webhookUrlOverride ?? null,
+                environment_id: environmentId,
+                metadata: metadata || null,
+                created_at: new Date(),
+                updated_at: new Date(),
+                id: -1,
+                last_fetched_at: new Date(),
                 credentials_expires_at: getExpiresAtFromCredentials(parsedRawCredentials),
                 last_refresh_success: new Date(),
                 last_refresh_failure: null,
                 refresh_attempts: null,
                 refresh_exhausted: false,
-                tags: tags ?? storedConnection.tags
+                deleted: false,
+                deleted_at: null,
+                tags: tags ?? {}
             });
+            const connection = await trx.from<DBConnection>(`_nango_connections`).insert(data).returning('*');
 
-            const connection = await db.knex
-                .from<DBConnection>(`_nango_connections`)
-                .where({ id: storedConnection.id, deleted: false })
-                .update(encryptedConnection)
-                .returning('*');
-
-            return [{ connection: connection[0]!, operation: 'override' }];
-        }
-
-        await this.enforceCreationCap(environmentId);
-
-        const { id, ...data } = getEncryptionManager().encryptConnection({
-            connection_id: connectionId,
-            provider_config_key: providerConfigKey,
-            config_id: config_id as number,
-            credentials: parsedRawCredentials,
-            connection_config: connectionConfig || {},
-            webhook_url_override: webhookUrlOverride ?? null,
-            environment_id: environmentId,
-            metadata: metadata || null,
-            created_at: new Date(),
-            updated_at: new Date(),
-            id: -1,
-            last_fetched_at: new Date(),
-            credentials_expires_at: getExpiresAtFromCredentials(parsedRawCredentials),
-            last_refresh_success: new Date(),
-            last_refresh_failure: null,
-            refresh_attempts: null,
-            refresh_exhausted: false,
-            deleted: false,
-            deleted_at: null,
-            tags: tags ?? {}
+            return [{ connection: connection[0]!, operation: 'creation' }];
         });
-        const connection = await db.knex.from<DBConnection>(`_nango_connections`).insert(data).returning('*');
-
-        return [{ connection: connection[0]!, operation: 'creation' }];
     }
 
     public async upsertAuthConnection({
@@ -368,10 +391,14 @@ export class ConnectionService {
         tags?: Tags | undefined;
     }): Promise<ConnectionUpsertResponse[]> {
         return await db.knex.transaction(async (trx) => {
-            const exists = await this.checkIfConnectionExists(trx, { connectionId, providerConfigKey, environmentId: environment.id });
+            const exists = await this.findExistingConnectionOrLockCreation(trx, {
+                connectionId,
+                providerConfigKey,
+                environmentId: environment.id
+            });
 
             if (!exists) {
-                await this.enforceCreationCap(environment.id);
+                await this.enforceCreationCap(environment.id, trx);
             }
 
             const { id, ...encryptedConnection } = getEncryptionManager().encryptConnection({
@@ -397,7 +424,7 @@ export class ConnectionService {
                 tags: tags ?? exists?.tags ?? {}
             });
 
-            const [connection] = await db.knex
+            const [connection] = await trx
                 .from<DBConnection>(`_nango_connections`)
                 .insert(encryptedConnection)
                 .onConflict(['connection_id', 'provider_config_key', 'environment_id', 'deleted_at'])
@@ -443,57 +470,64 @@ export class ConnectionService {
         environment: DBEnvironment;
         tags?: Tags | undefined;
     }): Promise<ConnectionUpsertResponse[]> {
-        const storedConnection = await this.checkIfConnectionExists(db.knex, { connectionId, providerConfigKey, environmentId: environment.id });
         const config_id = await configService.getIdByProviderConfigKey(environment.id, providerConfigKey); // TODO remove that
         const expiresAt = getExpiresAtFromCredentials({});
 
-        if (storedConnection) {
-            const connection = await db.knex
+        return await db.knex.transaction(async (trx) => {
+            const storedConnection = await this.findExistingConnectionOrLockCreation(trx, {
+                connectionId,
+                providerConfigKey,
+                environmentId: environment.id
+            });
+
+            if (storedConnection) {
+                const connection = await trx
+                    .from<DBConnection>(`_nango_connections`)
+                    .where({ id: storedConnection.id, deleted: false })
+                    .update({
+                        connection_id: connectionId,
+                        provider_config_key: providerConfigKey,
+                        config_id: config_id as number,
+                        updated_at: new Date(),
+                        connection_config: connectionConfig || storedConnection.connection_config,
+                        webhook_url_override: webhookUrlOverride !== undefined ? webhookUrlOverride : (storedConnection.webhook_url_override ?? null),
+                        metadata: metadata || storedConnection.metadata || null,
+                        credentials_expires_at: expiresAt,
+                        last_refresh_success: new Date(),
+                        last_refresh_failure: null,
+                        refresh_attempts: null,
+                        refresh_exhausted: false,
+                        tags: tags ?? storedConnection.tags
+                    })
+                    .returning('*');
+
+                return [{ connection: connection[0]!, operation: 'override' }];
+            }
+
+            await this.enforceCreationCap(environment.id, trx);
+
+            const connection = await trx
                 .from<DBConnection>(`_nango_connections`)
-                .where({ id: storedConnection.id, deleted: false })
-                .update({
+                .insert({
                     connection_id: connectionId,
                     provider_config_key: providerConfigKey,
-                    config_id: config_id as number,
-                    updated_at: new Date(),
-                    connection_config: connectionConfig || storedConnection.connection_config,
-                    webhook_url_override: webhookUrlOverride !== undefined ? webhookUrlOverride : (storedConnection.webhook_url_override ?? null),
-                    metadata: metadata || storedConnection.metadata || null,
+                    credentials: {},
+                    connection_config: connectionConfig || {},
+                    webhook_url_override: webhookUrlOverride ?? null,
+                    metadata: metadata || {},
+                    environment_id: environment.id,
+                    config_id: config_id!,
                     credentials_expires_at: expiresAt,
                     last_refresh_success: new Date(),
                     last_refresh_failure: null,
                     refresh_attempts: null,
                     refresh_exhausted: false,
-                    tags: tags ?? storedConnection.tags
+                    tags: tags ?? {}
                 })
                 .returning('*');
 
-            return [{ connection: connection[0]!, operation: 'override' }];
-        }
-
-        await this.enforceCreationCap(environment.id);
-
-        const connection = await db.knex
-            .from<DBConnection>(`_nango_connections`)
-            .insert({
-                connection_id: connectionId,
-                provider_config_key: providerConfigKey,
-                credentials: {},
-                connection_config: connectionConfig || {},
-                webhook_url_override: webhookUrlOverride ?? null,
-                metadata: metadata || {},
-                environment_id: environment.id,
-                config_id: config_id!,
-                credentials_expires_at: expiresAt,
-                last_refresh_success: new Date(),
-                last_refresh_failure: null,
-                refresh_attempts: null,
-                refresh_exhausted: false,
-                tags: tags ?? {}
-            })
-            .returning('*');
-
-        return [{ connection: connection[0]!, operation: 'creation' }];
+            return [{ connection: connection[0]!, operation: 'creation' }];
+        });
     }
 
     public async importOAuthConnection({

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -19,7 +19,7 @@ import { refreshMcpGenericCredentials } from '../clients/mcpGeneric.client.js';
 import { getFreshOAuth2Credentials } from '../clients/oauth2.client.js';
 import providerClient from '../clients/provider.client.js';
 import { getEncryptionManager } from '../utils/encryption.manager.js';
-import { NangoError } from '../utils/error.js';
+import { ConnectionCreationCappedError, NangoError } from '../utils/error.js';
 import { loggedFetch } from '../utils/http.js';
 import {
     extractStepNumber,
@@ -223,6 +223,42 @@ export class ConnectionService {
         return uuidv4();
     }
 
+    public async enforceCreationCap(environmentId: number): Promise<void> {
+        const cappedPlan = await db.knex
+            .from({ target_environment: '_nango_environments' })
+            .join({ plan: 'plans' }, 'plan.account_id', 'target_environment.account_id')
+            .leftJoin({ account_environment: '_nango_environments' }, function () {
+                this.on('account_environment.account_id', 'target_environment.account_id').andOn('account_environment.deleted', db.knex.raw('false'));
+            })
+            .leftJoin({ connection: '_nango_connections' }, function () {
+                this.on('connection.environment_id', 'account_environment.id').andOn('connection.deleted', db.knex.raw('false'));
+            })
+            .select({
+                limit: 'plan.connections_max'
+            })
+            .count<{ connectionCount: string; limit: number }>({ connectionCount: 'connection.id' })
+            .where('target_environment.id', environmentId)
+            .where('target_environment.deleted', false)
+            .whereNotNull('plan.connections_max')
+            .groupBy('plan.connections_max')
+            .havingRaw('COUNT(connection.id) >= plan.connections_max')
+            .first();
+
+        if (!cappedPlan) {
+            return;
+        }
+
+        this.logCreationCapReached({ connectionCount: Number(cappedPlan.connectionCount), limit: cappedPlan.limit });
+        throw new ConnectionCreationCappedError();
+    }
+
+    private logCreationCapReached({ connectionCount, limit }: { connectionCount: number; limit: number }): void {
+        logger.info(
+            'You reached the maximum number of connections on your plan. Attempts to create new connections will be blocked. Upgrade your account, or delete some connections to add new ones.',
+            { connectionCount, limit }
+        );
+    }
+
     public async upsertConnection({
         connectionId,
         providerConfigKey,
@@ -272,6 +308,8 @@ export class ConnectionService {
 
             return [{ connection: connection[0]!, operation: 'override' }];
         }
+
+        await this.enforceCreationCap(environmentId);
 
         const { id, ...data } = getEncryptionManager().encryptConnection({
             connection_id: connectionId,
@@ -331,6 +369,10 @@ export class ConnectionService {
     }): Promise<ConnectionUpsertResponse[]> {
         return await db.knex.transaction(async (trx) => {
             const exists = await this.checkIfConnectionExists(trx, { connectionId, providerConfigKey, environmentId: environment.id });
+
+            if (!exists) {
+                await this.enforceCreationCap(environment.id);
+            }
 
             const { id, ...encryptedConnection } = getEncryptionManager().encryptConnection({
                 connection_id: connectionId,
@@ -428,6 +470,9 @@ export class ConnectionService {
 
             return [{ connection: connection[0]!, operation: 'override' }];
         }
+
+        await this.enforceCreationCap(environment.id);
+
         const connection = await db.knex
             .from<DBConnection>(`_nango_connections`)
             .insert({

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -33,6 +33,14 @@ export class AuthCredentialsError extends NangoInternalError {
     }
 }
 
+export class ConnectionCreationCappedError extends NangoInternalError {
+    constructor() {
+        super('resource_capped');
+        this.status = 400;
+        this.message = 'Reached maximum number of allowed connections. Upgrade your plan to get rid of connection limits.';
+    }
+}
+
 export class NangoError extends NangoInternalError {
     public additional_properties?: Record<string, JsonValue> | undefined = undefined;
     public override readonly message: string;

--- a/packages/shared/lib/utils/productTracking.ts
+++ b/packages/shared/lib/utils/productTracking.ts
@@ -14,8 +14,6 @@ export type ProductTrackingTypes =
     | 'deploy:success'
     | 'deploy:error'
     | 'prod:connections:threshold_hit'
-    | 'server:resource_capped:connection_creation'
-    | 'server:resource_capped:connection_imported'
     | 'server:resource_capped:script_activate'
     | 'server:resource_capped:script_deploy_is_disabled'
     | 'server:resource_capped:action_triggered'

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -117,11 +117,14 @@ export type PostInternalConnectSessions = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/connect/sessions';
+    Querystring: { env: string };
     Success: PostConnectSessions['Success'];
     Body: Pick<
         ConnectSessionInput,
         'allowed_integrations' | 'end_user' | 'organization' | 'integrations_config_defaults' | 'overrides' | 'webhook_url_override'
-    >;
+    > & {
+        is_preview?: boolean | undefined;
+    };
 }>;
 
 export type PostPublicConnectTelemetry = ApiEndpoint<{

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/components/ConnectUIPreview.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/components/ConnectUIPreview.tsx
@@ -41,6 +41,7 @@ export const ConnectUIPreview = forwardRef<ConnectUIPreviewRef, { className?: st
         queryKey: [env, 'preview-session-token'],
         queryFn: async () => {
             const res = await apiConnectSessions(env, {
+                is_preview: true,
                 end_user: {
                     id: 'previewUserId',
                     email: 'preview@nango.dev',


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Connect UI preview sessions can now be created when an account has reached its connection cap. Normal session creation still enforces the cap, and every real connection insertion rechecks it while allowing updates and reconnects. Capped failures return resource_capped across HTTP and WebSocket flows and continue emitting customer auth-failure webhooks.

<!-- Issue ticket number and link (if applicable) -->
[NAN-6860](https://linear.app/nango/issue/NAN-6860/fix-the-broken-connect-ui-preview-in-environment-settings)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

