### PR TITLE
fix(orchestrator): drain the processor queue after the loop exits (NAN-6896)

### DIFF
--- a/packages/orchestrator/lib/clients/processor.ts
+++ b/packages/orchestrator/lib/clients/processor.ts
@@ -44,10 +44,11 @@ export class OrchestratorProcessor {
 
     public async stop(): Promise<void> {
         const waitUntilStopped = async (): Promise<void> => {
-            await this.queue.onIdle();
+            // The loop must exit before draining: its in-flight dequeue can still return a batch
             while (this.status !== 'stopped') {
                 await setTimeout(100); // Wait until the processing loop exits
             }
+            await this.queue.onIdle();
         };
         this.status = 'stopping';
         await waitUntilStopped();


### PR DESCRIPTION
- On shutdown, `stop()` sets the stop flag and then waits for the queue to drain. But the loop only sees that flag *after* its current iteration finishes, and it can be parked in a 10s long-poll dequeue when the flag is set. So the drain completes first — on an empty queue — and `stop()` reports "done" while a dequeue is still in flight. When that dequeue lands it pushes its batch onto a queue nobody is waiting on any more, and shutdown carries on to `process.exit()` underneath it. Swapping the two lines closes the race: wait for the loop to actually exit, then drain. Once the loop is gone, nothing can add to the queue.

Side effect of the race: those tasks are already marked `STARTED` by the dequeue query, so a dropped batch sits unattended until its heartbeat deadline expires — 5 minutes for actions, surfacing to the caller as an empty error.

## Test plan

- [x] `tsc`, oxlint and prettier clean on the changed file
- [x] Existing `processor.integration.test.ts` unaffected — its helper waits for all tasks to reach a terminal state before calling `stop()`
- [ ] Regression test racing `stop()` against an in-flight dequeue, asserting nothing is left non-terminal
- [ ] After deploy: watch `nango.orch.tasks.expired` for the `action*` group