### PR TITLE
feat: allow setting function http trigger subscriptions

### DIFF
--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -148,10 +148,9 @@ describe('validateFunction', () => {
         expect(res.isOk()).toBe(true);
     });
 
-    it('rejects an http trigger with subscriptions', () => {
+    it('accepts an http trigger with subscriptions', () => {
         const res = validateFunction({ ...base, params: { trigger: { kind: 'http', subscriptions: ['issues'] } } });
-        assert(res.isErr());
-        expect(res.error.message).toContain("unsupported HTTP trigger options: 'subscriptions'");
+        expect(res.isOk()).toBe(true);
     });
 
     it('rejects an http trigger with debounce', () => {
@@ -166,7 +165,7 @@ describe('validateFunction', () => {
             params: { trigger: { kind: 'http', subscriptions: [], debounce: { windowMs: 1000 } } }
         });
         assert(res.isErr());
-        expect(res.error.message).toContain("unsupported HTTP trigger options: 'subscriptions', 'debounce'");
+        expect(res.error.message).toContain("unsupported HTTP trigger options: 'debounce'");
     });
 
     it('rejects unknown http trigger attributes', () => {

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -361,17 +361,9 @@ export function validateFunction({
             return Err(new Error(`Function '${fnPath}' has an invalid trigger definition: ${details}`));
         }
     }
-    // TODO: Add support for HTTP trigger options (subscriptions, debounce)
-    if (params.trigger?.kind === 'http') {
-        const unsupportedOptions = [
-            ...(params.trigger.subscriptions !== undefined ? ['subscriptions'] : []),
-            ...(params.trigger.debounce !== undefined ? ['debounce'] : [])
-        ];
-        if (unsupportedOptions.length > 0) {
-            return Err(
-                new Error(`Function '${fnPath}' uses unsupported HTTP trigger options: ${unsupportedOptions.map((option) => `'${option}'`).join(', ')}.`)
-            );
-        }
+    // TODO: Add support for HTTP trigger options (debounce)
+    if (params.trigger?.kind === 'http' && params.trigger.debounce !== undefined) {
+        return Err(new Error(`Function '${fnPath}' uses unsupported HTTP trigger options: 'debounce'.`));
     }
     if (params.data?.models) {
         return Err(new Error(`Function '${fnPath}' declares 'data.models', which is not supported yet.`));


### PR DESCRIPTION
https://github.com/NangoHQ/nango/pull/7384 is adding webhook support to function. This PR is "ungating" subscriptions in CLI to allow creating function with HTTP trigger subscriptions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

