### PR TITLE
feat(webapp): let customers add and remove the Growth add-on

### DIFF
--- a/packages/design-system/src/components/ui/button.tsx
+++ b/packages/design-system/src/components/ui/button.tsx
@@ -122,7 +122,7 @@ export const buttonVariants = cva(
                 // 20px square — smallest icon-only size (use with IconButton); icon sizing comes from the base
                 '2xs': 'size-5 p-1',
                 xs: 'h-6 px-1.5 text-ds-xs',
-                sm: 'h-7 px-2',
+                sm: 'h-7 px-2 text-ds-xs',
                 md: 'h-8 px-2.5',
                 lg: 'h-9 px-3'
             }
@@ -132,9 +132,7 @@ export const buttonVariants = cva(
             // link-danger alone gets 2px horizontal padding that link-accent/link-neutral don't have.
             { variant: ['link-accent', 'link-neutral'], className: 'h-auto w-auto p-0' },
             { variant: 'link-danger', className: 'h-auto w-auto px-0.5 py-0' },
-            // Figma's link text/icon scale is its own two-tier scale, distinct from the solid-button sizes:
-            // xs/sm render at 12px text (md/lg keep the base 14px text-ds-md, so no override needed there).
-            { variant: ['link-accent', 'link-danger', 'link-neutral'], size: ['xs', 'sm'], className: 'text-ds-xs gap-1' },
+            { variant: ['link-accent', 'link-danger', 'link-neutral'], size: ['xs', 'sm'], className: 'gap-1' },
             // xs takes the smallest (12px) icon; sm's icon is 14px, between xs and md/lg. No radius override:
             // link variants are bare text with no border or background, so a pill only ever showed up as a
             // capsule-shaped focus ring around a few words.

--- a/packages/webapp/src/components/patterns/PermissionGate.tsx
+++ b/packages/webapp/src/components/patterns/PermissionGate.tsx
@@ -8,13 +8,9 @@ interface PermissionGateProps {
     tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
 }
 
-export const PermissionGate = ({
-    condition,
-    message = 'This action is not permitted for your role.',
-    children,
-    asChild,
-    tooltipSide = 'bottom'
-}: PermissionGateProps) => {
+export const PERMISSION_DENIED_REASON = 'This action is not permitted for your role.';
+
+export const PermissionGate = ({ condition, message = PERMISSION_DENIED_REASON, children, asChild, tooltipSide = 'bottom' }: PermissionGateProps) => {
     return (
         <ConditionalTooltip condition={!condition} content={message} asChild={asChild} side={tooltipSide} delayDuration={0}>
             {children(condition)}

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -15,6 +15,7 @@ import { cn } from '@/utils/utils';
 import { DEFAULTS, usePlanOverrideStore } from './planOverride';
 
 import type { PeriodCostsOverride, SpendOverride, UsageLimitOverride } from './planOverride';
+import type { GrowthAddonState } from '@/pages/Team/Billing/planVisibility';
 import type { PlanDefinition } from '@nangohq/types';
 
 const REAL_PLAN_VALUE = '__real__';
@@ -25,6 +26,7 @@ const UNAVAILABLE_SPEND_VALUE = 'unavailable';
 // A base-only Starter bill, a mid-period Growth bill, and the startup deal's real zero.
 const SPEND_PRESETS_IN_CENTS = [0, 5000, 128430];
 const REAL_PERIOD_COSTS_VALUE = '__real_period_costs__';
+const REAL_ADDON_VALUE = '__real_addon__';
 interface PlanOverrideContentProps {
     onBack: () => void;
     onClose: () => void;
@@ -50,6 +52,8 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
     const setMetricChargesEnabled = usePlanOverrideStore((s) => s.setMetricChargesEnabled);
     const periodCostsOverride = usePlanOverrideStore((s) => s.periodCostsOverride);
     const setPeriodCostsOverride = usePlanOverrideStore((s) => s.setPeriodCostsOverride);
+    const addonState = usePlanOverrideStore((s) => s.addonState);
+    const setAddonState = usePlanOverrideStore((s) => s.setAddonState);
     const paymentMethodOverride = usePlanOverrideStore((s) => s.paymentMethodOverride);
     const setPaymentMethodOverride = usePlanOverrideStore((s) => s.setPaymentMethodOverride);
     const resetAll = usePlanOverrideStore((s) => s.resetAll);
@@ -58,6 +62,7 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
     // aren't plan-specific — a downgraded account can still owe one — so that one is always offered.
     const { data: environmentData } = useCurrentPlan(env);
     const isFreePlan = environmentData?.plan?.name === 'free';
+    const isPayAsYouGo = environmentData?.plan?.name === 'pay-as-you-go';
     const leadsWithSpend = hasMonthlySpend(environmentData?.plan);
 
     // Several plans share a title — `starter` and `starter-legacy` are both "Starter (legacy)", as are
@@ -144,6 +149,23 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                                             {plan.code === 'free' ? 'Free (cancellation)' : `${plan.title} (downgrade)`}
                                         </SelectItem>
                                     ))}
+                                </SelectContent>
+                            </Select>
+                        </Row>
+                    )}
+
+                    {isPayAsYouGo && (
+                        <Row label="Growth add-on" hint="Removal scheduled has no real source yet — it is preview-only.">
+                            <Select
+                                value={addonState ?? REAL_ADDON_VALUE}
+                                onValueChange={(value) => setAddonState(value === REAL_ADDON_VALUE ? null : (value as GrowthAddonState))}
+                            >
+                                <RowTrigger placeholder="Real" />
+                                <SelectContent>
+                                    <SelectItem value={REAL_ADDON_VALUE}>Real</SelectItem>
+                                    <SelectItem value="none">Not on plan</SelectItem>
+                                    <SelectItem value="active">Active</SelectItem>
+                                    <SelectItem value="pending-removal">Removal scheduled</SelectItem>
                                 </SelectContent>
                             </Select>
                         </Row>

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -1,8 +1,10 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+import { nextUsageResetDate } from '@/pages/Team/Billing/billingPeriod';
 import { LocalStorageKeys } from '@/utils/local-storage';
 
+import type { GrowthAddonState } from '@/pages/Team/Billing/planVisibility';
 import type { ApiPlan, GetBillingPeriodCosts, GetOverdueInvoices, GetStripePaymentMethods, GetUpcomingInvoice, PlanDefinition } from '@nangohq/types';
 
 /** Simulated aggregate usage state, matching what `getAggregateUsageState` can return. */
@@ -30,6 +32,7 @@ interface PlanOverrideState {
     spendOverride: SpendOverride | null;
     metricChargesEnabled: boolean;
     periodCostsOverride: PeriodCostsOverride | null;
+    addonState: GrowthAddonState | null;
     paymentMethodOverride: boolean;
     setOverride: (code: PlanDefinition['code'] | null) => void;
     setScheduledTarget: (code: PlanDefinition['code'] | null) => void;
@@ -39,6 +42,7 @@ interface PlanOverrideState {
     setSpendOverride: (override: SpendOverride | null) => void;
     setMetricChargesEnabled: (enabled: boolean) => void;
     setPeriodCostsOverride: (override: PeriodCostsOverride | null) => void;
+    setAddonState: (state: GrowthAddonState | null) => void;
     setPaymentMethodOverride: (override: boolean) => void;
     resetAll: () => void;
 }
@@ -52,6 +56,7 @@ export const DEFAULTS = {
     spendOverride: null,
     metricChargesEnabled: false,
     periodCostsOverride: null,
+    addonState: null,
     paymentMethodOverride: false
 } satisfies Partial<PlanOverrideState>;
 
@@ -68,7 +73,8 @@ export const usePlanOverrideStore = create<PlanOverrideState>()(
                     overdueOverride: false,
                     usageLimitOverride: null,
                     spendOverride: null,
-                    periodCostsOverride: null
+                    periodCostsOverride: null,
+                    addonState: null
                 }),
             setScheduledTarget: (scheduledTargetCode) => set({ scheduledTargetCode }),
             setOverdueOverride: (overdueOverride) => set({ overdueOverride }),
@@ -77,6 +83,7 @@ export const usePlanOverrideStore = create<PlanOverrideState>()(
             setSpendOverride: (spendOverride) => set({ spendOverride }),
             setMetricChargesEnabled: (metricChargesEnabled) => set({ metricChargesEnabled }),
             setPeriodCostsOverride: (periodCostsOverride) => set({ periodCostsOverride }),
+            setAddonState: (addonState) => set({ addonState }),
             setPaymentMethodOverride: (paymentMethodOverride) => set({ paymentMethodOverride }),
             resetAll: () => set(DEFAULTS)
         }),
@@ -149,20 +156,36 @@ export function buildPeriodCostsOverride(override: PeriodCostsOverride): GetBill
 /** Overlays a dev-tool plan override (and optional simulated scheduled change) onto a real plan, for visual QA only. */
 export function applyPlanOverride(
     realPlan: ApiPlan | null | undefined,
-    { overridePlan, scheduledTarget }: { overridePlan?: PlanDefinition | null; scheduledTarget?: PlanDefinition | null }
+    {
+        overridePlan,
+        scheduledTarget,
+        addonState
+    }: { overridePlan?: PlanDefinition | null; scheduledTarget?: PlanDefinition | null; addonState?: GrowthAddonState | null }
 ): ApiPlan | null | undefined {
-    if (!realPlan || !overridePlan) {
+    if (!realPlan || (!overridePlan && !addonState)) {
         return realPlan;
     }
 
+    const withPlan: ApiPlan = overridePlan
+        ? {
+              ...realPlan,
+              // `flags` is typed against `DBPlan` (pre-serialization), so its never-set Date fields
+              // (trial_start_at, etc.) don't match `ApiPlan`'s stringified dates — safe to assert since
+              // plan definitions only ever set those fields to `null`, never an actual Date.
+              ...(overridePlan.flags as Partial<ApiPlan>),
+              name: overridePlan.code,
+              orb_future_plan: scheduledTarget?.code ?? null,
+              orb_future_plan_at: scheduledTarget ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString() : null
+          }
+        : realPlan;
+
+    if (!addonState) {
+        return withPlan;
+    }
+
     return {
-        ...realPlan,
-        // `flags` is typed against `DBPlan` (pre-serialization), so its never-set Date fields
-        // (trial_start_at, etc.) don't match `ApiPlan`'s stringified dates — safe to assert since
-        // plan definitions only ever set those fields to `null`, never an actual Date.
-        ...(overridePlan.flags as Partial<ApiPlan>),
-        name: overridePlan.code,
-        orb_future_plan: scheduledTarget?.code ?? null,
-        orb_future_plan_at: scheduledTarget ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString() : null
+        ...withPlan,
+        has_growth_features: addonState !== 'none',
+        growth_features_ends_at: addonState === 'pending-removal' ? nextUsageResetDate(new Date()).toISOString() : null
     };
 }

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -50,17 +50,18 @@ export function currentPlanQueryOptions(env: string) {
 function usePlanOverride(env: string, realPlan: ApiPlan | null | undefined): ApiPlan | null | undefined {
     const overrideCode = usePlanOverrideStore((s) => s.overrideCode);
     const scheduledTargetCode = usePlanOverrideStore((s) => s.scheduledTargetCode);
+    const addonState = usePlanOverrideStore((s) => s.addonState);
     // Only fetch when an override is set, to avoid an extra /plans request on every load.
     const { data: plansList } = useApiGetPlans(env, { enabled: Boolean(overrideCode) });
 
     return useMemo(() => {
-        if (!overrideCode) {
+        if (!overrideCode && !addonState) {
             return realPlan;
         }
         const overridePlan = plansList?.data.find((p) => p.code === overrideCode) ?? null;
         const scheduledTarget = plansList?.data.find((p) => p.code === scheduledTargetCode) ?? null;
-        return applyPlanOverride(realPlan, { overridePlan, scheduledTarget });
-    }, [realPlan, overrideCode, scheduledTargetCode, plansList]);
+        return applyPlanOverride(realPlan, { overridePlan, scheduledTarget, addonState });
+    }, [realPlan, overrideCode, scheduledTargetCode, addonState, plansList]);
 }
 
 export function useApiGetCurrentPlan(env: string) {

--- a/packages/webapp/src/pages/Team/Billing/components/GrowthAddon.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/GrowthAddon.tsx
@@ -36,9 +36,11 @@ export const GrowthAddon: React.FC<{ state: GrowthAddonState; endsAt?: string; o
                     </ConditionalTooltip>
                 )}
                 {state === 'active' && (
-                    <Button variant="link-danger" size="sm" onClick={onActionClicked}>
-                        Remove
-                    </Button>
+                    <ConditionalTooltip condition={!!lockedReason} content={lockedReason} side="left" asChild>
+                        <Button variant="link-danger" size="sm" disabled={!!lockedReason} onClick={onActionClicked}>
+                            Remove
+                        </Button>
+                    </ConditionalTooltip>
                 )}
                 {/* Keeping the add-on has no action behind it until NAN-6816 lets a scheduled removal be cancelled. */}
             </div>

--- a/packages/webapp/src/pages/Team/Billing/components/GrowthAddon.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/GrowthAddon.tsx
@@ -42,7 +42,6 @@ export const GrowthAddon: React.FC<{ state: GrowthAddonState; endsAt?: string; o
                         </Button>
                     </ConditionalTooltip>
                 )}
-                {/* Keeping the add-on has no action behind it until NAN-6816 lets a scheduled removal be cancelled. */}
             </div>
             <div className="flex items-center gap-1.5">
                 {state !== 'none' && <Dot variant={state === 'active' ? 'success' : 'warning'} />}

--- a/packages/webapp/src/pages/Team/Billing/components/GrowthAddon.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/GrowthAddon.tsx
@@ -1,0 +1,56 @@
+import { Button } from '@nangohq/design-system';
+
+import { ConditionalTooltip } from '@/components/patterns/ConditionalTooltip';
+import { Dot } from '@/components/ui/Dot';
+import { track } from '@/utils/analytics';
+import { formatBillingDate } from '../billingPeriod.js';
+import { GROWTH_ADDON_COPY } from './planCardCopy.js';
+
+import type { GrowthAddonState } from '../planVisibility.js';
+
+export const GrowthAddon: React.FC<{ state: GrowthAddonState; endsAt?: string; onAdd: () => void; onRemove: () => void; lockedReason?: string }> = ({
+    state,
+    endsAt,
+    onAdd,
+    onRemove,
+    lockedReason
+}) => {
+    const onActionClicked = () => {
+        track('web:usage:addon_action_clicked', { state });
+        if (state === 'none') {
+            onAdd();
+        } else {
+            onRemove();
+        }
+    };
+
+    return (
+        <div className="flex flex-col gap-2 rounded bg-surface-input-muted border border-dashed border-border-strong p-3">
+            <div className="flex items-start justify-between gap-2">
+                <span className="text-text-strong text-body-medium-medium">{GROWTH_ADDON_COPY.title}</span>
+                {state === 'none' && (
+                    <ConditionalTooltip condition={!!lockedReason} content={lockedReason} side="left" asChild>
+                        <Button variant="primary" size="sm" disabled={!!lockedReason} onClick={onActionClicked}>
+                            Add to plan
+                        </Button>
+                    </ConditionalTooltip>
+                )}
+                {state === 'active' && (
+                    <Button variant="link-danger" size="sm" onClick={onActionClicked}>
+                        Remove
+                    </Button>
+                )}
+                {/* Keeping the add-on has no action behind it until NAN-6816 lets a scheduled removal be cancelled. */}
+            </div>
+            <div className="flex items-center gap-1.5">
+                {state !== 'none' && <Dot variant={state === 'active' ? 'success' : 'warning'} />}
+                <span className="text-text-secondary text-body-medium-regular">
+                    {state === 'none' && GROWTH_ADDON_COPY.price}
+                    {state === 'active' && `${GROWTH_ADDON_COPY.price} · included in this period`}
+                    {state === 'pending-removal' && `Deactivates ${endsAt ? formatBillingDate(new Date(endsAt)) : 'at the end of this period'}`}
+                </span>
+            </div>
+            <span className="text-text-secondary text-body-small-regular">{GROWTH_ADDON_COPY.features}</span>
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -130,7 +130,7 @@ const PlanCard: React.FC<{
     /** Undefined while the old set of cards is on screen. */
     card?: S26PlanCard;
     addonState: GrowthAddonState;
-    /** When a scheduled add-on removal takes effect, as Orb's period end rather than a guess at it. */
+    /** Orb's period end, not a client-side guess at it. */
     endsAt?: string;
     /** Set when a plan change is already coming: the add-on cannot then move the other way. */
     pendingChangeAt?: string;

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -130,9 +130,7 @@ const PlanCard: React.FC<{
     /** Undefined while the old set of cards is on screen. */
     card?: S26PlanCard;
     addonState: GrowthAddonState;
-    /** Orb's period end, not a client-side guess at it. */
     endsAt?: string;
-    /** A scheduled plan change locks the add-on, in both directions. */
     pendingChangeAt?: string;
     /** Whether this plan is no longer something the account can move to. */
     closed?: boolean;

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -417,7 +417,7 @@ const PlanChangeDialog: React.FC<{
                         </div>
                         {offersAddon && (
                             <>
-                                <label className="flex gap-3 items-start rounded-md border border-dashed border-border-muted p-3 cursor-pointer">
+                                <label className="flex gap-3 items-start rounded bg-surface-input-muted border border-dashed border-border-strong p-3 cursor-pointer">
                                     <Checkbox checked={withAddon} onCheckedChange={(checked) => setWithAddon(checked === true)} className="mt-0.5" />
                                     <span className="flex flex-col gap-1">
                                         <span className="text-text-strong text-body-medium-medium">Include {GROWTH_ADDON_COPY.title}</span>

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -18,6 +18,7 @@ import {
 } from '@nangohq/design-system';
 
 import { PermissionGate } from '@/components/patterns/PermissionGate.js';
+import { Checkbox } from '@/components/ui/Checkbox';
 import { Separator } from '@/components/ui/Separator';
 import { useMeta } from '@/hooks/useMeta';
 import { usePermissions } from '@/hooks/usePermissions.js';
@@ -29,11 +30,14 @@ import { openSupportChat } from '@/utils/support';
 import { isOnS26Pricing } from '@/utils/usage';
 import { cn } from '@/utils/utils';
 import { formatBillingDate, nextUsageResetDate } from '../billingPeriod.js';
-import { isRetiredPlan } from '../planVisibility.js';
+import { growthAddonState, isRetiredPlan } from '../planVisibility.js';
+import { pendingPlanChange } from '../summaryState.js';
 import { PlanChangeErrorAlert, usePlanChangeRequest } from '../usePlanChangeRequest.js';
+import { GrowthAddon } from './GrowthAddon.js';
 import { PaymentMethodDialog } from './PaymentMethodDialog.js';
-import { ENTERPRISE_PLAN_DESCRIPTION, PLAN_CARD_LIMITS, S26_PLAN_CARDS } from './planCardCopy.js';
+import { ENTERPRISE_PLAN_DESCRIPTION, GROWTH_ADDON_COPY, GROWTH_ADDON_PRICE, PLAN_CARD_LIMITS, S26_PLAN_CARDS } from './planCardCopy.js';
 
+import type { GrowthAddonState } from '../planVisibility.js';
 import type { PlanDefinitionList } from '../types.js';
 import type { S26PlanCard } from './planCardCopy.js';
 import type { PlanDefinition, StripePaymentMethod } from '@nangohq/types';
@@ -78,6 +82,11 @@ export const Plans: React.FC = () => {
     }, [currentPlan, plansList, showsNewPlans]);
 
     const activeIsOffered = plans?.list.some((p) => p.active) ?? false;
+    const pendingChange = useMemo(
+        () => (currentPlan ? pendingPlanChange({ plan: currentPlan, plans: plansList?.data, now: new Date() }) : null),
+        [currentPlan, plansList]
+    );
+    const addonState = growthAddonState(currentPlan);
 
     return (
         <div className="flex flex-col gap-4">
@@ -90,6 +99,9 @@ export const Plans: React.FC = () => {
                         activePlan={plans?.activePlan}
                         activeIsOffered={activeIsOffered}
                         card={showsNewPlans ? S26_PLAN_CARDS.find((c) => c.code === plan.plan.code) : undefined}
+                        addonState={addonState}
+                        endsAt={currentPlan?.growth_features_ends_at ?? undefined}
+                        pendingChangeAt={pendingChange?.at}
                         closed={s26Pricing && !showsNewPlans && isRetiredPlan(plan.plan.code)}
                         paymentMethod={paymentMethod}
                     />
@@ -117,11 +129,17 @@ const PlanCard: React.FC<{
     activeIsOffered: boolean;
     /** Undefined while the old set of cards is on screen. */
     card?: S26PlanCard;
+    addonState: GrowthAddonState;
+    /** When a scheduled add-on removal takes effect, as Orb's period end rather than a guess at it. */
+    endsAt?: string;
+    /** Set when a plan change is already coming: the add-on cannot then move the other way. */
+    pendingChangeAt?: string;
     /** Whether this plan is no longer something the account can move to. */
     closed?: boolean;
     paymentMethod?: StripePaymentMethod | null;
-}> = ({ planDefinition, activePlan, activeIsOffered, card, closed, paymentMethod }) => {
+}> = ({ planDefinition, activePlan, activeIsOffered, card, addonState, endsAt, pendingChangeAt, closed, paymentMethod }) => {
     const { plan, active, isFuture, isDowngrade, isUpgrade } = planDefinition;
+    const [addonAction, setAddonAction] = useState<'add' | 'remove' | null>(null);
 
     const { can } = usePermissions();
     const canChangePlan = can('account:plan:update');
@@ -195,6 +213,9 @@ const PlanCard: React.FC<{
     })();
 
     if (card) {
+        const showsAddon = active && plan.code === 'pay-as-you-go';
+        const features = showsAddon || !card.addonTeaser ? card.features : [...card.features, card.addonTeaser];
+
         return (
             <Card selected={active}>
                 <div className="flex flex-col gap-4 p-4 flex-1">
@@ -212,13 +233,27 @@ const PlanCard: React.FC<{
                     </div>
                     <Separator />
                     <ul className="flex flex-col gap-2">
-                        {card.features.map((feature) => (
+                        {features.map((feature) => (
                             <li key={feature} className="flex gap-2 items-baseline">
                                 <span className="text-text-muted text-body-small-regular">&middot;</span>
                                 <span className="text-text-secondary text-body-small-regular">{feature}</span>
                             </li>
                         ))}
                     </ul>
+                    {showsAddon && (
+                        <>
+                            <GrowthAddon
+                                state={addonState}
+                                endsAt={endsAt}
+                                onAdd={() => setAddonAction('add')}
+                                onRemove={() => setAddonAction('remove')}
+                                lockedReason={pendingChangeAt ? `Your plan changes on ${pendingChangeAt}.` : undefined}
+                            />
+                            {addonAction && (
+                                <GrowthAddonDialog planCode={plan.code} action={addonAction} open onOpenChange={(next) => !next && setAddonAction(null)} />
+                            )}
+                        </>
+                    )}
                 </div>
                 <div className="w-full px-4 py-6">{ButtonComponent}</div>
             </Card>
@@ -299,6 +334,10 @@ const PlanChangeDialog: React.FC<{
     const env = useStore((state) => state.env);
     const { submit, reset, loading, longWait, error } = usePlanChangeRequest(env);
 
+    const offersAddon = Boolean(newPricing && selectedPlan.isUpgrade && selectedPlan.plan.code === 'pay-as-you-go');
+    const [withAddon, setWithAddon] = useState(false);
+    const wantsAddon = offersAddon && withAddon;
+
     const [internalOpen, setInternalOpen] = useState(false);
     const isControlled = openProp !== undefined;
     const open = isControlled ? openProp : internalOpen;
@@ -309,6 +348,7 @@ const PlanChangeDialog: React.FC<{
             }
             if (!value) {
                 reset();
+                setWithAddon(false);
             }
             onOpenChange?.(value);
         },
@@ -320,11 +360,13 @@ const PlanChangeDialog: React.FC<{
         const done = selectedPlan.isUpgrade
             ? await submit({
                   orbId: code,
-                  settled: (plan) => plan.name === code,
+                  withGrowthFeatures: wantsAddon,
+                  settled: (plan) => plan.name === code && plan.has_growth_features === wantsAddon,
                   successTitle: `Upgraded successfully to ${selectedPlan.plan.title}`
               })
             : await submit({
                   orbId: code,
+                  withGrowthFeatures: false,
                   settled: (plan) => plan.orb_future_plan === code,
                   successTitle: `Downgraded successfully to ${selectedPlan.plan.title}`
               });
@@ -373,6 +415,25 @@ const PlanChangeDialog: React.FC<{
                                 <p className="text-s text-text-muted text-right">{selectedPlan.isUpgrade ? 'Payment is processing...' : 'Downgrading...'}</p>
                             )}
                         </div>
+                        {offersAddon && (
+                            <>
+                                <label className="flex gap-3 items-start rounded-md border border-dashed border-border-muted p-3 cursor-pointer">
+                                    <Checkbox checked={withAddon} onCheckedChange={(checked) => setWithAddon(checked === true)} className="mt-0.5" />
+                                    <span className="flex flex-col gap-1">
+                                        <span className="text-text-strong text-body-medium-medium">Include {GROWTH_ADDON_COPY.title}</span>
+                                        <span className="text-text-secondary text-body-medium-regular">{GROWTH_ADDON_COPY.price}</span>
+                                        <span className="text-text-secondary text-body-small-regular">{GROWTH_ADDON_COPY.features}</span>
+                                    </span>
+                                </label>
+                                <div className="flex items-baseline justify-between">
+                                    <span className="text-text-strong text-body-medium-medium">Monthly total</span>
+                                    <span className="text-text-strong type-text-medium-md">
+                                        ${(selectedPlan.plan.basePrice ?? 0) + (wantsAddon ? GROWTH_ADDON_PRICE : 0)}
+                                        <span className="text-text-secondary type-text-regular-md">/mo</span>
+                                    </span>
+                                </div>
+                            </>
+                        )}
                         <PlanChangeErrorAlert error={error} />
                     </div>
                 </DialogBody>
@@ -390,6 +451,80 @@ const PlanChangeDialog: React.FC<{
                     >
                         {loading && <Loader className="size-4 animate-spin" />}
                         {confirmLabel}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+/** There is no add-on endpoint: `POST /plans/change` takes an end state, so this is a plan change in place. */
+const GrowthAddonDialog: React.FC<{
+    planCode: PlanDefinition['code'];
+    action: 'add' | 'remove';
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}> = ({ planCode, action, open, onOpenChange }) => {
+    const env = useStore((state) => state.env);
+    const { submit, reset, loading, error } = usePlanChangeRequest(env);
+    const endsOn = useMemo(() => formatBillingDate(nextUsageResetDate(new Date())), []);
+
+    const setOpen = (value: boolean) => {
+        if (!value) {
+            reset();
+        }
+        onOpenChange(value);
+    };
+
+    const onConfirm = async () => {
+        const done =
+            action === 'add'
+                ? await submit({
+                      orbId: planCode,
+                      withGrowthFeatures: true,
+                      settled: (plan) => plan.has_growth_features,
+                      successTitle: `${GROWTH_ADDON_COPY.title} added`
+                  })
+                : await submit({
+                      orbId: planCode,
+                      withGrowthFeatures: false,
+                      successTitle: `${GROWTH_ADDON_COPY.title} will be removed on ${endsOn}`
+                  });
+
+        if (done) {
+            onOpenChange(false);
+        }
+    };
+
+    const description =
+        action === 'add'
+            ? `The ${GROWTH_ADDON_COPY.title} is ${GROWTH_ADDON_COPY.price.replace('/mo', '')} per month, billed alongside your plan. You'll be charged a prorated amount today, then the full amount from ${endsOn}.`
+            : `You'll keep Growth features until the end of your current billing period. The add-on is removed on ${endsOn}, and you won't be charged for it after that.`;
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>
+                        {action === 'add' ? 'Confirm' : 'Remove'} {GROWTH_ADDON_COPY.title}
+                    </DialogTitle>
+                    <DialogDescription className="sr-only">{description}</DialogDescription>
+                </DialogHeader>
+                <DialogBody>
+                    <div className="flex flex-col gap-4">
+                        <p className="text-text-secondary text-sm">{description}</p>
+                        <PlanChangeErrorAlert error={error} />
+                    </div>
+                </DialogBody>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button variant="outline" size="sm">
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button variant={action === 'add' ? 'primary' : 'danger'} size="sm" onClick={() => void onConfirm()} disabled={loading}>
+                        {loading && <Loader className="size-4 animate-spin" />}
+                        {action === 'add' ? `Add ${GROWTH_ADDON_COPY.title}` : `Remove ${GROWTH_ADDON_COPY.title}`}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -383,7 +383,7 @@ const PlanChangeDialog: React.FC<{
             if (newPricing) {
                 // Orb prices every metric in arrears under a plan-level minimum, so there is no base
                 // fee to prorate and the upgrade collects nothing.
-                return `${selectedPlan.plan.title} bills at the end of each month — your usage, or a $${selectedPlan.plan.basePrice} monthly minimum, whichever is higher. Nothing is charged today.`;
+                return `${selectedPlan.plan.title} bills at the end of each month — your usage, or a $${selectedPlan.plan.basePrice} monthly minimum, whichever is higher. Nothing is charged today, and this month's minimum is prorated from the day you upgrade.`;
             }
             return `The ${selectedPlan.plan.title} plan includes a ${selectedPlan.plan.basePrice} monthly base fee, plus additional usage-based charges. When you upgrade, you'll be charged a prorated base fee for the current month.`;
         }

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -388,7 +388,7 @@ const PlanChangeDialog: React.FC<{
             return `The ${selectedPlan.plan.title} plan includes a ${selectedPlan.plan.basePrice} monthly base fee, plus additional usage-based charges. When you upgrade, you'll be charged a prorated base fee for the current month.`;
         }
         if (newPricing) {
-            return `You'll keep ${activePlan?.title ?? 'your current plan'}'s features until the end of your current billing period. Your plan switches to ${selectedPlan.plan.title} on ${switchesOn}, and your usage will be capped to the ${selectedPlan.plan.title} limits.`;
+            return `You'll keep ${activePlan?.title ?? 'your current plan'} features until the end of your current billing period. Your plan switches to ${selectedPlan.plan.title} on ${switchesOn}, and your usage will be capped to the ${selectedPlan.plan.title} limits.`;
         }
         return `Your ${activePlan?.title ? activePlan.title : 'current'} subscription will end at the end of this month and won't renew. Any remaining usage will be billed after the month ends.`;
     }, [selectedPlan, activePlan, newPricing, switchesOn]);
@@ -498,8 +498,8 @@ const GrowthAddonDialog: React.FC<{
 
     const description =
         action === 'add'
-            ? `The ${GROWTH_ADDON_COPY.title} is ${GROWTH_ADDON_COPY.price.replace('/mo', '')} per month, billed alongside your plan. You'll be charged a prorated amount today, then the full amount from ${endsOn}.`
-            : `You'll keep Growth features until the end of your current billing period. The add-on is removed on ${endsOn}, and you won't be charged for it after that.`;
+            ? `The ${GROWTH_ADDON_COPY.title} is ${GROWTH_ADDON_COPY.price.replace('/mo', '')} per month, billed alongside your plan. Nothing is charged today — a prorated amount lands on your next invoice, then the full amount each month from ${endsOn}.`
+            : `You'll keep Growth features until the end of your current billing period. The add-on is removed on ${endsOn}, and you won't be charged for it moving forward.`;
 
     return (
         <Dialog open={open} onOpenChange={setOpen}>

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -132,7 +132,7 @@ const PlanCard: React.FC<{
     addonState: GrowthAddonState;
     /** Orb's period end, not a client-side guess at it. */
     endsAt?: string;
-    /** Set when a plan change is already coming: the add-on cannot then move the other way. */
+    /** A scheduled plan change locks the add-on, in both directions. */
     pendingChangeAt?: string;
     /** Whether this plan is no longer something the account can move to. */
     closed?: boolean;
@@ -460,7 +460,6 @@ const PlanChangeDialog: React.FC<{
     );
 };
 
-/** There is no add-on endpoint: `POST /plans/change` takes an end state, so this is a plan change in place. */
 const GrowthAddonDialog: React.FC<{
     planCode: PlanDefinition['code'];
     action: 'add' | 'remove';

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -17,7 +17,7 @@ import {
     IconButton
 } from '@nangohq/design-system';
 
-import { PermissionGate } from '@/components/patterns/PermissionGate.js';
+import { PERMISSION_DENIED_REASON, PermissionGate } from '@/components/patterns/PermissionGate.js';
 import { Checkbox } from '@/components/ui/Checkbox';
 import { Separator } from '@/components/ui/Separator';
 import { useMeta } from '@/hooks/useMeta';
@@ -247,7 +247,9 @@ const PlanCard: React.FC<{
                                 endsAt={endsAt}
                                 onAdd={() => setAddonAction('add')}
                                 onRemove={() => setAddonAction('remove')}
-                                lockedReason={pendingChangeAt ? `Your plan changes on ${pendingChangeAt}.` : undefined}
+                                lockedReason={
+                                    !canChangePlan ? PERMISSION_DENIED_REASON : pendingChangeAt ? `Your plan changes on ${pendingChangeAt}.` : undefined
+                                }
                             />
                             {addonAction && (
                                 <GrowthAddonDialog planCode={plan.code} action={addonAction} open onOpenChange={(next) => !next && setAddonAction(null)} />
@@ -383,7 +385,7 @@ const PlanChangeDialog: React.FC<{
             if (newPricing) {
                 // Orb prices every metric in arrears under a plan-level minimum, so there is no base
                 // fee to prorate and the upgrade collects nothing.
-                return `${selectedPlan.plan.title} bills at the end of each month — your usage, or a $${selectedPlan.plan.basePrice} monthly minimum, whichever is higher. Nothing is charged today, and this month's minimum is prorated from the day you upgrade.`;
+                return `${selectedPlan.plan.title} bills at the end of each month — your usage, or a $${selectedPlan.plan.basePrice} monthly minimum, whichever is higher. Nothing is charged today, and this month's minimum and any add-on are prorated from the day you upgrade.`;
             }
             return `The ${selectedPlan.plan.title} plan includes a ${selectedPlan.plan.basePrice} monthly base fee, plus additional usage-based charges. When you upgrade, you'll be charged a prorated base fee for the current month.`;
         }

--- a/packages/webapp/src/pages/Team/Billing/components/planCardCopy.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/planCardCopy.ts
@@ -44,7 +44,6 @@ export interface S26PlanCard {
     priceSuffix?: string;
     tagline: string;
     features: string[];
-    /** A last bullet, shown only while the add-on isn't spelled out in a block of its own. */
     addonTeaser?: string;
 }
 

--- a/packages/webapp/src/pages/Team/Billing/components/planCardCopy.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/planCardCopy.ts
@@ -44,7 +44,17 @@ export interface S26PlanCard {
     priceSuffix?: string;
     tagline: string;
     features: string[];
+    /** A last bullet, shown only while the add-on isn't spelled out in a block of its own. */
+    addonTeaser?: string;
 }
+
+export const GROWTH_ADDON_PRICE = 450;
+
+export const GROWTH_ADDON_COPY = {
+    title: 'Growth add-on',
+    price: `$${GROWTH_ADDON_PRICE}/mo`,
+    features: 'Shared Slack channel, unlimited environments, RBAC, realtime logs export, SAML SSO, HIPAA, and 5-day integration delivery.'
+};
 
 /** In the order they are offered. */
 export const S26_PLAN_CARDS: readonly S26PlanCard[] = [
@@ -60,7 +70,8 @@ export const S26_PLAN_CARDS: readonly S26PlanCard[] = [
         price: '$50',
         priceSuffix: '/mo minimum',
         tagline: '$50 in credits per month included.',
-        features: ['$0.29 / connection / mo', '$0.72 / h of compute time', '$0.50 / GB data transfer', 'SOC 2 Type II', 'Growth add-on available for $450/mo']
+        features: ['$0.29 / connection / mo', '$0.72 / h of compute time', '$0.50 / GB data transfer', 'SOC 2 Type II'],
+        addonTeaser: `${GROWTH_ADDON_COPY.title} available for ${GROWTH_ADDON_COPY.price}`
     },
     {
         code: 'enterprise',

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -155,3 +155,13 @@ export function planAccruesCharges(plan: ApiPlan | null | undefined): boolean {
 export function isRetiredPlan(code: DBPlan['name']): boolean {
     return PLAN_IS_RETIRED[code];
 }
+
+export type GrowthAddonState = 'none' | 'active' | 'pending-removal';
+
+/** A scheduled removal still reads as `has_growth_features` until its date, so the date separates the two. */
+export function growthAddonState(plan: ApiPlan | null | undefined): GrowthAddonState {
+    if (!plan?.has_growth_features) {
+        return 'none';
+    }
+    return plan.growth_features_ends_at ? 'pending-removal' : 'active';
+}

--- a/packages/webapp/src/pages/Team/Billing/usePlanChangeRequest.tsx
+++ b/packages/webapp/src/pages/Team/Billing/usePlanChangeRequest.tsx
@@ -14,6 +14,7 @@ import type { ApiPlan } from '@nangohq/types';
 
 interface PlanChangeRequest {
     orbId: string;
+    /** The end state, not a delta: `false` drops an add-on the account already has. */
     withGrowthFeatures: boolean;
     settled?: (plan: ApiPlan) => boolean;
     successTitle: string;

--- a/packages/webapp/src/pages/Team/Billing/usePlanChangeRequest.tsx
+++ b/packages/webapp/src/pages/Team/Billing/usePlanChangeRequest.tsx
@@ -14,7 +14,6 @@ import type { ApiPlan } from '@nangohq/types';
 
 interface PlanChangeRequest {
     orbId: string;
-    /** The end state, not a delta: `false` drops an add-on the account already has. */
     withGrowthFeatures: boolean;
     settled?: (plan: ApiPlan) => boolean;
     successTitle: string;

--- a/packages/webapp/src/pages/Team/Billing/usePlanChangeRequest.tsx
+++ b/packages/webapp/src/pages/Team/Billing/usePlanChangeRequest.tsx
@@ -14,6 +14,7 @@ import type { ApiPlan } from '@nangohq/types';
 
 interface PlanChangeRequest {
     orbId: string;
+    withGrowthFeatures: boolean;
     settled?: (plan: ApiPlan) => boolean;
     successTitle: string;
 }
@@ -66,15 +67,14 @@ export function usePlanChangeRequest(env: string) {
     );
 
     const submit = useCallback(
-        async ({ orbId, settled, successTitle }: PlanChangeRequest): Promise<boolean> => {
+        async ({ orbId, withGrowthFeatures, settled, successTitle }: PlanChangeRequest): Promise<boolean> => {
             setLoading(true);
             setLongWait(false);
             setError(null);
 
             let json: Awaited<ReturnType<typeof postPlanChange>>;
             try {
-                // TODO: set a real value once the UI lets customers self-serve the growth add-on.
-                json = await postPlanChange({ orbId, withGrowthFeatures: false });
+                json = await postPlanChange({ orbId, withGrowthFeatures });
             } catch {
                 return fail('Something went wrong', true);
             }

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -27,6 +27,7 @@ export interface AnalyticsEvents {
     'web:usage:invoice_details_clicked': Record<string, never>;
     'web:usage:billing_portal_clicked': Record<string, never>;
     'web:usage:upgrade_clicked': Record<string, never>;
+    'web:usage:addon_action_clicked': { state: 'none' | 'active' | 'pending-removal' };
     'web:usage:edit_payment_method_clicked': { source: 'billing_page' };
     'web:usage:overdue_alert_clicked': Record<string, never>;
 


### PR DESCRIPTION
## Problem

The Pay-as-you-go card names the Growth add-on as a feature bullet and nothing more. Nothing shows whether an account has one, and buying or dropping it is a support conversation.

## Solution

- The add-on block on the Pay-as-you-go card, in its three states: not on the plan, active, deactivating on a date.
- Add and remove dialogs, plus a checkbox and live monthly total in the upgrade dialog. Add-on and plan move in one `POST /plans/change`, which takes an end state.
- Both actions are locked while a plan change is already scheduled, and for members without `account:plan:update`.
- An `addonState` override in the dev panel, so all three states preview without Orb.
- Solid `sm` buttons drop to 12px, matching Figma, and the dialog's add-on block gets its `surface/inputMuted` fill.

Fixes [NAN-6834](https://linear.app/nango/issue/NAN-6834)

## Testing

Full round trip against Orb test mode on `test+orb@nango.dev`, checked in the DB and against Orb's API: upgrading with the add-on added `Growth Add-on / Ytp8wFpTKfVjiY8r` to the subscription, and removing scheduled that interval to end at the period boundary.

## Follow-ups

- `Keep add-on` stays hidden until [NAN-6816](https://linear.app/nango/issue/NAN-6816) lets a scheduled removal be cancelled.
- The dialog shows a $500 monthly total while a mid-month first invoice is prorated — Orb prorates both the minimum and the add-on. Three copy variants are mocked in Figma; this ships the one explaining proration in prose.
