### PR TITLE
feat(webapp): rework the audit trail filter UI

### DIFF
--- a/packages/webapp/src/components/patterns/FilterMultiSelect.tsx
+++ b/packages/webapp/src/components/patterns/FilterMultiSelect.tsx
@@ -15,6 +15,7 @@ export interface FilterOption<T extends string = string> {
 
 interface FilterMultiSelectProps<T extends string = string> {
     label: string;
+    icon?: React.ReactNode;
     options: FilterOption<T>[];
     selected: T[];
     defaultSelect?: T[];
@@ -31,6 +32,7 @@ interface FilterMultiSelectProps<T extends string = string> {
 
 export function FilterMultiSelect<T extends string = string>({
     label,
+    icon,
     options,
     selected,
     defaultSelect = [],
@@ -181,7 +183,8 @@ export function FilterMultiSelect<T extends string = string>({
     return (
         <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
-                <Button variant="outline" size="md" disabled={disabled} className={cn('text-text-muted', isDirty && 'text-text-strong')}>
+                <Button variant="outline" size="md" disabled={disabled}>
+                    {icon}
                     {label}
                     {isDirty && (
                         <span

--- a/packages/webapp/src/pages/Audit/Show.tsx
+++ b/packages/webapp/src/pages/Audit/Show.tsx
@@ -1,14 +1,15 @@
-import { ChevronRight } from 'lucide-react';
+import { Box, ChevronRight, Zap } from 'lucide-react';
+import { parseAsArrayOf, parseAsStringLiteral, parseAsTimestamp, useQueryState } from 'nuqs';
 import { useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 
 import { Button } from '@nangohq/design-system';
 
-import { ConditionalTooltip } from '@/components/patterns/ConditionalTooltip';
 import { FilterMultiSelect } from '@/components/patterns/FilterMultiSelect';
 import { PeriodSelector } from '@/components/patterns/PeriodSelector';
+import { Separator } from '@/components/ui/Separator';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { Tag } from '@/components/ui/Tag';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/Table';
 import { useApiGetAuditTrail } from '@/hooks/useAudit';
 import { useMeta } from '@/hooks/useMeta';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -18,28 +19,29 @@ import { last14dPreset, logsPresets } from '@/utils/logs';
 import { formatDateToLogFormat } from '@/utils/utils';
 import { AuditEventDrawer } from './components/AuditEventDrawer';
 import { AuditExportDialog } from './components/AuditExportDialog';
+import { OutcomeTag } from './components/OutcomeTag';
 import {
-    actionLabel,
-    actionOptionsFor,
+    actionOptionsForResources,
+    actionValues,
     actorLabel,
     ALL,
-    environmentLabel,
-    resourceLabel,
+    eventLabel,
     resourceOptions,
-    scopeLabel,
+    resourcesOwningActions,
+    resourceValues,
     targetsLabel,
     viaLabel
 } from './constants';
 
-import type { ActionFilter, ResourceFilter } from './constants';
+import type { ActionFilter } from './constants';
 import type { Period } from '@/utils/dates';
-import type { ApiAuditTrailEvent, AuditAction, AuditOutcome, AuditResource } from '@nangohq/types';
+import type { ApiAuditTrailEvent, AuditAction, AuditResource } from '@nangohq/types';
 
-const outcomeVariant: Record<AuditOutcome, React.ComponentProps<typeof Tag>['variant']> = {
-    success: 'success',
-    failure: 'alert',
-    denied: 'warning'
-};
+const parseResources = parseAsArrayOf(parseAsStringLiteral(resourceValues), ',').withDefault([ALL]).withOptions({ history: 'push' });
+const parseActions = parseAsArrayOf(parseAsStringLiteral(actionValues), ',').withDefault([ALL]).withOptions({ history: 'push' });
+// A preset period has no `to` (see utils/logs), so this is variable-length by design.
+const periodToParam = (period: Period | null): Date[] => (!period ? [] : period.to ? [period.from, period.to] : [period.from]);
+const parsePeriod = parseAsArrayOf(parseAsTimestamp, ',').withOptions({ history: 'push' }).withDefault(periodToParam(last14dPreset.toPeriod()));
 
 export const AuditShow: React.FC = () => {
     const { data: metaData } = useMeta();
@@ -47,27 +49,35 @@ export const AuditShow: React.FC = () => {
     const { user } = useUser();
     const { can } = usePermissions();
     const canReadAuditTrail = can('account:audit_trail:read');
-    const [period, setPeriod] = useState<Period | null>(() => last14dPreset.toPeriod());
-    const [resources, setResources] = useState<ResourceFilter[]>([ALL]);
-    const [actions, setActions] = useState<ActionFilter[]>([ALL]);
+    const [resources, setResources] = useQueryState('resources', parseResources);
+    const [actions, setActions] = useQueryState('actions', parseActions);
+    const [period, setPeriod] = useQueryState('period', parsePeriod);
     const [selected, setSelected] = useState<ApiAuditTrailEvent | null>(null);
 
-    const from = period?.from ? period.from.toISOString() : undefined;
-    const to = period?.to ? period.to.toISOString() : undefined;
+    const from = period[0]?.toISOString();
+    const to = period[1]?.toISOString();
+    const selectorPeriod = useMemo(() => (period[0] ? { from: period[0], to: period[1] } : null), [period]);
 
-    // Actions are matched as `resource.action` pairs, so they're only offered once the resource half is unambiguous.
-    const singleResource: AuditResource | null = resources.length === 1 && resources[0] !== ALL ? resources[0] : null;
-    const onResourcesChange = (next: ResourceFilter[]) => {
-        setResources(next);
-        setActions([ALL]);
-    };
+    const resourceSelection = useMemo(() => resources.filter((resource): resource is AuditResource => resource !== ALL), [resources]);
+    const actionOptions = useMemo(() => actionOptionsForResources(resourceSelection), [resourceSelection]);
 
-    const resourceFilter = useMemo(() => resources.filter((resource): resource is AuditResource => resource !== ALL), [resources]);
-    const actionFilter = useMemo(() => (singleResource ? actions.filter((action): action is AuditAction => action !== ALL) : []), [actions, singleResource]);
+    // Reconciled here, not in the change handler: a selection also arrives from the URL, and an action the
+    // chosen resources don't declare would be sent as a pair that can never match.
+    const offeredActions = useMemo<ActionFilter[]>(() => {
+        const offered = new Set(actionOptions.map((option) => option.value));
+        const kept = actions.filter((action) => offered.has(action));
+        return kept.length ? kept : [ALL];
+    }, [actions, actionOptions]);
+    const actionSelection = useMemo(() => offeredActions.filter((action): action is AuditAction => action !== ALL), [offeredActions]);
+
+    const resourceFilter = useMemo(
+        () => (resourceSelection.length ? resourceSelection : actionSelection.length ? resourcesOwningActions(actionSelection) : []),
+        [resourceSelection, actionSelection]
+    );
 
     // Only read audit data once the flag and the caller's permission are confirmed; stays idle otherwise.
     const { data, isLoading, isError, refetch, isFetchingNextPage, hasNextPage, fetchNextPage } = useApiGetAuditTrail(
-        { from, to, resources: resourceFilter, actions: actionFilter },
+        { from, to, resources: resourceFilter, actions: actionSelection },
         { enabled: meta?.auditTrail === true && canReadAuditTrail }
     );
     const events = useMemo(() => data?.pages.flatMap((page) => page.data) ?? [], [data]);
@@ -104,106 +114,104 @@ export const AuditShow: React.FC = () => {
         );
     }
 
+    const resultCount = !showLoading && !isError && total && total.value > 0 && (
+        <div className="text-text-muted text-body-small-regular font-code">
+            {total.value.toLocaleString()}
+            {total.relation === 'gte' ? '+' : ''} {total.value === 1 && total.relation === 'eq' ? 'result' : 'results'} found
+        </div>
+    );
+
     return (
-        <DashboardLayout fullWidth title="Audit trail">
+        <DashboardLayout fullWidth title="Audit trail" titleActions={resultCount}>
             <Helmet>
                 <title>Audit trail - Nango</title>
             </Helmet>
 
-            <div className="flex flex-col gap-3">
-                <div className="flex gap-2 justify-between">
-                    {/* Left side is reserved for search + filters (status, actor, …) added later. */}
-                    <div className="flex-1 min-w-0" />
-                    <div className="flex gap-2">
-                        <FilterMultiSelect label="Resource" options={resourceOptions} selected={resources} defaultSelect={[ALL]} onChange={onResourcesChange} />
-                        <ConditionalTooltip condition={!singleResource} content="Select a single resource to filter by action" asChild>
-                            <span>
-                                <FilterMultiSelect
-                                    label="Action"
-                                    options={singleResource ? actionOptionsFor(singleResource) : []}
-                                    selected={actions}
-                                    defaultSelect={[ALL]}
-                                    onChange={setActions}
-                                    disabled={!singleResource}
-                                />
-                            </span>
-                        </ConditionalTooltip>
+            <div className="flex flex-col gap-5">
+                <div className="flex gap-4 justify-end">
+                    <div className="flex gap-2.5">
+                        <FilterMultiSelect
+                            label="Resource"
+                            icon={<Box size={14} />}
+                            options={resourceOptions}
+                            selected={resources}
+                            defaultSelect={[ALL]}
+                            onChange={(next) => void setResources(next)}
+                        />
+                        <FilterMultiSelect
+                            label="Action"
+                            icon={<Zap size={14} />}
+                            options={actionOptions}
+                            selected={offeredActions}
+                            defaultSelect={[ALL]}
+                            onChange={(next) => void setActions(next)}
+                            showSearch
+                        />
                         <PeriodSelector
                             isLive={false}
-                            period={period}
-                            onChange={(next) => setPeriod(next)}
+                            period={selectorPeriod}
+                            onChange={(next) => void setPeriod(periodToParam(next))}
                             presets={logsPresets}
                             defaultPreset={last14dPreset}
                         />
-                        <AuditExportDialog from={from} to={to} resources={resourceFilter} actions={actionFilter} disabled={showLoading || isError} />
                     </div>
+                    {/* Overrides the primitive's own `h-full`, which resolves to 0 against this auto-height row. */}
+                    <Separator orientation="vertical" className="data-[orientation=vertical]:h-7" />
+                    <AuditExportDialog
+                        query={{ from, to, resources: resourceFilter, actions: actionSelection }}
+                        selection={{ resources: resourceSelection, actions: actionSelection }}
+                        disabled={showLoading || isError}
+                    />
                 </div>
 
-                {total && total.value > 0 && (
-                    <div className="flex items-center justify-end">
-                        <div className="text-text-muted text-body-small-regular">
-                            {total.value.toLocaleString()}
-                            {total.relation === 'gte' ? '+' : ''} {total.value === 1 && total.relation === 'eq' ? 'event' : 'events'}
-                        </div>
-                    </div>
+                {events.length > 0 && (
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Time</TableHead>
+                                <TableHead>Actor</TableHead>
+                                <TableHead>Event</TableHead>
+                                <TableHead>Target</TableHead>
+                                <TableHead>Outcome</TableHead>
+                                <TableHead className="w-8">
+                                    <span className="sr-only">Details</span>
+                                </TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {events.map((event) => {
+                                const via = viaLabel(event.via);
+                                return (
+                                    <TableRow key={event.id} onClick={() => setSelected(event)} className="cursor-pointer text-text-muted">
+                                        <TableCell className="font-code">{formatDateToLogFormat(event.occurredAt)}</TableCell>
+                                        <TableCell>
+                                            {actorLabel(event.actor)}
+                                            {via && <span className="text-text-muted"> via {via}</span>}
+                                        </TableCell>
+                                        <TableCell>{eventLabel(event)}</TableCell>
+                                        <TableCell>{targetsLabel(event.targets)}</TableCell>
+                                        <TableCell>
+                                            <OutcomeTag outcome={event.outcome} />
+                                        </TableCell>
+                                        <TableCell className="text-icon-secondary">
+                                            <button
+                                                type="button"
+                                                aria-label="View event details"
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    setSelected(event);
+                                                }}
+                                                className="flex items-center rounded hover:text-text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-default"
+                                            >
+                                                <ChevronRight size={16} />
+                                            </button>
+                                        </TableCell>
+                                    </TableRow>
+                                );
+                            })}
+                        </TableBody>
+                    </Table>
                 )}
-
-                <table className="w-full text-s text-text-strong">
-                    <thead>
-                        <tr className="border-b border-border-muted">
-                            <th className="px-4 py-2 text-left font-semibold">Time</th>
-                            <th className="px-4 py-2 text-left font-semibold">Scope</th>
-                            <th className="px-4 py-2 text-left font-semibold">Environment</th>
-                            <th className="px-4 py-2 text-left font-semibold">Actor</th>
-                            <th className="px-4 py-2 text-left font-semibold">Resource</th>
-                            <th className="px-4 py-2 text-left font-semibold">Action</th>
-                            <th className="px-4 py-2 text-left font-semibold">Target</th>
-                            <th className="px-4 py-2 text-left font-semibold">Outcome</th>
-                            <th className="w-8 px-4 py-2" />
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {events.map((event) => {
-                            const via = viaLabel(event.via);
-                            return (
-                                <tr
-                                    key={event.id}
-                                    onClick={() => setSelected(event)}
-                                    className="text-text-muted border-b border-border-muted transition-colors hover:bg-surface-page hover:text-text-strong cursor-pointer"
-                                >
-                                    <td className="px-4 py-2.5 align-middle">
-                                        <div className="font-code text-s">{formatDateToLogFormat(event.occurredAt)}</div>
-                                    </td>
-                                    <td className="px-4 py-2.5 align-middle">{scopeLabel(event.scope)}</td>
-                                    <td className="px-4 py-2.5 align-middle">{environmentLabel(event.environment)}</td>
-                                    <td className="px-4 py-2.5 align-middle">
-                                        {actorLabel(event.actor)}
-                                        {via && <span className="text-text-muted"> via {via}</span>}
-                                    </td>
-                                    <td className="px-4 py-2.5 align-middle">{resourceLabel(event.resource)}</td>
-                                    <td className="px-4 py-2.5 align-middle">{actionLabel(event)}</td>
-                                    <td className="px-4 py-2.5 align-middle">{targetsLabel(event.targets)}</td>
-                                    <td className="px-4 py-2.5 align-middle">
-                                        <Tag variant={outcomeVariant[event.outcome]}>{event.outcome}</Tag>
-                                    </td>
-                                    <td className="px-4 py-2.5 align-middle text-icon-secondary">
-                                        <button
-                                            type="button"
-                                            aria-label="View event details"
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                                                setSelected(event);
-                                            }}
-                                            className="flex items-center rounded hover:text-text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-default"
-                                        >
-                                            <ChevronRight size={16} />
-                                        </button>
-                                    </td>
-                                </tr>
-                            );
-                        })}
-                    </tbody>
-                </table>
 
                 {showLoading && (
                     <div className="flex flex-col gap-2">

--- a/packages/webapp/src/pages/Audit/Show.tsx
+++ b/packages/webapp/src/pages/Audit/Show.tsx
@@ -1,9 +1,9 @@
 import { Box, ChevronRight, Zap } from 'lucide-react';
 import { parseAsArrayOf, parseAsStringLiteral, parseAsTimestamp, useQueryState } from 'nuqs';
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
 
-import { Button } from '@nangohq/design-system';
+import { Badge, Button } from '@nangohq/design-system';
 
 import { FilterMultiSelect } from '@/components/patterns/FilterMultiSelect';
 import { PeriodSelector } from '@/components/patterns/PeriodSelector';
@@ -29,7 +29,7 @@ import {
     resourceOptions,
     resourcesOwningActions,
     resourceValues,
-    targetsLabel,
+    targetsSummary,
     viaLabel
 } from './constants';
 
@@ -42,6 +42,19 @@ const parseActions = parseAsArrayOf(parseAsStringLiteral(actionValues), ',').wit
 // A preset period has no `to` (see utils/logs), so this is variable-length by design.
 const periodToParam = (period: Period | null): Date[] => (!period ? [] : period.to ? [period.from, period.to] : [period.from]);
 const parsePeriod = parseAsArrayOf(parseAsTimestamp, ',').withOptions({ history: 'push' }).withDefault(periodToParam(last14dPreset.toPeriod()));
+
+const TargetCell: React.FC<{ targets: ApiAuditTrailEvent['targets'] }> = ({ targets }) => {
+    const summary = targetsSummary(targets);
+    if (!summary) {
+        return <>—</>;
+    }
+    return (
+        <div className="flex items-center gap-2">
+            <span className="truncate">{summary.first}</span>
+            {summary.rest > 0 && <Badge variant="secondary">+{summary.rest}</Badge>}
+        </div>
+    );
+};
 
 export const AuditShow: React.FC = () => {
     const { data: metaData } = useMeta();
@@ -81,6 +94,26 @@ export const AuditShow: React.FC = () => {
         { enabled: meta?.auditTrail === true && canReadAuditTrail }
     );
     const events = useMemo(() => data?.pages.flatMap((page) => page.data) ?? [], [data]);
+
+    // The button below stays: it is the keyboard path, and the fallback if the observer never fires.
+    const loadMoreRef = useRef<HTMLDivElement | null>(null);
+    const canLoadMore = hasNextPage && !isFetchingNextPage;
+    const observeLoadMore = useCallback((node: HTMLDivElement | null) => {
+        loadMoreRef.current = node;
+    }, []);
+    useEffect(() => {
+        const node = loadMoreRef.current;
+        if (!node || !canLoadMore) {
+            return;
+        }
+        const observer = new IntersectionObserver((entries) => {
+            if (entries.some((entry) => entry.isIntersecting)) {
+                void fetchNextPage();
+            }
+        });
+        observer.observe(node);
+        return () => observer.disconnect();
+    }, [canLoadMore, fetchNextPage, events.length]);
     // Absent when the count failed, in which case say nothing rather than pass the loaded rows off as the total.
     const total = data?.pages.at(-1)?.total;
     const showLoading = !meta || !user || isLoading;
@@ -160,6 +193,7 @@ export const AuditShow: React.FC = () => {
                     <AuditExportDialog
                         query={{ from, to, resources: resourceFilter, actions: actionSelection }}
                         selection={{ resources: resourceSelection, actions: actionSelection }}
+                        total={total}
                         disabled={showLoading || isError}
                     />
                 </div>
@@ -189,7 +223,9 @@ export const AuditShow: React.FC = () => {
                                             {via && <span className="text-text-muted"> via {via}</span>}
                                         </TableCell>
                                         <TableCell>{eventLabel(event)}</TableCell>
-                                        <TableCell>{targetsLabel(event.targets)}</TableCell>
+                                        <TableCell className="max-w-md">
+                                            <TargetCell targets={event.targets} />
+                                        </TableCell>
                                         <TableCell>
                                             <OutcomeTag outcome={event.outcome} />
                                         </TableCell>
@@ -237,7 +273,7 @@ export const AuditShow: React.FC = () => {
                 )}
 
                 {events.length > 0 && hasNextPage && (
-                    <div className="flex justify-center mt-2">
+                    <div ref={observeLoadMore} className="flex justify-center mt-2">
                         <Button variant="outline" loading={isFetchingNextPage} onClick={() => void fetchNextPage()}>
                             Load more...
                         </Button>

--- a/packages/webapp/src/pages/Audit/Show.tsx
+++ b/packages/webapp/src/pages/Audit/Show.tsx
@@ -97,7 +97,8 @@ export const AuditShow: React.FC = () => {
 
     // The button below stays: it is the keyboard path, and the fallback if the observer never fires.
     const loadMoreRef = useRef<HTMLDivElement | null>(null);
-    const canLoadMore = hasNextPage && !isFetchingNextPage;
+    // Stops on error: the sentinel stays visible after a failed page, so the observer would retry it in a loop.
+    const canLoadMore = hasNextPage && !isFetchingNextPage && !isError;
     const observeLoadMore = useCallback((node: HTMLDivElement | null) => {
         loadMoreRef.current = node;
     }, []);

--- a/packages/webapp/src/pages/Audit/Show.tsx
+++ b/packages/webapp/src/pages/Audit/Show.tsx
@@ -74,8 +74,7 @@ export const AuditShow: React.FC = () => {
     const resourceSelection = useMemo(() => resources.filter((resource): resource is AuditResource => resource !== ALL), [resources]);
     const actionOptions = useMemo(() => actionOptionsForResources(resourceSelection), [resourceSelection]);
 
-    // Reconciled here, not in the change handler: a selection also arrives from the URL, and an action the
-    // chosen resources don't declare would be sent as a pair that can never match.
+    // Reconciled here, not in the change handler: a selection also arrives from the URL.
     const offeredActions = useMemo<ActionFilter[]>(() => {
         const offered = new Set(actionOptions.map((option) => option.value));
         const kept = actions.filter((action) => offered.has(action));
@@ -95,7 +94,6 @@ export const AuditShow: React.FC = () => {
     );
     const events = useMemo(() => data?.pages.flatMap((page) => page.data) ?? [], [data]);
 
-    // The button below stays: it is the keyboard path, and the fallback if the observer never fires.
     const loadMoreRef = useRef<HTMLDivElement | null>(null);
     // Stops on error: the sentinel stays visible after a failed page, so the observer would retry it in a loop.
     const canLoadMore = hasNextPage && !isFetchingNextPage && !isError;

--- a/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
@@ -3,22 +3,16 @@ import { X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { Sheet, SheetClose, SheetContent, SheetTitle } from '@/components/ui/Sheet';
-import { Tag } from '@/components/ui/Tag';
 import { darkModeSelector, useThemeStore } from '@/lib/theme';
 import { formatDateToLogFormat } from '@/utils/utils';
-import { actionLabel, actorLabel, environmentLabel, resourceLabel, scopeLabel, targetsLabel, targetTypesLabel, viaLabel } from '../constants';
+import { actorLabel, environmentLabel, eventLabel, targetsLabel, viaLabel } from '../constants';
+import { OutcomeTag } from './OutcomeTag';
 
-import type { ApiAuditTrailEvent, AuditOutcome } from '@nangohq/types';
-
-const outcomeVariant: Record<AuditOutcome, React.ComponentProps<typeof Tag>['variant']> = {
-    success: 'success',
-    failure: 'alert',
-    denied: 'warning'
-};
+import type { ApiAuditTrailEvent } from '@nangohq/types';
 
 const Meta: React.FC<{ label: string; value: string; mono?: boolean }> = ({ label, value, mono }) => (
     <>
-        <dt className="text-text-muted">{label}</dt>
+        <dt className="uppercase text-text-muted">{label}</dt>
         <dd className={mono ? 'font-code break-all' : 'break-all'}>{value}</dd>
     </>
 );
@@ -45,39 +39,35 @@ export const AuditEventDrawer: React.FC<{ event: ApiAuditTrailEvent; onClose: ()
                 className="w-full sm:w-[720px] max-w-none sm:max-w-none p-0 bg-surface-page text-text-strong border-l-border-muted"
             >
                 <SheetTitle className="sr-only">Audit event details</SheetTitle>
-                <div className="relative h-full select-text overflow-y-auto p-8">
-                    <div className="absolute right-6 top-8 flex items-center gap-1">
+                <div className="h-full select-text overflow-y-auto">
+                    <div className="flex h-14 items-center justify-between border-b border-border-muted px-6">
+                        <h2 className="text-lg font-semibold">Audit event</h2>
                         <SheetClose
                             title="Close"
-                            className="bg-transparent text-text-muted hover:text-text-strong focus:text-text-strong transition-colors size-8 flex items-center justify-center"
+                            className="-mr-2 flex size-8 items-center justify-center bg-transparent text-text-muted transition-colors hover:text-text-strong focus:text-text-strong"
                         >
                             <X size={16} />
                         </SheetClose>
                     </div>
 
-                    <h2 className="text-xl font-semibold">Audit event</h2>
-                    <div className="flex items-center gap-3 mt-3 mb-6">
-                        <Tag variant={outcomeVariant[event.outcome]}>{event.outcome}</Tag>
-                        <span className="text-text-muted text-s font-code">{formatDateToLogFormat(event.occurredAt)}</span>
+                    <div className="flex h-14 items-center justify-between border-b border-border-muted px-6">
+                        <span className="font-code text-s">{formatDateToLogFormat(event.occurredAt)}</span>
+                        <OutcomeTag outcome={event.outcome} />
                     </div>
 
-                    <dl className="grid grid-cols-[130px_1fr] gap-x-4 gap-y-2 text-s mb-6">
-                        <Meta label="Scope" value={scopeLabel(event.scope)} />
-                        <Meta label="Environment" value={environmentLabel(event.environment)} />
+                    <dl className="grid grid-cols-[180px_1fr] gap-x-4 gap-y-5 px-6 py-6 text-s">
                         <Meta label="Actor" value={actorLabel(event.actor)} />
                         {via && <Meta label="Via" value={via} />}
-                        <Meta label="Resource" value={resourceLabel(event.resource)} />
-                        <Meta label="Action" value={actionLabel(event)} />
+                        <Meta label="Event" value={eventLabel(event)} />
                         <Meta label="Target" value={targetsLabel(event.targets)} />
-                        {event.targets.length > 0 && <Meta label="Target type" value={targetTypesLabel(event.targets)} />}
+                        <Meta label="Environment" value={environmentLabel(event)} />
                         {event.context.ip && <Meta label="IP" value={event.context.ip} mono />}
                         {event.context.userAgent && <Meta label="User agent" value={event.context.userAgent} />}
                         <Meta label="Event ID" value={event.id} mono />
                         <Meta label="Version" value={event.version} mono />
                     </dl>
 
-                    <h4 className="font-semibold text-sm mb-2">Event</h4>
-                    <div className="text-text-muted text-sm bg-surface-panel-inset py-2">
+                    <div className="mx-6 mb-6 rounded bg-surface-panel-inset p-4 text-sm text-text-muted">
                         <Prism
                             language="json"
                             className="transparent-code"

--- a/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
@@ -5,7 +5,7 @@ import { useMemo, useState } from 'react';
 import { Sheet, SheetClose, SheetContent, SheetTitle } from '@/components/ui/Sheet';
 import { darkModeSelector, useThemeStore } from '@/lib/theme';
 import { formatDateToLogFormat } from '@/utils/utils';
-import { actorLabel, environmentLabel, eventLabel, targetsLabel, viaLabel } from '../constants';
+import { actorLabel, environmentLabel, eventLabel, targetNames, viaLabel } from '../constants';
 import { OutcomeTag } from './OutcomeTag';
 
 import type { ApiAuditTrailEvent } from '@nangohq/types';
@@ -59,7 +59,18 @@ export const AuditEventDrawer: React.FC<{ event: ApiAuditTrailEvent; onClose: ()
                         <Meta label="Actor" value={actorLabel(event.actor)} />
                         {via && <Meta label="Via" value={via} />}
                         <Meta label="Event" value={eventLabel(event)} />
-                        <Meta label="Target" value={targetsLabel(event.targets)} />
+                        <dt className="uppercase text-text-muted">{event.targets.length > 1 ? 'Targets' : 'Target'}</dt>
+                        <dd className="break-all">
+                            {event.targets.length === 0 ? (
+                                '—'
+                            ) : (
+                                <ul>
+                                    {targetNames(event.targets).map((name) => (
+                                        <li key={name}>{name}</li>
+                                    ))}
+                                </ul>
+                            )}
+                        </dd>
                         <Meta label="Environment" value={environmentLabel(event)} />
                         {event.context.ip && <Meta label="IP" value={event.context.ip} mono />}
                         {event.context.userAgent && <Meta label="User agent" value={event.context.userAgent} />}

--- a/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
@@ -5,7 +5,7 @@ import { useMemo, useState } from 'react';
 import { Sheet, SheetClose, SheetContent, SheetTitle } from '@/components/ui/Sheet';
 import { darkModeSelector, useThemeStore } from '@/lib/theme';
 import { formatDateToLogFormat } from '@/utils/utils';
-import { actorLabel, environmentLabel, eventLabel, targetNames, viaLabel } from '../constants';
+import { actorLabel, environmentLabel, eventLabel, viaLabel } from '../constants';
 import { OutcomeTag } from './OutcomeTag';
 
 import type { ApiAuditTrailEvent } from '@nangohq/types';
@@ -65,8 +65,8 @@ export const AuditEventDrawer: React.FC<{ event: ApiAuditTrailEvent; onClose: ()
                                 '—'
                             ) : (
                                 <ul>
-                                    {targetNames(event.targets).map((name) => (
-                                        <li key={name}>{name}</li>
+                                    {event.targets.map((target, index) => (
+                                        <li key={`${target.type}:${target.id}:${index}`}>{target.display ?? target.id}</li>
                                     ))}
                                 </ul>
                             )}

--- a/packages/webapp/src/pages/Audit/components/AuditExportDialog.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditExportDialog.tsx
@@ -2,6 +2,8 @@ import { Share } from 'lucide-react';
 import { useRef, useState } from 'react';
 
 import {
+    Alert,
+    AlertDescription,
     Button,
     Dialog,
     DialogBody,
@@ -21,7 +23,7 @@ import { openSupportChat } from '@/utils/support';
 import { actionSelectionLabel, resourceSelectionLabel } from '../constants';
 import { AUDIT_EXPORT_MAX_ROWS, exportWindowField } from '../export';
 
-import type { AuditAction, AuditResource } from '@nangohq/types';
+import type { AuditAction, AuditResource, AuditTrailTotal } from '@nangohq/types';
 
 // Matches DialogContent's own `duration-200` exit animation.
 const DIALOG_EXIT_MS = 200;
@@ -30,16 +32,21 @@ interface AuditExportDialogProps {
     /** Sent to the API. Its resources can be wider than the ones picked, since an action only matches paired with a resource. */
     query: { from: string | undefined; to: string | undefined; resources: AuditResource[]; actions: AuditAction[] };
     selection: { resources: AuditResource[]; actions: AuditAction[] };
+    /** Absent when the count failed, in which case the cap has to be stated unconditionally. */
+    total?: AuditTrailTotal | undefined;
     disabled?: boolean;
 }
 
-export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ query, selection, disabled }) => {
+export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ query, selection, total, disabled }) => {
     const { toast } = useToast();
     const [isOpen, setIsOpen] = useState(false);
     const [isExporting, setIsExporting] = useState(false);
     const exportButtonRef = useRef<HTMLButtonElement>(null);
     const openSupportOnClose = useRef(false);
     const windowField = exportWindowField(query.from, query.to);
+    // A capped count knows only that the window is bigger than the cap, never by how much.
+    const truncates = total ? total.relation === 'gte' || total.value > AUDIT_EXPORT_MAX_ROWS : undefined;
+    const exportedCount = total && (truncates ? AUDIT_EXPORT_MAX_ROWS : total.value);
 
     const onContact = () => {
         openSupportOnClose.current = true;
@@ -108,10 +115,30 @@ export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ query, sel
                         <dd className="font-code text-text-primary">{resourceSelectionLabel(selection.resources)}</dd>
                         <dt className="uppercase text-text-muted">Action</dt>
                         <dd className="font-code text-text-primary">{actionSelectionLabel(selection.actions)}</dd>
-                        <dt className="uppercase text-text-muted">Limit</dt>
-                        <dd className="font-code text-text-primary">{AUDIT_EXPORT_MAX_ROWS.toLocaleString()} events</dd>
+                        {total && (
+                            <>
+                                <dt className="uppercase text-text-muted">Events</dt>
+                                <dd className="font-code text-text-primary">
+                                    {exportedCount?.toLocaleString()}
+                                    {truncates && <span className="text-text-muted"> (max)</span>}
+                                </dd>
+                            </>
+                        )}
                     </dl>
-                    <p className="mt-5 text-body-small-regular text-text-secondary">
+                    {truncates === true && (
+                        <div className="mt-5">
+                            <Alert variant="info" size="compact">
+                                <AlertDescription>
+                                    Your filters match more than the {AUDIT_EXPORT_MAX_ROWS.toLocaleString()} events a single export can hold. Narrow the date
+                                    range or filters to export older events.
+                                </AlertDescription>
+                            </Alert>
+                        </div>
+                    )}
+                    {truncates === undefined && (
+                        <p className="mt-5 text-body-small-regular text-text-secondary">An export stops at {AUDIT_EXPORT_MAX_ROWS.toLocaleString()} events.</p>
+                    )}
+                    <p className="mt-3 text-body-small-regular text-text-secondary">
                         Need a larger or scheduled export?{' '}
                         <Button variant="link-accent" size="sm" onClick={onContact}>
                             Contact us

--- a/packages/webapp/src/pages/Audit/components/AuditExportDialog.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditExportDialog.tsx
@@ -1,5 +1,5 @@
-import { Download } from 'lucide-react';
-import { useState } from 'react';
+import { Share } from 'lucide-react';
+import { useRef, useState } from 'react';
 
 import {
     Button,
@@ -17,27 +17,39 @@ import {
 import { apiAuditTrailExport } from '@/hooks/useAudit';
 import { useToast } from '@/hooks/useToast';
 import { track } from '@/utils/analytics';
-import { AUDIT_EXPORT_MAX_ROWS, exportFilterLabel, exportWindowLabel } from '../export';
+import { openSupportChat } from '@/utils/support';
+import { actionSelectionLabel, resourceSelectionLabel } from '../constants';
+import { AUDIT_EXPORT_MAX_ROWS, exportWindowField } from '../export';
 
 import type { AuditAction, AuditResource } from '@nangohq/types';
 
+// Matches DialogContent's own `duration-200` exit animation.
+const DIALOG_EXIT_MS = 200;
+
 interface AuditExportDialogProps {
-    from: string | undefined;
-    to: string | undefined;
-    resources: AuditResource[];
-    actions: AuditAction[];
+    /** Sent to the API. Its resources can be wider than the ones picked, since an action only matches paired with a resource. */
+    query: { from: string | undefined; to: string | undefined; resources: AuditResource[]; actions: AuditAction[] };
+    selection: { resources: AuditResource[]; actions: AuditAction[] };
     disabled?: boolean;
 }
 
-export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ from, to, resources, actions, disabled }) => {
+export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ query, selection, disabled }) => {
     const { toast } = useToast();
     const [isOpen, setIsOpen] = useState(false);
     const [isExporting, setIsExporting] = useState(false);
+    const exportButtonRef = useRef<HTMLButtonElement>(null);
+    const openSupportOnClose = useRef(false);
+    const windowField = exportWindowField(query.from, query.to);
+
+    const onContact = () => {
+        openSupportOnClose.current = true;
+        setIsOpen(false);
+    };
 
     const onExport = async () => {
         setIsExporting(true);
         try {
-            const { truncated } = await apiAuditTrailExport({ from, to, resources, actions });
+            const { truncated } = await apiAuditTrailExport(query);
             track('web:audit:exported', { truncated });
             setIsOpen(false);
             toast(
@@ -59,28 +71,53 @@ export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ from, to, 
     return (
         <Dialog open={isOpen} onOpenChange={setIsOpen}>
             <DialogTrigger asChild>
-                <Button variant="outline" disabled={disabled}>
-                    <Download />
+                <Button variant="outline" size="md" disabled={disabled}>
+                    <Share size={14} />
                     Export
                 </Button>
             </DialogTrigger>
-            <DialogContent>
+            {/* Radix would otherwise land on the body's "Contact us" link, making Enter open support instead of exporting. */}
+            <DialogContent
+                onOpenAutoFocus={(event) => {
+                    event.preventDefault();
+                    exportButtonRef.current?.focus();
+                }}
+                onCloseAutoFocus={(event) => {
+                    if (!openSupportOnClose.current) {
+                        return;
+                    }
+                    openSupportOnClose.current = false;
+                    // Radix would pull focus back to the Export trigger, and the focus trap and `aria-hidden`
+                    // only come off with the content — so opening waits for the exit animation.
+                    event.preventDefault();
+                    setTimeout(openSupportChat, DIALOG_EXIT_MS);
+                }}
+            >
                 <DialogHeader>
                     <DialogTitle>Export audit trail</DialogTitle>
-                    <DialogDescription>The window and filters selected on the page are what gets exported.</DialogDescription>
+                    <DialogDescription>Downloads the events matching these filters as a CSV file.</DialogDescription>
                 </DialogHeader>
                 <DialogBody>
-                    <div className="flex flex-col gap-3 text-body-small-regular text-text-secondary">
-                        <p className="text-text-primary">
-                            Exports up to {AUDIT_EXPORT_MAX_ROWS.toLocaleString()} events as CSV, covering {exportWindowLabel(from, to)}, filtered by{' '}
-                            {exportFilterLabel(resources, actions)}.
-                        </p>
-                        <p>
-                            The file is built while you wait, so it is capped at {AUDIT_EXPORT_MAX_ROWS.toLocaleString()} events. If the window holds more, the
-                            export stops there and we will tell you — narrow the window or the filters to get the rest.
-                        </p>
-                        <p>Need a larger export, or a scheduled one? Contact us and we will arrange it.</p>
-                    </div>
+                    <dl className="grid grid-cols-[80px_1fr] gap-x-4 gap-y-2.5 text-body-small-regular">
+                        <dt className="uppercase text-text-muted">{windowField.label}</dt>
+                        <dd className="font-code text-text-primary">
+                            {windowField.value}
+                            {windowField.zone && <span className="text-text-muted"> {windowField.zone}</span>}
+                        </dd>
+                        <dt className="uppercase text-text-muted">Resource</dt>
+                        <dd className="font-code text-text-primary">{resourceSelectionLabel(selection.resources)}</dd>
+                        <dt className="uppercase text-text-muted">Action</dt>
+                        <dd className="font-code text-text-primary">{actionSelectionLabel(selection.actions)}</dd>
+                        <dt className="uppercase text-text-muted">Limit</dt>
+                        <dd className="font-code text-text-primary">{AUDIT_EXPORT_MAX_ROWS.toLocaleString()} events</dd>
+                    </dl>
+                    <p className="mt-5 text-body-small-regular text-text-secondary">
+                        Need a larger or scheduled export?{' '}
+                        <Button variant="link-accent" size="sm" onClick={onContact}>
+                            Contact us
+                        </Button>
+                        .
+                    </p>
                 </DialogBody>
                 <DialogFooter>
                     <DialogClose asChild>
@@ -88,7 +125,7 @@ export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ from, to, 
                             Cancel
                         </Button>
                     </DialogClose>
-                    <Button size="sm" loading={isExporting} onClick={() => void onExport()}>
+                    <Button ref={exportButtonRef} size="sm" loading={isExporting} onClick={() => void onExport()}>
                         Export CSV
                     </Button>
                 </DialogFooter>

--- a/packages/webapp/src/pages/Audit/components/AuditExportDialog.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditExportDialog.tsx
@@ -83,9 +83,9 @@ export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ query, sel
                     Export
                 </Button>
             </DialogTrigger>
-            {/* Radix would otherwise land on the body's "Contact us" link, making Enter open support instead of exporting. */}
             <DialogContent
                 onOpenAutoFocus={(event) => {
+                    // Radix would otherwise land on the body's "Contact us" link, making Enter open support.
                     event.preventDefault();
                     exportButtonRef.current?.focus();
                 }}

--- a/packages/webapp/src/pages/Audit/components/OutcomeTag.tsx
+++ b/packages/webapp/src/pages/Audit/components/OutcomeTag.tsx
@@ -1,0 +1,19 @@
+import { Check, X } from 'lucide-react';
+
+import { Tag } from '@/components/ui/Tag';
+
+import type { AuditOutcome } from '@nangohq/types';
+
+const outcomeVariant: Record<AuditOutcome, React.ComponentProps<typeof Tag>['variant']> = {
+    success: 'success',
+    failure: 'alert',
+    denied: 'warning'
+};
+
+// `normal-case` overrides Tag's uppercase base: the outcome is a value from the event, shown as it is stored.
+export const OutcomeTag: React.FC<{ outcome: AuditOutcome }> = ({ outcome }) => (
+    <Tag variant={outcomeVariant[outcome]} className="gap-1 font-code normal-case">
+        {outcome === 'success' ? <Check size={12} /> : <X size={12} />}
+        {outcome}
+    </Tag>
+);

--- a/packages/webapp/src/pages/Audit/components/OutcomeTag.tsx
+++ b/packages/webapp/src/pages/Audit/components/OutcomeTag.tsx
@@ -10,8 +10,8 @@ const outcomeVariant: Record<AuditOutcome, React.ComponentProps<typeof Tag>['var
     denied: 'warning'
 };
 
-// `normal-case` overrides Tag's uppercase base: the outcome is a value from the event, shown as it is stored.
 export const OutcomeTag: React.FC<{ outcome: AuditOutcome }> = ({ outcome }) => (
+    // `normal-case` overrides Tag's uppercase base: the outcome is shown as the event stored it.
     <Tag variant={outcomeVariant[outcome]} className="gap-1 font-code normal-case">
         {outcome === 'success' ? <Check size={12} /> : <X size={12} />}
         {outcome}

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -1,7 +1,8 @@
-import { formatKeyToLabel } from '@/utils/utils';
+// Relative, not `@/`: the root vitest config has no alias, and this module is reachable from a unit test.
+import { formatKeyToLabel } from '../../utils/utils';
 
 import type { FilterOption } from '@/components/patterns/FilterMultiSelect';
-import type { ApiAuditTrailEvent, AuditAction, AuditActionOf, AuditEventKey, AuditResource, AuditScope } from '@nangohq/types';
+import type { ApiAuditTrailEvent, AuditAction, AuditActionOf, AuditEventKey, AuditResource } from '@nangohq/types';
 
 /**
  * Runtime twin of the audit event vocabulary, which `@nangohq/types` carries as types only. Kept in
@@ -55,13 +56,40 @@ export const ALL = 'all';
 export type ResourceFilter = AuditResource | typeof ALL;
 export type ActionFilter = AuditAction | typeof ALL;
 
+const allResources = Object.keys(actionsByResource) as AuditResource[];
+
+const byLabel = (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label);
+
 export const resourceOptions: FilterOption<ResourceFilter>[] = [
     { value: ALL, label: 'All' },
-    ...(Object.keys(actionsByResource) as AuditResource[]).map((resource) => ({ value: resource, label: resourceLabels[resource] }))
+    ...allResources.map((resource) => ({ value: resource, label: resourceLabels[resource] })).sort(byLabel)
 ];
 
-export function actionOptionsFor(resource: AuditResource): FilterOption<ActionFilter>[] {
-    return [{ value: ALL, label: 'All' }, ...actionsByResource[resource].map((action) => ({ value: action, label: formatKeyToLabel(action) }))];
+export const resourceValues: ResourceFilter[] = [ALL, ...allResources];
+export const actionValues: ActionFilter[] = [ALL, ...new Set(allResources.flatMap((resource) => actionsByResource[resource] as readonly AuditAction[]))];
+
+export function actionOptionsForResources(resources: AuditResource[]): FilterOption<ActionFilter>[] {
+    const scope = resources.length ? resources : allResources;
+    const actions = new Set(scope.flatMap((resource) => actionsByResource[resource] as readonly AuditAction[]));
+    const options = [...actions].map((action) => ({ value: action, label: formatKeyToLabel(action) })).sort(byLabel);
+    return [{ value: ALL, label: 'All' }, ...options];
+}
+
+function selectionLabel<T>(values: T[], toLabel: (value: T) => string): string {
+    return values.length ? values.map(toLabel).join(', ') : 'All';
+}
+
+export function resourceSelectionLabel(resources: AuditResource[]): string {
+    return selectionLabel(resources, (resource) => resourceLabels[resource]);
+}
+
+export function actionSelectionLabel(actions: AuditAction[]): string {
+    return selectionLabel(actions, formatKeyToLabel);
+}
+
+/** The API rejects `actions` without `resources`, so an action-only filter names the resources that declare it. */
+export function resourcesOwningActions(actions: AuditAction[]): AuditResource[] {
+    return allResources.filter((resource) => (actionsByResource[resource] as readonly AuditAction[]).some((action) => actions.includes(action)));
 }
 
 export function actorLabel(actor: ApiAuditTrailEvent['actor']): string {
@@ -72,32 +100,19 @@ export function viaLabel(via: ApiAuditTrailEvent['via']): string | undefined {
     return via?.map((entry) => `${entry.display ?? entry.id} (${entry.type}${entry.actorId ? `, actor ${entry.actorId}` : ''})`).join(', ');
 }
 
-export function resourceLabel(resource: ApiAuditTrailEvent['resource']): string {
-    return resourceLabels[resource] ?? resource;
-}
-
-export function actionLabel(event: Pick<ApiAuditTrailEvent, 'action'>): string {
-    return event.action.replace(/_/g, ' ');
+// Display names, not the raw `resource.action` key — that stays available in the drawer's JSON and the CSV.
+export function eventLabel(event: Pick<ApiAuditTrailEvent, 'resource' | 'action'>): string {
+    return `${resourceLabels[event.resource]} · ${formatKeyToLabel(event.action)}`;
 }
 
 export function targetsLabel(targets: ApiAuditTrailEvent['targets']): string {
     return targets.map((target) => target.display ?? target.id).join(', ') || '—';
 }
 
-export function targetTypesLabel(targets: ApiAuditTrailEvent['targets']): string {
-    return [...new Set(targets.map((target) => target.type))].join(', ');
-}
-
-const scopeLabels: Record<AuditScope, string> = {
-    account: 'Account',
-    environment: 'Environment'
-};
-
-export function scopeLabel(scope: ApiAuditTrailEvent['scope']): string {
-    return scopeLabels[scope];
-}
-
-// The scope column says why this is empty, so the cell no longer stands in for it.
-export function environmentLabel(environment: ApiAuditTrailEvent['environment']): string {
-    return environment?.display ?? '—';
+export function environmentLabel(event: Pick<ApiAuditTrailEvent, 'environment' | 'scope'>): string {
+    if (event.environment) {
+        return event.environment.display;
+    }
+    // An environment-scoped event can store a null environment, and `scope` is absent before NAN-6802.
+    return event.scope === 'environment' ? '—' : 'Account-level';
 }

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -105,8 +105,14 @@ export function eventLabel(event: Pick<ApiAuditTrailEvent, 'resource' | 'action'
     return `${resourceLabels[event.resource]} · ${formatKeyToLabel(event.action)}`;
 }
 
-export function targetsLabel(targets: ApiAuditTrailEvent['targets']): string {
-    return targets.map((target) => target.display ?? target.id).join(', ') || '—';
+export function targetNames(targets: ApiAuditTrailEvent['targets']): string[] {
+    return targets.map((target) => target.display ?? target.id);
+}
+
+/** First target plus a count, so a deploy touching a dozen functions still occupies one row. */
+export function targetsSummary(targets: ApiAuditTrailEvent['targets']): { first: string; rest: number } | null {
+    const [first, ...rest] = targetNames(targets);
+    return first ? { first, rest: rest.length } : null;
 }
 
 export function environmentLabel(event: Pick<ApiAuditTrailEvent, 'environment' | 'scope'>): string {

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -100,7 +100,6 @@ export function viaLabel(via: ApiAuditTrailEvent['via']): string | undefined {
     return via?.map((entry) => `${entry.display ?? entry.id} (${entry.type}${entry.actorId ? `, actor ${entry.actorId}` : ''})`).join(', ');
 }
 
-// Display names, not the raw `resource.action` key — that stays available in the drawer's JSON and the CSV.
 export function eventLabel(event: Pick<ApiAuditTrailEvent, 'resource' | 'action'>): string {
     // Falls back to the raw key: a newer backend can send a resource this build has no label for.
     return `${resourceLabels[event.resource] ?? event.resource} · ${formatKeyToLabel(event.action)}`;

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -102,16 +102,13 @@ export function viaLabel(via: ApiAuditTrailEvent['via']): string | undefined {
 
 // Display names, not the raw `resource.action` key — that stays available in the drawer's JSON and the CSV.
 export function eventLabel(event: Pick<ApiAuditTrailEvent, 'resource' | 'action'>): string {
-    return `${resourceLabels[event.resource]} · ${formatKeyToLabel(event.action)}`;
-}
-
-export function targetNames(targets: ApiAuditTrailEvent['targets']): string[] {
-    return targets.map((target) => target.display ?? target.id);
+    // Falls back to the raw key: a newer backend can send a resource this build has no label for.
+    return `${resourceLabels[event.resource] ?? event.resource} · ${formatKeyToLabel(event.action)}`;
 }
 
 /** First target plus a count, so a deploy touching a dozen functions still occupies one row. */
 export function targetsSummary(targets: ApiAuditTrailEvent['targets']): { first: string; rest: number } | null {
-    const [first, ...rest] = targetNames(targets);
+    const [first, ...rest] = targets.map((target) => target.display ?? target.id);
     return first ? { first, rest: rest.length } : null;
 }
 

--- a/packages/webapp/src/pages/Audit/constants.unit.test.ts
+++ b/packages/webapp/src/pages/Audit/constants.unit.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { actionSelectionLabel, environmentLabel, resourceSelectionLabel } from './constants';
+
+describe('resourceSelectionLabel', () => {
+    it('reads as All when nothing narrows the resource', () => {
+        expect(resourceSelectionLabel([])).toBe('All');
+    });
+
+    it('uses the names the dropdown offered, not the raw vocabulary', () => {
+        expect(resourceSelectionLabel(['api_key', 'app_auth'])).toBe('API key, Authentication');
+    });
+});
+
+describe('actionSelectionLabel', () => {
+    it('reads as All when nothing narrows the action', () => {
+        expect(actionSelectionLabel([])).toBe('All');
+    });
+
+    it('uses the names the dropdown offered, not the raw vocabulary', () => {
+        expect(actionSelectionLabel(['metadata_updated', 'deleted'])).toBe('Metadata updated, Deleted');
+    });
+});
+
+describe('environmentLabel', () => {
+    it('names the environment when the event carries one', () => {
+        expect(environmentLabel({ environment: { id: 1, display: 'dev' }, scope: 'environment' })).toBe('dev');
+    });
+
+    it('calls an account-scoped event account-level rather than leaving it blank', () => {
+        expect(environmentLabel({ environment: null, scope: 'account' })).toBe('Account-level');
+    });
+
+    it('does not claim account-level for an environment-scoped event that stored no environment', () => {
+        expect(environmentLabel({ environment: null, scope: 'environment' })).toBe('—');
+    });
+
+    it('falls back to account-level on events recorded before scope existed', () => {
+        expect(environmentLabel({ environment: null } as Parameters<typeof environmentLabel>[0])).toBe('Account-level');
+    });
+});

--- a/packages/webapp/src/pages/Audit/constants.unit.test.ts
+++ b/packages/webapp/src/pages/Audit/constants.unit.test.ts
@@ -24,7 +24,7 @@ describe('actionSelectionLabel', () => {
 
 describe('environmentLabel', () => {
     it('names the environment when the event carries one', () => {
-        expect(environmentLabel({ environment: { id: 1, display: 'dev' }, scope: 'environment' })).toBe('dev');
+        expect(environmentLabel({ environment: { id: '1', display: 'dev' }, scope: 'environment' })).toBe('dev');
     });
 
     it('calls an account-scoped event account-level rather than leaving it blank', () => {

--- a/packages/webapp/src/pages/Audit/export.ts
+++ b/packages/webapp/src/pages/Audit/export.ts
@@ -1,28 +1,30 @@
-import { formatDateToLogFormat } from '../../utils/utils';
+import { format } from 'date-fns';
 
-import type { AuditAction, AuditExportMaxRows, AuditResource } from '@nangohq/types';
+import type { AuditExportMaxRows } from '@nangohq/types';
 
 // Stated to the customer before an export starts, so it has to be the server's ceiling. The annotation is
 // what enforces that - `@nangohq/types` ships no runtime entry, so the value cannot be imported.
 export const AUDIT_EXPORT_MAX_ROWS: AuditExportMaxRows = 50_000;
 
-export function exportWindowLabel(from: string | undefined, to: string | undefined): string {
+const boundary = (iso: string) => format(new Date(iso), 'MMM d, HH:mm');
+
+// Read off the boundary rather than now, so a window on the other side of a DST change still labels itself correctly.
+const zone = (iso: string) => `UTC${format(new Date(iso), 'xxx')}`;
+
+export function exportWindowField(from: string | undefined, to: string | undefined): { label: string; value: string; zone?: string } {
     if (from && to) {
-        return `${formatDateToLogFormat(from)} to ${formatDateToLogFormat(to)}`;
+        const fromZone = zone(from);
+        const toZone = zone(to);
+        // A window spanning a DST change has an offset per end, so one shared label would misdate the other.
+        return fromZone === toZone
+            ? { label: 'Window', value: `${boundary(from)} – ${boundary(to)}`, zone: fromZone }
+            : { label: 'Window', value: `${boundary(from)} ${fromZone} – ${boundary(to)} ${toZone}` };
     }
     if (from) {
-        return `since ${formatDateToLogFormat(from)}`;
+        return { label: 'Since', value: boundary(from), zone: zone(from) };
     }
     if (to) {
-        return `up to ${formatDateToLogFormat(to)}`;
+        return { label: 'Until', value: boundary(to), zone: zone(to) };
     }
-    return 'the full retention window';
-}
-
-export function exportFilterLabel(resources: AuditResource[], actions: AuditAction[]): string {
-    if (!resources.length) {
-        return 'all resources';
-    }
-    const resourceLabel = resources.join(', ');
-    return actions.length ? `${resourceLabel} (${actions.join(', ')})` : resourceLabel;
+    return { label: 'Window', value: 'All time' };
 }

--- a/packages/webapp/src/pages/Audit/export.unit.test.ts
+++ b/packages/webapp/src/pages/Audit/export.unit.test.ts
@@ -1,39 +1,35 @@
 import { describe, expect, it } from 'vitest';
 
-import { exportFilterLabel, exportWindowLabel } from './export';
+import { exportWindowField } from './export';
 
-describe('exportWindowLabel', () => {
+describe('exportWindowField', () => {
     it('names both ends of a closed window', () => {
-        expect(exportWindowLabel('2026-08-01T00:00:00.000Z', '2026-08-15T00:00:00.000Z')).toContain(' to ');
+        expect(exportWindowField('2026-08-01T00:00:00.000Z', '2026-08-15T00:00:00.000Z')).toMatchObject({ label: 'Window' });
+        expect(exportWindowField('2026-08-01T00:00:00.000Z', '2026-08-15T00:00:00.000Z').value).toContain(' – ');
     });
 
-    it('reads as open-ended when only the start is set', () => {
-        expect(exportWindowLabel('2026-08-01T00:00:00.000Z', undefined)).toMatch(/^since /);
+    it('moves the preposition into the label so the value is only the date', () => {
+        expect(exportWindowField('2026-08-01T00:00:00.000Z', undefined)).toMatchObject({ label: 'Since' });
+        expect(exportWindowField('2026-08-01T00:00:00.000Z', undefined).value).not.toMatch(/since/i);
     });
 
     it('names the end when only that is set', () => {
-        expect(exportWindowLabel(undefined, '2026-08-15T00:00:00.000Z')).toMatch(/^up to /);
+        expect(exportWindowField(undefined, '2026-08-15T00:00:00.000Z')).toMatchObject({ label: 'Until' });
     });
 
     it('says what an absent window actually means, rather than leaving it blank', () => {
-        expect(exportWindowLabel(undefined, undefined)).toBe('the full retention window');
-    });
-});
-
-describe('exportFilterLabel', () => {
-    it('says all resources when nothing is filtered', () => {
-        expect(exportFilterLabel([], [])).toBe('all resources');
+        expect(exportWindowField(undefined, undefined)).toEqual({ label: 'Window', value: 'All time' });
     });
 
-    it('lists the resources', () => {
-        expect(exportFilterLabel(['connection', 'sync'], [])).toBe('connection, sync');
+    it('drops the sub-minute precision a range boundary has no use for', () => {
+        expect(exportWindowField('2026-08-01T09:07:42.813Z', undefined).value).not.toMatch(/42|813/);
     });
 
-    it('attaches the actions to the resource they narrow', () => {
-        expect(exportFilterLabel(['connection'], ['created', 'deleted'])).toBe('connection (created, deleted)');
+    it('names the offset the boundary is shown in, since the CSV outlives the tab', () => {
+        expect(exportWindowField('2026-08-01T00:00:00.000Z', undefined).zone).toMatch(/^UTC[+-]\d\d:\d\d$/);
     });
 
-    it('ignores actions with no resource, matching what the server would accept', () => {
-        expect(exportFilterLabel([], ['created'])).toBe('all resources');
+    it('has no offset to name when there is no boundary', () => {
+        expect(exportWindowField(undefined, undefined).zone).toBeUndefined();
     });
 });


### PR DESCRIPTION
## Problem

The audit trail shipped functional but unfinished. The Action filter was disabled unless exactly one Resource was picked, filters were lost on reload, a deploy naming a dozen targets wrapped rows over three lines, and the export dialog stated the 50,000 cap whether or not it could be reached.

Design: [Figma](https://www.figma.com/design/UPhGLAHKgFxGfnb7vwJ6YK/Nango-%E2%80%94-Product?node-id=1070-8633), approved by Pau.

## Solution

- Table reworked to the approved design: Time · Actor · Event · Target · Outcome, on the shared table primitives. Resource and action merge into one Event column; the drawer follows suit.
- Action is no longer gated on picking one resource. Its options are the union of those selected, and an action chosen alone names the resources declaring it, since the API matches only the pair.
- Filters live in the URL, as on every other list page, so a filtered view survives a reload and can be shared.
- A row shows its first target plus a count badge, keeping every row one line; the drawer lists them all.
- The next page loads as the end of the table comes into view.
- The export dialog shows how many events the file will hold, and only mentions the ceiling when the filters exceed it.

Fixes [NAN-6672](https://linear.app/nango/issue/NAN-6672)

## Testing

Run against the local stack with ~52,000 seeded events, covering both sides of the export cap. Checked filter reconciliation from a URL naming an action its resources don't declare, auto-pagination at 25 → 50 → 75 rows, and both export dialog states.

<img width="2912" height="1806" alt="image" src="https://github.com/user-attachments/assets/b2606be2-3717-4726-ae0a-e65c1d8c330d" />

<img width="2912" height="1806" alt="image" src="https://github.com/user-attachments/assets/1c5762d5-2cde-40d9-82e5-b510a7411cb1" />

