### PR TITLE
feat: add support for webhook functions

### DIFF
--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -11,33 +11,61 @@ import { GroupThrottles } from './groupThrottle.js';
 import { changeVisibility, deferSeconds } from './visibility.js';
 
 import type { Message } from '@aws-sdk/client-sqs';
-import type { ExecuteWebhookProps, OrchestratorClient } from '@nangohq/nango-orchestrator';
-import type { WebhookDispatchMessage } from '@nangohq/types';
+import type { ClientError, ExecuteFunctionBatchProps, ExecuteWebhookProps, OrchestratorClient } from '@nangohq/nango-orchestrator';
+import type { DispatchMessage, FunctionDispatchMessage, LegacyDispatchMessage } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 const logger = getLogger('jobs.webhook.dispatch-queue.consumer');
 
 const THROTTLED_LOG_MESSAGE = 'Webhook execution is delayed: this environment reached its webhook dispatch rate limit';
 
-const messageSchema: z.ZodType<WebhookDispatchMessage> = z.object({
+const commonMessageSchema = {
     version: z.literal(1),
-    kind: z.literal('webhook'),
-    taskName: z.string().min(1),
     createdAt: z.string().min(1),
     accountId: z.number(),
     integrationId: z.number(),
     provider: z.string(),
-    parentSyncName: z.string().min(1),
     activityLogId: z.string(),
-    webhookName: z.string().min(1),
     connection: z.object({
         id: z.number().positive(),
         connection_id: z.string().min(1),
         provider_config_key: z.string().min(1),
         environment_id: z.number().positive()
+    })
+};
+
+const functionTriggerSchema: z.ZodType<FunctionDispatchMessage['trigger']> = z.object({
+    kind: z.literal('http'),
+    input: jsonSchema.optional().default(null),
+    request: z.object({
+        method: z.enum(['GET', 'POST', 'PATCH', 'PUT', 'DELETE']),
+        path: z.string(),
+        headers: z.record(z.string(), z.string()),
+        query: z.record(z.string(), z.string()),
+        body: jsonSchema.optional().default(null)
     }),
-    payload: jsonSchema
+    subscriptions: z.array(z.string()),
+    connection: z.object({ connectionId: z.string().min(1), integrationId: z.string().min(1) })
 });
+
+const messageSchema: z.ZodType<DispatchMessage> = z.discriminatedUnion('kind', [
+    z.object({
+        ...commonMessageSchema,
+        kind: z.literal('webhook'),
+        taskName: z.string().min(1),
+        parentSyncName: z.string().min(1),
+        webhookName: z.string().min(1),
+        payload: jsonSchema
+    }),
+    z.object({
+        ...commonMessageSchema,
+        kind: z.literal('function'),
+        idempotencyKey: z.string().min(1),
+        functionName: z.string().min(1),
+        trigger: functionTriggerSchema,
+        maxConcurrency: z.number().int().min(0)
+    })
+]);
 
 export interface DispatchQueueConsumerProps {
     queueUrl: string;
@@ -56,7 +84,15 @@ export interface DispatchQueueConsumerProps {
 
 interface ParsedEntry {
     msg: Message;
-    parsed: WebhookDispatchMessage;
+    parsed: DispatchMessage;
+}
+
+interface ParsedLegacyEntry extends ParsedEntry {
+    parsed: LegacyDispatchMessage;
+}
+
+interface ParsedFunctionEntry extends ParsedEntry {
+    parsed: FunctionDispatchMessage;
 }
 
 export class DispatchQueueConsumer {
@@ -153,11 +189,12 @@ export class DispatchQueueConsumer {
                 // SQS might deliver the same message multiple times, so we guard against duplicates
                 const groups = new Map<string, ParsedEntry[]>();
                 for (const entry of entries) {
-                    const group = groups.get(entry.parsed.taskName);
+                    const groupKey = getGroupKey(entry.parsed);
+                    const group = groups.get(groupKey);
                     if (group) {
                         group.push(entry);
                     } else {
-                        groups.set(entry.parsed.taskName, [entry]);
+                        groups.set(groupKey, [entry]);
                     }
                 }
                 const groupedEntries: ParsedEntry[][] = [];
@@ -177,7 +214,6 @@ export class DispatchQueueConsumer {
                 span.setTag('received', entries.length);
                 span.setTag('throttled', throttled);
 
-                const dispatched = entries.length - throttled;
                 if (groupedEntries.length === 0) {
                     await Promise.all(deferrals);
                     return;
@@ -185,37 +221,33 @@ export class DispatchQueueConsumer {
 
                 const deferralsDone = Promise.all(deferrals);
 
-                const propsList: ExecuteWebhookProps[] = groupedEntries.map((group) => {
-                    const m = group[0]!.parsed;
-                    return {
-                        name: m.taskName,
-                        group: { key: dispatchGroupKey(m), maxConcurrency: this.webhookMaxConcurrency },
-                        args: {
-                            webhookName: m.webhookName,
-                            parentSyncName: m.parentSyncName,
-                            connection: m.connection,
-                            activityLogId: m.activityLogId,
-                            input: m.payload
-                        }
-                    };
-                });
-
                 try {
-                    const res = await this.orchestratorClient.executeWebhookBatch(propsList);
-                    if (res.isErr()) {
+                    const legacyGroups = groupedEntries.filter(isLegacyGroup);
+                    const functionGroups = groupedEntries.filter(isFunctionGroup);
+                    const [legacyRes, functionRes] = await Promise.all([
+                        this.processLegacyGroups(legacyGroups, receivedAt),
+                        this.processFunctionGroups(functionGroups, receivedAt)
+                    ]);
+
+                    const reportError = ({ err, count }: { err: ClientError; count: number }) => {
                         span.setTag('error', true);
-                        span.setTag('error.type', res.error.name);
-                        span.setTag('error.message', res.error.message);
-                        const responsePayload = getClientErrorResponsePayload(res.error);
+                        span.setTag('error.type', err.name);
+                        span.setTag('error.message', err.message);
+                        const responsePayload = getClientErrorResponsePayload(err);
                         if (responsePayload) {
                             span.setTag('error.details', responsePayload);
                         }
-                        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, dispatched, { result: 'failure' });
-                        report(new Error('webhook dispatch consumer batch failed', { cause: res.error }));
-                        return;
+                        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, count, { result: 'failure' });
+                        report(new Error('webhook dispatch consumer batch failed', { cause: err }));
+                    };
+
+                    if (legacyRes.isErr()) {
+                        reportError({ err: legacyRes.error, count: legacyGroups.reduce((count, group) => count + group.length, 0) });
                     }
 
-                    await this.handleBatchResult(groupedEntries, res.value, receivedAt);
+                    if (functionRes.isErr()) {
+                        reportError({ err: functionRes.error, count: functionGroups.reduce((count, group) => count + group.length, 0) });
+                    }
                 } finally {
                     await deferralsDone;
                 }
@@ -223,6 +255,65 @@ export class DispatchQueueConsumer {
                 span.finish();
             }
         }));
+    }
+
+    private async processLegacyGroups(groupedEntries: ParsedLegacyEntry[][], receivedAt: number): Promise<Result<void, ClientError>> {
+        if (groupedEntries.length === 0) return Ok(undefined);
+
+        const propsList: ExecuteWebhookProps[] = groupedEntries.map((group) => {
+            const message = group[0]!.parsed;
+            return {
+                name: message.taskName,
+                group: { key: `webhook:environment:${message.connection.environment_id}`, maxConcurrency: this.webhookMaxConcurrency },
+                args: {
+                    webhookName: message.webhookName,
+                    parentSyncName: message.parentSyncName,
+                    connection: message.connection,
+                    activityLogId: message.activityLogId,
+                    input: message.payload
+                }
+            };
+        });
+
+        const result = await this.orchestratorClient.executeWebhookBatch(propsList);
+        if (result.isErr()) {
+            return Err(result.error);
+        }
+
+        await this.handleBatchResult(groupedEntries, result.value, receivedAt);
+        return Ok(undefined);
+    }
+
+    private async processFunctionGroups(groupedEntries: ParsedFunctionEntry[][], receivedAt: number): Promise<Result<void, ClientError>> {
+        if (groupedEntries.length === 0) return Ok(undefined);
+
+        const propsList: ExecuteFunctionBatchProps[] = groupedEntries.map((group) => {
+            const message = group[0]!.parsed;
+            return {
+                name: message.idempotencyKey,
+                group: {
+                    key: `function:environment:${message.connection.environment_id}:connection:${message.connection.id}:function:${message.functionName}`,
+                    maxConcurrency: message.maxConcurrency
+                },
+                retry: { count: 0, max: 0 },
+                ownerKey: `environment:${message.connection.environment_id}`,
+                args: {
+                    functionName: message.functionName,
+                    connection: message.connection,
+                    activityLogId: message.activityLogId,
+                    trigger: message.trigger,
+                    async: true
+                }
+            };
+        });
+
+        const result = await this.orchestratorClient.executeFunctionBatch(propsList);
+        if (result.isErr()) {
+            return Err(result.error);
+        }
+
+        await this.handleBatchResult(groupedEntries, result.value, receivedAt);
+        return Ok(undefined);
     }
 
     private async filterMessages(messages: Message[]): Promise<ParsedEntry[]> {
@@ -255,7 +346,10 @@ export class DispatchQueueConsumer {
                         providerConfigKey: message.connection.provider_config_key
                     });
                     const logCtx = logContextGetter.get({ id: message.activityLogId, accountId: message.accountId });
-                    await logCtx.warn('Webhook was discarded: it spent too long in the queue and was not processed.', { dwell_ms: dwellMs });
+                    await logCtx.warn('Webhook was discarded: it spent too long in the queue and was not processed.', {
+                        dwell_ms: dwellMs,
+                        kind: message.kind
+                    });
                     await this.tryDeleteMessage(msg.ReceiptHandle);
                     continue;
                 }
@@ -266,13 +360,8 @@ export class DispatchQueueConsumer {
         return entries;
     }
 
-    // `groupedEntries[i]` is the set of messages that shared one taskName and map to `results[i]`.
     // Each result applies to every message in its group (deduped SQS copies of the same task).
-    private async handleBatchResult(
-        groupedEntries: ParsedEntry[][],
-        results: Awaited<ReturnType<OrchestratorClient['executeWebhookBatch']>> extends Result<infer R> ? R : never,
-        receivedAt: number
-    ): Promise<void> {
+    private async handleBatchResult<T>(groupedEntries: ParsedEntry[][], results: Result<T, ClientError>[], receivedAt: number): Promise<void> {
         for (let i = 0; i < groupedEntries.length; i++) {
             const group = groupedEntries[i]!;
             const result = results[i];
@@ -357,7 +446,7 @@ export class DispatchQueueConsumer {
         await Promise.all(group.map((entry) => this.tryDeleteMessage(entry.msg.ReceiptHandle!)));
     }
 
-    private parseMessage(body: string): Result<WebhookDispatchMessage> {
+    private parseMessage(body: string): Result<DispatchMessage> {
         try {
             const json = JSON.parse(body);
             const result = messageSchema.safeParse(json);
@@ -379,7 +468,7 @@ export class DispatchQueueConsumer {
     }
 }
 
-function dispatchGroupKey(message: WebhookDispatchMessage): string {
+function dispatchGroupKey(message: DispatchMessage): string {
     return `webhook:environment:${message.connection.environment_id}`;
 }
 
@@ -389,6 +478,14 @@ function getRetryAfterMs(payload: unknown): number | null {
     }
     const retryAfterMs = payload.retryAfterMs;
     return typeof retryAfterMs === 'number' ? retryAfterMs : null;
+}
+
+function isLegacyGroup(group: ParsedEntry[]): group is ParsedLegacyEntry[] {
+    return group.every((entry) => entry.parsed.kind === 'webhook');
+}
+
+function isFunctionGroup(group: ParsedEntry[]): group is ParsedFunctionEntry[] {
+    return group.every((entry) => entry.parsed.kind === 'function');
 }
 
 function getClientErrorResponsePayload(err: { payload?: unknown }): string | null {
@@ -403,4 +500,8 @@ function getClientErrorResponsePayload(err: { payload?: unknown }): string | nul
     }
 
     return JSON.stringify(responsePayload);
+}
+
+function getGroupKey(message: DispatchMessage): string {
+    return message.kind === 'webhook' ? message.taskName : message.idempotencyKey;
 }

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -8,7 +8,7 @@ import { DispatchQueueConsumer } from './consumer.js';
 
 import type { SQSClient } from '@aws-sdk/client-sqs';
 import type { OrchestratorClient } from '@nangohq/nango-orchestrator';
-import type { WebhookDispatchMessage } from '@nangohq/types';
+import type { DispatchMessage, FunctionDispatchMessage, LegacyDispatchMessage } from '@nangohq/types';
 import type { Mock } from 'vitest';
 
 vi.mock('../../env.js', () => ({
@@ -17,7 +17,7 @@ vi.mock('../../env.js', () => ({
     }
 }));
 
-function buildMessage(overrides: Partial<WebhookDispatchMessage> = {}): WebhookDispatchMessage {
+function buildMessage(overrides: Partial<LegacyDispatchMessage> = {}): LegacyDispatchMessage {
     return {
         version: 1,
         kind: 'webhook',
@@ -31,6 +31,36 @@ function buildMessage(overrides: Partial<WebhookDispatchMessage> = {}): WebhookD
         webhookName: 'push',
         connection: { id: 42, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2 },
         payload: { hello: 'world' },
+        ...overrides
+    };
+}
+
+function buildFunctionMessage(overrides: Partial<FunctionDispatchMessage> = {}): FunctionDispatchMessage {
+    return {
+        version: 1,
+        kind: 'function',
+        idempotencyKey: 'function:abc123',
+        createdAt: '2026-04-23T00:00:00.000Z',
+        accountId: 1,
+        integrationId: 3,
+        provider: 'github',
+        activityLogId: 'function-log-1',
+        connection: { id: 42, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2 },
+        functionName: 'native-webhook',
+        trigger: {
+            kind: 'http',
+            input: { hello: 'world' },
+            request: {
+                method: 'POST',
+                path: '/webhook/env/github-dev',
+                headers: { authorization: 'Bearer webhook-secret', 'x-hubspot-correlation-id': 'correlation-id' },
+                query: {},
+                body: '{ "hello": "world" }\n'
+            },
+            subscriptions: ['push'],
+            connection: { connectionId: 'conn-1', integrationId: 'github-dev' }
+        },
+        maxConcurrency: 1,
         ...overrides
     };
 }
@@ -54,17 +84,19 @@ function deferred<T>() {
 type SqsSendFn = (command: unknown) => Promise<unknown>;
 type SqsDestroyFn = () => void;
 type OrchestratorExecuteWebhookBatchFn = (props: unknown[]) => Promise<unknown>;
+type OrchestratorExecuteFunctionBatchFn = (props: unknown[]) => Promise<unknown>;
 
 interface Harness {
     consumer: DispatchQueueConsumer;
     sqsSend: Mock<SqsSendFn>;
     sqsDestroy: Mock<SqsDestroyFn>;
     orchestratorExecuteWebhookBatch: Mock<OrchestratorExecuteWebhookBatchFn>;
+    orchestratorExecuteFunctionBatch: Mock<OrchestratorExecuteFunctionBatchFn>;
 }
 
 function makeHarness(
     opts: {
-        messages?: WebhookDispatchMessage[];
+        messages?: DispatchMessage[];
         badBody?: string;
         consumerConcurrency?: number;
         maxAgeMs?: number;
@@ -104,7 +136,14 @@ function makeHarness(
     orchestratorExecuteWebhookBatch.mockImplementation((props: unknown[]) =>
         Promise.resolve(Ok(props.map((_, i) => Ok({ taskId: `task-${i}`, retryKey: `rk-${i}` }))))
     );
-    const orchestratorClient = { executeWebhookBatch: orchestratorExecuteWebhookBatch } as unknown as OrchestratorClient;
+    const orchestratorExecuteFunctionBatch = vi.fn<OrchestratorExecuteFunctionBatchFn>().mockImplementation((props: unknown[]) => {
+        const results = props.map((_, i) => Ok({ taskId: `function-task-${i}`, retryKey: `function-rk-${i}` }));
+        return Promise.resolve(Ok(results));
+    });
+    const orchestratorClient = {
+        executeWebhookBatch: orchestratorExecuteWebhookBatch,
+        executeFunctionBatch: orchestratorExecuteFunctionBatch
+    } as unknown as OrchestratorClient;
 
     const consumer = new DispatchQueueConsumer({
         sqs,
@@ -121,7 +160,7 @@ function makeHarness(
         taskCapDeferMs: opts.taskCapDeferMs ?? 15_000
     });
 
-    return { consumer, sqsSend, sqsDestroy, orchestratorExecuteWebhookBatch };
+    return { consumer, sqsSend, sqsDestroy, orchestratorExecuteWebhookBatch, orchestratorExecuteFunctionBatch };
 }
 
 function getVisibilityCalls(h: Harness) {
@@ -152,11 +191,7 @@ describe('DispatchQueueConsumer', () => {
     });
 
     it('sends all received messages in a single executeWebhookBatch call', async () => {
-        const msgs = [
-            buildMessage({ taskName: 'webhook:1', activityLogId: 'log-1' }),
-            buildMessage({ taskName: 'webhook:2', activityLogId: 'log-2' }),
-            buildMessage({ taskName: 'webhook:3', activityLogId: 'log-3' })
-        ];
+        const msgs = [buildMessage({ taskName: 'webhook:1' }), buildMessage({ taskName: 'webhook:2' }), buildMessage({ taskName: 'webhook:3' })];
         const h = makeHarness({ messages: msgs });
 
         await runOnce(h, () => {
@@ -169,8 +204,73 @@ describe('DispatchQueueConsumer', () => {
         expect(calledWith?.[0]).toMatchObject({
             name: 'webhook:1',
             group: { key: 'webhook:environment:2', maxConcurrency: 500 },
-            args: { webhookName: msgs[0]!.webhookName, activityLogId: 'log-1' }
+            args: { webhookName: msgs[0]!.webhookName }
         });
+    });
+
+    it('dispatches mixed legacy and function messages through their respective orchestrator methods', async () => {
+        const legacy = buildMessage({ taskName: 'webhook:1' });
+        const func = buildFunctionMessage({ idempotencyKey: 'function:1' });
+        const h = makeHarness({ messages: [legacy, func] });
+
+        await runOnce(h, () => {
+            expect(getDeleteCalls(h)).toHaveLength(2);
+        });
+
+        expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledOnce();
+        expect(h.orchestratorExecuteWebhookBatch.mock.calls[0]![0]).toHaveLength(1);
+        expect(h.orchestratorExecuteFunctionBatch).toHaveBeenCalledOnce();
+        expect(h.orchestratorExecuteFunctionBatch.mock.calls[0]![0]).toEqual([
+            expect.objectContaining({
+                name: 'function:1',
+                group: { key: 'function:environment:2:connection:42:function:native-webhook', maxConcurrency: 1 },
+                retry: { count: 0, max: 0 },
+                ownerKey: 'environment:2',
+                args: expect.objectContaining({
+                    functionName: 'native-webhook',
+                    connection: func.connection,
+                    trigger: func.trigger,
+                    async: true
+                })
+            })
+        ]);
+    });
+
+    it('dedupes repeated function idempotency keys before scheduling', async () => {
+        const messages = [buildFunctionMessage({ idempotencyKey: 'function:dup' }), buildFunctionMessage({ idempotencyKey: 'function:dup' })];
+        const h = makeHarness({ messages });
+
+        await runOnce(h, () => {
+            expect(getDeleteCalls(h)).toHaveLength(2);
+        });
+
+        expect(h.orchestratorExecuteFunctionBatch).toHaveBeenCalledOnce();
+        expect(h.orchestratorExecuteFunctionBatch.mock.calls[0]![0]).toHaveLength(1);
+        expect(h.orchestratorExecuteWebhookBatch).not.toHaveBeenCalled();
+    });
+
+    it('sends distinct function messages in a single executeFunctionBatch call', async () => {
+        const messages = [buildFunctionMessage({ idempotencyKey: 'function:one' }), buildFunctionMessage({ idempotencyKey: 'function:two' })];
+        const h = makeHarness({ messages });
+
+        await runOnce(h, () => {
+            expect(getDeleteCalls(h)).toHaveLength(2);
+        });
+
+        expect(h.orchestratorExecuteFunctionBatch).toHaveBeenCalledOnce();
+        const calledWith = h.orchestratorExecuteFunctionBatch.mock.calls[0]![0] as { name: string }[];
+        expect(calledWith.map(({ name }) => name)).toEqual(['function:one', 'function:two']);
+    });
+
+    it('keeps function messages for redelivery when the entire function batch fails', async () => {
+        const h = makeHarness({ messages: [buildFunctionMessage()] });
+        h.orchestratorExecuteFunctionBatch.mockResolvedValueOnce(Err({ name: 'boom', message: 'boom', payload: null }));
+
+        await runOnce(h, () => {
+            expect(h.orchestratorExecuteFunctionBatch).toHaveBeenCalledOnce();
+        });
+
+        expect(getDeleteCalls(h)).toHaveLength(0);
     });
 
     it('dedupes repeated task names in one receive, scheduling once and deleting every copy', async () => {

--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -4,12 +4,13 @@ import * as z from 'zod';
 import db from '@nangohq/database';
 import { logContextGetter } from '@nangohq/logs';
 import { accountService, configService, getPlan, getProvider } from '@nangohq/shared';
-import { flagHasPlan, metrics, zodErrorToHTTP } from '@nangohq/utils';
+import { flagHasPlan, getHeaders, metrics, redactHeaders, zodErrorToHTTP } from '@nangohq/utils';
 
 import { providerConfigKeySchema } from '../../../helpers/validation.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { routeWebhook } from '../../../webhook/webhook.manager.js';
 
+import type { WebhookRequest } from '../../../webhook/types.js';
 import type { DBPlan, PostPublicWebhook } from '@nangohq/types';
 
 const paramValidation = z
@@ -28,7 +29,6 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
 
     await tracer.trace('server.sync.receiveWebhook', async (span) => {
         const { environmentUuid, providerConfigKey }: PostPublicWebhook['Params'] = req.params;
-        const headers = req.headers;
 
         try {
             const resEnv = await accountService.getAccountContext({ environmentUuid });
@@ -83,17 +83,24 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
                 return acc;
             }, {});
 
-            const query = Object.keys(queryFiltered).length > 0 ? queryFiltered : undefined;
+            const rawHeaders = getHeaders(req.headers);
+            const request: WebhookRequest = {
+                method: 'POST',
+                path: req.path,
+                headers: redactHeaders({ headers: rawHeaders }),
+                query: queryFiltered,
+                body: req.body,
+                // The raw headers and body are included for signature verification.
+                rawHeaders,
+                rawBody: req.rawBody!
+            };
 
             const response = await routeWebhook({
                 environment,
                 account,
                 plan,
                 integration,
-                headers,
-                body: req.body,
-                rawBody: req.rawBody!,
-                ...(query !== undefined ? { query } : {}),
+                request,
                 logContextGetter
             });
 

--- a/packages/server/lib/webhook/affinity-webhook-routing.ts
+++ b/packages/server/lib/webhook/affinity-webhook-routing.ts
@@ -4,7 +4,7 @@ import type { affinityWebhookResponse, WebhookHandler } from './types.js';
 
 const route: WebhookHandler<affinityWebhookResponse> = async (nango, _headers, body, _rawBody) => {
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: body.type
     });
 

--- a/packages/server/lib/webhook/airtable-webhook-routing.ts
+++ b/packages/server/lib/webhook/airtable-webhook-routing.ts
@@ -7,7 +7,7 @@ const route: WebhookHandler<AirtableWebhookReference> = async (nango, _headers, 
     // able to route it correctly
     const editedBodyWithCatchAll = { ...body, type: '*' };
     const response = await nango.executeScriptForWebhooks({
-        body: editedBodyWithCatchAll,
+        payload: editedBodyWithCatchAll,
         webhookType: 'type',
         connectionIdentifier: 'webhook.id',
         propName: 'metadata.webhooks'

--- a/packages/server/lib/webhook/attio-webhook-routing.ts
+++ b/packages/server/lib/webhook/attio-webhook-routing.ts
@@ -97,7 +97,7 @@ const route: WebhookHandler<AttioWebhook> = async (nango, headers, body, rawBody
 
         try {
             const response = await nango.executeScriptForWebhooks({
-                body: event,
+                payload: event,
                 webhookType: 'event_type',
                 connectionIdentifier: 'id.workspace_id',
                 propName: 'workspace_id',

--- a/packages/server/lib/webhook/autotask-webhook-routing.ts
+++ b/packages/server/lib/webhook/autotask-webhook-routing.ts
@@ -52,7 +52,7 @@ const route: WebhookHandler<AutotaskWebhookPayload> = async (nango, headers, bod
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'EntityType',
         connectionIdentifier: 'Guid',
         propName: 'webhookGuid'

--- a/packages/server/lib/webhook/autotask-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/autotask-webhook-routing.unit.test.ts
@@ -40,6 +40,7 @@ describe('Autotask webhook routing', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -65,7 +66,7 @@ describe('Autotask webhook routing', () => {
         expect(result.isOk()).toBe(true);
         expect(mock).toHaveBeenCalledOnce();
         expect(mock).toHaveBeenCalledWith({
-            body,
+            payload: body,
             webhookType: 'EntityType',
             connectionIdentifier: 'Guid',
             propName: 'webhookGuid'
@@ -81,6 +82,7 @@ describe('Autotask webhook routing', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -107,7 +109,7 @@ describe('Autotask webhook routing', () => {
         expect(result.isOk()).toBe(true);
         expect(mock).toHaveBeenCalledOnce();
         expect(mock).toHaveBeenCalledWith({
-            body,
+            payload: body,
             webhookType: 'EntityType',
             connectionIdentifier: 'Guid',
             propName: 'webhookGuid'
@@ -123,6 +125,7 @@ describe('Autotask webhook routing', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -153,6 +156,7 @@ describe('Autotask webhook routing', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;

--- a/packages/server/lib/webhook/cal-com-webhook-routing.ts
+++ b/packages/server/lib/webhook/cal-com-webhook-routing.ts
@@ -40,7 +40,7 @@ const route: WebhookHandler = async (nango, headers, body, rawBody, query) => {
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'triggerEvent',
         connectionIdentifierValue,
         propName: 'connectionId'

--- a/packages/server/lib/webhook/calendly-webhook-routing.ts
+++ b/packages/server/lib/webhook/calendly-webhook-routing.ts
@@ -75,7 +75,7 @@ const route: WebhookHandler = async (nango, headers, body, rawBody) => {
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'event',
         connectionIdentifier: 'created_by',
         propName: 'owner'

--- a/packages/server/lib/webhook/checkr-partner-webhook-routing.ts
+++ b/packages/server/lib/webhook/checkr-partner-webhook-routing.ts
@@ -43,7 +43,7 @@ const route: WebhookHandler<CheckrBody> = async (nango, headers, body, rawBody) 
     const parsedBody = body;
 
     const response = await nango.executeScriptForWebhooks({
-        body: parsedBody,
+        payload: parsedBody,
         webhookType: 'type',
         connectionIdentifier: 'account_id',
         propName: 'checkr_account_id'

--- a/packages/server/lib/webhook/connectwise-psa-webhook-routing.ts
+++ b/packages/server/lib/webhook/connectwise-psa-webhook-routing.ts
@@ -134,7 +134,7 @@ const route: WebhookHandler<ConnectWisePsaWebhookPayload> = async (nango, header
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'Type',
         connectionIdentifier: 'ProductInstanceId',
         propName: 'metadata.productInstanceId'

--- a/packages/server/lib/webhook/dispatch-queue/publisher.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.ts
@@ -4,7 +4,7 @@ import tracer from 'dd-trace';
 import { chunk, metrics, report, runWithConcurrencyLimit } from '@nangohq/utils';
 
 import type { SendMessageBatchCommandOutput, SendMessageBatchRequestEntry, SQSClient } from '@aws-sdk/client-sqs';
-import type { WebhookDispatchMessage } from '@nangohq/types';
+import type { DispatchMessage } from '@nangohq/types';
 
 const SQS_BATCH_MAX_ENTRIES = 10;
 const DEFAULT_PUBLISH_CONCURRENCY = 10;
@@ -25,8 +25,8 @@ export interface PublishResult {
     failedActivityLogIds: string[];
 }
 
-export interface PreparedDispatchMessage {
-    message: WebhookDispatchMessage;
+export interface PreparedDispatchMessage<T extends DispatchMessage = DispatchMessage> {
+    message: T;
     byteSize: number;
     delaySeconds?: number;
 }

--- a/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
@@ -5,7 +5,7 @@ import { DispatchQueuePublisher } from './publisher.js';
 
 import type { PreparedDispatchMessage } from './publisher.js';
 import type { SendMessageBatchCommandOutput, SQSClient } from '@aws-sdk/client-sqs';
-import type { WebhookDispatchMessage } from '@nangohq/types';
+import type { LegacyDispatchMessage } from '@nangohq/types';
 import type { Mock } from 'vitest';
 
 const tracerMocks = vi.hoisted(() => {
@@ -68,7 +68,7 @@ vi.mock('@nangohq/utils', async (importOriginal) => {
     };
 });
 
-function buildMessage(overrides: Partial<WebhookDispatchMessage> = {}): WebhookDispatchMessage {
+function buildMessage(overrides: Partial<LegacyDispatchMessage> = {}): LegacyDispatchMessage {
     return {
         version: 1,
         kind: 'webhook',
@@ -90,7 +90,7 @@ function buildPreparedMessage({
     messageOverrides,
     byteSize
 }: {
-    messageOverrides?: Partial<WebhookDispatchMessage>;
+    messageOverrides?: Partial<LegacyDispatchMessage>;
     byteSize?: number;
 } = {}): PreparedDispatchMessage {
     const message = buildMessage(messageOverrides);

--- a/packages/server/lib/webhook/dispatch.ts
+++ b/packages/server/lib/webhook/dispatch.ts
@@ -1,0 +1,290 @@
+import { createHash } from 'node:crypto';
+
+import db from '@nangohq/database';
+import { functionConfigService, getSyncConfigsByConfigIdForWebhook } from '@nangohq/shared';
+import { metrics, report, runWithConcurrencyLimit } from '@nangohq/utils';
+
+import { envs } from '../env.js';
+import { dispatchQueuePublisher } from './dispatch-queue/client.js';
+import { SQS_BATCH_MAX_BYTES } from './dispatch-queue/publisher.js';
+import { prepareFunctionDispatchExecution } from './dispatchFunction.js';
+import { prepareLegacyDispatchExecution } from './dispatchLegacy.js';
+
+import type { DispatchQueuePublisher, PreparedDispatchMessage } from './dispatch-queue/publisher.js';
+import type { MatchedFunctionExecution } from './dispatchFunction.js';
+import type { LogContextGetter } from '@nangohq/logs';
+import type {
+    ConnectionInternal,
+    DBConnectionDecrypted,
+    DBEnvironment,
+    DBFunctionConfig,
+    DBFunctionConfigVersion,
+    DBIntegrationDecrypted,
+    DBTeam,
+    DispatchMessage,
+    HttpRequest
+} from '@nangohq/types';
+
+const LARGE_FANOUT_THRESHOLD = 10;
+const DISPATCH_PREPARATION_CONCURRENCY = 25;
+
+export type WebhookConnection = DBConnectionDecrypted | ConnectionInternal;
+
+export interface DispatchContext {
+    team: DBTeam;
+    environment: DBEnvironment;
+    integration: DBIntegrationDecrypted;
+    request: HttpRequest;
+    logContextGetter: LogContextGetter;
+}
+
+export type DirectDispatchSource = 'webhook' | 'oversized';
+
+export interface PreparedDispatchExecution<TMessage extends DispatchMessage = DispatchMessage> {
+    preparedMessage: PreparedDispatchMessage<TMessage>;
+    executeDirect: (source: DirectDispatchSource) => Promise<boolean>;
+    onQueued: () => Promise<void>;
+    onQueueFailure: () => Promise<void>;
+    onOversized: () => Promise<void>;
+}
+
+export interface WebhookFunction {
+    config: DBFunctionConfig;
+    currentVersion: DBFunctionConfigVersion;
+}
+
+export async function dispatchWebhookExecutions({
+    context,
+    connections,
+    payload,
+    type,
+    webhookHeaderValue,
+    delaySeconds
+}: {
+    context: DispatchContext;
+    connections: WebhookConnection[];
+    type: string | undefined;
+    webhookHeaderValue: string | undefined;
+    payload: Record<string, any>;
+    delaySeconds?: number;
+}): Promise<void> {
+    const [legacyFunctions, functions] = await Promise.all([
+        getSyncConfigsByConfigIdForWebhook(context.environment.id, context.integration.id!),
+        findWebhookFunctions(context)
+    ]);
+
+    const matchedLegacyExecutions = legacyFunctions.flatMap((syncConfig) => {
+        const webhook = findMatchingSubscription({ subscriptions: syncConfig.webhook_subscriptions, type, headerValue: webhookHeaderValue });
+        return webhook ? connections.map((connection) => ({ syncConfig, webhook, connection })) : [];
+    });
+
+    const matchedFunctionExecutions: MatchedFunctionExecution[] = functions.flatMap((func) => {
+        const trigger = func.currentVersion.trigger;
+        if (trigger.kind !== 'http') {
+            return [];
+        }
+
+        const subscription = findMatchingSubscription({ subscriptions: trigger.subscriptions, type, headerValue: webhookHeaderValue });
+        return subscription ? connections.map((connection) => ({ config: func.config, version: func.currentVersion, subscription, connection })) : [];
+    });
+
+    const preparationTasks: (() => Promise<PreparedDispatchExecution | null>)[] = [
+        ...matchedLegacyExecutions.map((execution) => () => prepareLegacyDispatchExecution({ context, execution, payload })),
+        ...matchedFunctionExecutions.map((execution) => () => prepareFunctionDispatchExecution({ context, execution, payload }))
+    ];
+    const preparationResults = await runWithConcurrencyLimit(preparationTasks, DISPATCH_PREPARATION_CONCURRENCY, (prepare) => prepare());
+    const executions = preparationResults.filter((execution): execution is PreparedDispatchExecution => execution !== null);
+
+    const publisher = envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE ? dispatchQueuePublisher : null;
+    if (publisher) {
+        await dispatchViaQueue({
+            context,
+            publisher,
+            executions,
+            matchedExecutionCount: matchedLegacyExecutions.length + matchedFunctionExecutions.length,
+            delaySeconds
+        });
+    } else {
+        await dispatchViaDirect({ context, executions, source: 'webhook' });
+    }
+}
+
+async function dispatchViaDirect({
+    context,
+    executions,
+    source
+}: {
+    context: DispatchContext;
+    executions: PreparedDispatchExecution[];
+    source: DirectDispatchSource;
+}): Promise<void> {
+    const successes = new Map<DispatchMessage['kind'], number>([
+        ['webhook', 0],
+        ['function', 0]
+    ]);
+    for (const execution of executions) {
+        if (await execution.executeDirect(source)) {
+            const kind = execution.preparedMessage.message.kind;
+            successes.set(kind, (successes.get(kind) || 0) + 1);
+        }
+    }
+    if (source === 'webhook') {
+        for (const [kind, count] of successes.entries()) {
+            metrics.increment(metrics.Types.WEBHOOK_DIRECT_TRIGGER_SUCCESS, count, {
+                kind,
+                provider: context.integration.provider,
+                providerConfigKey: context.integration.unique_key
+            });
+        }
+    }
+}
+
+export async function findWebhookFunctions(context: DispatchContext): Promise<WebhookFunction[]> {
+    const result = await functionConfigService.search(db.knex, {
+        environmentId: context.environment.id,
+        filter: {
+            integrationKey: context.integration.unique_key,
+            enabled: true,
+            trigger: { kind: 'http', hasSubscriptions: true }
+        }
+    });
+    if (result.isErr()) {
+        report(result.error, {
+            context: 'webhook function discovery failed',
+            provider: context.integration.provider,
+            accountId: context.team.id,
+            environmentId: context.environment.id,
+            integration: context.integration.unique_key
+        });
+    } else {
+        return result.value;
+    }
+    return [];
+}
+
+async function dispatchViaQueue({
+    context,
+    publisher,
+    executions,
+    matchedExecutionCount,
+    delaySeconds
+}: {
+    context: DispatchContext;
+    publisher: DispatchQueuePublisher;
+    executions: PreparedDispatchExecution[];
+    matchedExecutionCount: number;
+    delaySeconds: number | undefined;
+}): Promise<void> {
+    if (executions.length === 0) return;
+
+    if (matchedExecutionCount > LARGE_FANOUT_THRESHOLD) {
+        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_LARGE_FANOUT, 1, {
+            provider: context.integration.provider,
+            accountId: context.team.id,
+            environmentId: context.environment.id,
+            providerConfigKey: context.integration.unique_key
+        });
+    }
+
+    const queueEligibleExecutions = executions.filter(({ preparedMessage }) => preparedMessage.byteSize <= SQS_BATCH_MAX_BYTES);
+    const oversizedExecutions = executions.filter(({ preparedMessage }) => preparedMessage.byteSize > SQS_BATCH_MAX_BYTES);
+
+    const executionsByKind = new Map<DispatchMessage['kind'], PreparedDispatchExecution[]>();
+    for (const execution of queueEligibleExecutions) {
+        const kind = execution.preparedMessage.message.kind;
+        const group = executionsByKind.get(kind);
+        if (group) {
+            group.push(execution);
+        } else {
+            executionsByKind.set(kind, [execution]);
+        }
+    }
+
+    for (const group of executionsByKind.values()) {
+        await publishExecutions({ context, publisher, executions: group, delaySeconds });
+    }
+
+    if (oversizedExecutions.length > 0) {
+        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_BYPASS_OVERSIZE, oversizedExecutions.length, {
+            provider: context.integration.provider,
+            accountId: context.team.id,
+            environmentId: context.environment.id,
+            providerConfigKey: context.integration.unique_key
+        });
+
+        for (const execution of oversizedExecutions) {
+            void execution.onOversized();
+        }
+        await dispatchViaDirect({ context, executions: oversizedExecutions, source: 'oversized' });
+    }
+}
+
+async function publishExecutions({
+    context,
+    publisher,
+    executions,
+    delaySeconds
+}: {
+    context: DispatchContext;
+    publisher: DispatchQueuePublisher;
+    executions: PreparedDispatchExecution[];
+    delaySeconds: number | undefined;
+}): Promise<void> {
+    if (executions.length === 0) return;
+
+    const publishResult = await publisher.publish(
+        executions.map(({ preparedMessage }) => (delaySeconds === undefined ? preparedMessage : { ...preparedMessage, delaySeconds })),
+        `account:${context.team.id}:env:${context.environment.id}`
+    );
+    const failedActivityLogIds = new Set(publishResult.failedActivityLogIds);
+    const unmappedFailureCount = publishResult.failed - failedActivityLogIds.size;
+
+    for (const execution of executions) {
+        const activityLogId = execution.preparedMessage.message.activityLogId;
+        if (!failedActivityLogIds.has(activityLogId) && unmappedFailureCount === 0) {
+            void execution.onQueued();
+        } else {
+            await execution.onQueueFailure();
+        }
+    }
+
+    if (unmappedFailureCount > 0) {
+        report(new Error('webhook_dispatch_fanout_unmapped_failures'), {
+            unmappedFailureCount,
+            kind: executions[0]!.preparedMessage.message.kind,
+            accountId: context.team.id,
+            environmentId: context.environment.id
+        });
+    }
+}
+
+export function computeIdempotencyKey({
+    kind,
+    environmentId,
+    providerConfigKey,
+    executionName,
+    connectionId,
+    activityLogId
+}: {
+    kind: 'webhook' | 'function';
+    environmentId: number;
+    providerConfigKey: string;
+    executionName: string;
+    connectionId: number;
+    activityLogId: string;
+}): string {
+    const hash = createHash('sha256').update(`${kind}:${environmentId}:${providerConfigKey}:${executionName}:${connectionId}:${activityLogId}`).digest('hex');
+    return `${kind}:env:${environmentId}:connection:${connectionId}:${hash.slice(0, 32)}`;
+}
+
+function findMatchingSubscription({
+    subscriptions,
+    type,
+    headerValue
+}: {
+    subscriptions: string[] | null | undefined;
+    type: string | undefined;
+    headerValue: string | undefined;
+}): string | undefined {
+    return subscriptions?.find((subscription) => subscription === '*' || subscription === type || subscription === headerValue);
+}

--- a/packages/server/lib/webhook/dispatch.unit.test.ts
+++ b/packages/server/lib/webhook/dispatch.unit.test.ts
@@ -1,0 +1,514 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InternalNango } from './internal-nango.js';
+
+const mocks = vi.hoisted(() => {
+    return {
+        envs: {
+            WEBHOOK_INGRESS_USE_DISPATCH_QUEUE: true,
+            WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY: 7
+        },
+        dispatchQueueClient: { dispatchQueuePublisher: null as any },
+        triggerWebhook: vi.fn(),
+        invokeFunction: vi.fn(),
+        increment: vi.fn(),
+        report: vi.fn(),
+        metricsIncrement: vi.fn(),
+        getConnection: vi.fn(),
+        getConnectionsByEnvironmentAndConfig: vi.fn(),
+        getSyncConfigsByConfigIdForWebhook: vi.fn(),
+        functionConfigSearch: vi.fn(),
+        validateFunctionInput: vi.fn()
+    };
+});
+
+vi.mock('../env.js', () => ({ envs: mocks.envs }));
+vi.mock('./dispatch-queue/client.js', () => mocks.dispatchQueueClient);
+vi.mock('../utils/utils.js', () => ({ getOrchestrator: () => ({ triggerWebhook: mocks.triggerWebhook, invokeFunction: mocks.invokeFunction }) }));
+vi.mock('@nangohq/database', () => ({ default: { knex: {} } }));
+vi.mock('@nangohq/utils', async (importOriginal) => {
+    const actual = await importOriginal();
+
+    if (!actual || typeof actual !== 'object' || !('metrics' in actual)) {
+        throw new Error('Invalid @nangohq/utils mock: missing metrics export');
+    }
+
+    const { metrics } = actual;
+    if (!metrics || typeof metrics !== 'object' || !('Types' in metrics) || !metrics.Types || typeof metrics.Types !== 'object') {
+        throw new Error('Invalid @nangohq/utils mock: missing metrics.Types export');
+    }
+
+    return {
+        ...(actual as object),
+        report: mocks.report,
+        metrics: {
+            ...metrics,
+            Types: {
+                ...metrics.Types,
+                WEBHOOK_DIRECT_TRIGGER_SUCCESS: 'nango.webhook.direct_trigger.success',
+                WEBHOOK_DISPATCH_LARGE_FANOUT: 'nango.webhook.dispatch_queue.large_fanout',
+                WEBHOOK_DISPATCH_BYPASS_OVERSIZE: 'nango.webhook.dispatch_queue.bypass_oversize'
+            },
+            increment: mocks.increment
+        }
+    };
+});
+vi.mock('@nangohq/shared', () => {
+    class NangoError extends Error {
+        public payload: Record<string, unknown>;
+
+        constructor(type: string, payload: Record<string, unknown>) {
+            super(type);
+            this.name = type;
+            this.payload = payload;
+        }
+    }
+
+    return {
+        NangoError,
+        connectionService: {
+            getConnection: mocks.getConnection,
+            getConnectionsByEnvironmentAndConfig: mocks.getConnectionsByEnvironmentAndConfig
+        },
+        getSyncConfigsByConfigIdForWebhook: mocks.getSyncConfigsByConfigIdForWebhook,
+        functionConfigService: { search: mocks.functionConfigSearch },
+        getFunctionMaxConcurrency: (version: any) => (version.limits?.concurrency?.perConnection === 1 ? 1 : 0),
+        validateFunctionInput: mocks.validateFunctionInput
+    };
+});
+
+function createLogCtx(id: string) {
+    return {
+        id,
+        operation: { id },
+        attachSpan: vi.fn(),
+        info: vi.fn().mockResolvedValue(true),
+        warn: vi.fn().mockResolvedValue(true),
+        error: vi.fn().mockResolvedValue(true),
+        enrichOperation: vi.fn().mockResolvedValue(undefined),
+        failed: vi.fn().mockResolvedValue(undefined)
+    };
+}
+
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+function makeInternalNango(logContexts: ReturnType<typeof createLogCtx>[], logContextGetterOverride?: any) {
+    return new InternalNango({
+        team: { id: 1 } as any,
+        environment: { id: 2 } as any,
+        integration: { id: 3, unique_key: 'github-dev', provider: 'github' } as any,
+        request: {
+            method: 'POST',
+            path: '/webhook/env/github-dev',
+            headers: {
+                'content-type': 'application/json',
+                'x-github-event': 'push'
+            },
+            query: {},
+            body: { event: 'x' }
+        },
+        logContextGetter: (logContextGetterOverride ?? {
+            create: vi.fn().mockImplementation(() => {
+                const next = logContexts.shift();
+                if (!next) {
+                    throw new Error('Missing log context');
+                }
+                return next;
+            })
+        }) as any
+    });
+}
+
+function nativeFunction({
+    subscriptions = ['push'],
+    inputSchemaRef = '#/definitions/Input'
+}: { subscriptions?: string[]; inputSchemaRef?: string | null } = {}) {
+    return {
+        integration: { id: 3, unique_key: 'github-dev', provider: 'github' },
+        config: { id: 31, name: 'native-webhook', enabled: true },
+        currentVersion: {
+            id: 32,
+            trigger: { kind: 'http', subscriptions },
+            limits: { concurrency: { perConnection: 1 } },
+            input_schema_ref: inputSchemaRef
+        }
+    };
+}
+
+describe('webhook dispatch', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.increment.mockClear();
+        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = true;
+        mocks.dispatchQueueClient.dispatchQueuePublisher = null;
+        mocks.getConnection.mockResolvedValue({
+            success: true,
+            response: { connection_id: 'conn-1', metadata: { webhookSecret: 'secret' } }
+        });
+        mocks.getConnectionsByEnvironmentAndConfig.mockResolvedValue([
+            { id: 11, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2, metadata: null },
+            { id: 12, connection_id: 'conn-2', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
+        ]);
+        mocks.getSyncConfigsByConfigIdForWebhook.mockResolvedValue([{ id: 21, sync_name: 'sync-1', webhook_subscriptions: ['push'] }]);
+        mocks.triggerWebhook.mockResolvedValue({ isErr: () => false });
+        mocks.invokeFunction.mockResolvedValue({ isErr: () => false });
+        mocks.functionConfigSearch.mockResolvedValue({ isErr: () => false, value: [] });
+        mocks.validateFunctionInput.mockImplementation((_version, input) => ({ isErr: () => false, value: input }));
+    });
+
+    it('falls back to direct orchestrator dispatch when the feature flag is off', async () => {
+        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = false;
+        const publisher = { publish: vi.fn() };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const nango = makeInternalNango([createLogCtx('log-1'), createLogCtx('log-2')]);
+
+        const result = await nango.executeScriptForWebhooks({ payload: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
+        expect(publisher.publish).not.toHaveBeenCalled();
+        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 2, {
+            kind: 'webhook',
+            provider: 'github',
+            providerConfigKey: 'github-dev'
+        });
+        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 0, {
+            kind: 'function',
+            provider: 'github',
+            providerConfigKey: 'github-dev'
+        });
+    });
+
+    it('queues function executions when queue dispatch is enabled', async () => {
+        mocks.getSyncConfigsByConfigIdForWebhook.mockResolvedValue([]);
+        mocks.functionConfigSearch.mockResolvedValue({ isErr: () => false, value: [nativeFunction()] });
+        const publisher = { publish: vi.fn().mockResolvedValue({ enqueued: 2, failed: 0, failedActivityLogIds: [] }) };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+        const nango = makeInternalNango([createLogCtx('log-1'), createLogCtx('log-2')]);
+
+        await nango.executeScriptForWebhooks({ payload: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(mocks.invokeFunction).not.toHaveBeenCalled();
+        expect(publisher.publish).toHaveBeenCalledOnce();
+        const messages = publisher.publish.mock.calls[0]![0].map((prepared: any) => prepared.message);
+        expect(messages).toHaveLength(2);
+        expect(messages).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    kind: 'function',
+                    functionName: 'native-webhook',
+                    idempotencyKey: expect.stringMatching(/^function:env:2:connection:/),
+                    maxConcurrency: 1,
+                    trigger: expect.objectContaining({ kind: 'http', subscriptions: ['push'] })
+                })
+            ])
+        );
+        expect(messages[0].trigger.request).toEqual({
+            method: 'POST',
+            path: '/webhook/env/github-dev',
+            headers: {
+                'content-type': 'application/json',
+                'x-github-event': 'push'
+            },
+            query: {},
+            body: { event: 'x' }
+        });
+    });
+
+    it('applies a requested queue delay to legacy and function executions', async () => {
+        mocks.functionConfigSearch.mockResolvedValue({ isErr: () => false, value: [nativeFunction()] });
+        const publisher = { publish: vi.fn().mockResolvedValue({ enqueued: 4, failed: 0, failedActivityLogIds: [] }) };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+        const nango = makeInternalNango([createLogCtx('legacy-1'), createLogCtx('legacy-2'), createLogCtx('function-1'), createLogCtx('function-2')]);
+
+        await nango.executeScriptForWebhooks({ payload: { event: 'x' }, webhookTypeValue: 'push', delaySeconds: 7 });
+
+        expect(publisher.publish).toHaveBeenCalledTimes(2);
+        expect(publisher.publish.mock.calls.flatMap(([messages]) => messages)).toEqual([
+            expect.objectContaining({ delaySeconds: 7, message: expect.objectContaining({ kind: 'webhook' }) }),
+            expect.objectContaining({ delaySeconds: 7, message: expect.objectContaining({ kind: 'webhook' }) }),
+            expect.objectContaining({ delaySeconds: 7, message: expect.objectContaining({ kind: 'function' }) }),
+            expect.objectContaining({ delaySeconds: 7, message: expect.objectContaining({ kind: 'function' }) })
+        ]);
+    });
+
+    it('dispatches oversized messages directly to the orchestrator', async () => {
+        const publisher = { publish: vi.fn() };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const logCtx1 = createLogCtx('log-1');
+        const logCtx2 = createLogCtx('log-2');
+        const nango = makeInternalNango([logCtx1, logCtx2]);
+
+        const result = await nango.executeScriptForWebhooks({ payload: { x: 'x'.repeat(1_100_000) }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).not.toHaveBeenCalled();
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
+        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.bypass_oversize', 2, {
+            provider: 'github',
+            accountId: 1,
+            environmentId: 2,
+            providerConfigKey: 'github-dev'
+        });
+        expect(logCtx1.warn).toHaveBeenCalledWith(
+            'The webhook payload exceeds the queue size limit and will be dispatched directly',
+            expect.objectContaining({ connection: 'conn-1' })
+        );
+        expect(logCtx2.warn).toHaveBeenCalledWith(
+            'The webhook payload exceeds the queue size limit and will be dispatched directly',
+            expect.objectContaining({ connection: 'conn-2' })
+        );
+        expect(mocks.increment).not.toHaveBeenCalledWith('nango.webhook.direct_trigger.success', expect.anything(), expect.anything());
+    });
+
+    it('logs queued successes and marks failed publishes as failed operations', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 1, failedActivityLogIds: ['log-2'] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const logCtx1 = createLogCtx('log-1');
+        const logCtx2 = createLogCtx('log-2');
+        const nango = makeInternalNango([logCtx1, logCtx2]);
+
+        const result = await nango.executeScriptForWebhooks({ payload: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).toHaveBeenCalledTimes(1);
+        expect(logCtx1.info).toHaveBeenCalledWith('The webhook was successfully queued for execution', {
+            action: 'push',
+            connection: 'conn-1',
+            integration: 'github-dev'
+        });
+        expect(logCtx2.error).toHaveBeenCalledWith('The webhook failed to queue for execution', {
+            error: expect.any(Error),
+            webhook: 'push',
+            connection: 'conn-2',
+            integration: 'github-dev'
+        });
+        expect(logCtx2.enrichOperation).toHaveBeenCalledWith({ error: expect.any(Error) });
+        expect(logCtx2.failed).toHaveBeenCalledOnce();
+    });
+
+    it('continues direct orchestrator dispatch when one execution fails', async () => {
+        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = false;
+        const publisher = { publish: vi.fn() };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+        mocks.triggerWebhook
+            .mockResolvedValueOnce({ isErr: () => false })
+            .mockResolvedValueOnce({ isErr: () => true, error: new Error('orchestrator unavailable') });
+
+        const nango = makeInternalNango([createLogCtx('log-1'), createLogCtx('log-2')]);
+
+        const result = await nango.executeScriptForWebhooks({ payload: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
+        expect(publisher.publish).not.toHaveBeenCalled();
+        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 1, {
+            kind: 'webhook',
+            provider: 'github',
+            providerConfigKey: 'github-dev'
+        });
+    });
+
+    it('creates log contexts concurrently before publishing queue messages', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 2, failed: 0, failedActivityLogIds: [] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const blockers = [deferred<void>(), deferred<void>()];
+        const contexts = [createLogCtx('log-1'), createLogCtx('log-2')];
+        let createIndex = 0;
+        let inFlight = 0;
+        let maxInFlight = 0;
+        const logContextGetter = {
+            create: vi.fn().mockImplementation(async () => {
+                const index = createIndex++;
+                inFlight += 1;
+                maxInFlight = Math.max(maxInFlight, inFlight);
+                await blockers[index]!.promise;
+                inFlight -= 1;
+                return contexts[index]!;
+            })
+        };
+        const nango = makeInternalNango([], logContextGetter);
+
+        const execution = nango.executeScriptForWebhooks({ payload: { event: 'x' }, webhookTypeValue: 'push' });
+
+        await vi.waitFor(() => {
+            expect(logContextGetter.create).toHaveBeenCalledTimes(2);
+        });
+        expect(maxInFlight).toBe(2);
+
+        blockers[0]!.resolve();
+        blockers[1]!.resolve();
+
+        const result = await execution;
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).toHaveBeenCalledOnce();
+    });
+
+    it('publishes successful executions even when one log context creation fails', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 0, failedActivityLogIds: [] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const logCtx = createLogCtx('log-2');
+        const logContextGetter = {
+            create: vi.fn().mockRejectedValueOnce(new Error('transient db failure')).mockResolvedValueOnce(logCtx)
+        };
+        const nango = makeInternalNango([], logContextGetter);
+
+        const result = await nango.executeScriptForWebhooks({ payload: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).toHaveBeenCalledTimes(1);
+        expect(publisher.publish).toHaveBeenCalledWith(
+            [
+                expect.objectContaining({
+                    message: expect.objectContaining({
+                        activityLogId: 'log-2',
+                        webhookName: 'push',
+                        connection: expect.objectContaining({ connection_id: 'conn-2' })
+                    })
+                })
+            ],
+            'account:1:env:2'
+        );
+        expect(logCtx.info).toHaveBeenCalledWith('The webhook was successfully queued for execution', {
+            action: 'push',
+            connection: 'conn-2',
+            integration: 'github-dev'
+        });
+        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), {
+            error: 'The webhook could not be prepared for dispatch',
+            provider: 'github',
+            accountId: 1,
+            environmentId: 2,
+            syncConfigId: 21,
+            syncName: 'sync-1',
+            webhook: 'push',
+            connectionId: 11,
+            connection: 'conn-1',
+            integration: 'github-dev'
+        });
+    });
+
+    it('fails the log context when queue preparation fails after creation', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 0, failedActivityLogIds: [] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const failedLogCtx = createLogCtx('log-1');
+        failedLogCtx.attachSpan.mockImplementation(() => {
+            throw new Error('attach span failed');
+        });
+        const successfulLogCtx = createLogCtx('log-2');
+        const nango = makeInternalNango([failedLogCtx, successfulLogCtx]);
+
+        const result = await nango.executeScriptForWebhooks({ payload: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).toHaveBeenCalledWith(
+            [
+                expect.objectContaining({
+                    message: expect.objectContaining({
+                        activityLogId: 'log-2',
+                        connection: expect.objectContaining({ connection_id: 'conn-2' })
+                    })
+                })
+            ],
+            'account:1:env:2'
+        );
+        expect(failedLogCtx.error).toHaveBeenCalledWith('The webhook failed during queue preparation', {
+            error: expect.any(Error),
+            webhook: 'push',
+            connection: 'conn-1',
+            integration: 'github-dev'
+        });
+        expect(failedLogCtx.enrichOperation).toHaveBeenCalledWith({ error: expect.any(Error) });
+        expect(failedLogCtx.failed).toHaveBeenCalledOnce();
+        expect(successfulLogCtx.info).toHaveBeenCalledWith('The webhook was successfully queued for execution', {
+            action: 'push',
+            connection: 'conn-2',
+            integration: 'github-dev'
+        });
+    });
+
+    it('marks all executions as failed and reports when publish has unmapped failures', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 0, failed: 2, failedActivityLogIds: [] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const logCtx1 = createLogCtx('log-1');
+        const logCtx2 = createLogCtx('log-2');
+        const nango = makeInternalNango([logCtx1, logCtx2]);
+
+        await nango.executeScriptForWebhooks({ payload: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(logCtx1.info).not.toHaveBeenCalled();
+        expect(logCtx2.info).not.toHaveBeenCalled();
+        expect(logCtx1.failed).toHaveBeenCalledOnce();
+        expect(logCtx2.failed).toHaveBeenCalledOnce();
+        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), {
+            unmappedFailureCount: 2,
+            kind: 'webhook',
+            accountId: 1,
+            environmentId: 2
+        });
+    });
+
+    it('reports but does not rethrow when oversized direct dispatch fails', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 0, failedActivityLogIds: [] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+        // triggerWebhook returns Err (never rejects) — logCtx.error/failed handled internally by triggerWebhook
+        mocks.triggerWebhook.mockResolvedValue({ isErr: () => true, error: new Error('orchestrator unavailable') });
+
+        mocks.getConnectionsByEnvironmentAndConfig.mockResolvedValue([
+            { id: 11, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
+        ]);
+        const nango = makeInternalNango([createLogCtx('log-1')]);
+
+        await expect(nango.executeScriptForWebhooks({ payload: { x: 'x'.repeat(1_100_000) }, webhookTypeValue: 'push' })).resolves.not.toThrow();
+
+        expect(publisher.publish).not.toHaveBeenCalled();
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(1);
+        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ context: 'oversized webhook direct dispatch failed' }));
+    });
+
+    it('only reports for the failing connection when oversize dispatch partially succeeds', async () => {
+        const publisher = { publish: vi.fn() };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+        // First call succeeds, second call returns Err — logCtx handling is triggerWebhook's responsibility
+        mocks.triggerWebhook
+            .mockResolvedValueOnce({ isErr: () => false })
+            .mockResolvedValueOnce({ isErr: () => true, error: new Error('orchestrator unavailable') });
+
+        const nango = makeInternalNango([createLogCtx('log-1'), createLogCtx('log-2')]);
+
+        await expect(nango.executeScriptForWebhooks({ payload: { x: 'x'.repeat(1_100_000) }, webhookTypeValue: 'push' })).resolves.not.toThrow();
+
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
+        // Only the failing connection triggers a report; the successful one does not
+        expect(mocks.report).toHaveBeenCalledTimes(1);
+        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ context: 'oversized webhook direct dispatch failed' }));
+    });
+});

--- a/packages/server/lib/webhook/dispatchFunction.ts
+++ b/packages/server/lib/webhook/dispatchFunction.ts
@@ -1,0 +1,243 @@
+import { LogContextOrigin, OtlpSpan } from '@nangohq/logs';
+import { getFunctionMaxConcurrency, NangoError, validateFunctionInput } from '@nangohq/shared';
+import { errorToObject, truncateJson } from '@nangohq/utils';
+
+import { getOrchestrator } from '../utils/utils.js';
+import { computeIdempotencyKey } from './dispatch.js';
+
+import type { DispatchContext, PreparedDispatchExecution, WebhookConnection } from './dispatch.js';
+import type { LogContext } from '@nangohq/logs';
+import type { DBFunctionConfig, DBFunctionConfigVersion, FunctionDispatchMessage, FunctionTrigger } from '@nangohq/types';
+
+export interface MatchedFunctionExecution {
+    config: DBFunctionConfig;
+    version: DBFunctionConfigVersion;
+    subscription: string;
+    connection: WebhookConnection;
+}
+
+interface PreparedFunctionExecution extends MatchedFunctionExecution {
+    logCtx: LogContext;
+    trigger: Extract<FunctionTrigger, { kind: 'http' }> & {
+        subscriptions: string[];
+        connection: NonNullable<Extract<FunctionTrigger, { kind: 'http' }>['connection']>;
+    };
+    maxConcurrency: number;
+}
+
+export async function prepareFunctionDispatchExecution({
+    context,
+    execution,
+    payload
+}: {
+    context: DispatchContext;
+    execution: MatchedFunctionExecution;
+    payload: Record<string, any>;
+}): Promise<PreparedDispatchExecution<FunctionDispatchMessage> | null> {
+    const preparedExecution = await prepareFunctionExecution({ context, execution, payload });
+    if (!preparedExecution) return null;
+
+    const message: FunctionDispatchMessage = {
+        version: 1,
+        kind: 'function',
+        idempotencyKey: computeIdempotencyKey({
+            kind: 'function',
+            environmentId: context.environment.id,
+            providerConfigKey: context.integration.unique_key,
+            executionName: preparedExecution.config.name,
+            connectionId: preparedExecution.connection.id,
+            activityLogId: preparedExecution.logCtx.id
+        }),
+        createdAt: new Date().toISOString(),
+        accountId: context.team.id,
+        integrationId: context.integration.id!,
+        provider: context.integration.provider,
+        activityLogId: preparedExecution.logCtx.id,
+        connection: {
+            id: preparedExecution.connection.id,
+            connection_id: preparedExecution.connection.connection_id,
+            provider_config_key: preparedExecution.connection.provider_config_key,
+            environment_id: preparedExecution.connection.environment_id
+        },
+        functionName: preparedExecution.config.name,
+        trigger: {
+            kind: 'http',
+            input: preparedExecution.trigger.input,
+            request: preparedExecution.trigger.request,
+            subscriptions: preparedExecution.trigger.subscriptions,
+            connection: preparedExecution.trigger.connection
+        },
+        maxConcurrency: preparedExecution.maxConcurrency
+    };
+    let byteSize: number | undefined;
+
+    return {
+        preparedMessage: {
+            message,
+            // Only serialize the payload when needed to compute the byte size
+            get byteSize() {
+                byteSize ??= Buffer.byteLength(JSON.stringify(message), 'utf8');
+                return byteSize;
+            }
+        },
+        executeDirect: () => executeFunctionDirect({ context, execution: preparedExecution }),
+        onQueued: async () => {
+            await preparedExecution.logCtx.info('The function was successfully queued for execution', {
+                function: message.functionName,
+                connection: message.connection.connection_id,
+                integration: message.connection.provider_config_key
+            });
+        },
+        onQueueFailure: () =>
+            handleFunctionDispatchFailure({
+                execution: preparedExecution,
+                error: new NangoError('function_failure', {
+                    error: 'The function could not be queued for execution',
+                    idempotencyKey: message.idempotencyKey
+                }),
+                logCtx: preparedExecution.logCtx,
+                message: 'The function failed to queue for execution'
+            }),
+        onOversized: async () => {
+            await preparedExecution.logCtx
+                .warn('The function payload exceeds the queue size limit and will be dispatched directly', {
+                    function: preparedExecution.config.name,
+                    connection: preparedExecution.connection.connection_id,
+                    integration: preparedExecution.connection.provider_config_key
+                })
+                .catch(() => {
+                    // Logging is best effort. Catch and do not throw the logging failure.
+                });
+        }
+    } satisfies PreparedDispatchExecution<FunctionDispatchMessage>;
+}
+
+async function prepareFunctionExecution({
+    context,
+    execution,
+    payload
+}: {
+    context: DispatchContext;
+    execution: MatchedFunctionExecution;
+    payload: Record<string, any>;
+}): Promise<PreparedFunctionExecution | null> {
+    let logCtx: LogContext | undefined;
+
+    try {
+        logCtx = await context.logContextGetter.create(
+            { operation: { type: 'function', action: 'invoke' }, expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() },
+            {
+                account: context.team,
+                environment: context.environment,
+                integration: { id: context.integration.id!, name: context.integration.unique_key, provider: context.integration.provider },
+                connection: { id: execution.connection.id, name: execution.connection.connection_id },
+                syncConfig: { id: execution.version.id, name: execution.config.name },
+                meta: { source: 'webhook', subscription: execution.subscription, ...truncateJson({ input: payload }) }
+            }
+        );
+        if (logCtx instanceof LogContextOrigin) {
+            logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+        }
+
+        // a function that declares no input schema receives no trigger.input.
+        // The payload can be read from trigger.request.
+        const validation = validateFunctionInput(execution.version, execution.version.input_schema_ref ? payload : undefined);
+        if (validation.isErr()) {
+            await handleFunctionDispatchFailure({
+                execution,
+                error: validation.error,
+                logCtx,
+                message: 'The function input failed validation during webhook dispatch preparation'
+            });
+            return null;
+        }
+
+        const trigger = execution.version.trigger;
+        if (trigger.kind !== 'http') {
+            throw new NangoError('function_failure', { error: 'The function no longer has an HTTP trigger' });
+        }
+
+        return {
+            ...execution,
+            logCtx,
+            trigger: {
+                kind: 'http',
+                input: validation.value,
+                request: context.request,
+                subscriptions: [execution.subscription],
+                connection: {
+                    connectionId: execution.connection.connection_id,
+                    integrationId: context.integration.unique_key
+                }
+            },
+            maxConcurrency: getFunctionMaxConcurrency(execution.version)
+        };
+    } catch (err) {
+        await handleFunctionDispatchFailure({
+            execution,
+            error: err,
+            logCtx,
+            message: 'The function failed during webhook dispatch preparation'
+        });
+        return null;
+    }
+}
+
+async function executeFunctionDirect({ context, execution }: { context: DispatchContext; execution: PreparedFunctionExecution }): Promise<boolean> {
+    try {
+        const result = await getOrchestrator().invokeFunction({
+            environment: context.environment,
+            connection: execution.connection,
+            functionName: execution.config.name,
+            trigger: execution.trigger,
+            async: true,
+            retryMax: 0,
+            maxConcurrency: execution.maxConcurrency,
+            logCtx: execution.logCtx
+        });
+
+        if (result.isErr()) {
+            await handleFunctionDispatchFailure({
+                execution,
+                error: result.error,
+                logCtx: execution.logCtx,
+                message: 'The function failed to schedule from the webhook'
+            });
+            return false;
+        }
+
+        return true;
+    } catch (err) {
+        await handleFunctionDispatchFailure({
+            execution,
+            error: err,
+            logCtx: execution.logCtx,
+            message: 'The function failed to schedule from the webhook'
+        });
+        return false;
+    }
+}
+
+async function handleFunctionDispatchFailure({
+    execution,
+    error,
+    logCtx,
+    message
+}: {
+    execution: MatchedFunctionExecution;
+    error: unknown;
+    logCtx: LogContext | undefined;
+    message: string;
+}): Promise<void> {
+    const formattedError = error instanceof NangoError ? error : new NangoError('function_failure', { error: errorToObject(error) });
+
+    await logCtx?.error(message, {
+        error,
+        function: execution.config.name,
+        subscription: execution.subscription,
+        connection: execution.connection.connection_id,
+        integration: execution.connection.provider_config_key
+    });
+    await logCtx?.enrichOperation({ error: formattedError });
+    await logCtx?.failed();
+}

--- a/packages/server/lib/webhook/dispatchLegacy.ts
+++ b/packages/server/lib/webhook/dispatchLegacy.ts
@@ -1,0 +1,224 @@
+import { OtlpSpan } from '@nangohq/logs';
+import { NangoError } from '@nangohq/shared';
+import { errorToObject, report } from '@nangohq/utils';
+
+import { envs } from '../env.js';
+import { getOrchestrator } from '../utils/utils.js';
+import { computeIdempotencyKey } from './dispatch.js';
+
+import type { DirectDispatchSource, DispatchContext, PreparedDispatchExecution, WebhookConnection } from './dispatch.js';
+import type { LogContextGetter } from '@nangohq/logs';
+import type { DBSyncConfig, LegacyDispatchMessage } from '@nangohq/types';
+
+export interface MatchedLegacyExecution {
+    syncConfig: DBSyncConfig;
+    webhook: string;
+    connection: WebhookConnection;
+}
+
+export async function prepareLegacyDispatchExecution({
+    context,
+    execution,
+    payload
+}: {
+    context: DispatchContext;
+    execution: MatchedLegacyExecution;
+    payload: Record<string, any>;
+}): Promise<PreparedDispatchExecution<LegacyDispatchMessage> | null> {
+    const { syncConfig, webhook, connection } = execution;
+    let logCtx: Awaited<ReturnType<LogContextGetter['create']>>;
+
+    try {
+        logCtx = await context.logContextGetter.create(
+            { operation: { type: 'webhook', action: 'incoming' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
+            {
+                account: context.team,
+                environment: context.environment,
+                integration: { id: context.integration.id!, name: context.integration.unique_key, provider: context.integration.provider },
+                connection: { id: connection.id, name: connection.connection_id },
+                syncConfig: { id: syncConfig.id, name: syncConfig.sync_name }
+            }
+        );
+    } catch (err) {
+        await handleLegacyPreparationFailure({ context, execution, error: err });
+        return null;
+    }
+
+    try {
+        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
+        const message: LegacyDispatchMessage = {
+            version: 1,
+            kind: 'webhook',
+            taskName: computeIdempotencyKey({
+                kind: 'webhook',
+                environmentId: context.environment.id,
+                providerConfigKey: context.integration.unique_key,
+                executionName: syncConfig.sync_name,
+                connectionId: connection.id,
+                activityLogId: logCtx.id
+            }),
+            createdAt: new Date().toISOString(),
+            accountId: context.team.id,
+            integrationId: context.integration.id!,
+            provider: context.integration.provider,
+            parentSyncName: syncConfig.sync_name,
+            activityLogId: logCtx.id,
+            webhookName: webhook,
+            connection: {
+                id: connection.id,
+                connection_id: connection.connection_id,
+                provider_config_key: connection.provider_config_key,
+                environment_id: connection.environment_id
+            },
+            payload
+        };
+        let byteSize: number | undefined;
+
+        return {
+            preparedMessage: {
+                message,
+                // Only serialize the payload when needed to compute the byte size
+                get byteSize() {
+                    byteSize ??= Buffer.byteLength(JSON.stringify(message), 'utf8');
+                    return byteSize;
+                }
+            },
+            executeDirect: (source) => executeLegacyDirect({ context, execution, payload, logCtx, source }),
+            onQueued: async () => {
+                await logCtx.info('The webhook was successfully queued for execution', {
+                    action: message.webhookName,
+                    connection: message.connection.connection_id,
+                    integration: message.connection.provider_config_key
+                });
+            },
+            onQueueFailure: async () => {
+                const error = new NangoError('webhook_failure', {
+                    error: 'The webhook could not be queued for execution',
+                    taskName: message.taskName
+                });
+
+                await logCtx.error('The webhook failed to queue for execution', {
+                    error,
+                    webhook: message.webhookName,
+                    connection: message.connection.connection_id,
+                    integration: message.connection.provider_config_key
+                });
+                await logCtx.enrichOperation({ error });
+                await logCtx.failed();
+            },
+            onOversized: async () => {
+                await logCtx
+                    .warn('The webhook payload exceeds the queue size limit and will be dispatched directly', {
+                        action: message.webhookName,
+                        connection: message.connection.connection_id,
+                        integration: message.connection.provider_config_key
+                    })
+                    .catch(() => {
+                        // Logging is best effort. Catch and do not throw the logging failure.
+                    });
+            }
+        };
+    } catch (err) {
+        await handleLegacyPreparationFailure({ context, execution, error: err, logCtx });
+        return null;
+    }
+}
+
+async function handleLegacyPreparationFailure({
+    context,
+    execution,
+    error,
+    logCtx
+}: {
+    context: DispatchContext;
+    execution: MatchedLegacyExecution;
+    error: unknown;
+    logCtx?: Awaited<ReturnType<LogContextGetter['create']>>;
+}): Promise<void> {
+    const formattedError = error instanceof NangoError ? error : new NangoError('webhook_failure', { error: errorToObject(error) });
+
+    await logCtx?.error('The webhook failed during queue preparation', {
+        error,
+        webhook: execution.webhook,
+        connection: execution.connection.connection_id,
+        integration: execution.connection.provider_config_key
+    });
+    await logCtx?.enrichOperation({ error: formattedError });
+    await logCtx?.failed();
+
+    report(error, {
+        error: 'The webhook could not be prepared for dispatch',
+        provider: context.integration.provider,
+        accountId: context.team.id,
+        environmentId: context.environment.id,
+        syncConfigId: execution.syncConfig.id,
+        syncName: execution.syncConfig.sync_name,
+        webhook: execution.webhook,
+        connectionId: execution.connection.id,
+        connection: execution.connection.connection_id,
+        integration: execution.connection.provider_config_key
+    });
+}
+
+async function executeLegacyDirect({
+    context,
+    execution,
+    payload,
+    logCtx,
+    source
+}: {
+    context: DispatchContext;
+    execution: MatchedLegacyExecution;
+    payload: Record<string, any>;
+    logCtx: Awaited<ReturnType<LogContextGetter['create']>>;
+    source: DirectDispatchSource;
+}): Promise<boolean> {
+    try {
+        const result = await getOrchestrator().triggerWebhook({
+            connection: execution.connection,
+            webhookName: execution.webhook,
+            syncConfig: execution.syncConfig,
+            input: payload,
+            maxConcurrency: envs.WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY,
+            logCtx
+        });
+
+        if (result.isErr()) {
+            reportOversizedFailure({ context, execution, error: result.error, source });
+            return false;
+        }
+
+        return true;
+    } catch (err) {
+        reportOversizedFailure({ context, execution, error: err, source });
+        return false;
+    }
+}
+
+function reportOversizedFailure({
+    context,
+    execution,
+    error,
+    source
+}: {
+    context: DispatchContext;
+    execution: MatchedLegacyExecution;
+    error: unknown;
+    source: DirectDispatchSource;
+}): void {
+    if (source !== 'oversized' || (error instanceof NangoError && error.type === 'webhook_rate_limit_exceeded')) return;
+
+    report(error, {
+        context: 'oversized webhook direct dispatch failed',
+        provider: context.integration.provider,
+        accountId: context.team.id,
+        environmentId: context.environment.id,
+        syncConfigId: execution.syncConfig.id,
+        syncName: execution.syncConfig.sync_name,
+        webhook: execution.webhook,
+        connectionId: execution.connection.id,
+        connection: execution.connection.connection_id,
+        integration: execution.connection.provider_config_key
+    });
+}

--- a/packages/server/lib/webhook/fathom-webhook-routing.ts
+++ b/packages/server/lib/webhook/fathom-webhook-routing.ts
@@ -65,7 +65,7 @@ const route: WebhookHandler<FathomWebhookResponse> = async (nango, headers, body
     const emailAddress = body.recorded_by?.email;
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         connectionIdentifierValue: emailAddress,
         propName: 'metadata.emailAddress'
     });

--- a/packages/server/lib/webhook/fillout-webhook-routing.ts
+++ b/packages/server/lib/webhook/fillout-webhook-routing.ts
@@ -12,7 +12,7 @@ const route: WebhookHandler = async (nango, _headers, body) => {
 
         for (const event of body) {
             const response = await nango.executeScriptForWebhooks({
-                body: event,
+                payload: event,
                 webhookType: 'type',
                 connectionIdentifier: 'formId',
                 propName: 'metadata.formId'
@@ -33,7 +33,7 @@ const route: WebhookHandler = async (nango, _headers, body) => {
         });
     } else {
         const response = await nango.executeScriptForWebhooks({
-            body,
+            payload: body,
             webhookType: 'type',
             connectionIdentifier: 'formId',
             propName: 'metadata.formId'

--- a/packages/server/lib/webhook/folk-webhook-routing.ts
+++ b/packages/server/lib/webhook/folk-webhook-routing.ts
@@ -58,7 +58,7 @@ const route: WebhookHandler<FolkWebhookPayload> = async (nango, headers, body, r
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'type',
         connectionIdentifierValue,
         propName: 'connectionId'

--- a/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
@@ -51,7 +51,7 @@ const route: WebhookHandler = async (nango, headers, body, rawBody) => {
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookHeaderValue: headers['x-github-event'] as string,
         connectionIdentifier: 'installation.id',
         propName: 'installation_id'

--- a/packages/server/lib/webhook/github-app-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-webhook-routing.ts
@@ -39,7 +39,7 @@ const route: WebhookHandler = async (nango, headers, body, rawBody) => {
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookHeaderValue: headers['x-github-event'] as string,
         connectionIdentifier: 'installation.id',
         propName: 'installation_id'

--- a/packages/server/lib/webhook/gitlab-webhook-routing.ts
+++ b/packages/server/lib/webhook/gitlab-webhook-routing.ts
@@ -85,7 +85,7 @@ const route: WebhookHandler = async (nango, headers, body, rawBody, query) => {
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookHeaderValue: headers['x-gitlab-event'] as string,
         connectionIdentifierValue,
         propName: 'connectionId'

--- a/packages/server/lib/webhook/gitlab-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/gitlab-webhook-routing.unit.test.ts
@@ -20,6 +20,7 @@ function getNangoMock(webhookSecret: unknown = SIGNING_TOKEN) {
         environment: seeders.getTestEnvironment(),
         plan: seeders.getTestPlan(),
         integration: getTestConfig({ provider: 'gitlab' }),
+        request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
         logContextGetter
     });
     const getConnection = vi.spyOn(nango, 'getConnectionForWebhook').mockResolvedValue({
@@ -60,7 +61,7 @@ describe('Gitlab webhook routing', () => {
         expect(result.isOk()).toBe(true);
         expect(getConnection).toHaveBeenCalledWith(CONNECTION_ID);
         expect(execute).toHaveBeenCalledWith({
-            body,
+            payload: body,
             webhookHeaderValue: 'Issue Hook',
             connectionIdentifierValue: CONNECTION_ID,
             propName: 'connectionId'

--- a/packages/server/lib/webhook/gmail-webhook-routing.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.ts
@@ -123,7 +123,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
     };
 
     let response = await nango.executeScriptForWebhooks({
-        body: editedBodyWithCatchAll,
+        payload: editedBodyWithCatchAll,
         webhookType: 'type',
         connectionIdentifier: 'emailAddressHash',
         propName: 'emailAddressHash'
@@ -131,7 +131,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
 
     if (response.connectionIds.length === 0) {
         response = await nango.executeScriptForWebhooks({
-            body: editedBodyWithCatchAll,
+            payload: editedBodyWithCatchAll,
             webhookType: 'type',
             connectionIdentifier: 'emailAddress',
             propName: 'metadata.emailAddress'
@@ -139,7 +139,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
 
         if (response.connectionIds.length === 0) {
             response = await nango.executeScriptForWebhooks({
-                body: editedBodyWithCatchAll,
+                payload: editedBodyWithCatchAll,
                 webhookType: 'type',
                 connectionIdentifier: 'emailAddress',
                 propName: 'metadata.email'

--- a/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
@@ -59,6 +59,7 @@ function getNangoMock(integration: IntegrationConfig) {
         environment,
         plan: seeders.getTestPlan(),
         integration,
+        request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
         logContextGetter
     });
     const execute = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'], connectionMetadata: {} });
@@ -89,7 +90,7 @@ describe('gmailWebhookRouting', () => {
                 propName: 'emailAddressHash',
                 webhookType: 'type',
                 connectionIdentifier: 'emailAddressHash',
-                body: expect.objectContaining({
+                payload: expect.objectContaining({
                     type: '*',
                     emailAddress: 'user@example.com',
                     emailAddressHash: hashEmailAddress('user@example.com')
@@ -115,6 +116,7 @@ describe('gmailWebhookRouting', () => {
             environment,
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nango.executeScriptForWebhooks = execute;

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.ts
@@ -25,7 +25,7 @@ const route: WebhookHandler = async (nango, headers) => {
     }
 
     const baseArgs = {
-        body: headers,
+        payload: headers,
         ...(headers['x-goog-resource-state'] && { webhookTypeValue: headers['x-goog-resource-state'] })
     };
 

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.unit.test.ts
@@ -26,6 +26,7 @@ describe('googleCalendarWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -81,6 +82,7 @@ describe('googleCalendarWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -111,6 +113,7 @@ describe('googleCalendarWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -135,6 +138,7 @@ describe('googleCalendarWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -158,6 +162,7 @@ describe('googleCalendarWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -184,6 +189,7 @@ describe('googleCalendarWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;

--- a/packages/server/lib/webhook/google-drive-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-drive-webhook-routing.ts
@@ -15,7 +15,7 @@ const route: WebhookHandler = async (nango, headers) => {
     const resourceUri = headers['x-goog-resource-uri'];
 
     const baseArgs = {
-        body: headers,
+        payload: headers,
         ...(headers['x-goog-resource-state'] && { webhookTypeValue: headers['x-goog-resource-state'] })
     };
 

--- a/packages/server/lib/webhook/google-drive-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/google-drive-webhook-routing.unit.test.ts
@@ -21,6 +21,7 @@ describe('googleDriveWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -60,6 +61,7 @@ describe('googleDriveWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -103,6 +105,7 @@ describe('googleDriveWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -130,6 +133,7 @@ describe('googleDriveWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -154,6 +158,7 @@ describe('googleDriveWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -177,6 +182,7 @@ describe('googleDriveWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -203,6 +209,7 @@ describe('googleDriveWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;

--- a/packages/server/lib/webhook/google-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-webhook-routing.ts
@@ -17,7 +17,7 @@ const route: WebhookHandler = async (nango, headers) => {
     const resourceUri = headers['x-goog-resource-uri'];
 
     const baseArgs = {
-        body: headers,
+        payload: headers,
         ...(headers['x-goog-resource-state'] && { webhookTypeValue: headers['x-goog-resource-state'] })
     };
 

--- a/packages/server/lib/webhook/google-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/google-webhook-routing.unit.test.ts
@@ -20,6 +20,7 @@ describe('googleWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -51,6 +52,7 @@ describe('googleWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -69,6 +71,7 @@ describe('googleWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -97,6 +100,7 @@ describe('googleWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -120,6 +124,7 @@ describe('googleWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -146,6 +151,7 @@ describe('googleWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;

--- a/packages/server/lib/webhook/highlevel-webhook-routing.ts
+++ b/packages/server/lib/webhook/highlevel-webhook-routing.ts
@@ -43,7 +43,7 @@ const route: WebhookHandler<HighLevelWebhookResponse> = async (nango, headers, b
     const connectionIdentifier = resolvedLocationId ? 'locationId' : companyId ? 'companyId' : '';
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookTypeValue: type ?? '',
         connectionIdentifier,
         ...(connectionIdentifier && { propName: connectionIdentifier })

--- a/packages/server/lib/webhook/hubspot-webhook-routing.ts
+++ b/packages/server/lib/webhook/hubspot-webhook-routing.ts
@@ -64,7 +64,7 @@ const route: WebhookHandler<HubSpotWebhook | HubSpotWebhook[]> = async (nango, h
 
             for (const event of sorted) {
                 const response = await nango.executeScriptForWebhooks({
-                    body: event,
+                    payload: event,
                     webhookType: 'subscriptionType',
                     connectionIdentifier: 'portalId'
                 });
@@ -88,7 +88,7 @@ const route: WebhookHandler<HubSpotWebhook | HubSpotWebhook[]> = async (nango, h
         }
 
         const response = await nango.executeScriptForWebhooks({
-            body,
+            payload: body,
             webhookType: 'subscriptionType',
             connectionIdentifier: 'portalId'
         });

--- a/packages/server/lib/webhook/hubspot-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/hubspot-webhook-routing.unit.test.ts
@@ -29,6 +29,7 @@ describe('Webhook route unit tests', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -112,7 +113,7 @@ describe('Webhook route unit tests', () => {
 
         expect(mock).toHaveBeenCalledTimes(body.length);
         expect(mock).toHaveBeenNthCalledWith(2, {
-            body: body[0],
+            payload: body[0],
             connectionIdentifier: 'portalId',
             webhookType: 'subscriptionType'
         });
@@ -127,6 +128,7 @@ describe('Webhook route unit tests', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter: logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -177,17 +179,17 @@ describe('Webhook route unit tests', () => {
 
         expect(mock).toHaveBeenCalledTimes(body.length);
         expect(mock).toHaveBeenNthCalledWith(1, {
-            body: body[2],
+            payload: body[2],
             connectionIdentifier: 'portalId',
             webhookType: 'subscriptionType'
         });
         expect(mock).toHaveBeenNthCalledWith(2, {
-            body: body[1],
+            payload: body[1],
             connectionIdentifier: 'portalId',
             webhookType: 'subscriptionType'
         });
         expect(mock).toHaveBeenNthCalledWith(3, {
-            body: body[0],
+            payload: body[0],
             connectionIdentifier: 'portalId',
             webhookType: 'subscriptionType'
         });
@@ -202,6 +204,7 @@ describe('Webhook route unit tests', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;
@@ -236,7 +239,7 @@ describe('Webhook route unit tests', () => {
 
         expect(mock).toHaveBeenCalledTimes(1);
         expect(mock).toHaveBeenCalledWith({
-            body: body[0],
+            payload: body[0],
             connectionIdentifier: 'portalId',
             webhookType: 'subscriptionType'
         });
@@ -251,6 +254,7 @@ describe('Webhook route unit tests', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
+            request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
             logContextGetter
         });
         nangoMock.executeScriptForWebhooks = mock;

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -1,86 +1,19 @@
-import { createHash } from 'node:crypto';
-
 import get from 'lodash-es/get.js';
 
-import { OtlpSpan } from '@nangohq/logs';
-import { connectionService, getSyncConfigsByConfigIdForWebhook, NangoError } from '@nangohq/shared';
-import { errorToObject, metrics, report, runWithConcurrencyLimit } from '@nangohq/utils';
+import { connectionService } from '@nangohq/shared';
 
-import { envs } from '../env.js';
-import { getOrchestrator } from '../utils/utils.js';
-import { dispatchQueuePublisher } from './dispatch-queue/client.js';
-import { SQS_BATCH_MAX_BYTES } from './dispatch-queue/publisher.js';
+import { dispatchWebhookExecutions } from './dispatch.js';
 
-import type { DispatchQueuePublisher, PreparedDispatchMessage } from './dispatch-queue/publisher.js';
-import type { LogContext, LogContextGetter } from '@nangohq/logs';
-import type {
-    ConnectionInternal,
-    DBConnectionDecrypted,
-    DBEnvironment,
-    DBIntegrationDecrypted,
-    DBPlan,
-    DBSyncConfig,
-    DBTeam,
-    Metadata,
-    WebhookDispatchMessage
-} from '@nangohq/types';
-
-const LARGE_FANOUT_THRESHOLD = 10;
-const LOG_CONTEXT_CREATE_CONCURRENCY = 25;
-
-interface MatchedExecution {
-    syncConfig: DBSyncConfig;
-    webhook: string;
-    connection: DBConnectionDecrypted | ConnectionInternal;
-}
-
-interface QueuedExecution {
-    syncConfig: DBSyncConfig;
-    webhook: string;
-    connection: DBConnectionDecrypted | ConnectionInternal;
-    kind: 'queued';
-    logCtx: Awaited<ReturnType<LogContextGetter['create']>>;
-    preparedMessage: PreparedDispatchMessage;
-}
-
-interface OrchestratorExecution {
-    syncConfig: DBSyncConfig;
-    webhook: string;
-    connection: DBConnectionDecrypted | ConnectionInternal;
-    logCtx: LogContext;
-}
-
-interface FailedOrchestratorExecution extends OrchestratorExecution {
-    error: unknown;
-}
-
-interface FailedQueuedExecution extends MatchedExecution {
-    kind: 'failed';
-    error: unknown;
-}
-
-function computeTaskName({
-    environmentId,
-    providerConfigKey,
-    parentSyncName,
-    connectionId,
-    activityLogId
-}: {
-    environmentId: number;
-    providerConfigKey: string;
-    parentSyncName: string;
-    connectionId: number;
-    activityLogId: string;
-}): string {
-    const hash = createHash('sha256').update(`${environmentId}:${providerConfigKey}:${parentSyncName}:${connectionId}:${activityLogId}`).digest('hex');
-    return `webhook:env:${environmentId}:connection:${connectionId}:${hash.slice(0, 32)}`;
-}
+import type { DispatchContext } from './dispatch.js';
+import type { LogContextGetter } from '@nangohq/logs';
+import type { ConnectionInternal, DBConnectionDecrypted, DBEnvironment, DBIntegrationDecrypted, DBPlan, DBTeam, HttpRequest, Metadata } from '@nangohq/types';
 
 export class InternalNango {
     readonly team: DBTeam;
     readonly environment: DBEnvironment;
     readonly plan?: DBPlan | undefined;
     readonly integration: DBIntegrationDecrypted;
+    readonly request: HttpRequest;
     readonly logContextGetter: LogContextGetter;
 
     constructor(opts: {
@@ -88,17 +21,15 @@ export class InternalNango {
         environment: DBEnvironment;
         plan?: DBPlan | undefined;
         integration: DBIntegrationDecrypted;
+        request: HttpRequest;
         logContextGetter: LogContextGetter;
     }) {
         this.team = opts.team;
         this.environment = opts.environment;
         this.plan = opts.plan;
         this.integration = opts.integration;
+        this.request = opts.request;
         this.logContextGetter = opts.logContextGetter;
-    }
-
-    async getWebhooks() {
-        return await getSyncConfigsByConfigIdForWebhook(this.environment.id, this.integration.id!);
     }
 
     async getConnectionForWebhook(connectionId: string): Promise<{ connectionId: string; metadata: Metadata | null } | null> {
@@ -115,7 +46,7 @@ export class InternalNango {
     }
 
     async executeScriptForWebhooks({
-        body,
+        payload,
         webhookType,
         webhookHeaderValue,
         webhookTypeValue,
@@ -124,7 +55,7 @@ export class InternalNango {
         propName,
         delaySeconds
     }: {
-        body: Record<string, any>;
+        payload: Record<string, any>;
         webhookType?: string;
         webhookHeaderValue?: string;
         webhookTypeValue?: string;
@@ -135,7 +66,7 @@ export class InternalNango {
     }): Promise<{ connectionIds: string[]; connectionMetadata: Record<string, Metadata | null> }> {
         let connections: DBConnectionDecrypted[] | null | ConnectionInternal[] = null;
 
-        const identifierValue = connectionIdentifierValue || (connectionIdentifier ? get(body, connectionIdentifier) : undefined);
+        const identifierValue = connectionIdentifierValue || (connectionIdentifier ? get(payload, connectionIdentifier) : undefined);
 
         if (!connectionIdentifier && !identifierValue) {
             connections = await connectionService.getConnectionsByEnvironmentAndConfig(this.environment.id, this.integration.unique_key);
@@ -168,393 +99,43 @@ export class InternalNango {
             return { connectionIds: [], connectionMetadata: {} };
         }
 
-        // Disable executions of webhooks but we still need to return the connection ids
+        // Disable all webhook executions, but still return the resolved connections.
         if (this.plan && !this.plan.has_webhooks_script) {
-            const connectionMetadata = connections.reduce<Record<string, Metadata | null>>((acc, connection) => {
-                acc[connection.connection_id] = 'metadata' in connection ? connection.metadata : null;
-                return acc;
-            }, {});
-            return { connectionIds: connections.map((connection) => connection.connection_id), connectionMetadata };
+            return connectionResult(connections);
         }
 
-        const syncConfigsWithWebhooks = await this.getWebhooks();
-
-        if (syncConfigsWithWebhooks.length <= 0) {
-            const connectionMetadata = connections.reduce<Record<string, Metadata | null>>((acc, connection) => {
-                acc[connection.connection_id] = 'metadata' in connection ? connection.metadata : null;
-                return acc;
-            }, {});
-            return { connectionIds: connections.map((connection) => connection.connection_id), connectionMetadata };
-        }
-
-        // use webhookTypeValue if provided (direct value from headers), otherwise extract from body
-        const type = webhookTypeValue || (webhookType ? get(body, webhookType) : undefined);
-
-        const publisher = envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE ? dispatchQueuePublisher : null;
-
-        if (publisher) {
-            await this.dispatchViaQueue({
-                publisher,
-                connections,
-                syncConfigsWithWebhooks,
-                body,
-                type,
-                webhookHeaderValue,
-                delaySeconds
-            });
-        } else {
-            await this.dispatchViaOrchestrator({ connections, syncConfigsWithWebhooks, body, type, webhookHeaderValue });
-        }
-
-        const connectionMetadata = connections.reduce<Record<string, Metadata | null>>((acc, connection) => {
-            acc[connection.connection_id] = 'metadata' in connection ? connection.metadata : null;
-            return acc;
-        }, {});
-
-        return { connectionIds: connections.map((connection) => connection.connection_id), connectionMetadata };
-    }
-
-    private async dispatchViaOrchestrator({
-        connections,
-        syncConfigsWithWebhooks,
-        body,
-        type,
-        webhookHeaderValue
-    }: {
-        connections: (DBConnectionDecrypted | ConnectionInternal)[];
-        syncConfigsWithWebhooks: DBSyncConfig[];
-        body: Record<string, any>;
-        type: string | undefined;
-        webhookHeaderValue: string | undefined;
-    }): Promise<void> {
-        const executions: OrchestratorExecution[] = [];
-
-        for (const syncConfig of syncConfigsWithWebhooks) {
-            const { webhook_subscriptions } = syncConfig;
-            if (!webhook_subscriptions) {
-                continue;
-            }
-
-            let triggered = false;
-
-            for (const webhook of webhook_subscriptions) {
-                if (triggered) {
-                    break;
-                }
-
-                if (type === webhook || webhookHeaderValue === webhook || webhook === '*') {
-                    for (const connection of connections) {
-                        const logCtx = await this.logContextGetter.create(
-                            { operation: { type: 'webhook', action: 'incoming' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
-                            {
-                                account: this.team,
-                                environment: this.environment,
-                                integration: { id: this.integration.id!, name: this.integration.unique_key, provider: this.integration.provider },
-                                connection: { id: connection.id, name: connection.connection_id },
-                                syncConfig: { id: syncConfig.id, name: syncConfig.sync_name }
-                            }
-                        );
-                        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
-                        executions.push({ syncConfig, webhook, connection, logCtx });
-                    }
-
-                    triggered = true;
-                    if (webhook === '*') {
-                        // Only trigger once since it will match all webhooks
-                        break;
-                    }
-                }
-            }
-        }
-
-        const dispatchResult = await this.dispatchExecutionsViaOrchestrator(executions, body);
-        metrics.increment(metrics.Types.WEBHOOK_DIRECT_TRIGGER_SUCCESS, dispatchResult.succeededCount, {
-            provider: this.integration.provider,
-            providerConfigKey: this.integration.unique_key
+        // Use webhookTypeValue if provided (direct value from headers), otherwise extract from payload.
+        const type = webhookTypeValue || (webhookType ? get(payload, webhookType) : undefined);
+        await dispatchWebhookExecutions({
+            context: this.dispatchContext(),
+            connections,
+            type,
+            webhookHeaderValue,
+            payload,
+            ...(delaySeconds === undefined ? {} : { delaySeconds })
         });
+
+        return connectionResult(connections);
     }
 
-    private async dispatchExecutionsViaOrchestrator(
-        executions: OrchestratorExecution[],
-        body: Record<string, any>
-    ): Promise<{ succeededCount: number; failedExecutions: FailedOrchestratorExecution[] }> {
-        const orchestrator = getOrchestrator();
-        let succeededCount = 0;
-        const failedExecutions: FailedOrchestratorExecution[] = [];
-
-        for (const execution of executions) {
-            const { syncConfig, webhook, connection, logCtx } = execution;
-
-            try {
-                const result = await orchestrator.triggerWebhook({
-                    connection,
-                    webhookName: webhook,
-                    syncConfig,
-                    input: body,
-                    maxConcurrency: envs.WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY,
-                    logCtx
-                });
-
-                if (result.isErr()) {
-                    failedExecutions.push({ ...execution, error: result.error });
-                    continue;
-                }
-
-                succeededCount += 1;
-            } catch (err) {
-                failedExecutions.push({ ...execution, error: err });
-            }
-        }
-
-        return { succeededCount, failedExecutions };
+    private dispatchContext(): DispatchContext {
+        return {
+            team: this.team,
+            environment: this.environment,
+            integration: this.integration,
+            request: this.request,
+            logContextGetter: this.logContextGetter
+        };
     }
+}
 
-    private async dispatchViaQueue({
-        publisher,
-        connections,
-        syncConfigsWithWebhooks,
-        body,
-        type,
-        webhookHeaderValue,
-        delaySeconds
-    }: {
-        publisher: DispatchQueuePublisher;
-        connections: (DBConnectionDecrypted | ConnectionInternal)[];
-        syncConfigsWithWebhooks: DBSyncConfig[];
-        body: Record<string, any>;
-        type: string | undefined;
-        webhookHeaderValue: string | undefined;
-        delaySeconds: number | undefined;
-    }): Promise<void> {
-        const matchedExecutions: MatchedExecution[] = [];
-
-        for (const syncConfig of syncConfigsWithWebhooks) {
-            const { webhook_subscriptions } = syncConfig;
-            if (!webhook_subscriptions) continue;
-
-            let matched = false;
-            for (const webhook of webhook_subscriptions) {
-                if (matched) break;
-
-                if (type === webhook || webhookHeaderValue === webhook || webhook === '*') {
-                    for (const connection of connections) {
-                        matchedExecutions.push({ syncConfig, webhook, connection });
-                    }
-
-                    matched = true;
-                }
-            }
-        }
-
-        if (matchedExecutions.length === 0) return;
-
-        const queuePreparationResults = await runWithConcurrencyLimit(
-            matchedExecutions,
-            LOG_CONTEXT_CREATE_CONCURRENCY,
-            async ({ syncConfig, webhook, connection }) => {
-                let logCtx: Awaited<ReturnType<LogContextGetter['create']>> | null = null;
-
-                try {
-                    // Create a log context per (syncConfig × connection × webhook) triple before publishing
-                    // so the runner picks up the same activityLogId it would have in the direct-schedule path.
-                    logCtx = await this.logContextGetter.create(
-                        { operation: { type: 'webhook', action: 'incoming' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
-                        {
-                            account: this.team,
-                            environment: this.environment,
-                            integration: { id: this.integration.id!, name: this.integration.unique_key, provider: this.integration.provider },
-                            connection: { id: connection.id, name: connection.connection_id },
-                            syncConfig: { id: syncConfig.id, name: syncConfig.sync_name }
-                        }
-                    );
-                    logCtx.attachSpan(new OtlpSpan(logCtx.operation));
-
-                    const message: WebhookDispatchMessage = {
-                        version: 1,
-                        kind: 'webhook',
-                        taskName: computeTaskName({
-                            environmentId: this.environment.id,
-                            providerConfigKey: this.integration.unique_key,
-                            parentSyncName: syncConfig.sync_name,
-                            connectionId: connection.id,
-                            activityLogId: logCtx.id
-                        }),
-                        createdAt: new Date().toISOString(),
-                        accountId: this.team.id,
-                        integrationId: this.integration.id!,
-                        provider: this.integration.provider,
-                        parentSyncName: syncConfig.sync_name,
-                        activityLogId: logCtx.id,
-                        webhookName: webhook,
-                        connection: {
-                            id: connection.id,
-                            connection_id: connection.connection_id,
-                            provider_config_key: connection.provider_config_key,
-                            environment_id: connection.environment_id
-                        },
-                        payload: body
-                    };
-                    const serializedBody = JSON.stringify(message);
-                    const preparedMessage: PreparedDispatchMessage = {
-                        message,
-                        byteSize: Buffer.byteLength(serializedBody, 'utf8'),
-                        ...(delaySeconds !== undefined ? { delaySeconds } : {})
-                    };
-
-                    return {
-                        kind: 'queued' as const,
-                        logCtx,
-                        syncConfig,
-                        webhook,
-                        connection,
-                        preparedMessage
-                    };
-                } catch (err) {
-                    if (logCtx) {
-                        const formattedError = err instanceof NangoError ? err : new NangoError('webhook_failure', { error: errorToObject(err) });
-
-                        await logCtx.error('The webhook failed during queue preparation', {
-                            error: err,
-                            webhook,
-                            connection: connection.connection_id,
-                            integration: connection.provider_config_key
-                        });
-                        await logCtx.enrichOperation({ error: formattedError });
-                        await logCtx.failed();
-                    }
-
-                    return {
-                        kind: 'failed' as const,
-                        error: err,
-                        syncConfig,
-                        webhook,
-                        connection
-                    };
-                }
-            }
-        );
-
-        const queuedExecutions = queuePreparationResults.filter((result): result is QueuedExecution => result.kind === 'queued');
-        const failedQueuedExecutions = queuePreparationResults.filter((result): result is FailedQueuedExecution => result.kind === 'failed');
-
-        for (const { error, syncConfig, webhook, connection } of failedQueuedExecutions) {
-            report(error, {
-                error: 'The webhook could not be prepared for queue dispatch',
-                provider: this.integration.provider,
-                accountId: this.team.id,
-                environmentId: this.environment.id,
-                syncConfigId: syncConfig.id,
-                syncName: syncConfig.sync_name,
-                webhook,
-                connectionId: connection.id,
-                connection: connection.connection_id,
-                integration: connection.provider_config_key
-            });
-        }
-
-        if (queuedExecutions.length === 0) {
-            return;
-        }
-
-        if (matchedExecutions.length > LARGE_FANOUT_THRESHOLD) {
-            metrics.increment(metrics.Types.WEBHOOK_DISPATCH_LARGE_FANOUT, 1, {
-                provider: this.integration.provider,
-                accountId: this.team.id,
-                environmentId: this.environment.id,
-                providerConfigKey: this.integration.unique_key
-            });
-        }
-
-        const queueEligibleExecutions = queuedExecutions.filter(({ preparedMessage }) => preparedMessage.byteSize <= SQS_BATCH_MAX_BYTES);
-        const oversizedExecutions = queuedExecutions.filter(({ preparedMessage }) => preparedMessage.byteSize > SQS_BATCH_MAX_BYTES);
-
-        let unmappedFailureCount = 0;
-
-        if (queueEligibleExecutions.length > 0) {
-            const messageGroupId = `account:${this.team.id}:env:${this.environment.id}`;
-            const publishResult = await publisher.publish(
-                queueEligibleExecutions.map(({ preparedMessage }) => preparedMessage),
-                messageGroupId
-            );
-            const failedActivityLogIds = new Set(publishResult.failedActivityLogIds);
-            unmappedFailureCount = publishResult.failed - failedActivityLogIds.size;
-
-            for (const {
-                preparedMessage: { message },
-                logCtx
-            } of queueEligibleExecutions) {
-                if (!failedActivityLogIds.has(message.activityLogId) && unmappedFailureCount === 0) {
-                    void logCtx.info('The webhook was successfully queued for execution', {
-                        action: message.webhookName,
-                        connection: message.connection.connection_id,
-                        integration: message.connection.provider_config_key
-                    });
-                    continue;
-                }
-
-                const error = new NangoError('webhook_failure', {
-                    error: 'The webhook could not be queued for execution',
-                    taskName: message.taskName
-                });
-
-                await logCtx.error('The webhook failed to queue for execution', {
-                    error,
-                    webhook: message.webhookName,
-                    connection: message.connection.connection_id,
-                    integration: message.connection.provider_config_key
-                });
-                await logCtx.enrichOperation({ error });
-                await logCtx.failed();
-            }
-        }
-
-        if (oversizedExecutions.length > 0) {
-            metrics.increment(metrics.Types.WEBHOOK_DISPATCH_BYPASS_OVERSIZE, oversizedExecutions.length, {
-                provider: this.integration.provider,
-                accountId: this.team.id,
-                environmentId: this.environment.id,
-                providerConfigKey: this.integration.unique_key
-            });
-
-            for (const {
-                preparedMessage: { message },
-                logCtx
-            } of oversizedExecutions) {
-                void logCtx.warn('The webhook payload exceeds the queue size limit and will be dispatched directly', {
-                    action: message.webhookName,
-                    connection: message.connection.connection_id,
-                    integration: message.connection.provider_config_key
-                });
-            }
-
-            const dispatchResult = await this.dispatchExecutionsViaOrchestrator(oversizedExecutions, body);
-
-            for (const { error, syncConfig, webhook, connection } of dispatchResult.failedExecutions) {
-                if (error instanceof NangoError && error.type === 'webhook_rate_limit_exceeded') {
-                    continue;
-                }
-
-                report(error, {
-                    context: 'oversized webhook direct dispatch failed',
-                    provider: this.integration.provider,
-                    accountId: this.team.id,
-                    environmentId: this.environment.id,
-                    syncConfigId: syncConfig.id,
-                    syncName: syncConfig.sync_name,
-                    webhook,
-                    connectionId: connection.id,
-                    connection: connection.connection_id,
-                    integration: connection.provider_config_key
-                });
-            }
-        }
-
-        if (unmappedFailureCount > 0) {
-            report(new Error('webhook_dispatch_fanout_unmapped_failures'), {
-                unmappedFailureCount,
-                accountId: this.team.id,
-                environmentId: this.environment.id
-            });
-        }
-    }
+function connectionResult(connections: (DBConnectionDecrypted | ConnectionInternal)[]): {
+    connectionIds: string[];
+    connectionMetadata: Record<string, Metadata | null>;
+} {
+    const connectionMetadata = connections.reduce<Record<string, Metadata | null>>((acc, connection) => {
+        acc[connection.connection_id] = 'metadata' in connection ? connection.metadata : null;
+        return acc;
+    }, {});
+    return { connectionIds: connections.map((connection) => connection.connection_id), connectionMetadata };
 }

--- a/packages/server/lib/webhook/internal-nango.unit.test.ts
+++ b/packages/server/lib/webhook/internal-nango.unit.test.ts
@@ -10,134 +10,43 @@ const mocks = vi.hoisted(() => {
         },
         dispatchQueueClient: { dispatchQueuePublisher: null as any },
         triggerWebhook: vi.fn(),
-        increment: vi.fn(),
-        report: vi.fn(),
-        metricsIncrement: vi.fn(),
         getConnection: vi.fn(),
-        getConnectionsByEnvironmentAndConfig: vi.fn(),
-        getSyncConfigsByConfigIdForWebhook: vi.fn()
+        functionConfigSearch: vi.fn()
     };
 });
 
 vi.mock('../env.js', () => ({ envs: mocks.envs }));
 vi.mock('./dispatch-queue/client.js', () => mocks.dispatchQueueClient);
 vi.mock('../utils/utils.js', () => ({ getOrchestrator: () => ({ triggerWebhook: mocks.triggerWebhook }) }));
-vi.mock('@nangohq/utils', async (importOriginal) => {
-    const actual = await importOriginal();
+vi.mock('@nangohq/database', () => ({ default: { knex: {} } }));
+vi.mock('@nangohq/shared', () => ({
+    NangoError: class NangoError extends Error {},
+    connectionService: { getConnection: mocks.getConnection },
+    functionConfigService: { search: mocks.functionConfigSearch }
+}));
 
-    if (!actual || typeof actual !== 'object' || !('metrics' in actual)) {
-        throw new Error('Invalid @nangohq/utils mock: missing metrics export');
-    }
-
-    const { metrics } = actual;
-    if (!metrics || typeof metrics !== 'object' || !('Types' in metrics) || !metrics.Types || typeof metrics.Types !== 'object') {
-        throw new Error('Invalid @nangohq/utils mock: missing metrics.Types export');
-    }
-
-    return {
-        ...(actual as object),
-        report: mocks.report,
-        metrics: {
-            ...metrics,
-            Types: {
-                ...metrics.Types,
-                WEBHOOK_DIRECT_TRIGGER_SUCCESS: 'nango.webhook.direct_trigger.success',
-                WEBHOOK_DISPATCH_LARGE_FANOUT: 'nango.webhook.dispatch_queue.large_fanout',
-                WEBHOOK_DISPATCH_BYPASS_OVERSIZE: 'nango.webhook.dispatch_queue.bypass_oversize'
-            },
-            increment: mocks.increment
-        }
-    };
-});
-vi.mock('@nangohq/shared', () => {
-    class NangoError extends Error {
-        public payload: Record<string, unknown>;
-
-        constructor(type: string, payload: Record<string, unknown>) {
-            super(type);
-            this.name = type;
-            this.payload = payload;
-        }
-    }
-
-    return {
-        NangoError,
-        connectionService: {
-            getConnection: mocks.getConnection,
-            getConnectionsByEnvironmentAndConfig: mocks.getConnectionsByEnvironmentAndConfig
-        },
-        getSyncConfigsByConfigIdForWebhook: mocks.getSyncConfigsByConfigIdForWebhook
-    };
-});
-
-function createLogCtx(id: string) {
-    return {
-        id,
-        operation: { id },
-        attachSpan: vi.fn(),
-        info: vi.fn().mockResolvedValue(true),
-        warn: vi.fn().mockResolvedValue(true),
-        error: vi.fn().mockResolvedValue(true),
-        enrichOperation: vi.fn().mockResolvedValue(undefined),
-        failed: vi.fn().mockResolvedValue(undefined)
-    };
-}
-
-function deferred<T>() {
-    let resolve!: (value: T | PromiseLike<T>) => void;
-    let reject!: (reason?: unknown) => void;
-    const promise = new Promise<T>((res, rej) => {
-        resolve = res;
-        reject = rej;
+function makeInternalNango() {
+    return new InternalNango({
+        team: { id: 1 } as any,
+        environment: { id: 2 } as any,
+        plan: undefined,
+        integration: { id: 3, unique_key: 'github-dev', provider: 'github' } as any,
+        request: { method: 'POST', path: '/webhook/env/github-dev', headers: {}, query: {}, body: null },
+        logContextGetter: { create: vi.fn() } as any
     });
-    return { promise, resolve, reject };
 }
 
-function makeInternalNango(logContexts: ReturnType<typeof createLogCtx>[], logContextGetterOverride?: any) {
-    const logContextGetter =
-        logContextGetterOverride ??
-        ({
-            create: vi.fn().mockImplementation(() => {
-                const next = logContexts.shift();
-                if (!next) {
-                    throw new Error('Missing log context');
-                }
-                return next;
-            })
-        } as any);
-
-    return {
-        nango: new InternalNango({
-            team: { id: 1 } as any,
-            environment: { id: 2 } as any,
-            plan: undefined,
-            integration: { id: 3, unique_key: 'github-dev', provider: 'github' } as any,
-            logContextGetter
-        }),
-        logContextGetter
-    };
-}
-
-describe('InternalNango queue dispatch', () => {
+describe('InternalNango', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mocks.increment.mockClear();
-        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = true;
-        mocks.dispatchQueueClient.dispatchQueuePublisher = null;
         mocks.getConnection.mockResolvedValue({
             success: true,
             response: { connection_id: 'conn-1', metadata: { webhookSecret: 'secret' } }
         });
-        mocks.getConnectionsByEnvironmentAndConfig.mockResolvedValue([
-            { id: 11, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2, metadata: null },
-            { id: 12, connection_id: 'conn-2', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
-        ]);
-        mocks.getSyncConfigsByConfigIdForWebhook.mockResolvedValue([{ id: 21, sync_name: 'sync-1', webhook_subscriptions: ['push'] }]);
-        mocks.triggerWebhook.mockResolvedValue({ isErr: () => false });
     });
 
     it('retrieves connection metadata without dispatching a webhook', async () => {
-        const { nango } = makeInternalNango([]);
+        const nango = makeInternalNango();
 
         const connection = await nango.getConnectionForWebhook('conn-1');
 
@@ -148,319 +57,8 @@ describe('InternalNango queue dispatch', () => {
 
     it('returns null when the webhook connection does not exist', async () => {
         mocks.getConnection.mockResolvedValue({ success: false, response: null });
-        const { nango } = makeInternalNango([]);
+        const nango = makeInternalNango();
 
         await expect(nango.getConnectionForWebhook('missing')).resolves.toBeNull();
-    });
-
-    it('logs queued successes and marks failed publishes as failed operations', async () => {
-        const publisher = {
-            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 1, failedActivityLogIds: ['log-2'] })
-        };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-
-        const logCtx1 = createLogCtx('log-1');
-        const logCtx2 = createLogCtx('log-2');
-        const { nango } = makeInternalNango([logCtx1, logCtx2]);
-
-        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
-
-        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
-        expect(publisher.publish).toHaveBeenCalledTimes(1);
-        expect(logCtx1.info).toHaveBeenCalledWith('The webhook was successfully queued for execution', {
-            action: 'push',
-            connection: 'conn-1',
-            integration: 'github-dev'
-        });
-        expect(logCtx2.error).toHaveBeenCalledWith('The webhook failed to queue for execution', {
-            error: expect.any(Error),
-            webhook: 'push',
-            connection: 'conn-2',
-            integration: 'github-dev'
-        });
-        expect(logCtx2.enrichOperation).toHaveBeenCalledWith({ error: expect.any(Error) });
-        expect(logCtx2.failed).toHaveBeenCalledOnce();
-    });
-
-    it('passes an optional delay to queued webhook messages', async () => {
-        const publisher = {
-            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 0, failedActivityLogIds: [] })
-        };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-        mocks.getConnectionsByEnvironmentAndConfig.mockResolvedValue([
-            { id: 11, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
-        ]);
-        const { nango } = makeInternalNango([createLogCtx('log-1')]);
-
-        await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push', delaySeconds: 7 });
-
-        expect(publisher.publish).toHaveBeenCalledWith([expect.objectContaining({ delaySeconds: 7 })], 'account:1:env:2');
-    });
-
-    it('falls back to direct orchestrator dispatch when the feature flag is off', async () => {
-        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = false;
-        const publisher = { publish: vi.fn() };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-
-        const logCtx1 = createLogCtx('log-1');
-        const logCtx2 = createLogCtx('log-2');
-        const { nango, logContextGetter } = makeInternalNango([logCtx1, logCtx2]);
-
-        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
-
-        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
-        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
-        expect(logContextGetter.create).toHaveBeenCalledTimes(2);
-        expect(publisher.publish).not.toHaveBeenCalled();
-        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 2, {
-            provider: 'github',
-            providerConfigKey: 'github-dev'
-        });
-    });
-
-    it('continues direct orchestrator dispatch when one execution fails', async () => {
-        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = false;
-        const publisher = { publish: vi.fn() };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-        mocks.triggerWebhook
-            .mockResolvedValueOnce({ isErr: () => false })
-            .mockResolvedValueOnce({ isErr: () => true, error: new Error('orchestrator unavailable') });
-
-        const logCtx1 = createLogCtx('log-1');
-        const logCtx2 = createLogCtx('log-2');
-        const { nango } = makeInternalNango([logCtx1, logCtx2]);
-
-        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
-
-        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
-        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
-        expect(publisher.publish).not.toHaveBeenCalled();
-        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 1, {
-            provider: 'github',
-            providerConfigKey: 'github-dev'
-        });
-    });
-
-    it('creates log contexts concurrently before publishing queue messages', async () => {
-        const publisher = {
-            publish: vi.fn().mockResolvedValue({ enqueued: 2, failed: 0, failedActivityLogIds: [] })
-        };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-
-        const blockers = [deferred<void>(), deferred<void>()];
-        const contexts = [createLogCtx('log-1'), createLogCtx('log-2')];
-        let createIndex = 0;
-        let inFlight = 0;
-        let maxInFlight = 0;
-        const logContextGetter = {
-            create: vi.fn().mockImplementation(async () => {
-                const index = createIndex++;
-                inFlight += 1;
-                maxInFlight = Math.max(maxInFlight, inFlight);
-                await blockers[index]!.promise;
-                inFlight -= 1;
-                return contexts[index]!;
-            })
-        } as any;
-        const { nango } = makeInternalNango([], logContextGetter);
-
-        const execution = nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
-
-        await vi.waitFor(() => {
-            expect(logContextGetter.create).toHaveBeenCalledTimes(2);
-        });
-        expect(maxInFlight).toBe(2);
-
-        blockers[0]!.resolve();
-        blockers[1]!.resolve();
-
-        const result = await execution;
-
-        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
-        expect(publisher.publish).toHaveBeenCalledOnce();
-    });
-
-    it('publishes successful executions even when one log context creation fails', async () => {
-        const publisher = {
-            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 0, failedActivityLogIds: [] })
-        };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-
-        const logCtx = createLogCtx('log-2');
-        const logContextGetter = {
-            create: vi.fn().mockRejectedValueOnce(new Error('transient db failure')).mockResolvedValueOnce(logCtx)
-        } as any;
-        const { nango } = makeInternalNango([], logContextGetter);
-
-        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
-
-        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
-        expect(publisher.publish).toHaveBeenCalledTimes(1);
-        expect(publisher.publish).toHaveBeenCalledWith(
-            [
-                expect.objectContaining({
-                    message: expect.objectContaining({
-                        activityLogId: 'log-2',
-                        webhookName: 'push',
-                        connection: expect.objectContaining({ connection_id: 'conn-2' })
-                    })
-                })
-            ],
-            'account:1:env:2'
-        );
-        expect(logCtx.info).toHaveBeenCalledWith('The webhook was successfully queued for execution', {
-            action: 'push',
-            connection: 'conn-2',
-            integration: 'github-dev'
-        });
-        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), {
-            error: 'The webhook could not be prepared for queue dispatch',
-            provider: 'github',
-            accountId: 1,
-            environmentId: 2,
-            syncConfigId: 21,
-            syncName: 'sync-1',
-            webhook: 'push',
-            connectionId: 11,
-            connection: 'conn-1',
-            integration: 'github-dev'
-        });
-    });
-
-    it('fails the log context when queue preparation fails after creation', async () => {
-        const publisher = {
-            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 0, failedActivityLogIds: [] })
-        };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-
-        const failedLogCtx = createLogCtx('log-1');
-        failedLogCtx.attachSpan.mockImplementation(() => {
-            throw new Error('attach span failed');
-        });
-        const successfulLogCtx = createLogCtx('log-2');
-        const { nango } = makeInternalNango([failedLogCtx, successfulLogCtx]);
-
-        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
-
-        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
-        expect(publisher.publish).toHaveBeenCalledWith(
-            [
-                expect.objectContaining({
-                    message: expect.objectContaining({
-                        activityLogId: 'log-2',
-                        connection: expect.objectContaining({ connection_id: 'conn-2' })
-                    })
-                })
-            ],
-            'account:1:env:2'
-        );
-        expect(failedLogCtx.error).toHaveBeenCalledWith('The webhook failed during queue preparation', {
-            error: expect.any(Error),
-            webhook: 'push',
-            connection: 'conn-1',
-            integration: 'github-dev'
-        });
-        expect(failedLogCtx.enrichOperation).toHaveBeenCalledWith({ error: expect.any(Error) });
-        expect(failedLogCtx.failed).toHaveBeenCalledOnce();
-        expect(successfulLogCtx.info).toHaveBeenCalledWith('The webhook was successfully queued for execution', {
-            action: 'push',
-            connection: 'conn-2',
-            integration: 'github-dev'
-        });
-    });
-
-    it('marks all executions as failed and reports when publish has unmapped failures', async () => {
-        const publisher = {
-            publish: vi.fn().mockResolvedValue({ enqueued: 0, failed: 2, failedActivityLogIds: [] })
-        };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-
-        const logCtx1 = createLogCtx('log-1');
-        const logCtx2 = createLogCtx('log-2');
-        const { nango } = makeInternalNango([logCtx1, logCtx2]);
-
-        await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
-
-        expect(logCtx1.info).not.toHaveBeenCalled();
-        expect(logCtx2.info).not.toHaveBeenCalled();
-        expect(logCtx1.failed).toHaveBeenCalledOnce();
-        expect(logCtx2.failed).toHaveBeenCalledOnce();
-        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), {
-            unmappedFailureCount: 2,
-            accountId: 1,
-            environmentId: 2
-        });
-    });
-
-    it('dispatches oversized messages directly to the orchestrator and emits a metric', async () => {
-        const publisher = { publish: vi.fn() };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-
-        const logCtx1 = createLogCtx('log-1');
-        const logCtx2 = createLogCtx('log-2');
-        const { nango } = makeInternalNango([logCtx1, logCtx2]);
-
-        const result = await nango.executeScriptForWebhooks({ body: { payload: 'x'.repeat(1_100_000) }, webhookTypeValue: 'push' });
-
-        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
-        expect(publisher.publish).not.toHaveBeenCalled();
-        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
-        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.bypass_oversize', 2, {
-            provider: 'github',
-            accountId: 1,
-            environmentId: 2,
-            providerConfigKey: 'github-dev'
-        });
-        expect(logCtx1.warn).toHaveBeenCalledWith(
-            'The webhook payload exceeds the queue size limit and will be dispatched directly',
-            expect.objectContaining({ connection: 'conn-1' })
-        );
-        expect(logCtx2.warn).toHaveBeenCalledWith(
-            'The webhook payload exceeds the queue size limit and will be dispatched directly',
-            expect.objectContaining({ connection: 'conn-2' })
-        );
-    });
-
-    it('reports but does not rethrow when oversized direct dispatch fails', async () => {
-        const publisher = {
-            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 0, failedActivityLogIds: [] })
-        };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-        // triggerWebhook returns Err (never rejects) — logCtx.error/failed handled internally by triggerWebhook
-        mocks.triggerWebhook.mockResolvedValue({ isErr: () => true, error: new Error('orchestrator unavailable') });
-
-        // Single connection with a body large enough to exceed 1 MiB → goes to oversize path
-        const logCtx1 = createLogCtx('log-1');
-
-        mocks.getConnectionsByEnvironmentAndConfig.mockResolvedValue([
-            { id: 11, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
-        ]);
-        const { nango } = makeInternalNango([logCtx1]);
-
-        await expect(nango.executeScriptForWebhooks({ body: { payload: 'x'.repeat(1_100_000) }, webhookTypeValue: 'push' })).resolves.not.toThrow();
-
-        expect(publisher.publish).not.toHaveBeenCalled();
-        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(1);
-        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ context: 'oversized webhook direct dispatch failed' }));
-    });
-
-    it('only reports for the failing connection when oversize dispatch partially succeeds', async () => {
-        const publisher = { publish: vi.fn() };
-        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
-        // First call succeeds, second call returns Err — logCtx handling is triggerWebhook's responsibility
-        mocks.triggerWebhook
-            .mockResolvedValueOnce({ isErr: () => false })
-            .mockResolvedValueOnce({ isErr: () => true, error: new Error('orchestrator unavailable') });
-
-        const logCtx1 = createLogCtx('log-1');
-        const logCtx2 = createLogCtx('log-2');
-        const { nango } = makeInternalNango([logCtx1, logCtx2]);
-
-        await expect(nango.executeScriptForWebhooks({ body: { payload: 'x'.repeat(1_100_000) }, webhookTypeValue: 'push' })).resolves.not.toThrow();
-
-        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
-        // Only the failing connection triggers a report; the successful one does not
-        expect(mocks.report).toHaveBeenCalledTimes(1);
-        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ context: 'oversized webhook direct dispatch failed' }));
     });
 });

--- a/packages/server/lib/webhook/jira-webhook-routing.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.ts
@@ -56,7 +56,7 @@ async function routeEvent(nango: InternalNango, event: Record<string, any>): Pro
         return [];
     }
     const response = await nango.executeScriptForWebhooks({
-        body: event,
+        payload: event,
         webhookType: 'webhookEvent',
         connectionIdentifierValue: baseUrl,
         propName: 'baseUrl'

--- a/packages/server/lib/webhook/jobber-webhook-routing.ts
+++ b/packages/server/lib/webhook/jobber-webhook-routing.ts
@@ -40,7 +40,7 @@ const route: WebhookHandler<JobberWebhookPayload> = async (nango, headers, body,
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body: event,
+        payload: event,
         webhookType: 'topic',
         connectionIdentifier: 'accountId',
         propName: 'accountId'

--- a/packages/server/lib/webhook/jobdiva-webhook-routing.ts
+++ b/packages/server/lib/webhook/jobdiva-webhook-routing.ts
@@ -36,7 +36,7 @@ const route: WebhookHandler<jobdivaWebhookResponse> = async (nango, headers, bod
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: `${body.type} ${body.operation}`
     });
 

--- a/packages/server/lib/webhook/linear-webhook-routing.ts
+++ b/packages/server/lib/webhook/linear-webhook-routing.ts
@@ -39,7 +39,7 @@ const route: WebhookHandler<LinearBody> = async (nango, headers, body, rawBody) 
     const parsedBody = body;
 
     const response = await nango.executeScriptForWebhooks({
-        body: parsedBody,
+        payload: parsedBody,
         webhookType: 'type',
         connectionIdentifier: 'organizationId'
     });

--- a/packages/server/lib/webhook/microsoft-client-credentials-webhook-routing.ts
+++ b/packages/server/lib/webhook/microsoft-client-credentials-webhook-routing.ts
@@ -44,7 +44,7 @@ const route: WebhookHandler<MicrosoftNotificationPayload> = async (nango, _heade
 
     for (const notification of validNotifications) {
         const response = await nango.executeScriptForWebhooks({
-            body: notification,
+            payload: notification,
             webhookType: 'changeType',
             connectionIdentifier: 'tenantId',
             propName: 'tenantId'

--- a/packages/server/lib/webhook/microsoft-teams-webhook-routing.ts
+++ b/packages/server/lib/webhook/microsoft-teams-webhook-routing.ts
@@ -4,7 +4,7 @@ import type { WebhookHandler } from './types.js';
 
 const route: WebhookHandler = async (nango, _headers, body) => {
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'type',
         connectionIdentifier: 'channelData.tenant.id',
         propName: 'tenantId'

--- a/packages/server/lib/webhook/notion-webhook-routing.ts
+++ b/packages/server/lib/webhook/notion-webhook-routing.ts
@@ -39,7 +39,7 @@ const route: WebhookHandler<NotionWebhook | NotionWebhookVerification> = async (
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'type',
         connectionIdentifier: 'workspace_id',
         propName: 'workspace_id'

--- a/packages/server/lib/webhook/outlook-webhook-routing.ts
+++ b/packages/server/lib/webhook/outlook-webhook-routing.ts
@@ -59,7 +59,7 @@ const route: WebhookHandler<OutlookNotificationPayload> = async (nango, _headers
         }
 
         const response = await nango.executeScriptForWebhooks({
-            body: notification,
+            payload: notification,
             webhookType: 'changeType',
             connectionIdentifierValue: subscriptionId,
             propName: 'metadata.subscriptionIds'

--- a/packages/server/lib/webhook/pagerduty-webhook-routing.ts
+++ b/packages/server/lib/webhook/pagerduty-webhook-routing.ts
@@ -22,7 +22,7 @@ const route: WebhookHandler<PagerDutyWebhookPayload> = async (nango, headers, bo
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'event.event_type',
         connectionIdentifierValue,
         propName: 'connectionId'

--- a/packages/server/lib/webhook/salesforce-webhook-routing.ts
+++ b/packages/server/lib/webhook/salesforce-webhook-routing.ts
@@ -4,7 +4,7 @@ import type { WebhookHandler } from './types.js';
 
 const route: WebhookHandler = async (nango, _headers, body) => {
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'nango.eventType',
         connectionIdentifier: 'nango.connectionId',
         propName: 'connectionId'

--- a/packages/server/lib/webhook/sellsy-webhook-routing.ts
+++ b/packages/server/lib/webhook/sellsy-webhook-routing.ts
@@ -45,7 +45,7 @@ const route: WebhookHandler<SellsyWebhookPayload> = async (nango, headers, body,
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookTypeValue,
         connectionIdentifier: 'corpid',
         propName: 'corpid'

--- a/packages/server/lib/webhook/sentry-oauth.ts
+++ b/packages/server/lib/webhook/sentry-oauth.ts
@@ -41,7 +41,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
 
     try {
         const response = await nango.executeScriptForWebhooks({
-            body,
+            payload: body,
             webhookType: 'action',
             connectionIdentifier: 'installation.id',
             propName: 'installation_id'

--- a/packages/server/lib/webhook/shipstation-webhook-routing.ts
+++ b/packages/server/lib/webhook/shipstation-webhook-routing.ts
@@ -36,7 +36,7 @@ const route: WebhookHandler<ShipStationWebhook> = async (nango, headers, body) =
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'resource_type',
         connectionIdentifierValue,
         propName

--- a/packages/server/lib/webhook/shopify-webhook-routing.ts
+++ b/packages/server/lib/webhook/shopify-webhook-routing.ts
@@ -50,7 +50,7 @@ const route: WebhookHandler = async (nango, headers, body, rawBody) => {
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookTypeValue: topic ?? '',
         connectionIdentifierValue: subdomain,
         propName: 'subdomain'

--- a/packages/server/lib/webhook/slack-webhook-routing.ts
+++ b/packages/server/lib/webhook/slack-webhook-routing.ts
@@ -23,7 +23,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
         // so we need to check both
         const teamId = payload['team_id'] || payload['team']?.['id'];
         const response = await nango.executeScriptForWebhooks({
-            body: { ...payload, teamId },
+            payload: { ...payload, teamId },
             webhookType: 'type',
             connectionIdentifier: 'teamId',
             propName: 'team.id'

--- a/packages/server/lib/webhook/slack-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/slack-webhook-routing.unit.test.ts
@@ -14,6 +14,7 @@ function makeNango(mock = vi.fn()) {
         environment: seeders.getTestEnvironment(),
         plan: seeders.getTestPlan(),
         integration,
+        request: { method: 'POST', path: '/webhook', headers: {}, query: {}, body: null },
         logContextGetter
     });
     nango.executeScriptForWebhooks = mock;

--- a/packages/server/lib/webhook/streak-webhook-routing.ts
+++ b/packages/server/lib/webhook/streak-webhook-routing.ts
@@ -14,7 +14,7 @@ const route: WebhookHandler = async (nango, headers, body, _rawBody) => {
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         connectionIdentifierValue: streakWebhookToken,
         propName: 'streakWebhookToken'
     });

--- a/packages/server/lib/webhook/types.ts
+++ b/packages/server/lib/webhook/types.ts
@@ -1,5 +1,11 @@
 import type { InternalNango } from './internal-nango.js';
+import type { HttpRequest } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+
+export type WebhookRequest = HttpRequest & {
+    rawHeaders: Record<string, string>;
+    rawBody: string;
+};
 
 export type WebhookHandler<T = any> = (
     internalNango: InternalNango,

--- a/packages/server/lib/webhook/unauthenticated-webhook-routing.ts
+++ b/packages/server/lib/webhook/unauthenticated-webhook-routing.ts
@@ -8,7 +8,7 @@ const route: WebhookHandler = async (nango, _headers, body) => {
      * { type: '__STRING__', connectionId: '__STRING__', ... }
      */
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'type',
         connectionIdentifier: 'connectionId',
         propName: 'connectionId'

--- a/packages/server/lib/webhook/videoask-webhook-routing.ts
+++ b/packages/server/lib/webhook/videoask-webhook-routing.ts
@@ -21,7 +21,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
     }
 
     const response = await nango.executeScriptForWebhooks({
-        body,
+        payload: body,
         webhookType: 'type',
         connectionIdentifierValue,
         propName: 'connectionId'

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -9,7 +9,7 @@ import { capping } from '../utils/usage.js';
 import * as webhookHandlers from './index.js';
 import { InternalNango } from './internal-nango.js';
 
-import type { WebhookHandlersMap, WebhookResponse } from './types.js';
+import type { WebhookHandlersMap, WebhookRequest, WebhookResponse } from './types.js';
 import type { LogContextGetter } from '@nangohq/logs';
 import type { MaybeStampedEvent } from '@nangohq/pubsub';
 import type { Config } from '@nangohq/shared';
@@ -24,26 +24,35 @@ export async function routeWebhook({
     environment,
     account,
     integration,
-    headers,
+    request,
     plan,
-    body,
-    rawBody,
-    query,
     logContextGetter
 }: {
     environment: DBEnvironment;
     account: DBTeam;
     integration: Config;
+    request: WebhookRequest;
     plan?: DBPlan | undefined;
-    headers: Record<string, any>;
-    body: any;
-    rawBody: string;
-    query?: Record<string, string>;
     logContextGetter: LogContextGetter;
 }): Promise<WebhookResponse> {
+    const internalNango = new InternalNango({
+        team: account,
+        environment,
+        plan,
+        integration,
+        request: {
+            method: request.method,
+            path: request.path,
+            headers: request.headers,
+            query: request.query,
+            body: request.body
+        },
+        logContextGetter
+    });
+
     // Check if both body and headers are empty
-    const hasBody = body && (typeof body === 'object' ? Object.keys(body).length > 0 : true);
-    const hasHeaders = headers && Object.keys(headers).length > 0;
+    const hasBody = request.body && (typeof request.body === 'object' ? Object.keys(request.body).length > 0 : true);
+    const hasHeaders = Object.keys(request.rawHeaders).length > 0;
 
     if (!hasBody && !hasHeaders) {
         return {
@@ -69,17 +78,9 @@ export async function routeWebhook({
         };
     }
 
-    const internalNango = new InternalNango({
-        team: account,
-        environment,
-        plan,
-        integration,
-        logContextGetter
-    });
-
     const result: Result<WebhookResponse> = await tracer.trace(`webhook.route.${integration.provider}`, async () => {
         try {
-            const handlerResult = await handler(internalNango, headers, body, rawBody, query);
+            const handlerResult = await handler(internalNango, request.rawHeaders, request.body, request.rawBody, request.query);
             return handlerResult;
         } catch (err) {
             logger.error(`error processing incoming webhook for ${integration.unique_key} - `, err);
@@ -106,7 +107,7 @@ export async function routeWebhook({
     // Only forward webhook if there is no capping and the response was successful
     const cappingStatus = await capping.getStatus(plan || null, 'webhook_forwards');
     if (!cappingStatus.isCapped && res.statusCode === 200 && ((plan && plan.has_webhooks_forward) || !plan)) {
-        const webhookBodyToForward = 'toForward' in res ? res.toForward : body;
+        const webhookBodyToForward = 'toForward' in res ? res.toForward : request.body;
         const connectionIds = 'connectionIds' in res ? res.connectionIds : [];
 
         const webhookSettings = await externalWebhookService.get(environment.id);
@@ -141,7 +142,7 @@ export async function routeWebhook({
             connectionIds,
             webhookUrlOverrideByConnectionId,
             payload: webhookBodyToForward,
-            webhookOriginalHeaders: headers,
+            webhookOriginalHeaders: request.rawHeaders,
             logContextGetter,
             onBytes: (bytes, connectionId) => {
                 pendingEvents.push(

--- a/packages/server/lib/webhook/xero-webhook-routing.ts
+++ b/packages/server/lib/webhook/xero-webhook-routing.ts
@@ -62,7 +62,7 @@ const route: WebhookHandler<XeroWebhookBody> = async (nango, headers, body, rawB
     let connectionIds: string[] = [];
     for (const event of parsedBody.events) {
         const response = await nango.executeScriptForWebhooks({
-            body: event,
+            payload: event,
             webhookType: 'eventType',
             connectionIdentifier: 'tenantId',
             propName: 'tenant_id'

--- a/packages/shared/lib/services/functions/index.ts
+++ b/packages/shared/lib/services/functions/index.ts
@@ -8,4 +8,4 @@ export { reconcile } from './reconcile.js';
 export type { DeploymentBundleReconciliation } from './reconcile.js';
 export { functionVersionHash } from './version.js';
 export { validateFunctionInput } from './models/validate.js';
-export { invokeFunction } from './invoke.js';
+export { getFunctionMaxConcurrency, invokeFunction } from './invoke.js';

--- a/packages/shared/lib/services/functions/invoke.ts
+++ b/packages/shared/lib/services/functions/invoke.ts
@@ -173,7 +173,7 @@ export async function invokeFunction({
         logCtx.attachSpan(new OtlpSpan(logCtx.operation));
 
         // `perConnection: 1` serializes concurrent invocations of the same function for a connection; 'max' is unbounded
-        const maxConcurrency = currentVersion.limits?.concurrency?.perConnection === 1 ? 1 : 0;
+        const maxConcurrency = getFunctionMaxConcurrency(currentVersion);
 
         const invocation = await orchestrator.invokeFunction({
             environment,
@@ -203,6 +203,11 @@ export async function invokeFunction({
         }
         return Ok(invocation.value);
     });
+}
+
+/** Convert a function's per-connection concurrency setting to the orchestrator convention (0 means unbounded). */
+export function getFunctionMaxConcurrency(version: DBFunctionConfigVersion): number {
+    return version.limits?.concurrency?.perConnection === 1 ? 1 : 0;
 }
 
 function buildRuntimeTrigger({

--- a/packages/shared/lib/services/functions/models/functions.integration.test.ts
+++ b/packages/shared/lib/services/functions/models/functions.integration.test.ts
@@ -7,15 +7,18 @@ import { createConfigSeed } from '../../../seeders/config.seeder.js';
 import { createEnvironmentSeed } from '../../../seeders/environment.seeder.js';
 import { search, upsert } from './functions.js';
 
-import type { DBFunctionConfigVersion } from '@nangohq/types';
+import type { DBFunctionConfigVersion, FunctionTriggerDefinition } from '@nangohq/types';
 
-function functionVersion(version: string): Omit<DBFunctionConfigVersion, 'id' | 'function_config_id' | 'created_at' | 'updated_at' | 'deleted_at'> {
+function functionVersion(
+    version: string,
+    trigger: FunctionTriggerDefinition = { kind: 'none' }
+): Omit<DBFunctionConfigVersion, 'id' | 'function_config_id' | 'created_at' | 'updated_at' | 'deleted_at'> {
     return {
         description: `Function ${version}`,
         file_location: `functions/${version}`,
         version,
         source: 'repo',
-        trigger: { kind: 'none' },
+        trigger,
         requires: { connection: true, outbound: false, invoke: false },
         capabilities: { usesRecords: false, usesOutbound: false, usesCheckpoints: false, usesMetadata: false, usesInvoke: false },
         limits: { concurrency: { perConnection: 'max' } },
@@ -127,6 +130,63 @@ describe(search, () => {
         const functions = (await search(db.knex, { environmentId: environment.id, filter: { integrationKey: github.unique_key, name: 'unknown' } })).unwrap();
 
         expect(functions).toStrictEqual([]);
+    });
+
+    it('filters functions with http trigger', async () => {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        const github = await createConfigSeed(environment, 'github', 'github');
+
+        await upsert(db.knex, {
+            environmentId: environment.id,
+            integrationId: github.unique_key,
+            name: 'subscribed',
+            version: functionVersion('subscribed', { kind: 'http', subscriptions: ['push'] })
+        });
+        await upsert(db.knex, {
+            environmentId: environment.id,
+            integrationId: github.unique_key,
+            name: 'empty',
+            version: functionVersion('empty', { kind: 'http', subscriptions: [] })
+        });
+        await upsert(db.knex, {
+            environmentId: environment.id,
+            integrationId: github.unique_key,
+            name: 'none',
+            version: functionVersion('none', { kind: 'http' })
+        });
+        const disabled = (
+            await upsert(db.knex, {
+                environmentId: environment.id,
+                integrationId: github.unique_key,
+                name: 'disabled',
+                version: functionVersion('disabled', { kind: 'http', subscriptions: ['push'] })
+            })
+        ).unwrap();
+        await db.knex('function_configs').where({ id: disabled.config.id }).update({ enabled: false });
+
+        const subscribed = (
+            await search(db.knex, {
+                environmentId: environment.id,
+                filter: { integrationKey: github.unique_key, enabled: true, trigger: { kind: 'http', hasSubscriptions: true } }
+            })
+        ).unwrap();
+        const withoutSubscriptions = (
+            await search(db.knex, {
+                environmentId: environment.id,
+                filter: { integrationKey: github.unique_key, enabled: true, trigger: { kind: 'http', hasSubscriptions: false } }
+            })
+        ).unwrap();
+        const disabledSubscribed = (
+            await search(db.knex, {
+                environmentId: environment.id,
+                filter: { integrationKey: github.unique_key, enabled: false, trigger: { kind: 'http', hasSubscriptions: true } }
+            })
+        ).unwrap();
+
+        expect(subscribed.map((func) => func.config.name)).toEqual(['subscribed']);
+        expect(withoutSubscriptions.map((func) => func.config.name).sort()).toEqual(['empty', 'none']);
+        expect(disabledSubscribed.map((func) => func.config.name)).toEqual(['disabled']);
     });
 
     it('does not ignore empty filter values', async () => {

--- a/packages/shared/lib/services/functions/models/functions.ts
+++ b/packages/shared/lib/services/functions/models/functions.ts
@@ -83,6 +83,13 @@ type SearchFunctionConfigRow = Prefixed<DBFunctionConfig, typeof CONFIG_PREFIX> 
     Prefixed<DBFunctionConfigVersion, typeof VERSION_PREFIX> &
     Prefixed<FunctionIntegration, typeof INTEGRATION_PREFIX>;
 
+interface FunctionSearchFilter {
+    integrationKey: string;
+    name?: string | undefined;
+    enabled?: boolean | undefined;
+    trigger?: { kind: 'http'; hasSubscriptions: boolean } | undefined;
+}
+
 export async function search(
     trx: Knex,
     {
@@ -90,7 +97,7 @@ export async function search(
         filter
     }: {
         environmentId: number;
-        filter?: { integrationKey: string; name?: string | undefined } | undefined;
+        filter?: FunctionSearchFilter | undefined;
     }
 ): Promise<Result<CurrentFunctionConfig[]>> {
     try {
@@ -115,6 +122,19 @@ export async function search(
         }
         if (filter?.name !== undefined) {
             query.where('config.name', filter.name);
+        }
+        if (filter?.enabled !== undefined) {
+            query.where('config.enabled', filter.enabled);
+        }
+        if (filter?.trigger) {
+            // TODO: index subscriptions array length for performance
+            query.whereRaw("version.trigger->>'kind' = ?", [filter.trigger.kind]);
+            const subscriptionCount = `CASE
+                WHEN jsonb_typeof(version.trigger->'subscriptions') = 'array'
+                THEN jsonb_array_length(version.trigger->'subscriptions')
+                ELSE 0
+            END`;
+            query.whereRaw(`${subscriptionCount} ${filter.trigger.hasSubscriptions ? '>' : '='} 0`);
         }
 
         const rows = await query;

--- a/packages/types/lib/webhooks/dispatch.ts
+++ b/packages/types/lib/webhooks/dispatch.ts
@@ -1,29 +1,13 @@
+import type { FunctionTrigger } from '../function/trigger.js';
 import type { JsonValue } from 'type-fest';
 
-/**
- * SQS message envelope for the webhook task-dispatch queue.
- *
- * The server produces one of these per (syncConfig × webhook subscription × connection)
- * triple resulting from an inbound provider webhook. The jobs consumer parses these and
- * calls the orchestrator to schedule the actual webhook task using `taskName` as the
- * idempotency key.
- */
-export interface WebhookDispatchMessage {
+interface DispatchMessageBase {
     version: 1;
-    kind: 'webhook';
-    /**
-     * Deterministic scheduler task name; used by the orchestrator as the
-     * idempotency key so duplicate SQS deliveries resolve to the same task.
-     */
-    taskName: string;
     createdAt: string;
     accountId: number;
     integrationId: number;
     provider: string;
-    parentSyncName: string;
-    /** Webhook subscription name matched on the inbound payload; passed to executeWebhook as args.webhookName. */
-    webhookName: string;
-    /** Activity log id created before enqueue; reused so redelivery of this published message keeps the same taskName. */
+    /** Activity log created before enqueue and reused by the eventual execution. */
     activityLogId: string;
     connection: {
         id: number;
@@ -31,5 +15,37 @@ export interface WebhookDispatchMessage {
         provider_config_key: string;
         environment_id: number;
     };
+}
+
+/**
+ * SQS message envelope for the webhook task-dispatch queue.
+ *
+ * The server produces one of these per (syncConfig × webhook subscription × connection)
+ * triple resulting from an inbound provider webhook. The jobs consumer parses these and
+ * calls the orchestrator to schedule the legacy webhook task using `taskName` as its
+ * task name.
+ */
+export interface LegacyDispatchMessage extends DispatchMessageBase {
+    kind: 'webhook';
+    /** Deterministic scheduler task name used to deduplicate queue redeliveries. */
+    taskName: string;
+    parentSyncName: string;
+    /** Webhook subscription name matched on the inbound payload; passed to executeWebhook as args.webhookName. */
+    webhookName: string;
     payload: JsonValue;
 }
+
+export interface FunctionDispatchMessage extends DispatchMessageBase {
+    kind: 'function';
+    /** Deterministic key used to deduplicate queue redeliveries. */
+    idempotencyKey: string;
+    functionName: string;
+    trigger: Omit<Extract<FunctionTrigger, { kind: 'http' }>, 'request' | 'connection'> & {
+        request: Extract<FunctionTrigger, { kind: 'http' }>['request'];
+        subscriptions: string[];
+        connection: NonNullable<Extract<FunctionTrigger, { kind: 'http' }>['connection']>;
+    };
+    maxConcurrency: number;
+}
+
+export type DispatchMessage = LegacyDispatchMessage | FunctionDispatchMessage;

--- a/packages/webhooks/lib/forward.ts
+++ b/packages/webhooks/lib/forward.ts
@@ -29,7 +29,7 @@ export const forwardWebhook = async ({
     webhookSettings: DBExternalWebhook | null;
     connectionIds: string[];
     webhookUrlOverrideByConnectionId: Map<string, string>;
-    payload: Record<string, any> | null;
+    payload: unknown;
     webhookOriginalHeaders: Record<string, string>;
     logContextGetter: LogContextGetter;
     onBytes?: (bytes: MeteredBytes, connectionId: string) => void;


### PR DESCRIPTION
Adding support for http trigger subscription in `functions` to handle webhooks.
The feature is still gated in the CLI so it is not yet possible in prod to deploy webhook functions.

I tried to consolidate the logic to handle legacy webhook and function webhook when I could. However I kept the legacy queue dispatch message separate to the new function dispatch message in order to avoid a 2 steps deployment.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

