### PR TITLE
chore(billing): remove the s26-pricing flag

### DIFF
--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -66,10 +66,6 @@ export function buildFlags(client: FeatureFlagsClient) {
             // targetingKey drives gradual-rollout stickiness; accountUuid lets strategies allow/exclude specific accounts.
             return client.isEnabled('audit-trail', { targetingKey: accountUuid, accountUuid }, false);
         },
-        /** Whether the account is measured against the new pricing's three metrics rather than today's seven. */
-        isS26PricingEnabled(accountUuid: string) {
-            return client.isEnabled('s26-pricing', { targetingKey: accountUuid, accountUuid }, false);
-        },
         /** Whether the Gmail webhook can be unverified. */
         allowUnauthorizedGmailWebhook(accountUuid: string) {
             return client.isEnabled('allow-unauthorized-gmail-webhook', { targetingKey: accountUuid, accountUuid }, false);

--- a/packages/server/lib/controllers/v1/meta/getMeta.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.ts
@@ -1,4 +1,3 @@
-import { getFlags } from '@nangohq/feature-flags';
 import { environmentService } from '@nangohq/shared';
 import { baseUrl, NANGO_VERSION, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -26,8 +25,7 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
             baseUrl,
             debugMode: req.session.debugMode === true,
             gettingStartedClosed: sessionUser.getting_started_closed,
-            auditTrail: await canViewAuditTrail(req, account.uuid, plan),
-            s26Pricing: await getFlags().isS26PricingEnabled(account.uuid)
+            auditTrail: await canViewAuditTrail(req, account.uuid, plan)
         }
     });
 });

--- a/packages/types/lib/meta/api.ts
+++ b/packages/types/lib/meta/api.ts
@@ -18,7 +18,6 @@ export type GetMeta = ApiEndpoint<{
             gettingStartedClosed: boolean;
             // Whether the audit trail is enabled for this account (per-account rollout flag); gates the dashboard UI.
             auditTrail: boolean;
-            s26Pricing: boolean;
         };
     };
 }>;

--- a/packages/webapp/src/layout/AppSidebar/UsageLimitAlert.tsx
+++ b/packages/webapp/src/layout/AppSidebar/UsageLimitAlert.tsx
@@ -4,7 +4,6 @@ import { Alert, AlertActions, AlertDescription, AlertTitle } from '@nangohq/desi
 
 import { AlertButtonLink } from '@/components/ui/AlertButtonLink';
 import { usePlanOverrideStore } from '@/features/planOverride';
-import { useMeta } from '@/hooks/useMeta';
 import { useStore } from '@/store';
 import { useApiGetUsage, useCurrentPlan } from '../../hooks/usePlan.js';
 import { billedUsageMetrics, getAggregateUsageState } from '../../utils/usage.js';
