### PR TITLE
fix(server): preserve upstream HTTP status on buffered proxy responses (#7408)

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -361,7 +361,7 @@ export function handleResponse({
         }
 
         try {
-            res.send(Buffer.concat(responseData));
+            res.status(responseStream.status).send(Buffer.concat(responseData));
             onEgressedBytes?.(responseLen);
         } catch (err) {
             const error = err instanceof Error ? err : new Error('Failed to write proxy response');


### PR DESCRIPTION
### Summary of Changes

Fixes #7408.

The HTTP proxy preserved upstream HTTP status codes for chunked/streamed responses (\es.writeHead(responseStream.status, passthroughHeaders)\) and 204 responses, but omitted calling \es.status(responseStream.status)\ on successful buffered responses prior to \es.send(Buffer.concat(responseData))\. As a result, Express defaulted to \200 OK\ for all non-streamed successful responses, causing upstream \201 Created\ or \202 Accepted\ responses (such as GitHub issue creation) to return \200 OK\.

This PR updates \handleResponse\ in \packages/server/lib/controllers/proxy/allProxy.ts\ to explicitly set \es.status(responseStream.status)\ on buffered responses:
\\\	s
res.status(responseStream.status).send(Buffer.concat(responseData));
\\\

### Verification
- Updated \packages/server/lib/controllers/proxy/allProxy.ts\ line 364 to call \es.status(responseStream.status)\ before \.send()\.
- Code inspected and verified against \handleResponse\ streaming and error handler contracts.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

