### PR TITLE
feat(server): auto-deploy catalog actions when an integration is created

### DIFF
--- a/packages/server/lib/controllers/integrations/postIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/postIntegration.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { seeders } from '@nangohq/shared';
+import { getActionsByProviderConfigKey, seeders } from '@nangohq/shared';
 import { Err, getLogger } from '@nangohq/utils';
 
 import integrationService, { IntegrationServiceError } from '../../services/integration.service.js';
@@ -202,5 +202,24 @@ describe(`POST ${endpoint}`, () => {
         isSuccess(resGet.json);
         const credentials = resGet.json.data.credentials as { webhook_secret: string | null };
         expect(credentials.webhook_secret).toBeNull();
+    });
+
+    it('should auto-deploy catalog actions when the integration is created', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: { provider: 'bitdefender', unique_key: 'bitdefender-actions' }
+        });
+
+        isSuccess(res.json);
+        const actions = await getActionsByProviderConfigKey(env.id, 'bitdefender-actions');
+        expect(actions).toHaveLength(1);
+        expect(actions[0]).toMatchObject({
+            sync_name: 'get-company-details',
+            type: 'action',
+            source: 'catalog',
+            enabled: true
+        });
     });
 });

--- a/packages/server/lib/controllers/v1/integrations/postIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/postIntegration.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { seeders } from '@nangohq/shared';
+import { getActionsByProviderConfigKey, getSyncConfigsByParams, seeders } from '@nangohq/shared';
 
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
 
@@ -336,5 +336,57 @@ describe(`POST ${endpoint}`, () => {
                 forward_webhooks: true
             }
         });
+    });
+
+    it('should auto-deploy catalog actions when the integration is created', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { env: env.name },
+            token: apiKey.secret,
+            body: { provider: 'bitdefender', useSharedCredentials: false, integrationId: 'bitdefender-actions' }
+        });
+
+        isSuccess(res.json);
+        const actions = await getActionsByProviderConfigKey(env.id, 'bitdefender-actions');
+        expect(actions).toHaveLength(1);
+        expect(actions[0]).toMatchObject({
+            sync_name: 'get-company-details',
+            type: 'action',
+            source: 'catalog',
+            enabled: true
+        });
+    });
+
+    it('should not auto-deploy syncs', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { env: env.name },
+            token: apiKey.secret,
+            body: { provider: 'google', useSharedCredentials: false, integrationId: 'google-no-actions' }
+        });
+
+        isSuccess(res.json);
+        const actions = await getActionsByProviderConfigKey(env.id, 'google-no-actions');
+        const syncs = await getSyncConfigsByParams(env.id, 'google-no-actions', false);
+        expect(actions).toEqual([]);
+        expect(syncs).toEqual([]);
+    });
+
+    it('should still create the integration when catalog deploy is blocked by an expired trial', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser({
+            plan: { auto_idle: true, trial_end_at: new Date(Date.now() - 60_000) }
+        });
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { env: env.name },
+            token: apiKey.secret,
+            body: { provider: 'bitdefender', useSharedCredentials: false, integrationId: 'bitdefender-idle' }
+        });
+
+        isSuccess(res.json);
+        const actions = await getActionsByProviderConfigKey(env.id, 'bitdefender-idle');
+        expect(actions).toEqual([]);
     });
 });

--- a/packages/server/lib/controllers/v1/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/postIntegration.ts
@@ -3,6 +3,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { integrationToApi } from '../../../formatters/integration.js';
 import { resolveIntegrationConfig } from '../../../services/integrationConfig.js';
+import { autoDeployCatalogActions } from '../../../services/integrationTemplate.service.js';
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { buildIntegrationConfig } from './buildIntegrationConfig.js';
 import { postIntegrationBodySchema } from './validation.js';
@@ -33,7 +34,7 @@ export const postIntegration = asyncWrapperWithEnvironment<PostIntegration>(asyn
         return;
     }
 
-    const { environment, account } = res.locals;
+    const { environment, account, plan, user } = res.locals;
 
     if ('integrationId' in body && body.integrationId) {
         const exists = await configService.getIdByProviderConfigKey(environment.id, body.integrationId);
@@ -121,6 +122,8 @@ export const postIntegration = asyncWrapperWithEnvironment<PostIntegration>(asyn
         }
         integration = createdIntegration;
     }
