### PR TITLE
fix(webhook): enforce signature verification for Checkr and GitHub App routes (P1)

### DIFF
--- a/packages/server/lib/webhook/checkr-partner-webhook-routing.ts
+++ b/packages/server/lib/webhook/checkr-partner-webhook-routing.ts
@@ -24,7 +24,9 @@ function validate(integration: IntegrationConfig, headerSignature: string, rawBo
     }
 
     const signature = crypto.createHmac('sha256', integration.custom['webhookSecret']).update(rawBody).digest('hex');
-    return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(headerSignature));
+    const trusted = Buffer.from(signature, 'utf8');
+    const untrusted = Buffer.from(headerSignature, 'utf8');
+    return trusted.length === untrusted.length && crypto.timingSafeEqual(trusted, untrusted);
 }
 
 const route: WebhookHandler<CheckrBody> = async (nango, headers, body, rawBody) => {
@@ -36,8 +38,7 @@ const route: WebhookHandler<CheckrBody> = async (nango, headers, body, rawBody) 
 
     if (!validate(nango.integration, signature, rawBody)) {
         logger.error('invalid signature', { configId: nango.integration.id });
-        // TODO the verification should use the API key
-        //return;
+        return Err(new NangoError('webhook_invalid_signature'));
     }
 
     const parsedBody = body;

--- a/packages/server/lib/webhook/checkr-partner-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/checkr-partner-webhook-routing.unit.test.ts
@@ -1,0 +1,207 @@
+import crypto from 'node:crypto';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { logContextGetter } from '@nangohq/logs';
+import { seeders } from '@nangohq/shared';
+import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
+
+import * as CheckrPartnerWebhookRouting from './checkr-partner-webhook-routing.js';
+import { InternalNango } from './internal-nango.js';
+
+const SECRET = 'test-checkr-webhook-secret';
+
+function makeSignature(rawBody: string): string {
+    return crypto.createHmac('sha256', SECRET).update(rawBody).digest('hex');
+}
+
+function getIntegration(secret: string | null = SECRET) {
+    return getTestConfig({
+        provider: 'checkr',
+        custom: secret ? { webhookSecret: secret } : {}
+    });
+}
+
+describe('Checkr partner webhook routing', () => {
+    it('routes a webhook with valid signature', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'], connectionMetadata: {} });
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body = {
+            id: '1',
+            object: 'candidate',
+            type: 'candidate.created',
+            created_at: '2024-01-01',
+            webhook_url: 'https://example.com',
+            data: {},
+            createdAt: '2024-01-01'
+        };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-checkr-signature': makeSignature(rawBody) };
+
+        const result = await CheckrPartnerWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body as any, rawBody);
+
+        expect(result.isOk()).toBe(true);
+        expect(mock).toHaveBeenCalledOnce();
+    });
+
+    it('rejects webhook with missing signature', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body = {
+            id: '1',
+            object: 'candidate',
+            type: 'candidate.created',
+            created_at: '2024-01-01',
+            webhook_url: 'https://example.com',
+            data: {},
+            createdAt: '2024-01-01'
+        };
+        const rawBody = JSON.stringify(body);
+
+        const result = await CheckrPartnerWebhookRouting.default(nangoMock as unknown as InternalNango, {} as any, body as any, rawBody);
+
+        expect(result.isErr()).toBe(true);
+        expect(result.isErr() && (result.error as any).type).toBe('webhook_missing_signature');
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('rejects webhook with invalid signature', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body = {
+            id: '1',
+            object: 'candidate',
+            type: 'candidate.created',
+            created_at: '2024-01-01',
+            webhook_url: 'https://example.com',
+            data: {},
+            createdAt: '2024-01-01'
+        };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-checkr-signature': 'invalid-signature' };
+
+        const result = await CheckrPartnerWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body as any, rawBody);
+
+        expect(result.isErr()).toBe(true);
+        expect(result.isErr() && (result.error as any).type).toBe('webhook_invalid_signature');
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('rejects webhook with tampered body (signature mismatch)', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body = {
+            id: '1',
+            object: 'candidate',
+            type: 'candidate.created',
+            created_at: '2024-01-01',
+            webhook_url: 'https://example.com',
+            data: {},
+            createdAt: '2024-01-01'
+        };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-checkr-signature': makeSignature(rawBody) };
+
+        // Tamper rawBody after signature was computed
+        const result = await CheckrPartnerWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body as any, rawBody + ' ');
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('rejects when integration has no webhookSecret configured', async () => {
+        const integration = getIntegration(null);
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body = {
+            id: '1',
+            object: 'candidate',
+            type: 'candidate.created',
+            created_at: '2024-01-01',
+            webhook_url: 'https://example.com',
+            data: {},
+            createdAt: '2024-01-01'
+        };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-checkr-signature': makeSignature(rawBody) };
+
+        const result = await CheckrPartnerWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body as any, rawBody);
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('does not throw on length-mismatch signature (timingSafeEqual guard)', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body = {
+            id: '1',
+            object: 'candidate',
+            type: 'candidate.created',
+            created_at: '2024-01-01',
+            webhook_url: 'https://example.com',
+            data: {},
+            createdAt: '2024-01-01'
+        };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-checkr-signature': 'short' };
+
+        const result = await CheckrPartnerWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body as any, rawBody);
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-oauth-webhook-routing.ts
@@ -28,19 +28,21 @@ function validate(integration: IntegrationConfig, headerSignature: string, rawBo
     const trusted = Buffer.from(`sha256=${signature}`, 'ascii');
     const untrusted = Buffer.from(headerSignature, 'ascii');
 
-    return crypto.timingSafeEqual(trusted, untrusted);
+    return trusted.length === untrusted.length && crypto.timingSafeEqual(trusted, untrusted);
 }
 
 const route: WebhookHandler = async (nango, headers, body, rawBody) => {
     const signature = headers['x-hub-signature-256'];
 
-    if (signature) {
-        const valid = validate(nango.integration, signature, rawBody);
+    if (!signature) {
+        logger.error('Github App webhook missing signature', { configId: nango.integration.id });
+        return Err(new NangoError('webhook_missing_signature'));
+    }
 
-        if (!valid) {
-            logger.error('Github App webhook signature invalid. Exiting');
-            return Err(new NangoError('webhook_invalid_signature'));
-        }
+    const valid = validate(nango.integration, signature, rawBody);
+    if (!valid) {
+        logger.error('Github App webhook signature invalid. Exiting', { configId: nango.integration.id });
+        return Err(new NangoError('webhook_invalid_signature'));
     }
 
     if (get(body, 'action') === 'created') {

--- a/packages/server/lib/webhook/github-app-oauth-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/github-app-oauth-webhook-routing.unit.test.ts
@@ -1,0 +1,121 @@
+import crypto from 'node:crypto';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { logContextGetter } from '@nangohq/logs';
+import { seeders } from '@nangohq/shared';
+import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
+
+import * as GithubAppOauthWebhookRouting from './github-app-oauth-webhook-routing.js';
+import { InternalNango } from './internal-nango.js';
+
+const APP_ID = '12345';
+const PRIVATE_KEY_RAW = 'test-private-key';
+const PRIVATE_KEY_B64 = Buffer.from(PRIVATE_KEY_RAW).toString('base64');
+const APP_LINK = 'https://github.com/apps/test-app';
+
+function makeSignature(rawBody: string): string {
+    const hash = `${APP_ID}${PRIVATE_KEY_RAW}${APP_LINK}`;
+    const secret = crypto.createHash('sha256').update(hash).digest('hex');
+    const sig = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+    return `sha256=${sig}`;
+}
+
+function getIntegration() {
+    return getTestConfig({
+        provider: 'github-app-oauth',
+        custom: { app_id: APP_ID, private_key: PRIVATE_KEY_B64, app_link: APP_LINK },
+        app_link: APP_LINK
+    } as any);
+}
+
+describe('Github App OAuth webhook routing', () => {
+    it('rejects webhook with missing signature', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+        // also mock handleCreate path dependencies to avoid calling DB
+        const body: any = { action: 'created', installation: { id: 1, app_id: Number(APP_ID) }, requester: { login: 'testuser' } };
+        const rawBody = JSON.stringify(body);
+
+        const result = await GithubAppOauthWebhookRouting.default(nangoMock as unknown as InternalNango, {} as any, body, rawBody);
+
+        expect(result.isErr()).toBe(true);
+        expect(result.isErr() && (result.error as any).type).toBe('webhook_missing_signature');
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('rejects webhook with invalid signature', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body: any = { action: 'opened' };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-hub-signature-256': 'sha256=invalid' };
+
+        const result = await GithubAppOauthWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body, rawBody);
+
+        expect(result.isErr()).toBe(true);
+        expect(result.isErr() && (result.error as any).type).toBe('webhook_invalid_signature');
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('routes webhook with valid signature (non-create action)', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'], connectionMetadata: {} });
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body: any = { action: 'opened', installation: { id: 1 } };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-hub-signature-256': makeSignature(rawBody), 'x-github-event': 'issues' };
+
+        const result = await GithubAppOauthWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body, rawBody);
+
+        expect(result.isOk()).toBe(true);
+        expect(mock).toHaveBeenCalledOnce();
+    });
+
+    it('does not throw on length-mismatch signature', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body: any = { action: 'opened' };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-hub-signature-256': 'short' };
+
+        const result = await GithubAppOauthWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body, rawBody);
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/server/lib/webhook/github-app-webhook-routing.ts
+++ b/packages/server/lib/webhook/github-app-webhook-routing.ts
@@ -29,13 +29,15 @@ function validate(integration: IntegrationConfig, headerSignature: string, rawBo
 const route: WebhookHandler = async (nango, headers, body, rawBody) => {
     const signature = headers?.['x-hub-signature-256'];
 
-    if (signature) {
-        const valid = validate(nango.integration, signature, rawBody);
+    if (!signature) {
+        logger.error('Github App webhook missing signature', { configId: nango.integration.id });
+        return Err(new NangoError('webhook_missing_signature'));
+    }
 
-        if (!valid) {
-            logger.error('Github App webhook signature invalid');
-            return Err(new NangoError('webhook_invalid_signature'));
-        }
+    const valid = validate(nango.integration, signature, rawBody);
+    if (!valid) {
+        logger.error('Github App webhook signature invalid', { configId: nango.integration.id });
+        return Err(new NangoError('webhook_invalid_signature'));
     }
 
     const response = await nango.executeScriptForWebhooks({

--- a/packages/server/lib/webhook/github-app-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/github-app-webhook-routing.unit.test.ts
@@ -1,0 +1,123 @@
+import crypto from 'node:crypto';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { logContextGetter } from '@nangohq/logs';
+import { seeders } from '@nangohq/shared';
+import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
+
+import * as GithubAppWebhookRouting from './github-app-webhook-routing.js';
+import { InternalNango } from './internal-nango.js';
+
+const APP_ID = '12345';
+const PRIVATE_KEY_RAW = 'test-private-key';
+const PRIVATE_KEY_B64 = Buffer.from(PRIVATE_KEY_RAW).toString('base64');
+const APP_LINK = 'https://github.com/apps/test-app';
+
+function makeSignature(rawBody: string): string {
+    const hash = `${APP_ID}${PRIVATE_KEY_RAW}${APP_LINK}`;
+    const secret = crypto.createHash('sha256').update(hash).digest('hex');
+    const sig = crypto.createHmac('sha256', secret).update(rawBody, 'utf8').digest('hex');
+    return `sha256=${sig}`;
+}
+
+function getIntegration() {
+    return getTestConfig({
+        provider: 'github-app',
+        oauth_client_id: APP_ID,
+        oauth_client_secret: PRIVATE_KEY_B64,
+        app_link: APP_LINK,
+        custom: { app_id: APP_ID, private_key: PRIVATE_KEY_B64 }
+    } as any);
+}
+
+describe('Github App webhook routing', () => {
+    it('routes a webhook with valid signature', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'], connectionMetadata: {} });
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body = { action: 'opened', installation: { id: 1 } };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-hub-signature-256': makeSignature(rawBody), 'x-github-event': 'issues' };
+
+        const result = await GithubAppWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body, rawBody);
+
+        expect(result.isOk()).toBe(true);
+        expect(mock).toHaveBeenCalledOnce();
+    });
+
+    it('rejects webhook with missing signature', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body = { action: 'opened' };
+        const rawBody = JSON.stringify(body);
+
+        const result = await GithubAppWebhookRouting.default(nangoMock as unknown as InternalNango, {} as any, body, rawBody);
+
+        expect(result.isErr()).toBe(true);
+        expect(result.isErr() && (result.error as any).type).toBe('webhook_missing_signature');
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('rejects webhook with invalid signature', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body = { action: 'opened' };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-hub-signature-256': 'sha256=invalid' };
+
+        const result = await GithubAppWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body, rawBody);
+
+        expect(result.isErr()).toBe(true);
+        expect(result.isErr() && (result.error as any).type).toBe('webhook_invalid_signature');
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('does not throw on length-mismatch signature', async () => {
+        const integration = getIntegration();
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock as any;
+
+        const body = { action: 'opened' };
+        const rawBody = JSON.stringify(body);
+        const headers = { 'x-hub-signature-256': 'short' };
+
+        const result = await GithubAppWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, body, rawBody);
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
Fixes highest-severity unauth webhook bypass (P1 of hygiene plan, 6/10 effort). Each fix isolated per-PR as requested.

### Problem
- **Checkr** (`packages/server/lib/webhook/checkr-partner-webhook-routing.ts:37`): invalid signature was logged but not rejected (`// TODO` + commented `return`). Any attacker could POST a forged `x-checkr-signature` and trigger `executeScriptForWebhooks` + connection routing.
- **GitHub App + GitHub App OAuth** (`github-app-webhook-routing.ts:32`, `github-app-oauth-webhook-routing.ts:37`): validation only ran `if (signature)` - missing header bypassed verification entirely. Also `validate()` called `timingSafeEqual` without length check, throwing on mismatch instead of returning `false`.

### Fix
- **Checkr** `validate()`: add `trusted.length === untrusted.length && timingSafeEqual` guard (prevents throw) + use `utf8` buffers. Route now returns `Err(webhook_invalid_signature)` (401 via `NangoError`) instead of continuing.
- **GitHub App (both)**: same length guard in OAuth validate, and **require** `x-hub-signature-256` -> `webhook_missing_signature` if absent, `webhook_invalid_signature` if invalid. Closes unauth bypass.
- No behavior change for valid signatures.

### Tests
Added 14 new unit tests (3 files):
- `checkr-partner-webhook-routing.unit.test.ts` (6 tests: valid, missing, invalid, tampered body, no secret, length-mismatch)
- `github-app-webhook-routing.unit.test.ts` (4 tests)
- `github-app-oauth-webhook-routing.unit.test.ts` (4 tests)

All webhook unit tests pass: 14/14 files, 76/76 tests (`npm run test:unit -- packages/server/lib/webhook/`).

### Verification
- `npm run lint` passes (warnings only, no errors introduced)
- `npm run test:unit -- packages/server/lib/webhook/checkr-partner-webhook-routing.unit.test.ts packages/server/lib/webhook/github-app-webhook-routing.unit.test.ts packages/server/lib/webhook/github-app-oauth-webhook-routing.unit.test.ts` -> 14 passed

### Risk
Low - pure validation tightening. Customers with misconfigured `webhookSecret` / missing GitHub App signature will now get 401 instead of silent success (intended). No new env vars, no migration.

### Follow-up
Next PRs: P2 listConnections limit bypass, P3 Docker USER node, etc. Each as separate branch.

Fixes the hygiene plan P1 vulnerability.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

