### PR TITLE
fix(design-system): attach tooltip arrow to chip

### DIFF
--- a/packages/design-system/src/components/ui/tooltip.tsx
+++ b/packages/design-system/src/components/ui/tooltip.tsx
@@ -21,16 +21,16 @@ const TooltipTrigger = React.forwardRef<React.ElementRef<typeof TooltipPrimitive
 TooltipTrigger.displayName = 'TooltipTrigger';
 
 const TooltipContent = React.forwardRef<React.ElementRef<typeof TooltipPrimitive.Content>, TooltipContentProps>(
-    ({ className, sideOffset = 0, children, ...props }, ref) => (
+    ({ className, sideOffset = 0, collisionPadding = 8, children, ...props }, ref) => (
         <TooltipPrimitive.Portal>
             <TooltipPrimitive.Content
                 ref={ref}
                 data-slot="tooltip-content"
                 sideOffset={sideOffset}
+                // Radix defaults this to 0, which leaves a shifted chip flush against the window.
+                collisionPadding={collisionPadding}
                 className={cn(
-                    'group bg-surface-inverse text-text-inverse type-label-sm shadow-container-panel rounded-ds-xs px-1.5 py-1',
-                    // The arrow paints over the chip, so the side it sits on needs room the text can't use.
-                    'data-[side=left]:pr-2.5 data-[side=right]:pl-2.5',
+                    'bg-surface-inverse text-text-inverse type-label-sm shadow-container-panel rounded-ds-xs px-1.5 py-1',
                     'origin-(--radix-tooltip-content-transform-origin) z-80 w-fit max-w-96',
                     // Link tokens are tuned for the page surface and lose contrast on the inverse chip. Redefining
                     // them in scope covers every state, since the link variants read these vars; the underline then
@@ -47,13 +47,13 @@ const TooltipContent = React.forwardRef<React.ElementRef<typeof TooltipPrimitive
                 {children}
                 <TooltipPrimitive.Arrow
                     className={cn(
-                        'bg-surface-inverse fill-surface-inverse rounded-ds-xs z-80 size-2.5 rotate-45',
-                        // The diamond is tucked back into the chip along whichever axis it sits on, so a
-                        // left/right tooltip must move on X — moving it on Y leaves it over the first word.
-                        'group-data-[side=top]:translate-y-[calc(-50%_-_2px)]',
-                        'group-data-[side=bottom]:translate-y-[calc(50%_+_2px)]',
-                        'group-data-[side=left]:translate-x-[calc(-50%_-_2px)]',
-                        'group-data-[side=right]:translate-x-[calc(50%_+_2px)]'
+                        'bg-surface-inverse fill-surface-inverse rounded-ds-xs size-2.5 rotate-45',
+                        // Radix rotates the arrow's wrapper per side, so -Y here always points back into the
+                        // chip whatever side it lands on — never per-side offsets.
+                        'translate-y-[calc(-50%_-_2px)]',
+                        // The clip drops the tucked-in half, which would otherwise paint over the text.
+                        // Applied pre-rotation, so this triangle is the outward-facing one.
+                        '[clip-path:polygon(100%_0,100%_100%,0_100%)]'
                     )}
                 />
             </TooltipPrimitive.Content>


### PR DESCRIPTION
## Problem

Tooltips across the dashboard render with their pointer detached from the bubble. Instead of attaching to it, the pointer floats over the button as a small diamond. This hits every tooltip that opens below, to the left of, or to the right of what it points at — most of them. Only tooltips opening above are correct.

Tooltips near the edge of the window also sit flush against it, with no margin.

Introduced by #7314.

## Solution

- The pointer attaches to the bubble on all four sides, and reads as a triangle rather than a floating diamond.
- Tooltips keep a small margin from the window edge.

Fixes [NAN-6893](https://linear.app/nango/issue/NAN-6893)

## Testing

Checked all four sides and all three alignments in the `Tooltip` stories, and the reported case — the Edit pencil on Environment settings — in the webapp.

Before
<img width="380" height="89" alt="image" src="https://github.com/user-attachments/assets/a9ff1f17-d10f-438e-b491-a50f48415e34" />

After
<img width="383" height="85" alt="image" src="https://github.com/user-attachments/assets/2dfc0948-f956-4d83-bce5-b9eb6dacf782" />


## Follow-ups

- Icon-only buttons still show the browser's native tooltip alongside the design-system one: [NAN-6894](https://linear.app/nango/issue/NAN-6894)
