### PR TITLE
fix(docker): cleanup lambda npm

### DIFF
--- a/packages/lambda-runner/Dockerfile.lambda
+++ b/packages/lambda-runner/Dockerfile.lambda
@@ -83,6 +83,14 @@ RUN true \
 # ------------------
 FROM public.ecr.aws/lambda/nodejs:22-arm64
 
+# npm/npx/corepack ship with the Lambda Node image and are unused at runtime
+RUN rm -rf \
+      /var/lang/lib/node_modules/npm \
+      /var/lang/lib/node_modules/corepack \
+      /var/lang/bin/npm \
+      /var/lang/bin/npx \
+      /var/lang/bin/corepack
+
 # Do not use root to run the app
 # BUT it does not work with secret mount (could not find a solution yet)
 # TODO: fix this


### PR DESCRIPTION
Cleanup npm from Lambda docker file

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

