### PR TITLE
fix(proxy): preserve the provider status code on the buffered path

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -361,7 +361,7 @@ export function handleResponse({
         }
 
         try {
-            res.send(Buffer.concat(responseData));
+            res.status(responseStream.status).send(Buffer.concat(responseData));
             onEgressedBytes?.(responseLen);
         } catch (err) {
             const error = err instanceof Error ? err : new Error('Failed to write proxy response');

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -149,6 +149,35 @@ describe('handleResponse', () => {
         expect(onEgressedBytes).toHaveBeenCalledWith(0);
     });
 
+    it.each([200, 201, 202, 206])('should send the buffered response with the provider status %i', async (status) => {
+        const body = '{"id": 123}';
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream(body, { status });
+        const onEgressedBytes = vi.fn();
+
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, onEgressedBytes });
+        await mockRes.waitForSend();
+
+        expect(mockRes.getStatusCode()).toBe(status);
+        expect(mockRes.getSentData()?.toString()).toBe(body);
+        expect(mockResponseStream.complete).toHaveBeenCalledOnce();
+        expect(onEgressedBytes).toHaveBeenCalledWith(Buffer.byteLength(body));
+    });
+
+    it('should handle 304 Not Modified response', async () => {
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream('', { status: 304 });
+        const onEgressedBytes = vi.fn();
+
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, onEgressedBytes });
+        await mockRes.waitForSend();
+
+        expect(mockRes.getStatusCode()).toBe(304);
+        expect(mockRes.getSentData()?.length).toBe(0);
+        expect(mockResponseStream.complete).toHaveBeenCalledOnce();
+        expect(onEgressedBytes).toHaveBeenCalledWith(0);
+    });
+
     it('should validate that response is valid JSON', async () => {
         const validJson = '{"id": 123, "name": "test"}';
         const mockRes = createMockResponse();


### PR DESCRIPTION
## Problem

The buffered success path in `handleResponse` sends the body without setting a status, so Express falls back to its default 200. Provider responses carrying 201, 202 or 206 reach the client as `200 OK`.

This diverges from the documented proxy behaviour, which says the external API's response code, headers and body are passed back exactly as Nango receives them. It is riskiest on POST: a client validating the response against the provider's documented contract reads a successful mutation as a failure and may retry it, creating a duplicate resource upstream.

## Three of the four paths were already correct

| Path | Status |
| --- | --- |
| Streamed — `res.writeHead(responseStream.status, ...)` | preserved |
| Buffered, 204 short-circuit | preserved |
| Buffered, errors — `res.status(responseStatus)` | preserved |
| **Buffered, success** | **lost** |

The other proxy surfaces already report the real status as well: the Management MCP tool returns `status: response.status`, and the Runner SDK reaches `ProxyRequest` directly and returns the untouched axios response. Only the HTTP route understated it.

## The change

```diff
-            res.send(Buffer.concat(responseData));
+            res.status(responseStream.status).send(Buffer.concat(responseData));
```

## Tests

Added to `handleResponse`: an `it.each` over 200, 201, 202 and 206, plus a dedicated 304 case. Without the fix exactly 201, 202, 206 and 304 fail, while 200 passes — it was never broken. Full `packages/server` unit suite: 1031 tests, all green.

## Notes for maintainers

**1. Compatibility.** `/proxy` is a public endpoint and `@nangohq/node` calls it. Client code pinned on `status === 200` will see a change. Response header passthrough was rolled out behind `shouldForwardAllProxyResponseHeaders`; the status is not gated here. Happy to put it behind the same flag if you prefer.

**2. Allowlist.** With that flag off, `PROXY_RESPONSE_HEADER_ALLOWLIST` holds only `content-type`, `mcp-session-id`, `x-request-id` and `x-correlation-id`. A passed-through 206 therefore arrives without the `content-range` that RFC 9110 section 15.3.7 requires, and a 201 without `location`. Previously a 206 was flattened to 200 with a partial body, so the client took truncated data for a complete response. I left the allowlist untouched to keep this change minimal, and raise it as a separate question.

**3. 304 changes shape.** It used to be a 200 with an empty body. It is now a real 304, whose `Content-Type`, `Content-Length` and `Transfer-Encoding` Express strips itself.

Fixes #7408


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

