### PR TITLE
feat(webapp): polish the audit event drawer and export dialog

### DIFF
--- a/packages/design-system/.storybook/preview-head.html
+++ b/packages/design-system/.storybook/preview-head.html
@@ -2,7 +2,34 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&display=swap" rel="stylesheet" />
 
-<!-- The webapp reads window._env at module scope (utils/env.ts); the dashboard gets it from /env.js, which Storybook doesn't serve. -->
+<!-- The webapp reads window._env at module scope (utils/env.ts); the dashboard gets it from /env.js, which Storybook doesn't serve.
+     Mirrors the full WindowEnv shape, since a story reaching a feature gate on a partial one throws. -->
 <script>
-    window._env = { apiUrl: 'http://localhost:3003', dashboardApiUrl: '/' };
+    window._env = {
+        apiUrl: 'http://localhost:3003',
+        dashboardApiUrl: '/',
+        publicUrl: 'http://localhost:3000',
+        connectUrl: 'http://localhost:3009',
+        gitHash: undefined,
+        publicSentryKey: '',
+        publicPosthogKey: '',
+        publicPosthogHost: '',
+        publicLogoDevKey: '',
+        publicStripeKey: '',
+        publicPlainAppId: '',
+        isCloud: false,
+        isHosted: true,
+        isEnterprise: false,
+        features: {
+            logs: true,
+            scripts: true,
+            auth: true,
+            allowSignup: true,
+            managedAuth: true,
+            gettingStarted: true,
+            slack: true,
+            plan: true,
+            authRoles: true
+        }
+    };
 </script>

--- a/packages/design-system/.storybook/preview-head.html
+++ b/packages/design-system/.storybook/preview-head.html
@@ -1,3 +1,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&display=swap" rel="stylesheet" />
+
+<!-- The webapp reads window._env at module scope (utils/env.ts); the dashboard gets it from /env.js, which Storybook doesn't serve. -->
+<script>
+    window._env = { apiUrl: 'http://localhost:3003', dashboardApiUrl: '/' };
+</script>

--- a/packages/design-system/stories/AuditExportDialog.stories.tsx
+++ b/packages/design-system/stories/AuditExportDialog.stories.tsx
@@ -1,0 +1,45 @@
+import { expect, userEvent, within } from 'storybook/test';
+
+import { AuditExportDialog } from '@/pages/Audit/components/AuditExportDialog';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * Confirms a CSV export of the audit trail. What the dialog says depends on the event count the list
+ * endpoint returned, which has three outcomes — one story each. The dialog owns its own `open` state,
+ * so each story clicks it open rather than passing a prop.
+ */
+const meta: Meta<typeof AuditExportDialog> = {
+    component: AuditExportDialog,
+    title: 'Features/Audit Trail/AuditExportDialog',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Fixed so the window label doesn't move between runs. Its zone suffix still follows the viewer's own.
+const filters = { from: '2026-08-21T00:00:00.000+02:00', to: undefined, resources: [], actions: [] };
+const selection = { resources: [], actions: [] };
+
+const openDialog = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Export' }));
+    await expect(await within(document.body).findByRole('heading', { name: 'Export audit trail' })).toBeVisible();
+};
+
+/** Everything the filters match fits in one export, so the count is exact and no cap is mentioned. */
+export const UnderCap: Story = {
+    args: { query: filters, selection, total: { value: 170, relation: 'eq' } },
+    play: openDialog
+};
+
+/** `gte` means the count stopped at the cap, so the export is a truncated slice and says so. */
+export const Capped: Story = {
+    args: { query: filters, selection, total: { value: 50_000, relation: 'gte' } },
+    play: openDialog
+};
+
+/** The count failed. With no number to show, the cap has to be stated unconditionally. */
+export const CountUnavailable: Story = {
+    args: { query: filters, selection, total: undefined },
+    play: openDialog
+};

