### PR TITLE
docs: Update for new pricing plans

### DIFF
--- a/docs/guides/auth/customize-connect-ui.mdx
+++ b/docs/guides/auth/customize-connect-ui.mdx
@@ -27,13 +27,13 @@ You can customize the Connect UI theme from the Nango dashboard:
 
 These settings apply to the pre-built Connect UI that you open with [`nango.openConnectUI()`](/reference/frontend/frontend-sdk#connect-using-nango-connect-ui).
 
-<Note>Connect UI branding customization is available on the [Growth plan](https://www.nango.dev/pricing).</Note>
+<Note>Connect UI branding customization is available with the [Growth add-on](https://www.nango.dev/pricing).</Note>
 
 ## Override documentation links
 
 By default, the Connect UI displays info icons that link to the Nango documentation. If you are embedding Connect UI in a customer-facing application and want these links to point to your own documentation instead, override them per integration using the `overrides` parameter when [creating a Connect session](/reference/backend/http-api/connect/sessions/create).
 
-<Note>This feature is available on the [Growth plan](https://www.nango.dev/pricing).</Note>
+<Note>This feature is available with the [Growth add-on](https://www.nango.dev/pricing).</Note>
 
 <Tabs>
 

--- a/docs/guides/platform/limits.mdx
+++ b/docs/guides/platform/limits.mdx
@@ -17,8 +17,8 @@ Rate limits apply to API requests from your application to Nango:
 | Plan | Requests per Minute |
 | - | - |
 | Free tier | 200 |
-| Starter | 1,000 |
-| Growth | 2,000 |
+| Pay-as-you-go  | 1,000 |
+| Growth add-on | 2,000 |
 | Enterprise | Custom |
 
 <Info>

--- a/docs/guides/platform/security.mdx
+++ b/docs/guides/platform/security.mdx
@@ -293,7 +293,7 @@ Nango Cloud uses [WorkOS](https://workos.com) to power SSO.
 
 | Plan | SSO support |
 | - | - |
-| Free / Starter | Google SSO only |
+| Free / Pay-as-you-go | Google SSO only |
 | Growth add-on | SAML SSO with 20+ identity providers |
 | Enterprise (Cloud) | SAML SSO + SCIM |
 | Enterprise (Self-hosted) | Not yet available (planned) |
@@ -305,7 +305,7 @@ Through WorkOS, Nango supports the main SSO providers, including **Okta**, **Ent
 ### How to enable SSO
 
 1. To enable SSO for your account, contact the Nango team (on our shared Slack channel or the [community](https://nango.dev/slack)).
-2. If you are on the Growth plan, we will subscribe your workspace to the SSO add-on.
+2. If you are on Pay-as-you-go, we will subscribe your workspace to the Growth add-on, which includes SAML SSO.
 3. We will invite an admin from your company to complete the SSO setup flow.
 
 ### Setup flow

--- a/docs/guides/platform/security.mdx
+++ b/docs/guides/platform/security.mdx
@@ -294,8 +294,8 @@ Nango Cloud uses [WorkOS](https://workos.com) to power SSO.
 | Plan | SSO support |
 | - | - |
 | Free / Starter | Google SSO only |
-| Growth | SSO with 20+ identity providers (add-on) |
-| Enterprise (Cloud) | SSO with 20+ identity providers (included) |
+| Growth add-on | SAML SSO with 20+ identity providers |
+| Enterprise (Cloud) | SAML SSO + SCIM |
 | Enterprise (Self-hosted) | Not yet available (planned) |
 
 ### Supported providers

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -201,17 +201,20 @@ For more details, see the [pricing page](https://nango.dev/pricing) or [schedule
 
 | Feature | Free self-hosted | Enterprise self-hosted / Nango Cloud |
 | --- | --- | --- |
-| Auth | Yes | Yes |
+| API Auth | Yes | Yes |
 | Proxy | Yes | Yes |
 | Observability | Auth + proxy only | Full |
 | OpenTelemetry export | No | Yes |
-| Functions | No | Yes |
+| Pre-built syncs, tools & triggers | No | Yes |
+| Syncs | No | Yes |
+| Tool calls | No | Yes |
 | Webhooks | No | Yes |
+| Triggers | No | Yes |
 | MCP server | No | Yes |
 | Customize auth branding | No | Yes |
-| Role-based permissions | No | Yes |
-| SAML SSO | No | On the roadmap |
-| Support SLA | No | Yes |
+| RBAC | No | Yes |
+| MFA | No | Yes |
+| SAML SSO | No | Yes |
 
 ### Server URL, callback URL, and custom domains
 

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -214,7 +214,7 @@ For more details, see the [pricing page](https://nango.dev/pricing) or [schedule
 | Customize auth branding | No | Yes |
 | RBAC | No | Yes |
 | MFA | No | Yes |
-| SAML SSO | No | Yes |
+| SAML SSO | No | Nango Cloud only |
 
 ### Server URL, callback URL, and custom domains
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6639,7 +6639,7 @@ Nango Cloud uses [WorkOS](https://workos.com) to power SSO.
 
 | Plan | SSO support |
 | - | - |
-| Free / Starter | Google SSO only |
+| Free / Pay-as-you-go | Google SSO only |
 | Growth add-on | SAML SSO with 20+ identity providers |
 | Enterprise (Cloud) | SAML SSO + SCIM |
 | Enterprise (Self-hosted) | Not yet available (planned) |
@@ -6651,7 +6651,7 @@ Through WorkOS, Nango supports the main SSO providers, including **Okta**, **Ent
 ### How to enable SSO
 
 1. To enable SSO for your account, contact the Nango team (on our shared Slack channel or the [community](https://nango.dev/slack)).
-2. If you are on the Growth plan, we will subscribe your workspace to the SSO add-on.
+2. If you are on Pay-as-you-go, we will subscribe your workspace to the Growth add-on, which includes SAML SSO.
 3. We will invite an admin from your company to complete the SSO setup flow.
 
 ### Setup flow
@@ -7037,7 +7037,7 @@ For more details, see the [pricing page](https://nango.dev/pricing) or [schedule
 | Customize auth branding | No | Yes |
 | RBAC | No | Yes |
 | MFA | No | Yes |
-| SAML SSO | No | Yes |
+| SAML SSO | No | Nango Cloud only |
 
 ### Server URL, callback URL, and custom domains
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1914,13 +1914,13 @@ You can customize the Connect UI theme from the Nango dashboard:
 
 These settings apply to the pre-built Connect UI that you open with [`nango.openConnectUI()`](/reference/frontend/frontend-sdk#connect-using-nango-connect-ui).
 
-<Note>Connect UI branding customization is available on the [Growth plan](https://www.nango.dev/pricing).</Note>
+<Note>Connect UI branding customization is available with the [Growth add-on](https://www.nango.dev/pricing).</Note>
 
 ## Override documentation links
 
 By default, the Connect UI displays info icons that link to the Nango documentation. If you are embedding Connect UI in a customer-facing application and want these links to point to your own documentation instead, override them per integration using the `overrides` parameter when [creating a Connect session](/reference/backend/http-api/connect/sessions/create).
 
-<Note>This feature is available on the [Growth plan](https://www.nango.dev/pricing).</Note>
+<Note>This feature is available with the [Growth add-on](https://www.nango.dev/pricing).</Note>
 
 <Tabs>
 
@@ -6273,8 +6273,8 @@ Rate limits apply to API requests from your application to Nango:
 | Plan | Requests per Minute |
 | - | - |
 | Free tier | 200 |
-| Starter | 1,000 |
-| Growth | 2,000 |
+| Pay-as-you-go  | 1,000 |
+| Growth add-on | 2,000 |
 | Enterprise | Custom |
 
 <Info>
@@ -6640,8 +6640,8 @@ Nango Cloud uses [WorkOS](https://workos.com) to power SSO.
 | Plan | SSO support |
 | - | - |
 | Free / Starter | Google SSO only |
-| Growth | SSO with 20+ identity providers (add-on) |
-| Enterprise (Cloud) | SSO with 20+ identity providers (included) |
+| Growth add-on | SAML SSO with 20+ identity providers |
+| Enterprise (Cloud) | SAML SSO + SCIM |
 | Enterprise (Self-hosted) | Not yet available (planned) |
 
 ### Supported providers
@@ -7024,17 +7024,20 @@ For more details, see the [pricing page](https://nango.dev/pricing) or [schedule
 
 | Feature | Free self-hosted | Enterprise self-hosted / Nango Cloud |
 | --- | --- | --- |
-| Auth | Yes | Yes |
+| API Auth | Yes | Yes |
 | Proxy | Yes | Yes |
 | Observability | Auth + proxy only | Full |
 | OpenTelemetry export | No | Yes |
-| Functions | No | Yes |
+| Pre-built syncs, tools & triggers | No | Yes |
+| Syncs | No | Yes |
+| Tool calls | No | Yes |
 | Webhooks | No | Yes |
+| Triggers | No | Yes |
 | MCP server | No | Yes |
 | Customize auth branding | No | Yes |
-| Role-based permissions | No | Yes |
-| SAML SSO | No | On the roadmap |
-| Support SLA | No | Yes |
+| RBAC | No | Yes |
+| MFA | No | Yes |
+| SAML SSO | No | Yes |
 
 ### Server URL, callback URL, and custom domains
 
@@ -11132,7 +11135,7 @@ const { data } = await nango.createConnectSession({
       }
     }
     ```
-    Available on the [Growth plan](https://www.nango.dev/pricing).
+    Available with the [Growth add-on](https://www.nango.dev/pricing).
   </ResponseField>
 </Expandable>
 

--- a/docs/reference/backend/backend-sdk/node.mdx
+++ b/docs/reference/backend/backend-sdk/node.mdx
@@ -363,7 +363,7 @@ const { data } = await nango.createConnectSession({
       }
     }
     ```
-    Available on the [Growth plan](https://www.nango.dev/pricing).
+    Available with the [Growth add-on](https://www.nango.dev/pricing).
   </ResponseField>
 </Expandable>
 


### PR DESCRIPTION
## Summary
- Replace Starter / Growth plan names with Pay-as-you-go and Growth add-on in limits, Connect UI, and the Node SDK.
- Update SSO availability: Growth add-on is SAML SSO; Enterprise Cloud is SAML SSO + SCIM.
- Refresh the free vs Enterprise self-hosted feature table (API Auth, pre-built syncs/tools/triggers, RBAC, MFA, SAML SSO).

## Test plan
- [ ] Skim the five changed pages and confirm plan names match the current pricing page
- [ ] Confirm SSO and self-hosted feature rows still match product (especially SCIM and SAML SSO)
- [ ] Click through the pricing links on Connect UI and the Node SDK `overrides` field


Made with [Cursor](https://cursor.com)