+
+    await autoDeployCatalogActions({ environment, account, plan, user, integration });
 
     res.status(200).send({
         data: integrationToApi(integration)

--- a/packages/server/lib/services/integration.service.ts
+++ b/packages/server/lib/services/integration.service.ts
@@ -1,10 +1,19 @@
 import db from '@nangohq/database';
-import { configService, connectionService, getGlobalWebhookReceiveUrl, getProvider, getProviders, sharedCredentialsService } from '@nangohq/shared';
+import {
+    configService,
+    connectionService,
+    environmentService,
+    getGlobalWebhookReceiveUrl,
+    getProvider,
+    getProviders,
+    sharedCredentialsService
+} from '@nangohq/shared';
 import { Err, getLogger, Ok } from '@nangohq/utils';
 
 import { getIntegrationCredentials } from '../utils/integrations.js';
 import { getOrchestrator } from '../utils/utils.js';
 import { resolveIntegrationConfig } from './integrationConfig.js';
+import { autoDeployCatalogActions } from './integrationTemplate.service.js';
 
 import type { IntegrationCredentials } from '../utils/integrations.js';
 import type { DBCreateIntegration, IntegrationConfig, Provider } from '@nangohq/types';
@@ -341,6 +350,11 @@ export class IntegrationService {
                     errorKind: 'empty_result'
                 });
                 return Err(new IntegrationServiceError({ code: 'create_failed', message: 'Failed to create integration' }));
+            }
+
+            const environment = await environmentService.getById(params.environmentId);
+            if (environment) {
+                await autoDeployCatalogActions({ environment, integration: created });
             }
 
             return Ok({ integration: created, provider });

--- a/packages/server/lib/services/integration.service.unit.test.ts
+++ b/packages/server/lib/services/integration.service.unit.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as shared from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
 import integrationService, { IntegrationService } from './integration.service.js';
+import * as integrationTemplateService from './integrationTemplate.service.js';
 
 import type { Config, Orchestrator } from '@nangohq/shared';
 import type { DBSharedCredentials, Provider, SimplifiedJSONSchema } from '@nangohq/types';