@@ -29,10 +28,9 @@ export default function UsageLimitAlert() {
     const env = useStore((state) => state.env);
     const { data: usage } = useApiGetUsage(env);
     const { data: environmentData } = useCurrentPlan(env);
-    const { data: metaData } = useMeta();
     const usageLimitOverride = usePlanOverrideStore((s) => s.usageLimitOverride);
 
-    const metrics = billedUsageMetrics(environmentData?.plan, metaData?.data.s26Pricing === true);
+    const metrics = billedUsageMetrics(environmentData?.plan);
     // Dev-tool override (planOverride.ts) — real usage rarely sits near a cap on demand.
     const state = usageLimitOverride ?? getAggregateUsageState(usage?.data ?? {}, metrics);
     if (state !== 'near' && state !== 'over') {

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -9,7 +9,6 @@ import { AlertButtonLink } from '@/components/ui/AlertButtonLink';
 import { Separator } from '@/components/ui/Separator';
 import { OverdueInvoiceAlert } from '@/features/Billing/OverdueInvoiceAlert';
 import { usePlanOverrideStore } from '@/features/planOverride';
-import { useMeta } from '@/hooks/useMeta';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useApiGetBillingUsage, useApiGetOverdueInvoices, useApiGetPlans, useApiGetUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
@@ -48,8 +47,7 @@ export const TeamBilling: React.FC = () => {
     // The cap warning belongs with the plan, not the usage table, so it sits above the divider.
     // Free is the only capped plan, and the sidebar alert already runs this query app-wide.
     const { data: caps } = useApiGetUsage(env);
-    const { data: metaData } = useMeta();
-    const billedMetrics = billedUsageMetrics(environmentData?.plan, metaData?.data.s26Pricing === true);
+    const billedMetrics = billedUsageMetrics(environmentData?.plan);
 
     // The dev override fabricates the overdue response, so it has to be handed a real portal URL for
     // the previewed "View invoices" link to open anything. Fetched only while the override is on, and

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -20,7 +20,6 @@ import {
 import { PERMISSION_DENIED_REASON, PermissionGate } from '@/components/patterns/PermissionGate.js';
 import { Checkbox } from '@/components/ui/Checkbox';
 import { Separator } from '@/components/ui/Separator';
-import { useMeta } from '@/hooks/useMeta';
 import { usePermissions } from '@/hooks/usePermissions.js';
 import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
 import { useStripePaymentMethods } from '@/hooks/useStripe.js';
@@ -54,9 +53,7 @@ export const Plans: React.FC = () => {
         return paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
     }, [paymentMethods]);
 
-    const { data: metaData } = useMeta();
-    const s26Pricing = metaData?.data.s26Pricing === true;
-    const showsNewPlans = isOnS26Pricing(currentPlan, s26Pricing);
+    const showsNewPlans = isOnS26Pricing(currentPlan);
 
     const plans = useMemo<null | { list: PlanDefinitionList[]; activePlan: PlanDefinition }>(() => {
         if (!currentPlan || !plansList) {
@@ -102,7 +99,7 @@ export const Plans: React.FC = () => {
                         addonState={addonState}
                         endsAt={currentPlan?.growth_features_ends_at ?? undefined}
                         pendingChangeAt={pendingChange?.at}
-                        closed={s26Pricing && !showsNewPlans && isRetiredPlan(plan.plan.code)}
+                        closed={!showsNewPlans && isRetiredPlan(plan.plan.code)}
                         paymentMethod={paymentMethod}
                     />
                 ))}

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react';
 import { IconButton } from '@nangohq/design-system';
 
 import { usePlanOverrideStore } from '@/features/planOverride';
-import { useMeta } from '@/hooks/useMeta';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useApiGetPlans, useApiGetUpcomingInvoice, useCurrentPlan } from '@/hooks/usePlan';
 import { useStripePaymentMethods } from '@/hooks/useStripe';
@@ -27,8 +26,7 @@ export const Summary: React.FC = () => {
     // plan codes, and "changes to growth-v2" is not a sentence to show a customer.
     const { data: plansList, isPending: arePlansPending } = useApiGetPlans(env);
     const { data: paymentMethods } = useStripePaymentMethods(env);
-    const { data: metaData } = useMeta();
-    const onS26Pricing = isOnS26Pricing(plan, metaData?.data.s26Pricing === true);
+    const onS26Pricing = isOnS26Pricing(plan);
     const paymentMethod = paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
 
     // Behind a dev-tool flag until the figure is reconciled against real Orb invoices (NAN-6246).

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -5,7 +5,6 @@ import { Alert, AlertActions, AlertDescription, AlertTitle, Button } from '@nang
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { usePlanOverrideStore } from '@/features/planOverride';
-import { useMeta } from '@/hooks/useMeta';
 import { useApiGetBillingPeriodCosts, useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
@@ -22,10 +21,9 @@ export const Usage: React.FC = () => {
     const env = useStore((state) => state.env);
     const { selectedMonth, isCurrentMonth } = useSelectedMonth();
     const { data: environmentData } = useCurrentPlan(env);
-    const { data: metaData } = useMeta();
     const plan = environmentData?.plan;
     const isFree = plan?.name === 'free';
-    const metrics = billedUsageMetrics(plan, metaData?.data.s26Pricing === true);
+    const metrics = billedUsageMetrics(plan);
 
     // Calculate timeframe for the selected month
     const timeframe = useMemo(() => {

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -75,12 +75,12 @@ export const S26_USAGE_METRICS: readonly UsageMetric[] = ['connections', 'functi
 
 const PLANS_ON_S26_PRICING: readonly DBPlan['name'][] = ['free', 'free-uncapped', 'pay-as-you-go'];
 
-export function isOnS26Pricing(plan: ApiPlan | null | undefined, s26PricingEnabled: boolean): boolean {
-    return !!plan && s26PricingEnabled && PLANS_ON_S26_PRICING.includes(plan.name);
+export function isOnS26Pricing(plan: ApiPlan | null | undefined): boolean {
+    return !!plan && PLANS_ON_S26_PRICING.includes(plan.name);
 }
 
-export function billedUsageMetrics(plan: ApiPlan | null | undefined, s26PricingEnabled: boolean): readonly UsageMetric[] {
-    return isOnS26Pricing(plan, s26PricingEnabled) ? S26_USAGE_METRICS : LEGACY_USAGE_METRICS;
+export function billedUsageMetrics(plan: ApiPlan | null | undefined): readonly UsageMetric[] {
+    return isOnS26Pricing(plan) ? S26_USAGE_METRICS : LEGACY_USAGE_METRICS;
 }
 
 const SECONDS_PER_HOUR = 3600;

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -95,7 +95,7 @@ describe('getAggregateUsageState', () => {
 });
 
 describe('billedUsageMetrics', () => {
-    const on = (name: string) => billedUsageMetrics({ name } as ApiPlan, true);
+    const on = (name: string) => billedUsageMetrics({ name } as ApiPlan);
 
     // Deliberately restates the source map: a wrong value there has to fail against something.
     const BILLED_ON: Record<ApiPlan['name'], 's26' | 'legacy'> = {
@@ -120,25 +120,20 @@ describe('billedUsageMetrics', () => {
         }
     });
 
-    it('leaves the view untouched while the flag is off', () => {
-        expect(billedUsageMetrics({ name: 'free' } as ApiPlan, false)).toEqual(LEGACY_USAGE_METRICS);
-    });
-
     it('falls back to the legacy set before the plan has loaded', () => {
-        expect(billedUsageMetrics(undefined, true)).toEqual(LEGACY_USAGE_METRICS);
+        expect(billedUsageMetrics(undefined)).toEqual(LEGACY_USAGE_METRICS);
     });
 });
 
 describe('isOnS26Pricing', () => {
     it('agrees with the metrics a plan is billed on', () => {
-        expect(isOnS26Pricing({ name: 'pay-as-you-go' } as ApiPlan, true)).toBe(true);
-        expect(isOnS26Pricing({ name: 'free' } as ApiPlan, true)).toBe(true);
-        expect(isOnS26Pricing({ name: 'growth-v2' } as ApiPlan, true)).toBe(false);
+        expect(isOnS26Pricing({ name: 'pay-as-you-go' } as ApiPlan)).toBe(true);
+        expect(isOnS26Pricing({ name: 'free' } as ApiPlan)).toBe(true);
+        expect(isOnS26Pricing({ name: 'growth-v2' } as ApiPlan)).toBe(false);
     });
 
-    it('is false while the flag is off, and before the plan has loaded', () => {
-        expect(isOnS26Pricing({ name: 'pay-as-you-go' } as ApiPlan, false)).toBe(false);
-        expect(isOnS26Pricing(undefined, true)).toBe(false);
+    it('is false before the plan has loaded', () => {
+        expect(isOnS26Pricing(undefined)).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Problem

`s26-pricing` gated the September 2026 pricing while it rolled out. It has been at 100% in development, staging and production with no exceptions for a while, so every read returns `true` — it now just threads a boolean from `GET /api/v1/meta` through five billing components to be ANDed with a plan check, and keeps two tests alive for a branch we no longer ship.

## Solution

- `isOnS26Pricing(plan)` and `billedUsageMetrics(plan)` drop the `s26PricingEnabled` parameter — the S26-vs-legacy split is now driven only by the account's plan.
- Five call sites drop `useMeta()` entirely; it had no other use in any of them.
- `s26Pricing` is gone from the meta payload and its type, and `isS26PricingEnabled` from `@nangohq/feature-flags`.
- Tests cover the surviving path only.

Removing the flag from `nango-environments` is [a separate PR](https://github.com/NangoHQ/nango-environments/pull/196) — land this one first.

Fixes [NAN-6842](https://linear.app/nango/issue/NAN-6842)

## Testing

`ts-build`, lint, Prettier and the webapp unit tests pass. On the preview, the billing page for a `pay-as-you-go` account and for a `startup-deal` account each render identically to the same account on `app-development` — diffed the accessibility trees, no change either way. The first keeps the three-metric table and three new cards, the second the seven-metric table and four cards with the retired ones closed.

## Follow-ups

- The retired plan cards, `LEGACY_USAGE_METRICS` and the pre-S26 spend tooltip stay for now: 590 production accounts are still on `starter-v2` or `growth-v2`. They come out, along with the `PLANS_ON_S26_PRICING` / `PLAN_IS_RETIRED` split, once [NAN-6744](https://linear.app/nango/issue/NAN-6744) has migrated them.
