### PR TITLE
fix(server): block unverified gmail webhooks with env setting

### DIFF
--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -69,6 +69,10 @@ export function buildFlags(client: FeatureFlagsClient) {
         /** Whether the account is measured against the new pricing's three metrics rather than today's seven. */
         isS26PricingEnabled(accountUuid: string) {
             return client.isEnabled('s26-pricing', { targetingKey: accountUuid, accountUuid }, false);
+        },
+        /** Whether the Gmail webhook can be unverified. */
+        allowUnauthorizedGmailWebhook(accountUuid: string) {
+            return client.isEnabled('allow-unauthorized-gmail-webhook', { targetingKey: accountUuid, accountUuid }, false);
         }
     };
 }

--- a/packages/server/lib/webhook/gmail-webhook-routing.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.ts
@@ -1,9 +1,9 @@
 import crypto from 'node:crypto';
 
+import { getFlags } from '@nangohq/feature-flags';
 import { environmentService, getGlobalWebhookReceiveUrl, NangoError } from '@nangohq/shared';
 import { Err, getLogger, metrics, Ok, report } from '@nangohq/utils';
 
-import { envs } from '../env.js';
 import { hashEmailAddress } from '../utils/pii.js';
 import { getGoogleJWKS } from './cache.js';
 
@@ -17,12 +17,16 @@ interface DecodedDataObject {
     historyId: string;
 }
 
-export async function validate(integration: IntegrationConfig, headers: Record<string, any>): Promise<boolean> {
+export async function validate(
+    integration: IntegrationConfig,
+    headers: Record<string, any>,
+    { allowUnauthorized }: { allowUnauthorized: boolean }
+): Promise<boolean> {
     try {
         const authHeader: string | undefined = headers['authorization'];
 
         if (!authHeader) {
-            return envs.ALLOW_GMAIL_WEBHOOK_UNAUTHORIZED;
+            return allowUnauthorized;
         }
 
         if (!authHeader.startsWith('Bearer ')) {
@@ -99,7 +103,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
         });
     }
 
-    const valid = await validate(nango.integration, headers);
+    const valid = await validate(nango.integration, headers, { allowUnauthorized: await getFlags().allowUnauthorizedGmailWebhook(nango.team.uuid) });
 
     if (!valid) {
         logger.error('webhook signature invalid');

--- a/packages/server/lib/webhook/gmail-webhook-routing.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.ts
@@ -3,6 +3,7 @@ import crypto from 'node:crypto';
 import { environmentService, getGlobalWebhookReceiveUrl, NangoError } from '@nangohq/shared';
 import { Err, getLogger, metrics, Ok, report } from '@nangohq/utils';
 
+import { envs } from '../env.js';
 import { hashEmailAddress } from '../utils/pii.js';
 import { getGoogleJWKS } from './cache.js';
 
@@ -21,7 +22,7 @@ export async function validate(integration: IntegrationConfig, headers: Record<s
         const authHeader: string | undefined = headers['authorization'];
 
         if (!authHeader) {
-            return true;
+            return envs.ALLOW_GMAIL_WEBHOOK_UNAUTHORIZED;
         }
 
         if (!authHeader.startsWith('Bearer ')) {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -959,6 +959,9 @@ const ENVS_SHAPE = z.object({
     NANGO_UNLEASH_REFRESH_INTERVAL_MS: z.coerce.number().optional().default(30_000),
     NANGO_UNLEASH_INIT_TIMEOUT_MS: z.coerce.number().optional().default(10_000),
 
+    // Allow Gmail webhook to be unverified
+    ALLOW_GMAIL_WEBHOOK_UNAUTHORIZED: z.stringbool().optional().default(true),
+
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
     NANGO_CLOUD: z.stringbool().optional().default(false),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -959,9 +959,6 @@ const ENVS_SHAPE = z.object({
     NANGO_UNLEASH_REFRESH_INTERVAL_MS: z.coerce.number().optional().default(30_000),
     NANGO_UNLEASH_INIT_TIMEOUT_MS: z.coerce.number().optional().default(10_000),
 
-    // Allow Gmail webhook to be unverified
-    ALLOW_GMAIL_WEBHOOK_UNAUTHORIZED: z.stringbool().optional().default(true),
-
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
     NANGO_CLOUD: z.stringbool().optional().default(false),


### PR DESCRIPTION
New environment variable to define gmail webhook behavior when no auth header is available.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