@@ -212,6 +213,11 @@ describe('integrationService', () => {
     });
 
     describe('create', () => {
+        beforeEach(() => {
+            vi.spyOn(shared.environmentService, 'getById').mockResolvedValue({ id: 42, account_id: 1 } as never);
+            vi.spyOn(integrationTemplateService, 'autoDeployCatalogActions').mockResolvedValue(undefined);
+        });
+
         it('creates an integration with caller-supplied credentials and configuration', async () => {
             const provider = configurableProviderFixture();
             const createdIntegration = integrationFixture({ uniqueKey: 'github-own', provider: 'github' });

--- a/packages/server/lib/services/integrationTemplate.service.ts
+++ b/packages/server/lib/services/integrationTemplate.service.ts
@@ -1,11 +1,13 @@
 import db from '@nangohq/database';
 import { logContextGetter } from '@nangohq/logs';
-import { configService, deployTemplate, productTracking, startTrial, syncManager } from '@nangohq/shared';
+import { accountService, configService, deployTemplate, deployTemplates, getPlan, productTracking, startTrial, syncManager } from '@nangohq/shared';
+import { report } from '@nangohq/utils';
 
 import { getOrchestrator } from '../utils/utils.js';
 import flowService from './flow.service.js';
 
-import type { DBEnvironment, DBPlan, DBTeam, DBUser, RunnableFunctionType, ScriptTypeLiteral, SyncDeploymentResult } from '@nangohq/types';
+import type { Config } from '@nangohq/shared';
+import type { DBEnvironment, DBPlan, DBTeam, DBUser, IntegrationConfig, RunnableFunctionType, ScriptTypeLiteral, SyncDeploymentResult } from '@nangohq/types';
 
 const orchestrator = getOrchestrator();
 
@@ -97,4 +99,110 @@ export async function deployIntegrationTemplate({
     await syncManager.triggerIfConnectionsExist({ flows: [deploy.result], environmentId: environment.id, logContextGetter, orchestrator });
 
     return { ok: true, result: deploy.result, type: resolvedType };
+}
+
+export type DeployCatalogActionsSkipReason = 'already_deployed' | 'missing_json_schema' | 'copy_failed';
+
+export type DeployCatalogActionsResult =
+    | { ok: true; deployed: string[]; skipped: { name: string; reason: DeployCatalogActionsSkipReason }[] }
+    | { ok: false; reason: 'plan_limit' };
+
+/**
+ * Deploy every catalog action for an integration's provider. Used after integration create.
+ * Syncs and on-events are not deployed. Failures are skipped, not thrown — create must still succeed.
+ */
+export async function deployCatalogActions({
+    environment,
+    account,
+    plan,
+    user,
+    integration
+}: {
+    environment: DBEnvironment;
+    account: DBTeam;
+    plan: DBPlan | null;
+    user?: Pick<DBUser, 'id' | 'email' | 'name'> | undefined;
+    integration: Pick<Config, 'id' | 'unique_key' | 'provider'> | IntegrationConfig;
+}): Promise<DeployCatalogActionsResult> {
+    if (plan && plan.auto_idle && plan.trial_end_at && plan.trial_end_at.getTime() < Date.now()) {
+        return { ok: false, reason: 'plan_limit' };
+    }
+    if (plan && !plan.trial_end_at && plan.auto_idle) {
+        await startTrial(db.knex, plan);
+        productTracking.track({ name: 'account:trial:started', team: account, user });
+    }
+
+    const catalog = flowService.getAllAvailableFlowsAsStandardConfig().find((entry) => entry.providerConfigKey === integration.provider);
+    const actions = catalog?.actions ?? [];
+    if (actions.length === 0) {
+        return { ok: true, deployed: [], skipped: [] };
+    }
+
+    const logCtx = await logContextGetter.create({ operation: { type: 'deploy', action: 'prebuilt' } }, { account, environment });
+    try {
+        const { deployed, skipped } = await deployTemplates({
+            environment,
+            team: account,
+            templates: actions,
+            integration,
+            deployInfo: { integrationId: integration.unique_key, provider: integration.provider },
+            logCtx
+        });
+
+        if (deployed.length === 0 && skipped.some((item) => item.reason === 'copy_failed')) {
+            await logCtx.failed();
+        } else {
+            await logCtx.success();
+        }
+
+        return { ok: true, deployed: deployed.map((item) => item.name), skipped };
+    } catch (err) {
+        await logCtx.failed();
+        throw err;
+    }
+}
+
+/**
+ * Best-effort wrapper for create paths: loads account/plan when they are not already on the request,
+ * and never throws — integration create must succeed even if catalog deploy fails.
+ */
+export async function autoDeployCatalogActions({
+    environment,
+    account,
+    plan,
+    user,
+    integration
+}: {
+    environment: DBEnvironment;
+    account?: DBTeam | null;
+    plan?: DBPlan | null;
+    user?: Pick<DBUser, 'id' | 'email' | 'name'> | undefined;
+    integration: Pick<Config, 'id' | 'unique_key' | 'provider'> | IntegrationConfig;
+}): Promise<void> {
+    try {
+        let resolvedAccount = account ?? null;
+        if (!resolvedAccount) {
+            resolvedAccount = await accountService.getAccountById(db.knex, environment.account_id);
+        }
+        if (!resolvedAccount) {
+            report(new Error('auto_deploy_catalog_actions_missing_account'), { environmentId: environment.id, integrationId: integration.unique_key });
+            return;
+        }
+
+        let resolvedPlan = plan ?? null;
+        if (plan === undefined) {
+            const planRes = await getPlan(db.knex, { accountId: resolvedAccount.id });
+            resolvedPlan = planRes.isOk() ? planRes.value : null;
+        }
+
+        await deployCatalogActions({
+            environment,
+            account: resolvedAccount,
+            plan: resolvedPlan,
+            user,
+            integration
+        });
+    } catch (err) {
+        report(err, { environmentId: environment.id, integrationId: integration.unique_key });
+    }
 }

--- a/packages/server/lib/services/integrationTemplate.service.unit.test.ts
+++ b/packages/server/lib/services/integrationTemplate.service.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { deployCatalogActions } from './integrationTemplate.service.js';
+
+import type { Config } from '@nangohq/shared';
+import type { DBEnvironment, DBPlan, DBTeam } from '@nangohq/types';
+
+const environment = { id: 1, account_id: 1 } as DBEnvironment;
+const account = { id: 1, name: 'test' } as DBTeam;
+
+describe('deployCatalogActions', () => {
+    it('skips deploy when the plan is auto-idled past trial', async () => {
+        const result = await deployCatalogActions({
+            environment,
+            account,
+            plan: { auto_idle: true, trial_end_at: new Date(0) } as DBPlan,
+            integration: { id: 1, unique_key: 'bitdefender', provider: 'bitdefender' } as Config
+        });
+
+        expect(result).toEqual({ ok: false, reason: 'plan_limit' });
+    });
+
+    it('is a no-op when the provider has no catalog actions', async () => {
+        const result = await deployCatalogActions({
+            environment,
+            account,
+            plan: null,
+            integration: { id: 1, unique_key: 'google', provider: 'google' } as Config
+        });
+
+        expect(result).toEqual({ ok: true, deployed: [], skipped: [] });
+    });
+});

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -66,7 +66,8 @@ export * from './services/plans/spendAlertNotifications.js';
 export * from './services/checkpoints/checkpoints.js';
 export * from './services/shared-credentials.service.js';
 export * as connectUISettingsService from './services/connect-ui-settings.service.js';
-export { deployTemplate, upgradeTemplate } from './services/deploy/template.js';
+export { deployTemplate, deployTemplates, upgradeTemplate } from './services/deploy/template.js';
+export type { DeployTemplatesResult, DeployTemplatesSkipReason } from './services/deploy/template.js';
 
 export * as oauth2Client from './clients/oauth2.client.js';
 export * as mcpClient from './clients/mcp.client.js';

--- a/packages/shared/lib/services/deploy/template.integration.test.ts
+++ b/packages/shared/lib/services/deploy/template.integration.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import db from '@nangohq/database';
+
+import { createConfigSeed, seedAccountEnvAndUser } from '../../seeders/index.js';
+import { getTestStdSyncConfig } from '../../seeders/syncConfig.seeder.js';
+import remoteFileService from '../file/remote.service.js';
+import { getActionsByProviderConfigKey } from '../sync/config/config.service.js';
+import { deployTemplates } from './template.js';
+
+import type { LogContext } from '@nangohq/logs';
+import type { DBSyncConfig, NangoSyncConfig } from '@nangohq/types';
+
+function mockLogCtx(): { logCtx: LogContext; success: ReturnType<typeof vi.fn>; failed: ReturnType<typeof vi.fn> } {
+    const success = vi.fn().mockResolvedValue(undefined);
+    const failed = vi.fn().mockResolvedValue(undefined);
+    return {
+        success,
+        failed,
+        logCtx: {
+            info: vi.fn().mockResolvedValue(undefined),
+            error: vi.fn().mockResolvedValue(undefined),
+            debug: vi.fn().mockResolvedValue(undefined),
+            success,
+            failed
+        } as unknown as LogContext
+    };
+}
+
+function actionTemplate(name: string, overrides: Partial<NangoSyncConfig> = {}): NangoSyncConfig {
+    return getTestStdSyncConfig({
+        name,
+        type: 'action',
+        endpoints: [{ method: 'POST', path: `/${name}` }],
+        returns: ['Result'],
+        json_schema: { type: 'object' },
+        ...overrides
+    });
+}
+
+describe('deployTemplates', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('deploys several catalog actions in one pass', async () => {
+        vi.spyOn(remoteFileService, 'copy').mockResolvedValue('_LOCAL_FILE_');
+        const { env, account } = await seedAccountEnvAndUser();
+        const integration = await createConfigSeed(env, 'bulk-actions', 'github');
+        const { logCtx, success, failed } = mockLogCtx();
+
+        const result = await deployTemplates({
+            environment: env,
+            team: account,
+            templates: [actionTemplate('create-issue'), actionTemplate('create-label')],
+            integration,
+            deployInfo: { integrationId: integration.unique_key, provider: 'github' },
+            logCtx
+        });
+
+        expect(result.skipped).toEqual([]);
+        expect(result.deployed.map((item) => item.name).sort()).toEqual(['create-issue', 'create-label']);
+
+        const stored = await getActionsByProviderConfigKey(env.id, integration.unique_key);
+        expect(stored.map((row) => row.sync_name).sort()).toEqual(['create-issue', 'create-label']);
+        expect(stored.every((row) => row.enabled && row.source === 'catalog' && row.type === 'action')).toBe(true);
+        expect(success).not.toHaveBeenCalled();
+        expect(failed).not.toHaveBeenCalled();
+    });
+
+    it('skips names that already have an active config, including custom source', async () => {
+        vi.spyOn(remoteFileService, 'copy').mockResolvedValue('_LOCAL_FILE_');
+        const { env, account } = await seedAccountEnvAndUser();
+        const integration = await createConfigSeed(env, 'bulk-skip', 'github');
+        const now = new Date();
+        await db.knex.from<DBSyncConfig>('_nango_sync_configs').insert({
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'create-issue',
+            type: 'action',
+            source: 'repo',
+            active: true,
+            deleted: false,
+            file_location: 'file_location',
+            version: '0.0.0',
+            models: [],
+            runs: null,
+            track_deletes: false,
+            auto_start: false,
+            enabled: true,
+            webhook_subscriptions: [],
+            created_at: now,
+            updated_at: now
+        });
+
+        const result = await deployTemplates({
+            environment: env,
+            team: account,
+            templates: [actionTemplate('create-issue'), actionTemplate('create-label')],
+            integration,
+            deployInfo: { integrationId: integration.unique_key, provider: 'github' },
+            logCtx: mockLogCtx().logCtx
+        });
+
+        expect(result.skipped).toEqual([{ name: 'create-issue', reason: 'already_deployed' }]);
+        expect(result.deployed.map((item) => item.name)).toEqual(['create-label']);
+    });
+
+    it('continues the batch when one copy fails', async () => {
+        vi.spyOn(remoteFileService, 'copy').mockImplementation(({ sourcePath }) => {
+            if (sourcePath.includes('create-issue')) {
+                return Promise.resolve(null);
+            }
+            return Promise.resolve('_LOCAL_FILE_');
+        });
+        const { env, account } = await seedAccountEnvAndUser();
+        const integration = await createConfigSeed(env, 'bulk-copy-fail', 'github');
+
+        const result = await deployTemplates({
+            environment: env,
+            team: account,
+            templates: [actionTemplate('create-issue'), actionTemplate('create-label')],
+            integration,
+            deployInfo: { integrationId: integration.unique_key, provider: 'github' },
+            logCtx: mockLogCtx().logCtx
+        });
+
+        expect(result.skipped).toEqual([{ name: 'create-issue', reason: 'copy_failed' }]);
+        expect(result.deployed.map((item) => item.name)).toEqual(['create-label']);
+    });
+});

--- a/packages/shared/lib/services/deploy/template.ts
+++ b/packages/shared/lib/services/deploy/template.ts
@@ -1,6 +1,7 @@
 import db from '@nangohq/database';
 import { env, Err, Ok } from '@nangohq/utils';
 
+import { envs } from '../../env.js';
 import { NangoError } from '../../utils/error.js';
 import remoteFileService from '../file/remote.service.js';
 import { getSyncAndActionConfigByParams, getSyncAndActionConfigsBySyncNameAndConfigId } from '../sync/config/config.service.js';
@@ -20,6 +21,8 @@ import type {
     Result,
     SyncDeploymentResult
 } from '@nangohq/types';
+
+type TemplateDeployIntegration = Pick<Config, 'id' | 'unique_key' | 'provider'>;
 
 /**
  * Deploy a template from the S3 public folder, to the database and S3
@@ -182,6 +185,227 @@ export async function deployTemplate({
 
         return Err(new NangoError('error_creating_sync_config'));
     }
+}
+
+export type DeployTemplatesSkipReason = 'already_deployed' | 'missing_json_schema' | 'copy_failed';
+
+export interface DeployTemplatesResult {
+    deployed: SyncDeploymentResult[];
+    skipped: { name: string; reason: DeployTemplatesSkipReason }[];
+}
+
+/**
+ * Deploy many catalog templates in one pass: parallel file copies, then a single DB transaction.
+ * Skips names that already have an active config (custom or catalog) instead of failing the batch.
+ * Does not call logCtx.success/failed — the caller owns the operation outcome.
+ */
+export async function deployTemplates({
+    environment,
+    team,
+    templates,
+    integration,
+    deployInfo,
+    logCtx
+}: {
+    environment: DBEnvironment;
+    team: DBTeam;
+    templates: NangoSyncConfig[];
+    integration: TemplateDeployIntegration;
+    deployInfo: { integrationId: string; provider: string };
+    logCtx: LogContext;
+}): Promise<DeployTemplatesResult> {
+    const skipped: DeployTemplatesResult['skipped'] = [];
+    if (templates.length === 0) {
+        return { deployed: [], skipped };
+    }
+
+    const existing = await db.knex
+        .from<DBSyncConfig>('_nango_sync_configs')
+        .where({
+            environment_id: environment.id,
+            nango_config_id: integration.id!,
+            active: true,
+            deleted: false
+        })
+        .select<{ sync_name: string }[]>('sync_name');
+    const existingNames = new Set(existing.map((row) => row.sync_name));
+
+    const toCopy: NangoSyncConfig[] = [];
+    for (const template of templates) {
+        if (existingNames.has(template.name)) {
+            skipped.push({ name: template.name, reason: 'already_deployed' });
+            continue;
+        }
+        if (!template.json_schema) {
+            void logCtx.error(`Template missing json schema: ${template.name}`);
+            skipped.push({ name: template.name, reason: 'missing_json_schema' });
+            continue;
+        }
+        toCopy.push(template);
+    }
+
+    const copied: { template: NangoSyncConfig; copyJs: string }[] = [];
+    for (let i = 0; i < toCopy.length; i += envs.DEPLOY_BATCH_SIZE) {
+        const batch = toCopy.slice(i, i + envs.DEPLOY_BATCH_SIZE);
+        const batchResults = await Promise.all(
+            batch.map(async (template) => {
+                const copyJs = await copyTemplateFiles({ template, integration, deployInfo, environment, team, logCtx });
+                return { template, copyJs };
+            })
+        );
+        for (const { template, copyJs } of batchResults) {
+            if (!copyJs) {
+                skipped.push({ name: template.name, reason: 'copy_failed' });
+                continue;
+            }
+            copied.push({ template, copyJs });
+        }
+    }
+
+    if (copied.length === 0) {
+        return { deployed: [], skipped };
+    }
+
+    const created_at = new Date();
+    const now = new Date();
+    const toInsert: DBSyncConfigInsert[] = copied.map(({ template, copyJs }) =>
+        toSyncConfigInsert({ template, integration, environment, fileLocation: copyJs, createdAt: created_at })
+    );
+
+    const deployResults: SyncDeploymentResult[] = copied.map(({ template }, index) => {
+        const insert = toInsert[index]!;
+        return {
+            ...template,
+            providerConfigKey: deployInfo.integrationId,
+            ...insert,
+            last_deployed: created_at,
+            input: template.input || null,
+            models: [...template.returns, template.input].filter(Boolean) as string[]
+        };
+    });
+
+    try {
+        await db.knex.transaction(async (trx) => {
+            const inserted = await trx.from<DBSyncConfig>('_nango_sync_configs').insert(toInsert).returning('*');
+            if (inserted.length !== toInsert.length) {
+                throw new NangoError('failed_to_insert');
+            }
+
+            const endpoints: DBSyncEndpointCreate[] = [];
+            for (const [index, row] of inserted.entries()) {
+                const template = copied[index]!.template;
+                deployResults[index]!.id = row.id;
+                for (const [endpointIndex, endpoint] of template.endpoints.entries()) {
+                    endpoints.push({
+                        sync_config_id: row.id,
+                        method: endpoint.method,
+                        path: endpoint.path,
+                        group_name: endpoint.group || null,
+                        model: template.returns[endpointIndex] || null,
+                        created_at: now,
+                        updated_at: now
+                    });
+                }
+            }
+            if (endpoints.length > 0) {
+                await trx.from<DBSyncEndpoint>('_nango_sync_endpoints').insert(endpoints);
+            }
+        });
+    } catch (err) {
+        void logCtx.error('Failed to deploy catalog templates', { error: err });
+        throw err;
+    }
+
+    const names = deployResults.map((result) => result.name);
+    void logCtx.info(`Successfully deployed ${names.length} catalog templates`, { names });
+    return { deployed: deployResults, skipped };
+}
+
+async function copyTemplateFiles({
+    template,
+    integration,
+    deployInfo,
+    environment,
+    team,
+    logCtx
+}: {
+    template: NangoSyncConfig;
+    integration: TemplateDeployIntegration;
+    deployInfo: { integrationId: string; provider: string };
+    environment: DBEnvironment;
+    team: DBTeam;
+    logCtx: LogContext;
+}): Promise<string | null> {
+    const version = template.version || '0.0.1';
+    const publicRoute = deployInfo.provider;
+    const remoteBasePathConfig = `${env}/account/${team.id}/environment/${environment.id}/config/${integration.id}`;
+
+    void logCtx.info(`Uploading ${deployInfo.integrationId} -> ${template.name}@${version}`);
+
+    const [copyJs, copyTs] = await Promise.all([
+        remoteFileService.copy({
+            sourcePath: `${publicRoute}/build/${deployInfo.provider}_${template.type}s_${template.name}.cjs`,
+            destinationPath: `${remoteBasePathConfig}/${template.name}-v${version}.js`,
+            destinationLocalFileName: `build/${deployInfo.provider}-${template.type}s-${template.name}.cjs`
+        }),
+        remoteFileService.copy({
+            sourcePath: `${publicRoute}/${template.type}s/${template.name}.ts`,
+            destinationPath: `${remoteBasePathConfig}/${template.name}.ts`,
+            destinationLocalFileName: `${deployInfo.integrationId}/${template.type}s/${template.name}.ts`
+        })
+    ]);
+
+    if (!copyJs) {
+        void logCtx.error(`There was an error uploading the main js file for ${template.name}`);
+        return null;
+    }
+    if (!copyTs) {
+        void logCtx.error(`There was an error uploading the source file for ${template.name}`);
+        return null;
+    }
+    return copyJs;
+}
+
+function toSyncConfigInsert({
+    template,
+    integration,
+    environment,
+    fileLocation,
+    createdAt
+}: {
+    template: NangoSyncConfig;
+    integration: TemplateDeployIntegration;
+    environment: DBEnvironment;
+    fileLocation: string;
+    createdAt: Date;
+}): DBSyncConfigInsert {
+    return {
+        created_at: createdAt,
+        sync_name: template.name,
+        nango_config_id: integration.id!,
+        file_location: fileLocation,
+        version: template.version || '0.0.1',
+        models: template.returns,
+        active: true,
+        runs: template.type === 'sync' ? template.runs! : null,
+        model_schema: null,
+        input: template.input || null,
+        environment_id: environment.id,
+        deleted: false,
+        track_deletes: template.type === 'sync' ? template.track_deletes! : false,
+        type: template.type!,
+        auto_start: template.type === 'sync' ? !!template.auto_start : false,
+        attributes: {},
+        metadata: { description: template.description, scopes: template.scopes },
+        source: 'catalog',
+        enabled: true,
+        webhook_subscriptions: null,
+        models_json_schema: template.json_schema,
+        sdk_version: template.sdk_version,
+        features: template.features,
+        updated_at: createdAt,
+        sync_type: 'sync_type' in template ? template.sync_type : null
+    };
 }
 
 /**

--- a/packages/shared/lib/services/file/remote.service.ts
+++ b/packages/shared/lib/services/file/remote.service.ts
@@ -134,6 +134,9 @@ class RemoteFileService {
     }): Promise<string | null> {
         const s3FilePath = `${this.publicZeroYamlRoute}/${sourcePath}`;
         try {
+            if (isTest) {
+                return '_LOCAL_FILE_';
+            }
             if (isCloud) {
                 await this.client.send(
                     new CopyObjectCommand({


### PR DESCRIPTION
## Summary
- Deploy every catalog **action** for a provider as soon as the integration is created (dashboard, public API, MCP, and quickstart), in one batched copy+insert instead of one-at-a-time.
- Syncs and on-events stay opt-in. Create still succeeds if some copies fail or the plan is auto-idled past trial; custom functions with the same name are not overwritten.
- Functions tab needs no change: deployed actions show up in the list, and undeployed sync templates remain addable.

## Test plan
- [x] Unit: expired-trial skip, providers with no catalog actions, `integrationService.create` still succeeds
- [x] Integration: bulk deploy, skip already-deployed/custom names, continue after a copy failure
- [x] Integration: dashboard + public create deploy Bitdefender’s action; Google create does not deploy its syncs; expired trial still creates the integration
- [ ] Staging: create a Shopify (or other large-catalog) integration and confirm create latency is acceptable and all actions show as enabled


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

