### PR TITLE
feat(webapp): show the Pay-as-you-go migration in-app

### DIFF
--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -80,8 +80,6 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
         return duplicated;
     }, [plansList]);
 
-    // A downgrade the account could pick itself, plus the Pay-as-you-go migration for the retired v2
-    // plans — which is scheduled on them rather than chosen, so it is absent from `prevPlan`.
     const scheduledChangeOptions = useMemo(() => {
         const definitions = plansList?.data;
         if (!definitions || !overrideCode) {
@@ -93,6 +91,7 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
             .filter((plan) => prevPlanCodes.includes(plan.code))
             .map((plan) => ({ code: plan.code, label: plan.code === 'free' ? 'Free (cancellation)' : `${plan.title} (downgrade)` }));
 
+        // Scheduled on the retired v2 plans rather than chosen by them, so it is absent from `prevPlan`.
         const migrationTarget = definitions.find((plan) => plan.code === 'pay-as-you-go');
         if (migrationTarget && migratesToPayAsYouGo(overrideCode) && !options.some((o) => o.code === migrationTarget.code)) {
             options.push({ code: migrationTarget.code, label: `${migrationTarget.title} (migration)` });

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -27,6 +27,11 @@ const UNAVAILABLE_SPEND_VALUE = 'unavailable';
 const SPEND_PRESETS_IN_CENTS = [0, 5000, 128430];
 const REAL_PERIOD_COSTS_VALUE = '__real_period_costs__';
 const REAL_ADDON_VALUE = '__real_addon__';
+// Every other scheduled change is a downgrade.
+const SCHEDULED_CHANGE_KIND: Partial<Record<PlanDefinition['code'], string>> = {
+    free: 'cancellation',
+    'pay-as-you-go': 'migration'
+};
 interface PlanOverrideContentProps {
     onBack: () => void;
     onClose: () => void;
@@ -81,23 +86,19 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
     }, [plansList]);
 
     const scheduledChangeOptions = useMemo(() => {
-        const definitions = plansList?.data;
-        if (!definitions || !overrideCode) {
+        const definitions = plansList?.data ?? [];
+        const current = definitions.find((plan) => plan.code === overrideCode);
+        if (!current) {
             return [];
         }
 
-        const prevPlanCodes = definitions.find((plan) => plan.code === overrideCode)?.prevPlan ?? [];
-        const options = definitions
-            .filter((plan) => prevPlanCodes.includes(plan.code))
-            .map((plan) => ({ code: plan.code, label: plan.code === 'free' ? 'Free (cancellation)' : `${plan.title} (downgrade)` }));
-
-        // Scheduled on the retired v2 plans rather than chosen by them, so it is absent from `prevPlan`.
-        const migrationTarget = definitions.find((plan) => plan.code === 'pay-as-you-go');
-        if (migrationTarget && migratesToPayAsYouGo(overrideCode) && !options.some((o) => o.code === migrationTarget.code)) {
-            options.push({ code: migrationTarget.code, label: `${migrationTarget.title} (migration)` });
+        const targets = new Set(current.prevPlan);
+        if (migratesToPayAsYouGo(current.code)) {
+            // We schedule the migration onto these plans, so `prevPlan` never lists it.
+            targets.add('pay-as-you-go');
         }
 
-        return options;
+        return definitions.filter((plan) => targets.has(plan.code));
     }, [plansList, overrideCode]);
 
     // `useCurrentPlan` already has the override applied, so the real plan has to come from the
@@ -161,9 +162,9 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                                 <RowTrigger placeholder="None" />
                                 <SelectContent>
                                     <SelectItem value={NO_SCHEDULED_CHANGE_VALUE}>None</SelectItem>
-                                    {scheduledChangeOptions.map((option) => (
-                                        <SelectItem key={option.code} value={option.code}>
-                                            {option.label}
+                                    {scheduledChangeOptions.map((plan) => (
+                                        <SelectItem key={plan.code} value={plan.code}>
+                                            {plan.title} ({SCHEDULED_CHANGE_KIND[plan.code] ?? 'downgrade'})
                                         </SelectItem>
                                     ))}
                                 </SelectContent>

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -27,10 +27,16 @@ const UNAVAILABLE_SPEND_VALUE = 'unavailable';
 const SPEND_PRESETS_IN_CENTS = [0, 5000, 128430];
 const REAL_PERIOD_COSTS_VALUE = '__real_period_costs__';
 const REAL_ADDON_VALUE = '__real_addon__';
-const SCHEDULED_CHANGE_KIND: Partial<Record<PlanDefinition['code'], string>> = {
-    free: 'cancellation',
-    'pay-as-you-go': 'migration'
-};
+function scheduledChangeKind(target: PlanDefinition['code'], from: PlanDefinition['code'] | null): string {
+    if (target === 'free') {
+        return 'cancellation';
+    }
+    // Enterprise lists Pay-as-you-go as an ordinary downgrade, so the source plan decides.
+    if (target === 'pay-as-you-go' && from && migratesToPayAsYouGo(from)) {
+        return 'migration';
+    }
+    return 'downgrade';
+}
 interface PlanOverrideContentProps {
     onBack: () => void;
     onClose: () => void;
@@ -163,7 +169,7 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                                     <SelectItem value={NO_SCHEDULED_CHANGE_VALUE}>None</SelectItem>
                                     {scheduledChangeOptions.map((plan) => (
                                         <SelectItem key={plan.code} value={plan.code}>
-                                            {plan.title} ({SCHEDULED_CHANGE_KIND[plan.code] ?? 'downgrade'})
+                                            {plan.title} ({scheduledChangeKind(plan.code, overrideCode)})
                                         </SelectItem>
                                     ))}
                                 </SelectContent>

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -9,7 +9,7 @@ import { Switch } from '@/components/ui/Switch';
 import { Tag } from '@/components/ui/Tag';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
-import { hasMonthlySpend } from '@/pages/Team/Billing/planVisibility';
+import { hasMonthlySpend, migratesToPayAsYouGo } from '@/pages/Team/Billing/planVisibility';
 import { useStore } from '@/store';
 import { cn } from '@/utils/utils';
 import { DEFAULTS, usePlanOverrideStore } from './planOverride';
@@ -80,8 +80,26 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
         return duplicated;
     }, [plansList]);
 
-    const prevPlanCodes = plansList?.data.find((plan) => plan.code === overrideCode)?.prevPlan;
-    const scheduledChangeOptions = plansList?.data.filter((plan) => prevPlanCodes?.includes(plan.code));
+    // A downgrade the account could pick itself, plus the Pay-as-you-go migration for the retired v2
+    // plans — which is scheduled on them rather than chosen, so it is absent from `prevPlan`.
+    const scheduledChangeOptions = useMemo(() => {
+        const definitions = plansList?.data;
+        if (!definitions || !overrideCode) {
+            return [];
+        }
+
+        const prevPlanCodes = definitions.find((plan) => plan.code === overrideCode)?.prevPlan ?? [];
+        const options = definitions
+            .filter((plan) => prevPlanCodes.includes(plan.code))
+            .map((plan) => ({ code: plan.code, label: plan.code === 'free' ? 'Free (cancellation)' : `${plan.title} (downgrade)` }));
+
+        const migrationTarget = definitions.find((plan) => plan.code === 'pay-as-you-go');
+        if (migrationTarget && migratesToPayAsYouGo(overrideCode) && !options.some((o) => o.code === migrationTarget.code)) {
+            options.push({ code: migrationTarget.code, label: `${migrationTarget.title} (migration)` });
+        }
+
+        return options;
+    }, [plansList, overrideCode]);
 
     // `useCurrentPlan` already has the override applied, so the real plan has to come from the
     // un-overridden query or the caption would name whatever is being previewed.
@@ -135,7 +153,7 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                 </div>
 
                 <Section title="Plan state">
-                    {scheduledChangeOptions && scheduledChangeOptions.length > 0 && (
+                    {scheduledChangeOptions.length > 0 && (
                         <Row label="Scheduled change">
                             <Select
                                 value={scheduledTargetCode ?? NO_SCHEDULED_CHANGE_VALUE}
@@ -144,9 +162,9 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                                 <RowTrigger placeholder="None" />
                                 <SelectContent>
                                     <SelectItem value={NO_SCHEDULED_CHANGE_VALUE}>None</SelectItem>
-                                    {scheduledChangeOptions.map((plan) => (
-                                        <SelectItem key={plan.code} value={plan.code}>
-                                            {plan.code === 'free' ? 'Free (cancellation)' : `${plan.title} (downgrade)`}
+                                    {scheduledChangeOptions.map((option) => (
+                                        <SelectItem key={option.code} value={option.code}>
+                                            {option.label}
                                         </SelectItem>
                                     ))}
                                 </SelectContent>

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -27,7 +27,6 @@ const UNAVAILABLE_SPEND_VALUE = 'unavailable';
 const SPEND_PRESETS_IN_CENTS = [0, 5000, 128430];
 const REAL_PERIOD_COSTS_VALUE = '__real_period_costs__';
 const REAL_ADDON_VALUE = '__real_addon__';
-// Every other scheduled change is a downgrade.
 const SCHEDULED_CHANGE_KIND: Partial<Record<PlanDefinition['code'], string>> = {
     free: 'cancellation',
     'pay-as-you-go': 'migration'

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -175,7 +175,6 @@ export function applyPlanOverride(
               ...(overridePlan.flags as Partial<ApiPlan>),
               name: overridePlan.code,
               orb_future_plan: scheduledTarget?.code ?? null,
-              // The period boundary real plan changes land on, so a simulated date reads like a live one.
               orb_future_plan_at: scheduledTarget ? nextUsageResetDate(new Date()).toISOString() : null
           }
         : realPlan;

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -175,7 +175,8 @@ export function applyPlanOverride(
               ...(overridePlan.flags as Partial<ApiPlan>),
               name: overridePlan.code,
               orb_future_plan: scheduledTarget?.code ?? null,
-              orb_future_plan_at: scheduledTarget ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString() : null
+              // The period boundary real plan changes land on, so a simulated date reads like a live one.
+              orb_future_plan_at: scheduledTarget ? nextUsageResetDate(new Date()).toISOString() : null
           }
         : realPlan;
 

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -20,6 +20,7 @@ import { Payment } from './components/Payment';
 import { PaymentMethodDialog } from './components/PaymentMethodDialog';
 import { Plans } from './components/Plans';
 import { PlanTransitionBanner } from './components/PlanTransitionBanner';
+import { PlanTransitionNotice } from './components/PlanTransitionNotice';
 import { ScheduledPlanChangeAlert } from './components/ScheduledPlanChangeAlert';
 import { SpendAlerts } from './components/SpendAlerts';
 import { Summary } from './components/Summary';
@@ -144,8 +145,7 @@ export const TeamBilling: React.FC = () => {
                         </Button>
                     </div>
                     {/* Outside the scroll container below, so the full-width alert doesn't scroll with the plan cards. */}
-                    {/* The transition banner at the top of the page already states this change. */}
-                    {!transition && <ScheduledPlanChangeAlert />}
+                    {transition ? <PlanTransitionNotice transition={transition} /> : <ScheduledPlanChangeAlert />}
                     <div className="w-full overflow-x-auto">
                         <Plans />
                     </div>

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -19,12 +19,14 @@ import { BillingHeaderAction } from './components/BillingHeaderAction';
 import { Payment } from './components/Payment';
 import { PaymentMethodDialog } from './components/PaymentMethodDialog';
 import { Plans } from './components/Plans';
+import { PlanTransitionBanner } from './components/PlanTransitionBanner';
 import { ScheduledPlanChangeAlert } from './components/ScheduledPlanChangeAlert';
 import { SpendAlerts } from './components/SpendAlerts';
 import { Summary } from './components/Summary';
 import { Usage } from './components/Usage';
 import { UsageLimitBanner } from './components/UsageLimitBanner';
 import { hasMonthlySpend, showsSummaryStrip } from './planVisibility';
+import { usePlanTransition } from './usePlanTransition';
 
 export const TeamBilling: React.FC = () => {
     const { can } = usePermissions();
@@ -40,6 +42,8 @@ export const TeamBilling: React.FC = () => {
     // so a failed load hides the section rather than leaking them or holding a skeleton forever.
     const { isError: didPlanListFail } = useApiGetPlans(env);
     const showSummary = !didPlanListFail && (isPlanPending || showsSummaryStrip(environmentData?.plan));
+
+    const transition = usePlanTransition();
 
     // A failed refetch keeps the previous plan cached, so the error is checked rather than trusting stale data.
     const showSpendAlerts = canManageBilling && !didPlanFail && hasMonthlySpend(environmentData?.plan) && !!environmentData?.plan?.orb_subscription_id;
@@ -106,6 +110,7 @@ export const TeamBilling: React.FC = () => {
                 {/* Legacy, enterprise and free-uncapped get no strip, but can still owe an invoice. */}
                 <div className="flex flex-col gap-3 empty:hidden">
                     {overdueBanner}
+                    {transition && <PlanTransitionBanner transition={transition} />}
                     {showSummary && <UsageLimitBanner state={usageLimitOverride ?? getAggregateUsageState(caps?.data ?? {}, billedMetrics)} />}
                 </div>
                 {showSummary && (
@@ -139,7 +144,8 @@ export const TeamBilling: React.FC = () => {
                         </Button>
                     </div>
                     {/* Outside the scroll container below, so the full-width alert doesn't scroll with the plan cards. */}
-                    <ScheduledPlanChangeAlert />
+                    {/* The transition banner at the top of the page already states this change. */}
+                    {!transition && <ScheduledPlanChangeAlert />}
                     <div className="w-full overflow-x-auto">
                         <Plans />
                     </div>

--- a/packages/webapp/src/pages/Team/Billing/components/GrowthAddon.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/GrowthAddon.tsx
@@ -49,6 +49,7 @@ export const GrowthAddon: React.FC<{ state: GrowthAddonState; endsAt?: string; o
                     {state === 'none' && GROWTH_ADDON_COPY.price}
                     {state === 'active' && `${GROWTH_ADDON_COPY.price} · included in this period`}
                     {state === 'pending-removal' && `Deactivates ${endsAt ? formatBillingDate(new Date(endsAt)) : 'at the end of this period'}`}
+                    {state === 'pending-activation' && `${GROWTH_ADDON_COPY.price} · included when you move to Pay-as-you-go`}
                 </span>
             </div>
             <span className="text-text-secondary text-body-small-regular">{GROWTH_ADDON_COPY.features}</span>

--- a/packages/webapp/src/pages/Team/Billing/components/GrowthAddon.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/GrowthAddon.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@nangohq/design-system';
+import { Badge, Button } from '@nangohq/design-system';
 
 import { ConditionalTooltip } from '@/components/patterns/ConditionalTooltip';
 import { Dot } from '@/components/ui/Dot';
@@ -35,6 +35,7 @@ export const GrowthAddon: React.FC<{ state: GrowthAddonState; endsAt?: string; o
                         </Button>
                     </ConditionalTooltip>
                 )}
+                {state === 'pending-activation' && <Badge variant="success">Included</Badge>}
                 {state === 'active' && (
                     <ConditionalTooltip condition={!!lockedReason} content={lockedReason} side="left" asChild>
                         <Button variant="link-danger" size="sm" disabled={!!lockedReason} onClick={onActionClicked}>
@@ -44,12 +45,12 @@ export const GrowthAddon: React.FC<{ state: GrowthAddonState; endsAt?: string; o
                 )}
             </div>
             <div className="flex items-center gap-1.5">
-                {state !== 'none' && <Dot variant={state === 'active' ? 'success' : 'warning'} />}
+                {(state === 'active' || state === 'pending-removal') && <Dot variant={state === 'active' ? 'success' : 'warning'} />}
                 <span className="text-text-secondary text-body-medium-regular">
                     {state === 'none' && GROWTH_ADDON_COPY.price}
                     {state === 'active' && `${GROWTH_ADDON_COPY.price} · included in this period`}
                     {state === 'pending-removal' && `Deactivates ${endsAt ? formatBillingDate(new Date(endsAt)) : 'at the end of this period'}`}
-                    {state === 'pending-activation' && `${GROWTH_ADDON_COPY.price} · included when you move to Pay-as-you-go`}
+                    {state === 'pending-activation' && GROWTH_ADDON_COPY.price}
                 </span>
             </div>
             <span className="text-text-secondary text-body-small-regular">{GROWTH_ADDON_COPY.features}</span>

--- a/packages/webapp/src/pages/Team/Billing/components/PlanTransitionBanner.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/PlanTransitionBanner.tsx
@@ -10,10 +10,6 @@ interface PlanTransitionBannerProps {
     transition: PlanTransition;
 }
 
-/**
- * Deliberately silent about the new usage metrics the design shows alongside it: an account is still
- * measured on the retired metrics until Orb moves it, so there is nothing new to review yet (NAN-6744).
- */
 export const PlanTransitionBanner: React.FC<PlanTransitionBannerProps> = ({ transition }) => {
     return (
         <Alert variant="info" size="wide">

--- a/packages/webapp/src/pages/Team/Billing/components/PlanTransitionBanner.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/PlanTransitionBanner.tsx
@@ -1,0 +1,30 @@
+import { Clock9 } from 'lucide-react';
+
+import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle } from '@nangohq/design-system';
+
+import { openSupportChat } from '@/utils/support';
+
+import type { PlanTransition } from '../planTransition';
+
+interface PlanTransitionBannerProps {
+    transition: PlanTransition;
+}
+
+/**
+ * Deliberately silent about the new usage metrics the design shows alongside it: an account is still
+ * measured on the retired metrics until Orb moves it, so there is nothing new to review yet (NAN-6744).
+ */
+export const PlanTransitionBanner: React.FC<PlanTransitionBannerProps> = ({ transition }) => {
+    return (
+        <Alert variant="info" size="wide">
+            <Clock9 />
+            <AlertTitle>Your plan is changing on {transition.at}</AlertTitle>
+            <AlertDescription>
+                Your account is scheduled to move to {transition.toPlanTitle} on {transition.at}. You&apos;ll keep access to all the features you have today.
+            </AlertDescription>
+            <AlertActions>
+                <AlertButton onClick={openSupportChat}>Contact us</AlertButton>
+            </AlertActions>
+        </Alert>
+    );
+};

--- a/packages/webapp/src/pages/Team/Billing/components/PlanTransitionNotice.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/PlanTransitionNotice.tsx
@@ -1,0 +1,26 @@
+import { Info } from 'lucide-react';
+
+import { Alert, AlertDescription } from '@nangohq/design-system';
+
+import type { PlanTransition } from '../planTransition';
+
+interface PlanTransitionNoticeProps {
+    transition: PlanTransition;
+}
+
+/**
+ * Names the retired plan, which has no card of its own in the grid below.
+ *
+ * States the change date rather than the design's day-before, so this and the banner can't read as
+ * two different deadlines.
+ */
+export const PlanTransitionNotice: React.FC<PlanTransitionNoticeProps> = ({ transition }) => {
+    return (
+        <Alert variant="info">
+            <Info />
+            <AlertDescription>
+                {transition.fromTitle} is your current plan until {transition.at}, then moves to {transition.toPlanTitle} automatically.
+            </AlertDescription>
+        </Alert>
+    );
+};

--- a/packages/webapp/src/pages/Team/Billing/components/PlanTransitionNotice.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/PlanTransitionNotice.tsx
@@ -9,8 +9,6 @@ interface PlanTransitionNoticeProps {
 }
 
 /**
- * Names the retired plan, which has no card of its own in the grid below.
- *
  * States the change date rather than the design's day-before, so this and the banner can't read as
  * two different deadlines.
  */

--- a/packages/webapp/src/pages/Team/Billing/components/PlanTransitionNotice.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/PlanTransitionNotice.tsx
@@ -8,10 +8,6 @@ interface PlanTransitionNoticeProps {
     transition: PlanTransition;
 }
 
-/**
- * States the change date rather than the design's day-before, so this and the banner can't read as
- * two different deadlines.
- */
 export const PlanTransitionNotice: React.FC<PlanTransitionNoticeProps> = ({ transition }) => {
     return (
         <Alert variant="info">

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -65,8 +65,6 @@ export const Plans: React.FC = () => {
 
         const curr = plansList.data.find((p) => p.code === currentPlan.name)!;
 
-        // `orb_future_plan` keeps stale rows. Read the pending change instead, so a card can't be
-        // disabled by a change that already passed.
         const scheduledCode = pendingPlanChange({ plan: currentPlan, plans: plansList.data, now: new Date() })?.toCode;
 
         // Picked by code rather than by `hidden`: `pay-as-you-go` is hidden in `plansList`, yet is one

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -170,8 +170,8 @@ const PlanCard: React.FC<{
         }
 
         // A custom or negotiated plan changes through sales, even where its own definition would permit
-        // the move — legacy Growth's `prevPlan` still lists Free. A transitioning account's plan is
-        // missing from the grid on purpose, so it keeps its own moves.
+        // the move — legacy Growth's `prevPlan` still lists Free.
+        // We hide a migrating account's own card, so `activeIsOffered` is false. It can still downgrade.
         const selfServeChange = (activeIsOffered || !!transition) && activePlan?.canChange !== false;
 
         if (!closed && isUpgrade && plan.canChange && selfServeChange) {

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -32,10 +32,12 @@ import { formatBillingDate, nextUsageResetDate } from '../billingPeriod.js';
 import { growthAddonState, isRetiredPlan } from '../planVisibility.js';
 import { pendingPlanChange } from '../summaryState.js';
 import { PlanChangeErrorAlert, usePlanChangeRequest } from '../usePlanChangeRequest.js';
+import { usePlanTransition } from '../usePlanTransition.js';
 import { GrowthAddon } from './GrowthAddon.js';
 import { PaymentMethodDialog } from './PaymentMethodDialog.js';
 import { ENTERPRISE_PLAN_DESCRIPTION, GROWTH_ADDON_COPY, GROWTH_ADDON_PRICE, PLAN_CARD_LIMITS, S26_PLAN_CARDS } from './planCardCopy.js';
 
+import type { PlanTransition } from '../planTransition.js';
 import type { GrowthAddonState } from '../planVisibility.js';
 import type { PlanDefinitionList } from '../types.js';
 import type { S26PlanCard } from './planCardCopy.js';
@@ -53,7 +55,8 @@ export const Plans: React.FC = () => {
         return paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
     }, [paymentMethods]);
 
-    const showsNewPlans = isOnS26Pricing(currentPlan);
+    const transition = usePlanTransition();
+    const showsNewPlans = isOnS26Pricing(currentPlan) || transition !== null;
 
     const plans = useMemo<null | { list: PlanDefinitionList[]; activePlan: PlanDefinition }>(() => {
         if (!currentPlan || !plansList) {
@@ -61,6 +64,10 @@ export const Plans: React.FC = () => {
         }
 
         const curr = plansList.data.find((p) => p.code === currentPlan.name)!;
+
+        // Taken from the pending change rather than the raw column, so a past-dated or same-plan
+        // mirror can't disable a card the strip and banner both treat as nothing.
+        const scheduledCode = pendingPlanChange({ plan: currentPlan, plans: plansList.data, now: new Date() })?.toCode;
 
         // Picked by code rather than by `hidden`: `pay-as-you-go` is hidden in `plansList`, yet is one
         // of the three cards.
@@ -71,7 +78,7 @@ export const Plans: React.FC = () => {
         const list: PlanDefinitionList[] = offered.map((plan) => ({
             plan,
             active: plan.code === currentPlan.name,
-            isFuture: plan.code === currentPlan.orb_future_plan,
+            isFuture: plan.code === scheduledCode,
             isDowngrade: curr.prevPlan?.includes(plan.code) || false,
             isUpgrade: curr.nextPlan?.includes(plan.code) || false
         }));
@@ -99,6 +106,7 @@ export const Plans: React.FC = () => {
                         addonState={addonState}
                         endsAt={currentPlan?.growth_features_ends_at ?? undefined}
                         pendingChangeAt={pendingChange?.at}
+                        transition={transition}
                         closed={!showsNewPlans && isRetiredPlan(plan.plan.code)}
                         paymentMethod={paymentMethod}
                     />
@@ -129,10 +137,11 @@ const PlanCard: React.FC<{
     addonState: GrowthAddonState;
     endsAt?: string;
     pendingChangeAt?: string;
+    transition?: PlanTransition | null;
     /** Whether this plan is no longer something the account can move to. */
     closed?: boolean;
     paymentMethod?: StripePaymentMethod | null;
-}> = ({ planDefinition, activePlan, activeIsOffered, card, addonState, endsAt, pendingChangeAt, closed, paymentMethod }) => {
+}> = ({ planDefinition, activePlan, activeIsOffered, card, addonState, endsAt, pendingChangeAt, transition, closed, paymentMethod }) => {
     const { plan, active, isFuture, isDowngrade, isUpgrade } = planDefinition;
     const [addonAction, setAddonAction] = useState<'add' | 'remove' | null>(null);
 
@@ -152,18 +161,20 @@ const PlanCard: React.FC<{
     }, [paymentMethod]);
 
     const CTA = card ? PlanFooterButton : PlanFooterCTA;
+    const isUpcoming = isFuture && !!transition;
 
     const ButtonComponent = (() => {
         if (active) {
             return <CTA label={card ? 'Your plan' : 'Current plan'} disabled />;
         }
         if (isFuture) {
-            return <CTA label="Scheduled" disabled />;
+            return <CTA label={isUpcoming ? 'Your upcoming plan' : 'Scheduled'} disabled />;
         }
 
         // A custom or negotiated plan changes through sales, even where its own definition would permit
-        // the move — legacy Growth's `prevPlan` still lists Free.
-        const selfServeChange = activeIsOffered && activePlan?.canChange !== false;
+        // the move — legacy Growth's `prevPlan` still lists Free. A transitioning account is the one
+        // case where the active plan is absent from the grid by design, so its own moves still stand.
+        const selfServeChange = (activeIsOffered || !!transition) && activePlan?.canChange !== false;
 
         if (!closed && isUpgrade && plan.canChange && selfServeChange) {
             return (
@@ -208,11 +219,12 @@ const PlanCard: React.FC<{
     })();
 
     if (card) {
-        const showsAddon = active && plan.code === 'pay-as-you-go';
+        const carriesAddon = isUpcoming && transition.keepsGrowthAddOn;
+        const showsAddon = carriesAddon || (active && plan.code === 'pay-as-you-go');
         const features = showsAddon || !card.addonTeaser ? card.features : [...card.features, card.addonTeaser];
 
         return (
-            <Card selected={active}>
+            <Card selected={active || isUpcoming}>
                 <div className="flex flex-col gap-4 p-4 flex-1">
                     <div className="flex flex-col gap-1">
                         <span className="text-text-strong text-body-medium-semi">{plan.title}</span>
@@ -238,7 +250,7 @@ const PlanCard: React.FC<{
                     {showsAddon && (
                         <>
                             <GrowthAddon
-                                state={addonState}
+                                state={carriesAddon ? 'pending-activation' : addonState}
                                 endsAt={endsAt}
                                 onAdd={() => setAddonAction('add')}
                                 onRemove={() => setAddonAction('remove')}

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -94,7 +94,7 @@ export const Plans: React.FC = () => {
 
     return (
         <div className="flex flex-col gap-4">
-            {plans && !activeIsOffered && <CurrentPlanCard plan={plans.activePlan} />}
+            {plans && !activeIsOffered && !transition && <CurrentPlanCard plan={plans.activePlan} />}
             <div className={cn('grid gap-4', showsNewPlans ? 'grid-cols-3' : 'grid-cols-4')}>
                 {plans?.list.map((plan) => (
                     <PlanCard
@@ -264,7 +264,17 @@ const PlanCard: React.FC<{
                         </>
                     )}
                 </div>
-                <div className="w-full px-4 py-6">{ButtonComponent}</div>
+                <div className="w-full px-4 py-6 flex flex-col gap-3">
+                    {isUpcoming && (
+                        <div className="flex items-center gap-1 text-body-small-regular">
+                            <span className="text-text-secondary">Question about your plan?</span>
+                            <button type="button" onClick={openSupportChat} className="text-text-default cursor-pointer hover:underline">
+                                Contact us
+                            </button>
+                        </div>
+                    )}
+                    {ButtonComponent}
+                </div>
             </Card>
         );
     }

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -65,8 +65,8 @@ export const Plans: React.FC = () => {
 
         const curr = plansList.data.find((p) => p.code === currentPlan.name)!;
 
-        // Taken from the pending change rather than the raw column, so a past-dated or same-plan
-        // mirror can't disable a card the strip and banner both treat as nothing.
+        // `orb_future_plan` keeps stale rows. Read the pending change instead, so a card can't be
+        // disabled by a change that already passed.
         const scheduledCode = pendingPlanChange({ plan: currentPlan, plans: plansList.data, now: new Date() })?.toCode;
 
         // Picked by code rather than by `hidden`: `pay-as-you-go` is hidden in `plansList`, yet is one
@@ -172,8 +172,8 @@ const PlanCard: React.FC<{
         }
 
         // A custom or negotiated plan changes through sales, even where its own definition would permit
-        // the move — legacy Growth's `prevPlan` still lists Free. A transitioning account is the one
-        // case where the active plan is absent from the grid by design, so its own moves still stand.
+        // the move — legacy Growth's `prevPlan` still lists Free. A transitioning account's plan is
+        // missing from the grid on purpose, so it keeps its own moves.
         const selfServeChange = (activeIsOffered || !!transition) && activePlan?.canChange !== false;
 
         if (!closed && isUpgrade && plan.canChange && selfServeChange) {

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -11,6 +11,7 @@ import { useStore } from '@/store';
 import { isOnS26Pricing } from '@/utils/usage';
 import { hasMonthlySpend, showsSummaryStrip } from '../planVisibility';
 import { buildSummaryState } from '../summaryState';
+import { usePlanTransition } from '../usePlanTransition';
 import { PaymentMethodDialog } from './PaymentMethodDialog';
 import { SummaryStrip } from './SummaryStrip';
 
@@ -27,6 +28,7 @@ export const Summary: React.FC = () => {
     const { data: plansList, isPending: arePlansPending } = useApiGetPlans(env);
     const { data: paymentMethods } = useStripePaymentMethods(env);
     const onS26Pricing = isOnS26Pricing(plan);
+    const transition = usePlanTransition();
     const paymentMethod = paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
 
     // Behind a dev-tool flag until the figure is reconciled against real Orb invoices (NAN-6246).
@@ -53,8 +55,8 @@ export const Summary: React.FC = () => {
         if (!plan || arePlansPending || isSpendResolving) {
             return null;
         }
-        return buildSummaryState({ plan, plans: plansList?.data, paymentMethod, canManageBilling, spend, onS26Pricing, now: new Date() });
-    }, [plan, plansList, arePlansPending, isSpendResolving, paymentMethod, canManageBilling, spend, onS26Pricing]);
+        return buildSummaryState({ plan, plans: plansList?.data, paymentMethod, canManageBilling, spend, onS26Pricing, transition, now: new Date() });
+    }, [plan, plansList, arePlansPending, isSpendResolving, paymentMethod, canManageBilling, spend, onS26Pricing, transition]);
 
     // Legacy, enterprise and free-uncapped accounts get no strip at all — their terms are negotiated
     // per customer or nothing is billable, so every field would be empty or untrue.

--- a/packages/webapp/src/pages/Team/Billing/planTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.ts
@@ -23,7 +23,7 @@ export function planTransition({
     plans: PlanDefinition[] | undefined;
     now: Date;
 }): PlanTransition | null {
-    if (!plan || !migratesToPayAsYouGo(plan)) {
+    if (!plan || !migratesToPayAsYouGo(plan.name)) {
         return null;
     }
 

--- a/packages/webapp/src/pages/Team/Billing/planTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.ts
@@ -10,11 +10,10 @@ export interface PlanTransition {
     toPlanTitle: string;
     fromCode: DBPlan['name'];
     fromTitle: string;
-    /** Pay-as-you-go's flags match Starter's, so only Growth needs the add-on to keep what it has. */
     keepsGrowthAddOn: boolean;
 }
 
-/** Reads the schedule Orb mirrors into the plan, so an account nobody scheduled shows nothing at all. */
+/** Only a change Orb has scheduled counts. An account we never scheduled sees no transition. */
 export function planTransition({
     plan,
     plans,

--- a/packages/webapp/src/pages/Team/Billing/planTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.ts
@@ -1,0 +1,41 @@
+import { migratesToPayAsYouGo } from './planVisibility';
+import { pendingPlanChange } from './summaryState';
+
+import type { ApiPlan, DBPlan, PlanDefinition } from '@nangohq/types';
+
+const TARGET_CODE = 'pay-as-you-go';
+
+export interface PlanTransition {
+    at: string;
+    toPlanTitle: string;
+    fromCode: DBPlan['name'];
+    /** Pay-as-you-go's flags match Starter's, so only Growth needs the add-on to keep what it has. */
+    keepsGrowthAddOn: boolean;
+}
+
+/** Reads the schedule Orb mirrors into the plan, so an account nobody scheduled shows nothing at all. */
+export function planTransition({
+    plan,
+    plans,
+    now
+}: {
+    plan: ApiPlan | null | undefined;
+    plans: PlanDefinition[] | undefined;
+    now: Date;
+}): PlanTransition | null {
+    if (!plan || !migratesToPayAsYouGo(plan)) {
+        return null;
+    }
+
+    const change = pendingPlanChange({ plan, plans, now });
+    if (!change || change.toCode !== TARGET_CODE) {
+        return null;
+    }
+
+    return {
+        at: change.at,
+        toPlanTitle: change.toPlanTitle,
+        fromCode: plan.name,
+        keepsGrowthAddOn: plan.name === 'growth-v2'
+    };
+}

--- a/packages/webapp/src/pages/Team/Billing/planTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.ts
@@ -13,7 +13,6 @@ export interface PlanTransition {
     keepsGrowthAddOn: boolean;
 }
 
-/** Only a change Orb has scheduled counts. An account we never scheduled sees no transition. */
 export function planTransition({
     plan,
     plans,

--- a/packages/webapp/src/pages/Team/Billing/planTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.ts
@@ -9,6 +9,7 @@ export interface PlanTransition {
     at: string;
     toPlanTitle: string;
     fromCode: DBPlan['name'];
+    fromTitle: string;
     /** Pay-as-you-go's flags match Starter's, so only Growth needs the add-on to keep what it has. */
     keepsGrowthAddOn: boolean;
 }
@@ -36,6 +37,7 @@ export function planTransition({
         at: change.at,
         toPlanTitle: change.toPlanTitle,
         fromCode: plan.name,
+        fromTitle: plans?.find((p) => p.code === plan.name)?.title ?? plan.name,
         keepsGrowthAddOn: plan.name === 'growth-v2'
     };
 }

--- a/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
@@ -34,6 +34,7 @@ describe('planTransition', () => {
                 at: 'October 1, 2026',
                 toPlanTitle: 'Pay-as-you-go',
                 fromCode: name,
+                fromTitle: name === 'growth-v2' ? 'Growth' : 'Starter',
                 keepsGrowthAddOn: name === 'growth-v2'
             });
         }

--- a/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { planTransition } from './planTransition.js';
+
+import type { ApiPlan, PlanDefinition } from '@nangohq/types';
+
+const NOW = new Date('2026-09-03T10:00:00Z');
+const IN_SCOPE = ['starter-v2', 'growth-v2'] as const;
+
+const plans = [
+    { code: 'free', title: 'Free' },
+    { code: 'pay-as-you-go', title: 'Pay-as-you-go' },
+    { code: 'starter-v2', title: 'Starter' },
+    { code: 'growth-v2', title: 'Growth' },
+    { code: 'startup-deal', title: 'Startup deal' }
+] as PlanDefinition[];
+
+function planOf(name: ApiPlan['name'], overrides: Partial<ApiPlan> = {}): ApiPlan {
+    return { name, orb_future_plan: null, orb_future_plan_at: null, ...overrides } as ApiPlan;
+}
+
+function scheduled(name: ApiPlan['name'], target = 'pay-as-you-go', at = '2026-10-01T00:00:00Z'): ApiPlan {
+    return planOf(name, { orb_future_plan: target, orb_future_plan_at: at });
+}
+
+function transitionOf(plan: ApiPlan) {
+    return planTransition({ plan, plans, now: NOW });
+}
+
+describe('planTransition', () => {
+    it('announces the migration for both retired v2 plans', () => {
+        for (const name of IN_SCOPE) {
+            expect(transitionOf(scheduled(name))).toEqual({
+                at: 'October 1, 2026',
+                toPlanTitle: 'Pay-as-you-go',
+                fromCode: name,
+                keepsGrowthAddOn: name === 'growth-v2'
+            });
+        }
+    });
+
+    it('carries the add-on across for Growth only, since Pay-as-you-go matches Starter otherwise', () => {
+        expect(transitionOf(scheduled('growth-v2'))?.keepsGrowthAddOn).toBe(true);
+        expect(transitionOf(scheduled('starter-v2'))?.keepsGrowthAddOn).toBe(false);
+    });
+
+    it('stays silent for an account with nothing scheduled', () => {
+        for (const name of IN_SCOPE) {
+            expect(transitionOf(planOf(name))).toBeNull();
+        }
+    });
+
+    it('stays silent for plans out of scope, whatever is scheduled', () => {
+        for (const name of ['free', 'startup-deal', 'growth', 'starter', 'growth-legacy', 'enterprise'] as const) {
+            expect(transitionOf(scheduled(name))).toBeNull();
+        }
+    });
+
+    it('ignores a change that lands somewhere other than Pay-as-you-go', () => {
+        expect(transitionOf(scheduled('growth-v2', 'free'))).toBeNull();
+        expect(transitionOf(scheduled('growth-v2', 'growth-v2'))).toBeNull();
+    });
+
+    it('ignores a past-dated mirror, which nothing clears once the date passes', () => {
+        expect(transitionOf(scheduled('growth-v2', 'pay-as-you-go', '2026-08-01T00:00:00Z'))).toBeNull();
+    });
+
+    it('ignores an unparseable date rather than rendering one', () => {
+        expect(transitionOf(scheduled('growth-v2', 'pay-as-you-go', 'not-a-date'))).toBeNull();
+    });
+
+    it('waits for the plans list, so the banner never names a raw plan code', () => {
+        expect(planTransition({ plan: scheduled('growth-v2'), plans: undefined, now: NOW })).toBeNull();
+    });
+
+    it('stays silent while the plan is still loading', () => {
+        expect(planTransition({ plan: null, plans, now: NOW })).toBeNull();
+    });
+});

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -116,27 +116,13 @@ const PLAN_IS_RETIRED: Record<DBPlan['name'], boolean> = {
     'enterprise-cloud-hosted': false
 };
 
-// Narrower than `PLAN_IS_RETIRED`: the pre-v2 codes get no summary strip or monthly spend, so the
-// transition surfaces have nowhere to land, and `startup-deal` schedules its own move to Growth.
-const MIGRATES_TO_PAY_AS_YOU_GO: Record<DBPlan['name'], boolean> = {
-    'starter-v2': true,
-    'growth-v2': true,
-    free: false,
-    'free-uncapped': false,
-    'pay-as-you-go': false,
-    'startup-deal': false,
-    enterprise: false,
-    'enterprise-cloud-hosted': false,
-    starter: false,
-    growth: false,
-    'starter-legacy': false,
-    'scale-legacy': false,
-    'growth-legacy': false
-};
+// Narrower than `PLAN_IS_RETIRED`. The pre-v2 plans get no summary strip, so the transition has
+// nowhere to show, and `startup-deal` converts to Growth instead.
+const MIGRATES_TO_PAY_AS_YOU_GO: readonly DBPlan['name'][] = ['starter-v2', 'growth-v2'];
 
-/** In scope for the migration by plan alone — says nothing about whether Orb has scheduled it. */
+/** True for plans in scope. Says nothing about whether Orb scheduled the change. */
 export function migratesToPayAsYouGo(code: DBPlan['name']): boolean {
-    return MIGRATES_TO_PAY_AS_YOU_GO[code];
+    return MIGRATES_TO_PAY_AS_YOU_GO.includes(code);
 }
 
 export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {
@@ -179,7 +165,7 @@ export function isRetiredPlan(code: DBPlan['name']): boolean {
     return PLAN_IS_RETIRED[code];
 }
 
-/** `pending-activation` is never derived from a plan — only a scheduled migration carries it. */
+/** Only a scheduled migration sets `pending-activation`. `growthAddonState` never returns it. */
 export type GrowthAddonState = 'none' | 'active' | 'pending-removal' | 'pending-activation';
 
 /** A scheduled removal still reads as `has_growth_features` until its date, so the date separates the two. */

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -135,11 +135,8 @@ const MIGRATES_TO_PAY_AS_YOU_GO: Record<DBPlan['name'], boolean> = {
 };
 
 /** In scope for the migration by plan alone — says nothing about whether Orb has scheduled it. */
-export function migratesToPayAsYouGo(plan: ApiPlan | null | undefined): boolean {
-    if (!plan) {
-        return false;
-    }
-    return MIGRATES_TO_PAY_AS_YOU_GO[plan.name];
+export function migratesToPayAsYouGo(code: DBPlan['name']): boolean {
+    return MIGRATES_TO_PAY_AS_YOU_GO[code];
 }
 
 export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -116,11 +116,8 @@ const PLAN_IS_RETIRED: Record<DBPlan['name'], boolean> = {
     'enterprise-cloud-hosted': false
 };
 
-// Narrower than `PLAN_IS_RETIRED`. The pre-v2 plans get no summary strip, so the transition has
-// nowhere to show, and `startup-deal` converts to Growth instead.
 const MIGRATES_TO_PAY_AS_YOU_GO: readonly DBPlan['name'][] = ['starter-v2', 'growth-v2'];
 
-/** True for plans in scope. Says nothing about whether Orb scheduled the change. */
 export function migratesToPayAsYouGo(code: DBPlan['name']): boolean {
     return MIGRATES_TO_PAY_AS_YOU_GO.includes(code);
 }

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -116,6 +116,32 @@ const PLAN_IS_RETIRED: Record<DBPlan['name'], boolean> = {
     'enterprise-cloud-hosted': false
 };
 
+// Narrower than `PLAN_IS_RETIRED`: the pre-v2 codes get no summary strip or monthly spend, so the
+// transition surfaces have nowhere to land, and `startup-deal` schedules its own move to Growth.
+const MIGRATES_TO_PAY_AS_YOU_GO: Record<DBPlan['name'], boolean> = {
+    'starter-v2': true,
+    'growth-v2': true,
+    free: false,
+    'free-uncapped': false,
+    'pay-as-you-go': false,
+    'startup-deal': false,
+    enterprise: false,
+    'enterprise-cloud-hosted': false,
+    starter: false,
+    growth: false,
+    'starter-legacy': false,
+    'scale-legacy': false,
+    'growth-legacy': false
+};
+
+/** In scope for the migration by plan alone — says nothing about whether Orb has scheduled it. */
+export function migratesToPayAsYouGo(plan: ApiPlan | null | undefined): boolean {
+    if (!plan) {
+        return false;
+    }
+    return MIGRATES_TO_PAY_AS_YOU_GO[plan.name];
+}
+
 export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {
     if (!plan) {
         return false;
@@ -156,7 +182,8 @@ export function isRetiredPlan(code: DBPlan['name']): boolean {
     return PLAN_IS_RETIRED[code];
 }
 
-export type GrowthAddonState = 'none' | 'active' | 'pending-removal';
+/** `pending-activation` is never derived from a plan — only a scheduled migration carries it. */
+export type GrowthAddonState = 'none' | 'active' | 'pending-removal' | 'pending-activation';
 
 /** A scheduled removal still reads as `has_growth_features` until its date, so the date separates the two. */
 export function growthAddonState(plan: ApiPlan | null | undefined): GrowthAddonState {

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -2,6 +2,7 @@ import { formatBillingDate, nextUsageResetDate } from './billingPeriod';
 import { formatMoneyFromCents } from './money';
 import { hasMonthlySpend, planAccruesCharges } from './planVisibility';
 
+import type { PlanTransition } from './planTransition';
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
 const SPEND_CAVEATS = 'Any account credit is applied when the invoice is issued. Usage syncs daily, so this can be up to 24 hours behind.';
@@ -140,6 +141,7 @@ export function buildSummaryState({
     canManageBilling,
     spend,
     onS26Pricing,
+    transition,
     now
 }: {
     plan: ApiPlan;
@@ -148,6 +150,7 @@ export function buildSummaryState({
     canManageBilling: boolean;
     spend?: SummarySpend | null;
     onS26Pricing: boolean;
+    transition?: PlanTransition | null;
     now: Date;
 }): SummaryStripState {
     const planTitle = planTitleOf(plan.name, plans);
@@ -156,7 +159,7 @@ export function buildSummaryState({
 
     let date: SummaryStripState['date'] = null;
     if (change) {
-        date = { label: 'CHANGES ON', value: change.at };
+        date = { label: transition ? 'TRANSITIONS ON' : 'CHANGES ON', value: change.at };
     } else if (isFree) {
         date = { label: 'LIMITS RESET', value: formatBillingDate(nextUsageResetDate(now)) };
     } else if (plan.name !== 'startup-deal') {
@@ -172,6 +175,7 @@ export function buildSummaryState({
         // no card — the slot is dropped rather than dashed, and the billing section below is where
         // a card gets added.
         payment: isFree || !canManageBilling || !paymentMethod ? null : { card: paymentMethod },
-        change
+        // The banner above the strip already states this change in full.
+        change: transition ? null : change
     };
 }

--- a/packages/webapp/src/pages/Team/Billing/summaryState.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.ts
@@ -175,7 +175,6 @@ export function buildSummaryState({
         // no card — the slot is dropped rather than dashed, and the billing section below is where
         // a card gets added.
         payment: isFree || !canManageBilling || !paymentMethod ? null : { card: paymentMethod },
-        // The banner above the strip already states this change in full.
         change: transition ? null : change
     };
 }

--- a/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/summaryState.unit.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { hasMonthlySpend, isBilledPlan, isLegacyPlan, planAccruesCharges, showsSummaryStrip } from './planVisibility.js';
 import { buildSummaryState, pendingPlanChange, SPEND_TOOLTIP, SPEND_TOOLTIP_S26, SPEND_TOOLTIP_WITHOUT_CHARGES } from './summaryState.js';
 
+import type { PlanTransition } from './planTransition.js';
 import type { SummarySpend } from './summaryState.js';
 import type { ApiPlan, PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
@@ -23,7 +24,13 @@ function planOf(name: ApiPlan['name'], overrides: Partial<ApiPlan> = {}): ApiPla
 }
 function build(
     plan: ApiPlan,
-    opts: { paymentMethod?: StripePaymentMethod | null; canManageBilling?: boolean; spend?: SummarySpend | null; onS26Pricing?: boolean } = {}
+    opts: {
+        paymentMethod?: StripePaymentMethod | null;
+        canManageBilling?: boolean;
+        spend?: SummarySpend | null;
+        onS26Pricing?: boolean;
+        transition?: PlanTransition | null;
+    } = {}
 ) {
     return buildSummaryState({
         plan,
@@ -32,6 +39,7 @@ function build(
         canManageBilling: opts.canManageBilling ?? true,
         spend: opts.spend ?? null,
         onS26Pricing: opts.onS26Pricing ?? false,
+        transition: opts.transition ?? null,
         now: NOW
     });
 }
@@ -328,5 +336,30 @@ describe('pendingPlanChange guards', () => {
         const change = pendingPlanChange({ plan, plans: undefined, now: NOW });
         expect(change?.toCode).toBe('free');
         expect(change?.detail).toBe('no further charges after this period.');
+    });
+});
+
+describe('buildSummaryState with a scheduled migration', () => {
+    const migrating = planOf('growth-v2', { orb_future_plan: 'pay-as-you-go', orb_future_plan_at: '2026-10-01T00:00:00Z' });
+    const transition: PlanTransition = {
+        at: 'October 1, 2026',
+        toPlanTitle: 'Pay as you go',
+        fromCode: 'growth-v2',
+        fromTitle: 'Growth',
+        keepsGrowthAddOn: true
+    };
+
+    it('renames the date slot', () => {
+        expect(build(migrating, { transition }).date).toEqual({ label: 'TRANSITIONS ON', value: 'October 1, 2026' });
+    });
+
+    it('drops the footer, which the banner states in full', () => {
+        expect(build(migrating, { transition }).change).toBeNull();
+    });
+
+    it('keeps both for a scheduled change that is not a migration', () => {
+        const state = build(migrating);
+        expect(state.date).toEqual({ label: 'CHANGES ON', value: 'October 1, 2026' });
+        expect(state.change?.toPlanTitle).toBe('Pay as you go');
     });
 });

--- a/packages/webapp/src/pages/Team/Billing/usePlanTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/usePlanTransition.ts
@@ -10,7 +10,7 @@ export function usePlanTransition(): PlanTransition | null {
     const env = useStore((state) => state.env);
     const { data: environmentData, isError: didPlanFail } = useCurrentPlan(env);
     const { data: plansList } = useApiGetPlans(env);
-    // Announcing a migration off a stale plan would promise a change the account may not have.
+    // A stale cached plan could announce a migration that is no longer scheduled.
     const plan = didPlanFail ? null : environmentData?.plan;
 
     return useMemo(() => planTransition({ plan, plans: plansList?.data, now: new Date() }), [plan, plansList]);

--- a/packages/webapp/src/pages/Team/Billing/usePlanTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/usePlanTransition.ts
@@ -10,8 +10,7 @@ export function usePlanTransition(): PlanTransition | null {
     const env = useStore((state) => state.env);
     const { data: environmentData, isError: didPlanFail } = useCurrentPlan(env);
     const { data: plansList } = useApiGetPlans(env);
-    // A failed refetch keeps the previous plan cached, so announcing a migration off it could promise
-    // a change the account no longer has scheduled.
+    // Announcing a migration off a stale plan would promise a change the account may not have.
     const plan = didPlanFail ? null : environmentData?.plan;
 
     return useMemo(() => planTransition({ plan, plans: plansList?.data, now: new Date() }), [plan, plansList]);

--- a/packages/webapp/src/pages/Team/Billing/usePlanTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/usePlanTransition.ts
@@ -8,9 +8,11 @@ import type { PlanTransition } from './planTransition';
 
 export function usePlanTransition(): PlanTransition | null {
     const env = useStore((state) => state.env);
-    const { data: environmentData } = useCurrentPlan(env);
+    const { data: environmentData, isError: didPlanFail } = useCurrentPlan(env);
     const { data: plansList } = useApiGetPlans(env);
-    const plan = environmentData?.plan;
+    // A failed refetch keeps the previous plan cached, so announcing a migration off it could promise
+    // a change the account no longer has scheduled.
+    const plan = didPlanFail ? null : environmentData?.plan;
 
     return useMemo(() => planTransition({ plan, plans: plansList?.data, now: new Date() }), [plan, plansList]);
 }

--- a/packages/webapp/src/pages/Team/Billing/usePlanTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/usePlanTransition.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+
+import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
+import { useStore } from '@/store';
+import { planTransition } from './planTransition';
+
+import type { PlanTransition } from './planTransition';
+
+export function usePlanTransition(): PlanTransition | null {
+    const env = useStore((state) => state.env);
+    const { data: environmentData } = useCurrentPlan(env);
+    const { data: plansList } = useApiGetPlans(env);
+    const plan = environmentData?.plan;
+
+    return useMemo(() => planTransition({ plan, plans: plansList?.data, now: new Date() }), [plan, plansList]);
+}

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -1,3 +1,4 @@
+import type { GrowthAddonState } from '@/pages/Team/Billing/planVisibility';
 import type { AnyBreakdownDimension } from '@/pages/Team/Billing/usageBreakdown';
 import type { PostOnboardingHearAboutUs, UsageMetric } from '@nangohq/types';
 
@@ -27,7 +28,7 @@ export interface AnalyticsEvents {
     'web:usage:invoice_details_clicked': Record<string, never>;
     'web:usage:billing_portal_clicked': Record<string, never>;
     'web:usage:upgrade_clicked': Record<string, never>;
-    'web:usage:addon_action_clicked': { state: 'none' | 'active' | 'pending-removal' };
+    'web:usage:addon_action_clicked': { state: GrowthAddonState };
     'web:usage:edit_payment_method_clicked': { source: 'billing_page' };
     'web:usage:overdue_alert_clicked': Record<string, never>;
 


### PR DESCRIPTION
## Problem

Accounts on `starter-v2` and `growth-v2` are moving to Pay-as-you-go. [NAN-6741](https://linear.app/nango/issue/NAN-6741) stopped offering them plans they can no longer buy. But nothing told them the migration was coming, or when.

## Solution

- Three places now say it: a banner at the top of the page, `TRANSITIONS ON` in the summary strip, and a line above the plan cards naming the plan being left.
- One predicate, `planTransition`, drives all of them. It reads the schedule Orb writes to `orb_future_plan`. An account nobody scheduled sees nothing, so grandfathering needs no flag or column.
- The three new cards replace the retired set. Pay-as-you-go is frozen at `Your upcoming plan`.
- Free keeps its self-serve `Downgrade`. Without that, scheduling a migration would have made it `Contact us`.
- Growth keeps its add-on, as a green `Included` badge. It's frozen too.

Fixes [NAN-6822](https://linear.app/nango/issue/NAN-6822)

## Testing

49 unit tests. The override panel now offers `Pay-as-you-go (migration)`, dated on the period boundary, so the state is reachable without editing local storage.

Checked four cases: growth-v2 scheduled, starter-v2 scheduled (no add-on card), growth-v2 unscheduled, and startup-deal moving to Growth. The last two are unchanged.

<img width="1278" height="153" alt="image" src="https://github.com/user-attachments/assets/7e0d64c7-721c-4b86-a7eb-a63086bb53aa" />

<img width="1267" height="580" alt="image" src="https://github.com/user-attachments/assets/291ce9f3-9bdc-45af-a640-feb8e65c40e8" />

## Follow-ups

- The new usage metrics with charges, and the legacy-metrics toggle. Both need a projected-charge source ([NAN-6744](https://linear.app/nango/issue/NAN-6744)).
- Orb has no "plan change un-scheduled" event. Un-schedule an account and the banner stays up until its date passes ([NAN-6693](https://linear.app/nango/issue/NAN-6693)).
