### PR TITLE
fix(docker): run as non-root USER node with secret-mount handling (P3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,16 +100,15 @@ RUN true \
       /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
   && rm -rf /var/lib/apt/lists/*
 
-# Do not use root to run the app
-# BUT it does not work with secret mount (could not find a solution yet)
-# TODO: fix this
-# USER node
+# Create app directory with correct ownership for non-root user.
+# Secret mounts (e.g. /etc/nango/tls) are expected to be world or group
+# readable (0440 with fsGroup 1000) so USER node can read them — see docs.
+RUN mkdir -p /app/nango && chown node:node /app/nango
 
 WORKDIR /app/nango
 
-# Code
-# COPY --from=build --chown=node:node /app/tmp /app/nango
-COPY --from=build /app/tmp /app/nango
+# Code — preserve ownership so the non-root user can read it
+COPY --from=build --chown=node:node /app/tmp /app/nango
 
 ARG git_hash
 
@@ -119,3 +118,6 @@ ENV GIT_HASH=$git_hash
 ENV SERVER_RUN_MODE=DOCKERIZED
 
 EXPOSE 8080
+
+# Run as non-root; secret volumes must be mounted group-readable (see docs).
+USER node

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -489,6 +489,24 @@ NANGO_INTERNAL_TLS_CA_FILE=/etc/nango/tls/ca.crt
 - `NANGO_INTERNAL_TLS_KEY_PASSPHRASE` is used exactly as given, including any leading or trailing whitespace, since that whitespace may be part of the passphrase. Surrounding whitespace *is* stripped from the other variables, where it is never significant.
 - Prefer ECDSA P-256 over RSA-2048. The per-handshake signature is roughly an order of magnitude cheaper, which matters on the jobs-to-runner path.
 - Certificates are read once at startup, including `_FILE` paths. Rotation requires a restart.
+- The Docker image runs as non-root (`USER node`, UID 1000). When mounting Kubernetes secrets via `_FILE`, set `securityContext.fsGroup: 1000` and `volumes[].secret.defaultMode: 0440` so the files are group-readable; the default `0400` is only readable by root and will fail with `EACCES` under `USER node`. Example:
+
+  ```yaml
+  securityContext:
+    fsGroup: 1000
+  volumes:
+    - name: internal-tls
+      secret:
+        secretName: nango-internal-tls
+        defaultMode: 0440
+        items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          - key: ca.crt
+            path: ca.crt
+  ```
 
 <Note>
 `NANGO_INTERNAL_TLS_CA` replaces the default root store for internal calls. One of those calls fetches `PROVIDERS_URL`—if that points at an endpoint with a publicly issued certificate, leave the CA unset and use `NODE_EXTRA_CA_CERTS` instead, which adds to the default roots rather than replacing them.

--- a/packages/utils/lib/tls/internal.ts
+++ b/packages/utils/lib/tls/internal.ts
@@ -43,7 +43,11 @@ function resolveAsset(env: EnvRecord, name: string): string | undefined {
         try {
             content = readFileSync(file, 'utf8').trim();
         } catch (err) {
-            throw new Error(`Unable to read ${fileVar} at '${file}'`, { cause: err });
+            const isPermissionError = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EACCES';
+            const hint = isPermissionError
+                ? ` (permission denied — if running as USER node, mount the secret with defaultMode 0440 and securityContext.fsGroup: 1000 so the file is group-readable)`
+                : '';
+            throw new Error(`Unable to read ${fileVar} at '${file}'${hint}`, { cause: err });
         }
         if (!containsPem(content)) {
             throw new Error(`${fileVar} at '${file}' does not contain a PEM block`);


### PR DESCRIPTION
## Summary
P3 of hygiene plan (6/10) — superagent P2: container kept running as root via commented `USER node`. Isolated PR (3 files).

### Problem
- `Dockerfile:103-107` (web stage) left `USER node` commented with `TODO: fix this — secret mount 0400 causes EACCES for UID 1000`. Image therefore runs as **root** (CIS failure).
- `packages/utils/lib/tls/internal.ts:43` threw generic `Unable to read NANGO_INTERNAL_TLS_*_FILE at '...'` on `EACCES`, giving no hint that the default Kubernetes secret `defaultMode: 0400` is unreadable by non-root.
- No docs for operators on required K8s `fsGroup`/`defaultMode` to make the non-root switch work.

### Fix
- **Dockerfile (web)** `Dockerfile:93-121`: 
  - Create `/app/nango` with `chown node:node`, switch `COPY --from=build /app/tmp /app/nango` → `--chown=node:node`, add `USER node` at end (final process UID 1000). Removes TODO and makes image CIS-compliant. Secret mounts are expected to be group-readable — see docs.
- **TLS loader** `packages/utils/lib/tls/internal.ts:46`: detect `EACCES` (`code === 'EACCES'`) and append hint ` (permission denied — if running as USER node, mount the secret with defaultMode 0440 and securityContext.fsGroup: 1000 so the file is group-readable)`.
- **Docs** `docs/guides/platform/self-hosting.mdx:489`: add K8s example with `securityContext.fsGroup: 1000` and `secret.defaultMode: 0440` plus note that `0400` fails under `USER node`.

### Verification
- `npm run lint` clean, `npm run test:unit -- packages/utils/lib/tls/internal.unit.test.ts` 26/26 pass (existing `Unable to read` test still matches, hint only on `EACCES`).
- Dockerfile now contains `USER node` (passes superagent check) and `COPY --chown=node:node`.
- Manual check: image builds with `USER node`; without K8s fix, TLS file `EACCES` now logs actionable hint instead of silent generic.

### Risk
Low. Non-root run may break if operator still uses `defaultMode: 0400` without `fsGroup` — now fails fast with clear hint vs previously running as root and masking the issue. Documented migration path. No code path change for non-TLS deployments.

Fixes superagent P2 and hygiene plan P3.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

