### PR TITLE
fix(cli): stop compile test hanging on npm audit

### DIFF
--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -46,7 +46,7 @@ describe('compileAll', () => {
         await fs.promises.copyFile(path.join(dir, 'github', 'functions', 'fetchIssues.ts'), path.join(dottedIntegrationFunctionsPath, 'fetchIssues.ts'));
         await fs.promises.appendFile(indexPath, "\nimport './github.js/functions/fetchIssues.js';\n");
         await fs.promises.writeFile(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2));
-        await exec('npm i', { cwd: dir });
+        await exec('npm i --no-audit --no-fund', { cwd: dir });
         const result = await compileAllFunctions({ fullPath: dir, debug: false });
         result.unwrap();
         expect(result.isOk()).toBe(true);


### PR DESCRIPTION
## Problem

`compile.unit.cli-test.ts > should compile a minimal integration` times out at 20s and fails `npm run test:cli` on unrelated PRs — [this run](https://github.com/NangoHQ/nango/actions/runs/33847751619/job/100949848121?pr=7395), plus the #7391 merge-queue run and several other branches.

The test shells out to a real `npm i`. npm's audit step POSTs to the registry and can leave that socket open after the install itself has finished, so the child process never exits. It reproduces on every local run but only intermittently in CI, which is why the test has been flaking rather than failing outright.

## Solution

- Pass `--no-audit --no-fund` to the `npm i` the test runs, so the child exits when the install does.

## Testing

Plain `npm i` hung on all five local attempts (up to a 300s timeout); `--no-audit` passed on all three; `--no-fund` alone still hung. The file now passes 30/30 in ~3s.
