### PR TITLE
fix(syncs): keep the variant badge beside the sync name

### DIFF
--- a/packages/webapp/src/pages/Connection/components/SyncsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncsTab.tsx
@@ -279,7 +279,7 @@ const SyncRow = memo(function SyncRow({
     return (
         <TableRow className={cn(rowLayout, 'absolute')} style={{ height: `${ROW_HEIGHT_PX}px`, transform: `translateY(${offsetY}px)` }}>
             <TableCell className={cn(cellLayout, col.name, 'gap-2')}>
-                <span className="text-body-small-semi text-text-strong truncate min-w-0 flex-1">{sync.name}</span>
+                <span className="text-body-small-semi text-text-strong truncate min-w-0">{sync.name}</span>
                 {sync.variant !== 'base' && (
                     <Tooltip>
                         <TooltipTrigger className="shrink-0">


### PR DESCRIPTION
## Problem

The variant badge renders against the right edge of the Sync Name column instead of beside the name, so a connection with many variants shows a column of badges with no header. Spotted on Levity's connection.

Needs a wide window to see — at 1280px the column is at its minimum and nothing moves; at 1920px the badge shifts ~130px.

## Solution

Drop `flex-1` from the name span.

Fixes [NAN-6915](https://linear.app/nango/issue/NAN-6915)

## Testing

Checked on the deployed dev dashboard at 1920px, against a connection with a dozen short-named syncs and long variants. A long name still truncates rather than disappearing.

## Screenshots

**Before**

![Syncs tab before the fix, badges pushed to the right edge](https://github.com/user-attachments/assets/bc717250-c9ad-4334-ab79-bf4f98cc1836)

**After**

![Syncs tab after the fix, badges beside each sync name](https://github.com/user-attachments/assets/8e107477-51df-4d6c-a668-fbb1b6dd7e74)
