### PR TITLE
refactor(records): share one helper for composite model names

### DIFF
--- a/packages/records/lib/helpers/model.ts
+++ b/packages/records/lib/helpers/model.ts
@@ -1,0 +1,7 @@
+/**
+ * Records are keyed by a composite model name. Callers must go through this rather than building the
+ * string, because a mismatch does not fail — the lookup just misses and reports zero records.
+ */
+export function recordModelName(model: string, variant?: string | null): string {
+    return !variant || variant === 'base' ? model : `${model}::${variant}`;
+}

--- a/packages/records/lib/helpers/model.ts
+++ b/packages/records/lib/helpers/model.ts
@@ -1,7 +1,3 @@
-/**
- * Records are keyed by a composite model name. Callers must go through this rather than building the
- * string, because a mismatch does not fail — the lookup just misses and reports zero records.
- */
 export function recordModelName(model: string, variant?: string | null): string {
     return !variant || variant === 'base' ? model : `${model}::${variant}`;
 }

--- a/packages/records/lib/helpers/model.unit.test.ts
+++ b/packages/records/lib/helpers/model.unit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { recordModelName } from './model.js';
+
+describe('recordModelName', () => {
+    it('leaves the base variant out of the name', () => {
+        expect(recordModelName('Email', 'base')).toBe('Email');
+    });
+
+    it('appends any other variant', () => {
+        expect(recordModelName('Email', 'inbox')).toBe('Email::inbox');
+    });
+
+    it('treats a missing variant as base', () => {
+        expect(recordModelName('Email')).toBe('Email');
+        expect(recordModelName('Email', null)).toBe('Email');
+        expect(recordModelName('Email', '')).toBe('Email');
+    });
+});

--- a/packages/records/lib/index.ts
+++ b/packages/records/lib/index.ts
@@ -1,5 +1,6 @@
 export * as format from './helpers/format.js';
 export { Cursor } from './cursor.js';
+export { recordModelName } from './helpers/model.js';
 export type * from './types.js';
 
 export { records } from './catalog/router.js';

--- a/packages/server/lib/controllers/v1/connections/connectionId/records/getRecords.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/records/getRecords.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 
-import { Cursor, records as recordsService } from '@nangohq/records';
+import { Cursor, recordModelName, records as recordsService } from '@nangohq/records';
 import { connectionService } from '@nangohq/shared';
 import { requireEmptyBody, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -80,7 +80,7 @@ export const getConnectionRecords = asyncWrapperWithEnvironment<GetConnectionRec
         return;
     }
 
-    const modelName = toRecordModelName(query.model, query.variant);
+    const modelName = recordModelName(query.model, query.variant);
     const connectionPkId = connection.value.connection.id;
 
     if (query.record_id) {
@@ -139,11 +139,3 @@ export const getConnectionRecords = asyncWrapperWithEnvironment<GetConnectionRec
         }
     });
 });
-
-function toRecordModelName(model: string, variant?: string | null) {
-    if (!variant || variant === 'base') {
-        return model;
-    }
-
-    return `${model}::${variant}`;
-}

--- a/packages/server/lib/controllers/v1/sync/getSyncs.ts
+++ b/packages/server/lib/controllers/v1/sync/getSyncs.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 
-import { records as recordsService } from '@nangohq/records';
+import { recordModelName, records as recordsService } from '@nangohq/records';
 import { connectionService, listConnectionSyncs } from '@nangohq/shared';
 import { getLogger, requireEmptyBody, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -83,7 +83,7 @@ async function getRecordCountsForPage({
     const models = new Set<string>();
     for (const sync of syncs) {
         for (const model of sync.models) {
-            models.add(toRecordModelName(model, sync.variant));
+            models.add(recordModelName(model, sync.variant));
         }
     }
     if (models.size === 0) {
@@ -99,16 +99,12 @@ async function getRecordCountsForPage({
     return counts.value;
 }
 
-function toRecordModelName(model: string, variant: string): string {
-    return variant === 'base' ? model : `${model}::${variant}`;
-}
-
 function toApi(sync: ListedSync, recordCounts: Record<string, RecordCount> | null): ApiConnectionSync {
     return {
         ...sync,
         record_count:
             recordCounts === null
                 ? null
-                : Object.fromEntries(sync.models.map((model) => [model, recordCounts[toRecordModelName(model, sync.variant)]?.count ?? 0]))
+                : Object.fromEntries(sync.models.map((model) => [model, recordCounts[recordModelName(model, sync.variant)]?.count ?? 0]))
     };
 }


### PR DESCRIPTION
## Problem

Records are keyed by a composite model name — the bare model for the `base` variant, `Model::variant` otherwise. Three places built that string by hand, each spelled a little differently, and nothing made them agree.

A format change that misses one doesn't fail loudly. The lookup just misses, and the sync reports zero records.

Raised by @kaposke reviewing #7369.

## Solution

- Add `recordModelName` to `packages/records`, which owns the format, with unit tests for the base / variant / missing cases.
- Move both server callers onto it: the syncs endpoint and the records endpoint.

Two copies stay, deliberately:

- `manager.service.ts` — `shared` has no runtime dependency on `records`, and `RecordsServiceInterface` exists precisely to avoid one. Adding that dependency to collapse a single line inverts the boundary, and [NAN-6820](https://linear.app/nango/issue/NAN-6820) reworks that path anyway.
- `syncTargetId` in `controllers/sync/helpers.ts` — byte-identical, but it builds *audit target ids*. Folding them together would mean a change to the audit format silently breaking record lookups.

Fixes [NAN-6913](https://linear.app/nango/issue/NAN-6913)

## Testing

3 unit tests on the helper, plus the existing suites for both migrated endpoints — 23 integration tests across `getSyncs` and `getRecords`. No behaviour change: the two implementations already agreed, one just also handled `null`, which the shared version keeps.