--- a/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
@@ -2,6 +2,8 @@ import { Prism } from '@mantine/prism';
 import { X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
+import { Button } from '@nangohq/design-system';
+
 import { Sheet, SheetClose, SheetContent, SheetTitle } from '@/components/ui/Sheet';
 import { darkModeSelector, useThemeStore } from '@/lib/theme';
 import { formatDateToLogFormat } from '@/utils/utils';
@@ -9,6 +11,17 @@ import { actorLabel, environmentLabel, eventLabel, viaLabel } from '../constants
 import { OutcomeTag } from './OutcomeTag';
 
 import type { ApiAuditTrailEvent } from '@nangohq/types';
+
+// Chosen so an ordinary event shows in full: outside function deploys, nothing in production carries more
+// than ten targets, and a single-target event's JSON runs to about thirty lines.
+const TARGETS_SHOWN_COLLAPSED = 10;
+const JSON_LINES_SHOWN_COLLAPSED = 40;
+
+const ShowAll: React.FC<{ hidden: number; noun: string; onClick: () => void }> = ({ hidden, noun, onClick }) => (
+    <Button variant="link-accent" size="sm" onClick={onClick}>
+        Show {hidden.toLocaleString()} more {noun}
+    </Button>
+);
 
 const Meta: React.FC<{ label: string; value: string; mono?: boolean }> = ({ label, value, mono }) => (
     <>
@@ -19,8 +32,16 @@ const Meta: React.FC<{ label: string; value: string; mono?: boolean }> = ({ labe
 
 export const AuditEventDrawer: React.FC<{ event: ApiAuditTrailEvent; onClose: () => void }> = ({ event, onClose }) => {
     const [open, setOpen] = useState(true);
+    const [allTargets, setAllTargets] = useState(false);
+    const [allJson, setAllJson] = useState(false);
     const darkMode = useThemeStore(darkModeSelector);
     const json = useMemo(() => JSON.stringify(event, null, 2), [event]);
+    const jsonLines = useMemo(() => json.split('\n'), [json]);
+    const jsonHiddenLines = Math.max(jsonLines.length - JSON_LINES_SHOWN_COLLAPSED, 0);
+    const shownJson = allJson || jsonHiddenLines === 0 ? json : jsonLines.slice(0, JSON_LINES_SHOWN_COLLAPSED).join('\n');
+
+    const targetsHidden = Math.max(event.targets.length - TARGETS_SHOWN_COLLAPSED, 0);
+    const shownTargets = allTargets || targetsHidden === 0 ? event.targets : event.targets.slice(0, TARGETS_SHOWN_COLLAPSED);
     const via = viaLabel(event.via);
 
     return (
@@ -59,16 +80,21 @@ export const AuditEventDrawer: React.FC<{ event: ApiAuditTrailEvent; onClose: ()
                         <Meta label="Actor" value={actorLabel(event.actor)} />
                         {via && <Meta label="Via" value={via} />}
                         <Meta label="Event" value={eventLabel(event)} />
-                        <dt className="uppercase text-text-muted">{event.targets.length > 1 ? 'Targets' : 'Target'}</dt>
+                        <dt className="uppercase text-text-muted">
+                            {event.targets.length > 1 ? `Targets · ${event.targets.length.toLocaleString()}` : 'Target'}
+                        </dt>
                         <dd className="break-all">
                             {event.targets.length === 0 ? (
                                 '—'
                             ) : (
-                                <ul>
-                                    {event.targets.map((target, index) => (
-                                        <li key={`${target.type}:${target.id}:${index}`}>{target.display ?? target.id}</li>
-                                    ))}
-                                </ul>
+                                <>
+                                    <ul>
+                                        {shownTargets.map((target, index) => (
+                                            <li key={`${target.type}:${target.id}:${index}`}>{target.display ?? target.id}</li>
+                                        ))}
+                                    </ul>
+                                    {targetsHidden > 0 && !allTargets && <ShowAll hidden={targetsHidden} noun="targets" onClick={() => setAllTargets(true)} />}
+                                </>
                             )}
                         </dd>
                         <Meta label="Environment" value={environmentLabel(event)} />
@@ -85,8 +111,9 @@ export const AuditEventDrawer: React.FC<{ event: ApiAuditTrailEvent; onClose: ()
                             colorScheme={darkMode ? 'dark' : 'light'}
                             styles={() => ({ code: { padding: '0', whiteSpace: 'pre-wrap' } })}
                         >
-                            {json}
+                            {shownJson}
                         </Prism>
+                        {jsonHiddenLines > 0 && !allJson && <ShowAll hidden={jsonHiddenLines} noun="lines" onClick={() => setAllJson(true)} />}
                     </div>
                 </div>
             </SheetContent>

--- a/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
@@ -18,7 +18,7 @@ const TARGETS_SHOWN_COLLAPSED = 10;
 const JSON_LINES_SHOWN_COLLAPSED = 40;
 
 const ExpandToggle: React.FC<{ expanded: boolean; hidden: number; noun: string; onClick: () => void }> = ({ expanded, hidden, noun, onClick }) => (
-    <Button variant="link-accent" size="sm" onClick={onClick}>
+    <Button variant="link-accent" size="sm" aria-expanded={expanded} onClick={onClick}>
         {expanded ? 'Show less' : `Show ${hidden.toLocaleString()} more ${noun}`}
     </Button>
 );

--- a/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditEventDrawer.tsx
@@ -17,9 +17,9 @@ import type { ApiAuditTrailEvent } from '@nangohq/types';
 const TARGETS_SHOWN_COLLAPSED = 10;
 const JSON_LINES_SHOWN_COLLAPSED = 40;
 
-const ShowAll: React.FC<{ hidden: number; noun: string; onClick: () => void }> = ({ hidden, noun, onClick }) => (
+const ExpandToggle: React.FC<{ expanded: boolean; hidden: number; noun: string; onClick: () => void }> = ({ expanded, hidden, noun, onClick }) => (
     <Button variant="link-accent" size="sm" onClick={onClick}>
-        Show {hidden.toLocaleString()} more {noun}
+        {expanded ? 'Show less' : `Show ${hidden.toLocaleString()} more ${noun}`}
     </Button>
 );
 
@@ -93,7 +93,9 @@ export const AuditEventDrawer: React.FC<{ event: ApiAuditTrailEvent; onClose: ()
                                             <li key={`${target.type}:${target.id}:${index}`}>{target.display ?? target.id}</li>
                                         ))}
                                     </ul>
-                                    {targetsHidden > 0 && !allTargets && <ShowAll hidden={targetsHidden} noun="targets" onClick={() => setAllTargets(true)} />}
+                                    {targetsHidden > 0 && (
+                                        <ExpandToggle expanded={allTargets} hidden={targetsHidden} noun="targets" onClick={() => setAllTargets(!allTargets)} />
+                                    )}
                                 </>
                             )}
                         </dd>
@@ -113,7 +115,7 @@ export const AuditEventDrawer: React.FC<{ event: ApiAuditTrailEvent; onClose: ()
                         >
                             {shownJson}
                         </Prism>
-                        {jsonHiddenLines > 0 && !allJson && <ShowAll hidden={jsonHiddenLines} noun="lines" onClick={() => setAllJson(true)} />}
+                        {jsonHiddenLines > 0 && <ExpandToggle expanded={allJson} hidden={jsonHiddenLines} noun="lines" onClick={() => setAllJson(!allJson)} />}
                     </div>
                 </div>
             </SheetContent>

--- a/packages/webapp/src/pages/Audit/components/AuditExportDialog.tsx
+++ b/packages/webapp/src/pages/Audit/components/AuditExportDialog.tsx
@@ -1,4 +1,4 @@
-import { Share } from 'lucide-react';
+import { Info, Share } from 'lucide-react';
 import { useRef, useState } from 'react';
 
 import {
@@ -105,19 +105,19 @@ export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ query, sel
                     <DialogDescription>Downloads the events matching these filters as a CSV file.</DialogDescription>
                 </DialogHeader>
                 <DialogBody>
-                    <dl className="grid grid-cols-[80px_1fr] gap-x-4 gap-y-2.5 text-body-small-regular">
-                        <dt className="uppercase text-text-muted">{windowField.label}</dt>
+                    <dl className="grid grid-cols-[80px_1fr] items-center gap-x-4 gap-y-2 text-body-small-regular">
+                        <dt className="type-label-sm uppercase text-text-muted">{windowField.label}</dt>
                         <dd className="font-code text-text-primary">
                             {windowField.value}
                             {windowField.zone && <span className="text-text-muted"> {windowField.zone}</span>}
                         </dd>
-                        <dt className="uppercase text-text-muted">Resource</dt>
+                        <dt className="type-label-sm uppercase text-text-muted">Resource</dt>
                         <dd className="font-code text-text-primary">{resourceSelectionLabel(selection.resources)}</dd>
-                        <dt className="uppercase text-text-muted">Action</dt>
+                        <dt className="type-label-sm uppercase text-text-muted">Action</dt>
                         <dd className="font-code text-text-primary">{actionSelectionLabel(selection.actions)}</dd>
                         {total && (
                             <>
-                                <dt className="uppercase text-text-muted">Events</dt>
+                                <dt className="type-label-sm uppercase text-text-muted">Events</dt>
                                 <dd className="font-code text-text-primary">
                                     {exportedCount?.toLocaleString()}
                                     {truncates && <span className="text-text-muted"> (max)</span>}
@@ -126,8 +126,9 @@ export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ query, sel
                         )}
                     </dl>
                     {truncates === true && (
-                        <div className="mt-5">
+                        <div className="mt-4">
                             <Alert variant="info" size="compact">
+                                <Info />
                                 <AlertDescription>
                                     Your filters match more than the {AUDIT_EXPORT_MAX_ROWS.toLocaleString()} events a single export can hold. Narrow the date
                                     range or filters to export older events.
@@ -136,9 +137,9 @@ export const AuditExportDialog: React.FC<AuditExportDialogProps> = ({ query, sel
                         </div>
                     )}
                     {truncates === undefined && (
-                        <p className="mt-5 text-body-small-regular text-text-secondary">An export stops at {AUDIT_EXPORT_MAX_ROWS.toLocaleString()} events.</p>
+                        <p className="mt-4 text-body-small-regular text-text-secondary">An export stops at {AUDIT_EXPORT_MAX_ROWS.toLocaleString()} events.</p>
                     )}
-                    <p className="mt-3 text-body-small-regular text-text-secondary">
+                    <p className="mt-4 text-body-small-regular text-text-secondary">
                         Need a larger or scheduled export?{' '}
                         <Button variant="link-accent" size="sm" onClick={onContact}>
                             Contact us


### PR DESCRIPTION
## Problem

A function deploy can name hundreds of targets — 365 in production today. The event drawer listed every one, pushing the fields below Targets and the thousand-line JSON far below the fold. Design review then found the export dialog out of step with its Figma component, and it had no stories.

## Solution

- Targets past the tenth and JSON past forty lines collapse behind a toggle that expands **and** collapses again. The Targets label carries the count (`TARGETS · 249`) so the scale shows without expanding.
- Thresholds come from production data, so an ordinary event never collapses: nothing but a function deploy exceeds ten targets.
- Export dialog: labels move to the label ramp, row spacing 10 → 8px, every vertical gap in the body at 16px, and the info alert gets the icon every other alert already passes.
- Three export dialog stories, one per event-count outcome.

Follow-up to [NAN-6672](https://linear.app/nango/issue/NAN-6672), which made the table row single-line but moved the problem into the drawer.

## Stories

- [Under cap](https://pr-7417-storybook.app-development.nango.dev/?path=/story/features-audit-trail-auditexportdialog--under-cap)
- [Capped](https://pr-7417-storybook.app-development.nango.dev/?path=/story/features-audit-trail-auditexportdialog--capped)
- [Count unavailable](https://pr-7417-storybook.app-development.nango.dev/?path=/story/features-audit-trail-auditexportdialog--count-unavailable)

## Testing

Locally against a seeded 249-target event: both toggles expand and collapse independently and every field is back above the fold. Export dialog checked in light and dark against Figma in both states.

Worth eyeballing on the preview deploy against account 11885 (Replo) or 1908 (Beam AI), which holds the 365-target deploy.
