### PR TITLE
feat(webapp): show pay-as-you-go minimum spend on the billing page

### DIFF
--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -10,6 +10,7 @@ import type {
     BillingCustomer,
     BillingEvent,
     BillingInvoicingDetails,
+    BillingMinimumSpend,
     BillingPeriodCosts,
     BillingSpendAlert,
     BillingUpcomingInvoice,
@@ -50,7 +51,7 @@ export function normalizeIsoCurrency(currency: string | null | undefined): strin
     return code && /^[A-Z]{3}$/.test(code) ? code : null;
 }
 
-export function fromOrbUpcomingInvoice(invoice: { amount_due: string; currency: string }): BillingUpcomingInvoice | null {
+export function fromOrbUpcomingInvoice(invoice: { amount_due: string; subtotal: string; total: string; currency: string }): BillingUpcomingInvoice | null {
     const amountInCents = orbAmountToCents(invoice.amount_due);
     if (amountInCents === null) {
         return null;
@@ -61,7 +62,22 @@ export function fromOrbUpcomingInvoice(invoice: { amount_due: string; currency: 
         return null;
     }
 
-    return { amountInCents, currency };
+    return { amountInCents, minimum: minimumSpendOf(invoice), currency };
+}
+
+/**
+ * Adjustments alone separate subtotal from total, and a discount moves the total down, so a total
+ * above the subtotal means a minimum. The total is also the only source for the figure Orb enforces:
+ * `invoice.minimum.minimum_amount` reports the plan's nominal one even over a prorated period.
+ */
+function minimumSpendOf(invoice: { subtotal: string; total: string }): BillingMinimumSpend | null {
+    const subtotalInCents = orbAmountToCents(invoice.subtotal);
+    const totalInCents = orbAmountToCents(invoice.total);
+    if (subtotalInCents === null || totalInCents === null || totalInCents <= subtotalInCents) {
+        return null;
+    }
+
+    return { enforcedInCents: totalInCents, topUpInCents: totalInCents - subtotalInCents };
 }
 
 /**

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -51,7 +51,7 @@ export function normalizeIsoCurrency(currency: string | null | undefined): strin
     return code && /^[A-Z]{3}$/.test(code) ? code : null;
 }
 
-export function fromOrbUpcomingInvoice(invoice: { amount_due: string; subtotal: string; total: string; currency: string }): BillingUpcomingInvoice | null {
+export function fromOrbUpcomingInvoice(invoice: OrbUpcomingInvoice): BillingUpcomingInvoice | null {
     const amountInCents = orbAmountToCents(invoice.amount_due);
     if (amountInCents === null) {
         return null;
@@ -65,12 +65,25 @@ export function fromOrbUpcomingInvoice(invoice: { amount_due: string; subtotal: 
     return { amountInCents, minimum: minimumSpendOf(invoice), currency };
 }
 
+interface OrbUpcomingInvoice {
+    amount_due: string;
+    subtotal: string;
+    total: string;
+    currency: string;
+    minimum?: { minimum_amount?: string | null } | null | undefined;
+}
+
 /**
- * Adjustments alone separate subtotal from total, and a discount moves the total down, so a total
- * above the subtotal means a minimum. The total is also the only source for the figure Orb enforces:
- * `invoice.minimum.minimum_amount` reports the plan's nominal one even over a prorated period.
+ * `invoice.minimum` says a minimum exists, never what it costs — it reports the plan's nominal figure
+ * even over a period Orb prorates — so the amount comes from the gap between subtotal and total, and
+ * the object only gates it. Without that gate anything else lifting the total, tax included, would
+ * read as a minimum.
  */
-function minimumSpendOf(invoice: { subtotal: string; total: string }): BillingMinimumSpend | null {
+function minimumSpendOf(invoice: OrbUpcomingInvoice): BillingMinimumSpend | null {
+    if (!invoice.minimum) {
+        return null;
+    }
+
     const subtotalInCents = orbAmountToCents(invoice.subtotal);
     const totalInCents = orbAmountToCents(invoice.total);
     if (subtotalInCents === null || totalInCents === null || totalInCents <= subtotalInCents) {

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -435,7 +435,9 @@ describe('fromOrbUpcomingInvoice', () => {
 
     it('reads a binding minimum off the gap between subtotal and total', () => {
         // Orb loses a cent splitting a $50 minimum across three prices, so a real total lands at 49.99.
-        expect(fromOrbUpcomingInvoice({ amount_due: '49.99', subtotal: '0.74', total: '49.99', currency: 'USD' })).toEqual({
+        expect(
+            fromOrbUpcomingInvoice({ amount_due: '49.99', subtotal: '0.74', total: '49.99', currency: 'USD', minimum: { minimum_amount: '50.00' } })
+        ).toEqual({
             amountInCents: 4999,
             minimum: { enforcedInCents: 4999, topUpInCents: 4925 },
             currency: 'USD'
@@ -443,7 +445,9 @@ describe('fromOrbUpcomingInvoice', () => {
     });
 
     it('reports the prorated minimum Orb enforces, not the plan-level figure it reports', () => {
-        expect(fromOrbUpcomingInvoice({ amount_due: '48.33', subtotal: '1.96', total: '48.33', currency: 'USD' })).toEqual({
+        expect(
+            fromOrbUpcomingInvoice({ amount_due: '48.33', subtotal: '1.96', total: '48.33', currency: 'USD', minimum: { minimum_amount: '50.00' } })
+        ).toEqual({
             amountInCents: 4833,
             minimum: { enforcedInCents: 4833, topUpInCents: 4637 },
             currency: 'USD'
@@ -451,19 +455,31 @@ describe('fromOrbUpcomingInvoice', () => {
     });
 
     it('states no minimum once usage passes it', () => {
-        expect(fromOrbUpcomingInvoice({ amount_due: '51.86', subtotal: '51.86', total: '51.86', currency: 'USD' })?.minimum).toBeNull();
+        expect(
+            fromOrbUpcomingInvoice({ amount_due: '51.86', subtotal: '51.86', total: '51.86', currency: 'USD', minimum: { minimum_amount: '50.00' } })?.minimum
+        ).toBeNull();
     });
 
     it('states no minimum when a discount puts the total under the subtotal', () => {
-        expect(fromOrbUpcomingInvoice({ amount_due: '90.00', subtotal: '100.00', total: '90.00', currency: 'USD' })?.minimum).toBeNull();
+        expect(
+            fromOrbUpcomingInvoice({ amount_due: '90.00', subtotal: '100.00', total: '90.00', currency: 'USD', minimum: { minimum_amount: '50.00' } })?.minimum
+        ).toBeNull();
+    });
+
+    it('states no minimum when the invoice carries none, whatever lifts the total', () => {
+        // Anything else raising the total above the subtotal — tax, say — would otherwise be reported
+        // as a minimum topping the invoice up.
+        expect(fromOrbUpcomingInvoice({ amount_due: '120.00', subtotal: '100.00', total: '120.00', currency: 'USD' })?.minimum).toBeNull();
     });
 
     it('keeps the amount when the minimum figures are unreadable', () => {
-        expect(fromOrbUpcomingInvoice({ amount_due: '49.99', subtotal: 'n/a', total: '49.99', currency: 'USD' })).toEqual({
-            amountInCents: 4999,
-            minimum: null,
-            currency: 'USD'
-        });
+        expect(fromOrbUpcomingInvoice({ amount_due: '49.99', subtotal: 'n/a', total: '49.99', currency: 'USD', minimum: { minimum_amount: '50.00' } })).toEqual(
+            {
+                amountInCents: 4999,
+                minimum: null,
+                currency: 'USD'
+            }
+        );
     });
 });
 

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -408,24 +408,62 @@ describe('orbAmountToCents', () => {
 });
 
 describe('fromOrbUpcomingInvoice', () => {
+    /** An invoice whose usage stands on its own, so no minimum tops it up. */
+    function invoiceOf(amount: string, currency = 'USD') {
+        return { amount_due: amount, subtotal: amount, total: amount, currency };
+    }
+
     it('maps amount and currency', () => {
-        expect(fromOrbUpcomingInvoice({ amount_due: '1284.30', currency: 'USD' })).toEqual({ amountInCents: 128430, currency: 'USD' });
+        expect(fromOrbUpcomingInvoice(invoiceOf('1284.30'))).toEqual({ amountInCents: 128430, minimum: null, currency: 'USD' });
     });
 
     it('uppercases the currency', () => {
-        expect(fromOrbUpcomingInvoice({ amount_due: '10.00', currency: 'usd' })).toEqual({ amountInCents: 1000, currency: 'USD' });
+        expect(fromOrbUpcomingInvoice(invoiceOf('10.00', 'usd'))).toEqual({ amountInCents: 1000, minimum: null, currency: 'USD' });
     });
 
     it('passes through non-USD currencies', () => {
-        expect(fromOrbUpcomingInvoice({ amount_due: '10.00', currency: 'EUR' })).toEqual({ amountInCents: 1000, currency: 'EUR' });
+        expect(fromOrbUpcomingInvoice(invoiceOf('10.00', 'EUR'))).toEqual({ amountInCents: 1000, minimum: null, currency: 'EUR' });
     });
 
     it('returns null for a credit-denominated invoice', () => {
-        expect(fromOrbUpcomingInvoice({ amount_due: '10.00', currency: 'credits' })).toBeNull();
+        expect(fromOrbUpcomingInvoice(invoiceOf('10.00', 'credits'))).toBeNull();
     });
 
     it('returns null for an unparseable amount', () => {
-        expect(fromOrbUpcomingInvoice({ amount_due: 'n/a', currency: 'USD' })).toBeNull();
+        expect(fromOrbUpcomingInvoice(invoiceOf('n/a'))).toBeNull();
+    });
+
+    it('reads a binding minimum off the gap between subtotal and total', () => {
+        // Orb loses a cent splitting a $50 minimum across three prices, so a real total lands at 49.99.
+        expect(fromOrbUpcomingInvoice({ amount_due: '49.99', subtotal: '0.74', total: '49.99', currency: 'USD' })).toEqual({
+            amountInCents: 4999,
+            minimum: { enforcedInCents: 4999, topUpInCents: 4925 },
+            currency: 'USD'
+        });
+    });
+
+    it('reports the prorated minimum Orb enforces, not the plan-level figure it reports', () => {
+        expect(fromOrbUpcomingInvoice({ amount_due: '48.33', subtotal: '1.96', total: '48.33', currency: 'USD' })).toEqual({
+            amountInCents: 4833,
+            minimum: { enforcedInCents: 4833, topUpInCents: 4637 },
+            currency: 'USD'
+        });
+    });
+
+    it('states no minimum once usage passes it', () => {
+        expect(fromOrbUpcomingInvoice({ amount_due: '51.86', subtotal: '51.86', total: '51.86', currency: 'USD' })?.minimum).toBeNull();
+    });
+
+    it('states no minimum when a discount puts the total under the subtotal', () => {
+        expect(fromOrbUpcomingInvoice({ amount_due: '90.00', subtotal: '100.00', total: '90.00', currency: 'USD' })?.minimum).toBeNull();
+    });
+
+    it('keeps the amount when the minimum figures are unreadable', () => {
+        expect(fromOrbUpcomingInvoice({ amount_due: '49.99', subtotal: 'n/a', total: '49.99', currency: 'USD' })).toEqual({
+            amountInCents: 4999,
+            minimum: null,
+            currency: 'USD'
+        });
     });
 });
 

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.integration.test.ts
@@ -36,7 +36,7 @@ describe(`GET ${route}`, () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        getUpcomingInvoiceSpy.mockResolvedValue(Ok({ amountInCents: 128430, currency: 'USD' }));
+        getUpcomingInvoiceSpy.mockResolvedValue(Ok({ amountInCents: 128430, minimum: null, currency: 'USD' }));
     });
 
     describe('Authentication & Authorization', () => {
@@ -81,7 +81,7 @@ describe(`GET ${route}`, () => {
 
             isSuccess(res.json);
             expect(res.res.status).toBe(200);
-            expect(res.json.data).toStrictEqual({ amountInCents: null, currency: null });
+            expect(res.json.data).toStrictEqual({ amountInCents: null, minimum: null, currency: null });
             // The gate exists to keep a non-monthly plan's contract total off this endpoint, so
             // "returned null" is not enough — the call must not happen at all.
             expect(getUpcomingInvoiceSpy).not.toHaveBeenCalled();
@@ -94,18 +94,18 @@ describe(`GET ${route}`, () => {
 
             isSuccess(res.json);
             expect(res.res.status).toBe(200);
-            expect(res.json.data).toStrictEqual({ amountInCents: 128430, currency: 'USD' });
+            expect(res.json.data).toStrictEqual({ amountInCents: 128430, minimum: null, currency: 'USD' });
             expect(getUpcomingInvoiceSpy).toHaveBeenCalledWith('orb_sub_123');
         });
 
         it('should report zero rather than falling back — the startup deal really does bill $0.00', async () => {
             const { apiKey } = await seedPlan('startup-deal');
-            getUpcomingInvoiceSpy.mockResolvedValue(Ok({ amountInCents: 0, currency: 'USD' }));
+            getUpcomingInvoiceSpy.mockResolvedValue(Ok({ amountInCents: 0, minimum: null, currency: 'USD' }));
 
             const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
 
             isSuccess(res.json);
-            expect(res.json.data).toStrictEqual({ amountInCents: 0, currency: 'USD' });
+            expect(res.json.data).toStrictEqual({ amountInCents: 0, minimum: null, currency: 'USD' });
         });
     });
 
@@ -117,7 +117,17 @@ describe(`GET ${route}`, () => {
             const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
 
             isSuccess(res.json);
-            expect(res.json.data).toStrictEqual({ amountInCents: null, currency: null });
+            expect(res.json.data).toStrictEqual({ amountInCents: null, minimum: null, currency: null });
+        });
+
+        it('should pass a binding minimum through', async () => {
+            const { apiKey } = await seedPlan('pay-as-you-go');
+            getUpcomingInvoiceSpy.mockResolvedValue(Ok({ amountInCents: 4833, minimum: { enforcedInCents: 4833, topUpInCents: 4637 }, currency: 'USD' }));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data).toStrictEqual({ amountInCents: 4833, minimum: { enforcedInCents: 4833, topUpInCents: 4637 }, currency: 'USD' });
         });
 
         it('should 500 when the Orb read fails', async () => {
@@ -139,7 +149,7 @@ describe(`GET ${route}`, () => {
 
             isSuccess(res.json);
             expect(res.res.status).toBe(200);
-            expect(res.json.data).toStrictEqual({ amountInCents: null, currency: null });
+            expect(res.json.data).toStrictEqual({ amountInCents: null, minimum: null, currency: null });
             expect(getUpcomingInvoiceSpy).not.toHaveBeenCalled();
         });
     });

--- a/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getUpcomingInvoice.ts
@@ -6,7 +6,7 @@ import { isSpendPlan } from '../../../../utils/spendPlans.js';
 
 import type { GetUpcomingInvoice } from '@nangohq/types';
 
-const NO_SPEND = { amountInCents: null, currency: null };
+const NO_SPEND = { amountInCents: null, minimum: null, currency: null };
 
 export const getUpcomingInvoice = asyncWrapper<GetUpcomingInvoice>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
@@ -41,5 +41,5 @@ export const getUpcomingInvoice = asyncWrapper<GetUpcomingInvoice>(async (req, r
     }
 
     const invoice = invoiceRes.value;
-    res.status(200).send({ data: invoice ? { amountInCents: invoice.amountInCents, currency: invoice.currency } : NO_SPEND });
+    res.status(200).send({ data: invoice ? { amountInCents: invoice.amountInCents, minimum: invoice.minimum, currency: invoice.currency } : NO_SPEND });
 });

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -79,9 +79,17 @@ export interface BillingOverdueInvoices {
     hasOverdue: boolean;
 }
 
+export interface BillingMinimumSpend {
+    /** A prorated share of the plan's monthly minimum over a partial period, not the plan's figure. */
+    enforcedInCents: number;
+    topUpInCents: number;
+}
+
 /** Orb's upcoming invoice for a subscription — the whole invoice, not a month's slice of it. */
 export interface BillingUpcomingInvoice {
     amountInCents: number;
+    /** Null when no minimum binds, which says nothing about the amount above — that still stands. */
+    minimum: BillingMinimumSpend | null;
     /** ISO 4217, uppercased. Orb's `credits` is rejected upstream. */
     currency: string;
 }

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -167,6 +167,7 @@ export type GetUpcomingInvoice = ApiEndpoint<{
     Success: {
         data: {
             amountInCents: number | null;
+            minimum: { enforcedInCents: number; topUpInCents: number } | null;
             currency: string | null;
         };
     };

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -12,7 +12,7 @@ import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
 import { hasMonthlySpend } from '@/pages/Team/Billing/planVisibility';
 import { useStore } from '@/store';
 import { cn } from '@/utils/utils';
-import { DEFAULTS, usePlanOverrideStore } from './planOverride';
+import { DEFAULTS, PAY_AS_YOU_GO_MINIMUM_IN_CENTS, usePlanOverrideStore } from './planOverride';
 
 import type { PeriodCostsOverride, SpendOverride, UsageLimitOverride } from './planOverride';
 import type { PlanDefinition } from '@nangohq/types';
@@ -22,8 +22,7 @@ const NO_SCHEDULED_CHANGE_VALUE = '__none__';
 const REAL_USAGE_VALUE = '__real_usage__';
 const REAL_SPEND_VALUE = '__real_spend__';
 const UNAVAILABLE_SPEND_VALUE = 'unavailable';
-// A base-only Starter bill, a mid-period Growth bill, and the startup deal's real zero.
-const SPEND_PRESETS_IN_CENTS = [0, 5000, 128430];
+const SPEND_PRESETS_IN_CENTS = [0, PAY_AS_YOU_GO_MINIMUM_IN_CENTS, 128430];
 const REAL_PERIOD_COSTS_VALUE = '__real_period_costs__';
 interface PlanOverrideContentProps {
     onBack: () => void;

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -10,6 +10,8 @@ export type UsageLimitOverride = 'near' | 'over';
 
 export type SpendOverride = number | 'unavailable';
 
+export const PAY_AS_YOU_GO_MINIMUM_IN_CENTS = 5000;
+
 export type PeriodCostsOverride = 'populated' | 'zero' | 'unavailable';
 
 interface PlanOverrideState {
@@ -111,9 +113,12 @@ export function buildPaymentMethodOverride(): GetStripePaymentMethods['Success']
 /** Stands in for the real upcoming-invoice response when the override is on, for visual QA only. */
 export function buildSpendOverride(override: SpendOverride): GetUpcomingInvoice['Success'] {
     if (override === 'unavailable') {
-        return { data: { amountInCents: null, currency: null } };
+        return { data: { amountInCents: null, minimum: null, currency: null } };
     }
-    return { data: { amountInCents: override, currency: 'USD' } };
+    // The whole preset is the top-up, matching an account billing no usage. Anything less assumes a
+    // usage figure the charges column doesn't share, and the previewed table stops adding up.
+    const minimum = override === PAY_AS_YOU_GO_MINIMUM_IN_CENTS ? { enforcedInCents: override, topUpInCents: override } : null;
+    return { data: { amountInCents: override, minimum, currency: 'USD' } };
 }
 
 /**

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -342,7 +342,7 @@ const PlanChangeDialog: React.FC<{
             if (newPricing) {
                 // Orb prices every metric in arrears under a plan-level minimum, so there is no base
                 // fee to prorate and the upgrade collects nothing.
-                return `${selectedPlan.plan.title} bills at the end of each month — your usage, or a $${selectedPlan.plan.basePrice} monthly minimum, whichever is higher. Nothing is charged today.`;
+                return `${selectedPlan.plan.title} bills at the end of each month — your usage, or a $${selectedPlan.plan.basePrice} monthly minimum, whichever is higher. This first period is charged a prorated share of that minimum. Nothing is charged today.`;
             }
             return `The ${selectedPlan.plan.title} plan includes a ${selectedPlan.plan.basePrice} monthly base fee, plus additional usage-based charges. When you upgrade, you'll be charged a prorated base fee for the current month.`;
         }

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -54,8 +54,11 @@ export const Usage: React.FC = () => {
 
     const minimumEnabled = chargesEnabled && hasPlanMinimum(plan);
     const { data: upcoming, isError: upcomingError } = useApiGetUpcomingInvoice(env, plan, { enabled: minimumEnabled });
+    // Stating the minimum beside dashes or skeletons would show a total the rows can't add up to, so
+    // the row waits for charges the reader can actually check it against.
+    const chargesStated = !costsPending && !costsError && periodCosts?.data.noCosts === false;
     const minimumSpend = buildMinimumSpendRow({
-        enabled: minimumEnabled && !upcomingError,
+        enabled: minimumEnabled && chargesStated && !upcomingError,
         minimum: upcoming?.data.minimum ?? null,
         currency: upcoming?.data.currency ?? null
     });

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -54,9 +54,11 @@ export const Usage: React.FC = () => {
 
     const minimumEnabled = chargesEnabled && hasPlanMinimum(plan);
     const { data: upcoming, isError: upcomingError } = useApiGetUpcomingInvoice(env, plan, { enabled: minimumEnabled });
-    // Stating the minimum beside dashes or skeletons would show a total the rows can't add up to, so
-    // the row waits for charges the reader can actually check it against.
-    const chargesStated = !costsPending && !costsError && periodCosts?.data.noCosts === false;
+    // Stating the minimum beside a dash or a skeleton would show a total the rows can't add up to, so
+    // the row waits for every metric to carry a figure — which a malformed or unattributed price
+    // denies just as much as a failed request does.
+    const costs = costsPending || costsError ? null : periodCosts?.data;
+    const chargesStated = costs ? !costs.noCosts && costs.malformedMetrics.length === 0 && costs.fullyAttributed : false;
     const minimumSpend = buildMinimumSpendRow({
         enabled: minimumEnabled && chargesStated && !upcomingError,
         minimum: upcoming?.data.minimum ?? null,

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -6,11 +6,12 @@ import { Alert, AlertActions, AlertDescription, AlertTitle, Button } from '@nang
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { usePlanOverrideStore } from '@/features/planOverride';
 import { useMeta } from '@/hooks/useMeta';
-import { useApiGetBillingPeriodCosts, useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
+import { useApiGetBillingPeriodCosts, useApiGetBillingUsage, useApiGetUpcomingInvoice, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
 import { billedUsageMetrics } from '@/utils/usage';
-import { hasMonthlySpend, isLegacyPlan } from '../planVisibility';
+import { buildMinimumSpendRow } from '../minimumSpend';
+import { hasMonthlySpend, hasPlanMinimum, isLegacyPlan } from '../planVisibility';
 import { buildUsageRowCharges } from '../usageCharges';
 import { useSelectedMonth } from '../useSelectedMonth';
 import { FreeUsage } from './FreeUsage';
@@ -50,6 +51,14 @@ export const Usage: React.FC = () => {
     const chargesEnabled = metricChargesEnabled && isCurrentMonth && hasMonthlySpend(plan);
     const { data: periodCosts, isPending: costsPending, isError: costsError } = useApiGetBillingPeriodCosts(env, plan, { enabled: chargesEnabled });
     const charges = buildUsageRowCharges({ enabled: chargesEnabled, isPending: costsPending, isError: costsError, data: periodCosts });
+
+    const minimumEnabled = chargesEnabled && hasPlanMinimum(plan);
+    const { data: upcoming, isError: upcomingError } = useApiGetUpcomingInvoice(env, plan, { enabled: minimumEnabled });
+    const minimumSpend = buildMinimumSpendRow({
+        enabled: minimumEnabled && !upcomingError,
+        minimum: upcoming?.data.minimum ?? null,
+        currency: upcoming?.data.currency ?? null
+    });
 
     if (usageError) {
         return (
@@ -121,6 +130,7 @@ export const Usage: React.FC = () => {
                 chartMode="daily"
                 variant={charges ? 'charges' : 'usage'}
                 charges={charges}
+                minimumSpend={minimumSpend}
             />
         </div>
     );

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -1,5 +1,6 @@
 import { Info } from 'lucide-react';
 
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { cn } from '@/utils/utils';
 import { UsageRow, usageRowGrid } from './UsageRow';
 
@@ -28,6 +29,8 @@ interface UsageTableProps {
      *  (each row manages its own open state) when omitted. */
     isRowOpen?: (metric: UsageMetric) => boolean;
     onRowOpenChange?: (metric: UsageMetric, open: boolean) => void;
+    /** Closing row for what the plan minimum adds on top of the metric charges, not a total. */
+    minimumSpend?: { formatted: string; tooltip: string } | null;
 }
 
 /** The two right-hand column headers, which differ by variant. */
@@ -46,7 +49,18 @@ function usageColumnHeaders(variant: UsageTableProps['variant']): { thisPeriod: 
  * The bordered per-metric usage table shared by Free and paid: a header row, then one collapsible
  * {@link UsageRow} per metric.
  */
-export const UsageTable: React.FC<UsageTableProps> = ({ rows, isLoading, env, timeframe, chartMode, variant, charges, isRowOpen, onRowOpenChange }) => {
+export const UsageTable: React.FC<UsageTableProps> = ({
+    rows,
+    isLoading,
+    env,
+    timeframe,
+    chartMode,
+    variant,
+    charges,
+    isRowOpen,
+    onRowOpenChange,
+    minimumSpend
+}) => {
     const { thisPeriod, rightmost } = usageColumnHeaders(variant);
     return (
         <div className="w-full flex flex-col gap-4">
@@ -76,6 +90,19 @@ export const UsageTable: React.FC<UsageTableProps> = ({ rows, isLoading, env, ti
                         charge={charges?.(row.metric)}
                     />
                 ))}
+                {minimumSpend && (
+                    <div className={cn(usageRowGrid(variant), 'py-3.5 border-t border-border-default')}>
+                        <div className="flex items-center gap-1.5 min-w-0">
+                            <span className="text-text-default type-text-regular-sm truncate">Minimum spend</span>
+                            <InfoTooltip side="top" align="start">
+                                {minimumSpend.tooltip}
+                            </InfoTooltip>
+                        </div>
+                        <span />
+                        <div className="text-text-default type-text-regular-sm">{minimumSpend.formatted}</div>
+                        <span />
+                    </div>
+                )}
             </div>
             <span className="flex items-center gap-1.5 text-text-muted text-body-small-regular px-1">
                 <Info className="size-3.5 shrink-0" />

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -91,7 +91,7 @@ export const UsageTable: React.FC<UsageTableProps> = ({
                     />
                 ))}
                 {minimumSpend && (
-                    <div className={cn(usageRowGrid(variant), 'py-3.5 border-t border-border-default')}>
+                    <div className={cn(usageRowGrid(variant), 'py-3.5')}>
                         <div className="flex items-center gap-1.5 min-w-0">
                             <span className="text-text-default type-text-regular-sm truncate">Minimum spend</span>
                             <InfoTooltip side="top" align="start">

--- a/packages/webapp/src/pages/Team/Billing/minimumSpend.ts
+++ b/packages/webapp/src/pages/Team/Billing/minimumSpend.ts
@@ -1,0 +1,33 @@
+import { formatMoneyFromCents } from './money';
+
+import type { GetUpcomingInvoice } from '@nangohq/types';
+
+export interface MinimumSpendRow {
+    /** What the minimum adds on top of the metric charges. */
+    formatted: string;
+    tooltip: string;
+}
+
+interface BuildArgs {
+    enabled: boolean;
+    minimum: GetUpcomingInvoice['Success']['data']['minimum'];
+    currency: string | null;
+}
+
+export function buildMinimumSpendRow({ enabled, minimum, currency }: BuildArgs): MinimumSpendRow | null {
+    if (!enabled || !minimum) {
+        return null;
+    }
+
+    const formatted = formatMoneyFromCents(minimum.topUpInCents, currency);
+    const enforced = formatMoneyFromCents(minimum.enforcedInCents, currency);
+    if (formatted === null || enforced === null) {
+        return null;
+    }
+
+    return {
+        formatted,
+        // The invoice's figure, not the plan's: Orb prorates the minimum over a partial period.
+        tooltip: `Tops this period's usage up to its ${enforced} minimum. A partial period is charged a prorated share of the monthly minimum.`
+    };
+}

--- a/packages/webapp/src/pages/Team/Billing/minimumSpend.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/minimumSpend.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildMinimumSpendRow } from './minimumSpend.js';
+
+describe('buildMinimumSpendRow', () => {
+    // 74c of usage under a $50 minimum, from a live pay-as-you-go invoice.
+    const binding = { enforcedInCents: 4999, topUpInCents: 4925 };
+
+    it('states what the minimum adds, not the minimum itself', () => {
+        // The charges above already carry the usage, so the enforced figure would double-count it.
+        expect(buildMinimumSpendRow({ enabled: true, minimum: binding, currency: 'USD' })?.formatted).toBe('$49.25');
+    });
+
+    it('names the enforced minimum in the tooltip', () => {
+        expect(buildMinimumSpendRow({ enabled: true, minimum: { enforcedInCents: 4833, topUpInCents: 4637 }, currency: 'USD' })?.tooltip).toContain(
+            '$48.33 minimum'
+        );
+    });
+
+    it('states nothing when no minimum binds', () => {
+        expect(buildMinimumSpendRow({ enabled: true, minimum: null, currency: 'USD' })).toBeNull();
+    });
+
+    it('states nothing on a plan that sells no minimum', () => {
+        expect(buildMinimumSpendRow({ enabled: false, minimum: binding, currency: 'USD' })).toBeNull();
+    });
+
+    it('states nothing rather than a bare number when the currency cannot be formatted', () => {
+        expect(buildMinimumSpendRow({ enabled: true, minimum: binding, currency: 'credits' })).toBeNull();
+        expect(buildMinimumSpendRow({ enabled: true, minimum: binding, currency: null })).toBeNull();
+    });
+});

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -98,6 +98,24 @@ const PLAN_ACCRUES_CHARGES: Record<DBPlan['name'], boolean> = {
     'growth-legacy': false
 };
 
+// Only Pay-as-you-go is sold with a minimum as standard: a negotiated one on an individual Growth or
+// Enterprise contract does not put the row on that plan's page.
+const PLAN_HAS_MINIMUM: Record<DBPlan['name'], boolean> = {
+    'pay-as-you-go': true,
+    'starter-v2': false,
+    'growth-v2': false,
+    'startup-deal': false,
+    free: false,
+    'free-uncapped': false,
+    enterprise: false,
+    'enterprise-cloud-hosted': false,
+    starter: false,
+    growth: false,
+    'starter-legacy': false,
+    'scale-legacy': false,
+    'growth-legacy': false
+};
+
 // Plans September 2026 stops selling: their cards stay on screen but every CTA targeting one
 // becomes Contact us. Which card *set* an account sees is `isOnS26Pricing`, a different question.
 const PLAN_IS_RETIRED: Record<DBPlan['name'], boolean> = {
@@ -150,6 +168,13 @@ export function planAccruesCharges(plan: ApiPlan | null | undefined): boolean {
         return false;
     }
     return PLAN_ACCRUES_CHARGES[plan.name];
+}
+
+export function hasPlanMinimum(plan: ApiPlan | null | undefined): boolean {
+    if (!plan) {
+        return false;
+    }
+    return PLAN_HAS_MINIMUM[plan.name];
 }
 
 export function isRetiredPlan(code: DBPlan['name']): boolean {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -8,8 +8,11 @@ const SPEND_CAVEATS = 'Any account credit is applied when the invoice is issued.
 
 export const SPEND_TOOLTIP = `Next month's base fee plus this period's usage beyond your plan's included quota. ${SPEND_CAVEATS}`;
 
-/** Orb prices Pay-as-you-go as a $50 plan-level minimum over the three metrics, not as a base fee. */
-export const SPEND_TOOLTIP_S26 = `This period's usage, or the $50 monthly minimum, whichever is higher. ${SPEND_CAVEATS}`;
+/**
+ * Names no figure: Orb prorates the minimum over a partial period, so the plan's $50 would routinely
+ * be above the headline it sits on. The usage table's minimum row carries the account's real amount.
+ */
+export const SPEND_TOOLTIP_S26 = `This period's usage, or your plan's monthly minimum, whichever is higher. A partial period is charged a prorated share of that minimum. ${SPEND_CAVEATS}`;
 
 /** Drops the opening sentence for plans with no base fee and no billable overage. */
 export const SPEND_TOOLTIP_WITHOUT_CHARGES = SPEND_CAVEATS;

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -12,7 +12,7 @@ export const SPEND_TOOLTIP = `Next month's base fee plus this period's usage bey
  * Names no figure: Orb prorates the minimum over a partial period, so the plan's $50 would routinely
  * be above the headline it sits on. The usage table's minimum row carries the account's real amount.
  */
-export const SPEND_TOOLTIP_S26 = `This period's usage, or your plan's monthly minimum, whichever is higher. A partial period is charged a prorated share of that minimum. ${SPEND_CAVEATS}`;
+export const SPEND_TOOLTIP_S26 = `This period's usage, or your plan's monthly minimum, whichever is higher. ${SPEND_CAVEATS}`;
 
 /** Drops the opening sentence for plans with no base fee and no billable overage. */
 export const SPEND_TOOLTIP_WITHOUT_CHARGES = SPEND_CAVEATS;

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -115,9 +115,14 @@ describe('planAccruesCharges', () => {
     });
 
     it('names the minimum rather than a base fee on the new pricing', () => {
-        expect(SPEND_TOOLTIP_S26).toContain('$50 monthly minimum');
+        expect(SPEND_TOOLTIP_S26).toContain('monthly minimum');
         expect(SPEND_TOOLTIP_S26).not.toContain('base fee');
         expect(SPEND_TOOLTIP_S26).toContain(SPEND_TOOLTIP_WITHOUT_CHARGES);
+    });
+
+    it('quotes no amount, and says the minimum prorates', () => {
+        expect(SPEND_TOOLTIP_S26).not.toMatch(/\$\d/);
+        expect(SPEND_TOOLTIP_S26).toContain('prorated');
     });
 });
 
@@ -129,8 +134,8 @@ describe('buildSummaryState headline', () => {
     });
 
     it('explains the spend as a minimum for an account on the new pricing', () => {
-        const state = build(planOf('pay-as-you-go'), { spend: spendOf(1200), onS26Pricing: true });
-        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: '$12.00', tooltip: SPEND_TOOLTIP_S26 });
+        const state = build(planOf('pay-as-you-go'), { spend: spendOf(4833), onS26Pricing: true });
+        expect(state.headline).toEqual({ label: 'CURRENT PERIOD SPEND', value: '$48.33', tooltip: SPEND_TOOLTIP_S26 });
     });
 
     it('reports $0.00 on the startup deal rather than treating it as missing', () => {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -120,9 +120,8 @@ describe('planAccruesCharges', () => {
         expect(SPEND_TOOLTIP_S26).toContain(SPEND_TOOLTIP_WITHOUT_CHARGES);
     });
 
-    it('quotes no amount, and says the minimum prorates', () => {
+    it('quotes no amount', () => {
         expect(SPEND_TOOLTIP_S26).not.toMatch(/\$\d/);
-        expect(SPEND_TOOLTIP_S26).toContain('prorated');
     });
 });
 


### PR DESCRIPTION
## Problem

On pay-as-you-go the plan minimum carries nearly the whole bill and the billing page never showed it — a $49.99 headline above a usage table adding up to $0.74, with no line for the rest. The headline tooltip also promised a "$50 monthly minimum" while routinely sitting above a smaller number, because Orb prorates the minimum over a partial period.

## Solution

- `/plans/billing/upcoming-invoice` returns the minimum topping the period up, taken from the gap between subtotal and total — Orb's `minimum.minimum_amount` reports the plan's nominal figure even where a prorated one is enforced.
- The usage table closes with a minimum-spend row stating what the minimum *adds*, so the metric charges plus that row sum to the headline exactly.
- The headline tooltip names no figure and says the minimum prorates; the row carries the account's real amount.
- The upgrade dialog gains the same caveat about the first period.
- Gated to pay-as-you-go via a new exhaustive `PLAN_HAS_MINIMUM` map, so no other plan changes.

Fixes [NAN-6883](https://linear.app/nango/issue/NAN-6883)

## Testing

- Checked against all ten live pay-as-you-go invoices: charges + minimum row = headline on every one, including the two already over their minimum where the row is absent.
- In the browser: row renders and aligns, both tooltips read correctly, the row disappears once usage passes the minimum, and Growth gets no row.

<img width="2574" height="1152" alt="image" src="https://github.com/user-attachments/assets/bd7dbb30-87c4-44b0-8407-b71ca4d41f5c" />
