### PR TITLE
chore(proxy): remove the proxy-forward-all-response-headers flag (NAN-6922)

### DIFF
--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -50,13 +50,6 @@ export function buildFlags(client: FeatureFlagsClient) {
                 true
             );
         },
-        /**
-         * Whether proxy responses forward all provider headers (minus hop-by-hop / CORS)
-         * instead of the buffered-path allowlist. Default `false`.
-         */
-        shouldForwardAllProxyResponseHeaders(accountUuid: string) {
-            return client.isEnabled('proxy-forward-all-response-headers', { targetingKey: accountUuid, accountUuid }, false);
-        },
         /** Whether the Gmail webhook can be unverified. */
         allowUnauthorizedGmailWebhook(accountUuid: string) {
             return client.isEnabled('allow-unauthorized-gmail-webhook', { targetingKey: accountUuid, accountUuid }, false);

--- a/packages/feature-flags/lib/index.unit.test.ts
+++ b/packages/feature-flags/lib/index.unit.test.ts
@@ -237,28 +237,6 @@ describe('getFeatureFlagsClient', () => {
         );
     });
 
-    it('shouldForwardAllProxyResponseHeaders evaluates per account', async () => {
-        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
-        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
-        vi.resetModules();
-        const { initialize, getFlags } = await import('./index.js');
-        await initialize();
-        const [unleash] = unleashInstances;
-        if (!unleash) {
-            throw new Error('Expected Unleash provider to initialize');
-        }
-        unleash.isEnabled.mockReturnValue(true);
-        await expect(getFlags().shouldForwardAllProxyResponseHeaders('uuid1')).resolves.toBe(true);
-        expect(unleash.isEnabled).toHaveBeenCalledWith(
-            'proxy-forward-all-response-headers',
-            {
-                userId: 'uuid1',
-                properties: { accountUuid: 'uuid1' }
-            },
-            false
-        );
-    });
-
     it('reads non-boolean variant payloads (getString), falling back to default otherwise', async () => {
         mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
         mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';

--- a/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
@@ -2,7 +2,6 @@ import { Readable } from 'node:stream';
 
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import * as featureFlags from '@nangohq/feature-flags';
 import { ProxyRequest, seeders } from '@nangohq/shared';
 
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
@@ -114,33 +113,26 @@ describe(`GET ${route}`, () => {
         });
     });
 
-    it.each([
-        { forwardAllResponseHeaders: false, expectedProviderHeader: null },
-        { forwardAllResponseHeaders: true, expectedProviderHeader: 'provider-value' }
-    ])(
-        'should respect the response header feature flag when it is $forwardAllResponseHeaders',
-        async ({ forwardAllResponseHeaders, expectedProviderHeader }) => {
-            vi.spyOn(featureFlags.getFlags(), 'shouldForwardAllProxyResponseHeaders').mockResolvedValue(forwardAllResponseHeaders);
-            mockGithubUserResponse({
-                'x-request-id': 'request-id',
-                'x-provider-header': 'provider-value'
-            });
-            const { env, apiKey } = await seeders.seedAccountEnvAndUser();
-            const integration = await seeders.createConfigSeed(env, 'github', 'github');
-            const connection = await seeders.createConnectionSeed({ env, config_id: integration.id!, provider: 'github' });
+    it('should forward the provider response headers', async () => {
+        mockGithubUserResponse({
+            'x-request-id': 'request-id',
+            'x-provider-header': 'provider-value'
+        });
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, config_id: integration.id!, provider: 'github' });
 
-            const res = await api.fetch(route, {
-                method: 'GET',
-                token: apiKey.secret,
-                params: { anyPath: 'users/octocat' },
-                headers: { 'connection-id': connection.connection_id, 'provider-config-key': integration.unique_key }
-            });
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: apiKey.secret,
+            params: { anyPath: 'users/octocat' },
+            headers: { 'connection-id': connection.connection_id, 'provider-config-key': integration.unique_key }
+        });
 
-            isSuccess(res.json);
-            expect(res.res.headers.get('x-request-id')).toBe('request-id');
-            expect(res.res.headers.get('x-provider-header')).toBe(expectedProviderHeader);
-        }
-    );
+        isSuccess(res.json);
+        expect(res.res.headers.get('x-request-id')).toBe('request-id');
+        expect(res.res.headers.get('x-provider-header')).toBe('provider-value');
+    });
 
     it('should return 400 base_url_override_not_allowed when base-url-override host is denylisted', async () => {
         const { env, apiKey } = await seeders.seedAccountEnvAndUser();

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -2,7 +2,6 @@ import { finished, PassThrough } from 'node:stream';
 
 import * as z from 'zod';
 
-import { getFlags } from '@nangohq/feature-flags';
 import { getHeaders, getLogger, redactHeaders, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
@@ -36,14 +35,6 @@ const schemaHeaders = z.object({
     'nango-is-sync': z.enum(['true', 'false']).optional(),
     'nango-is-dry-run': z.enum(['true', 'false']).optional()
 });
-
-// Legacy buffered-path allowlist used when proxy-forward-all-response-headers is off.
-const PROXY_RESPONSE_HEADER_ALLOWLIST = new Set([
-    'content-type',
-    'mcp-session-id', // MCP RFC — https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management
-    'x-request-id',
-    'x-correlation-id'
-]);
 
 // Headers from provider responses that must not be forwarded to the client.
 // content-length is handled per path via allowContentLength (stripped on buffered/error, optionally kept on stream).
@@ -84,15 +75,6 @@ export function filterProxyResponseHeaders(headers: Record<string, unknown> | ob
         }
     }
     return filtered;
-}
-
-function applyAllowlistedResponseHeaders(res: Response, headers: Record<string, unknown> | object) {
-    for (const header of PROXY_RESPONSE_HEADER_ALLOWLIST) {
-        const value = (headers as Record<string, unknown>)[header];
-        if (typeof value === 'string' && value !== '') {
-            res.setHeader(header, value);
-        }
-    }
 }
 
 function applyFilteredResponseHeaders(res: Response, headers: Record<string, unknown> | object, options?: { allowContentLength?: boolean }) {
@@ -139,7 +121,6 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
             files = req.files as ProxyFile[];
         }
 
-        const forwardAllResponseHeaders = await getFlags().shouldForwardAllProxyResponseHeaders(account.uuid);
         const execution = await proxyService.request({
             account,
             environment,
@@ -177,16 +158,14 @@ export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async 
                 res,
                 responseStream,
                 logCtx,
-                onEgressedBytes: recordEgressedBytes,
-                forwardAllResponseHeaders
+                onEgressedBytes: recordEgressedBytes
             });
         } else {
             handleErrorResponse({
                 res,
                 responseStream,
                 logCtx,
-                onEgressedBytes: recordEgressedBytes,
-                forwardAllResponseHeaders
+                onEgressedBytes: recordEgressedBytes
             });
         }
     } catch (err) {
@@ -258,14 +237,12 @@ export function handleResponse({
     res,
     responseStream,
     logCtx,
-    onEgressedBytes,
-    forwardAllResponseHeaders = false
+    onEgressedBytes
 }: {
     res: Response;
     responseStream: Pick<ProxyServiceResponse, 'status' | 'headers' | 'body' | 'wasCompressed' | 'complete'>;
     logCtx?: LogContext | undefined;
     onEgressedBytes?: ((egressedBytes: number) => void) | undefined;
-    forwardAllResponseHeaders?: boolean;
 }) {
     const contentDisposition = responseStream.headers['content-disposition'] || '';
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
@@ -274,9 +251,7 @@ export function handleResponse({
     const isAttachmentOrInline = /^(attachment|inline)(;|\s|$)/i.test(contentDisposition);
 
     if (isChunked || isAttachmentOrInline) {
-        const passthroughHeaders = forwardAllResponseHeaders
-            ? filterProxyResponseHeaders(responseStream.headers, { allowContentLength: true })
-            : (Object.fromEntries(Object.entries(responseStream.headers)) as OutgoingHttpHeaders);
+        const passthroughHeaders = filterProxyResponseHeaders(responseStream.headers, { allowContentLength: true });
         if (responseStream.wasCompressed) {
             // axios decompressed the response, so the `content-length` header is no longer valid
             delete passthroughHeaders['content-length'];
@@ -345,20 +320,14 @@ export function handleResponse({
         }
 
         if (responseStream.status === 204) {
-            if (forwardAllResponseHeaders) {
-                applyFilteredResponseHeaders(res, responseStream.headers);
-            }
+            applyFilteredResponseHeaders(res, responseStream.headers);
             res.status(204).end();
             onEgressedBytes?.(0);
             void responseStream.complete();
             return;
         }
 
-        if (forwardAllResponseHeaders) {
-            applyFilteredResponseHeaders(res, responseStream.headers);
-        } else {
-            applyAllowlistedResponseHeaders(res, responseStream.headers);
-        }
+        applyFilteredResponseHeaders(res, responseStream.headers);
 
         try {
             res.send(Buffer.concat(responseData));
@@ -377,14 +346,12 @@ export function handleErrorResponse({
     res,
     responseStream,
     logCtx,
-    onEgressedBytes,
-    forwardAllResponseHeaders = false
+    onEgressedBytes
 }: {
     res: Response;
     responseStream: Pick<ProxyServiceResponse, 'status' | 'headers' | 'body'>;
     logCtx?: LogContext | undefined;
     onEgressedBytes?: ((egressedBytes: number) => void) | undefined;
-    forwardAllResponseHeaders?: boolean;
 }): void {
     const errorStream = responseStream.body;
     const chunks: Buffer[] = [];
@@ -418,10 +385,7 @@ export function handleErrorResponse({
         }
 
         const responseStatus = responseStream.status || 500;
-        const responseHeaders = forwardAllResponseHeaders ? filterProxyResponseHeaders(responseStream.headers || {}) : { ...responseStream.headers };
-        if (!forwardAllResponseHeaders) {
-            delete responseHeaders['transfer-encoding'];
-        }
+        const responseHeaders = filterProxyResponseHeaders(responseStream.headers || {});
         void logCtx?.error('Failed with this body', { body: parsedBody });
 
         res.status(responseStatus).set(responseHeaders).send(data);

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -191,7 +191,7 @@ describe('handleResponse', () => {
         expect(sentData!.toString()).toBe(nonJsonPayload);
     });
 
-    it('should forward provider response headers on the buffered path when the flag is on', async () => {
+    it('should forward provider response headers on the buffered path', async () => {
         const mockRes = createMockResponse();
         const mockResponseStream = createMockResponseStream('{"ok":true}', {
             contentType: 'application/json',
@@ -205,7 +205,7 @@ describe('handleResponse', () => {
             }
         });
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: true });
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
         await mockRes.waitForSend();
 
         expect(mockRes.res.setHeader).toHaveBeenCalledWith('content-type', 'application/json');
@@ -214,29 +214,6 @@ describe('handleResponse', () => {
         expect(mockRes.res.setHeader).toHaveBeenCalledWith('x-ratelimit-limit', '100');
         expect(mockRes.res.setHeader).toHaveBeenCalledWith('x-ratelimit-remaining', '42');
         expect(mockRes.res.setHeader).toHaveBeenCalledWith('link', '<https://api.example.com/page/2>; rel="next"');
-    });
-
-    it('should only forward allowlisted headers on the buffered path when the flag is off', async () => {
-        const mockRes = createMockResponse();
-        const mockResponseStream = createMockResponseStream('{"ok":true}', {
-            contentType: 'application/json',
-            status: 200,
-            headers: {
-                'mcp-session-id': 'session-abc123',
-                'x-request-id': 'req-xyz',
-                'x-ratelimit-limit': '100',
-                link: '<https://api.example.com/page/2>; rel="next"'
-            }
-        });
-
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: false });
-        await mockRes.waitForSend();
-
-        expect(mockRes.res.setHeader).toHaveBeenCalledWith('content-type', 'application/json');
-        expect(mockRes.res.setHeader).toHaveBeenCalledWith('mcp-session-id', 'session-abc123');
-        expect(mockRes.res.setHeader).toHaveBeenCalledWith('x-request-id', 'req-xyz');
-        expect(mockRes.res.setHeader).not.toHaveBeenCalledWith('x-ratelimit-limit', expect.anything());
-        expect(mockRes.res.setHeader).not.toHaveBeenCalledWith('link', expect.anything());
     });
 
     it('should not forward hop-by-hop, content-length and CORS headers on the buffered path', async () => {
@@ -253,7 +230,7 @@ describe('handleResponse', () => {
             }
         });
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: true });
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
         await mockRes.waitForSend();
 
         expect(mockRes.res.setHeader).not.toHaveBeenCalledWith('connection', expect.anything());
@@ -263,7 +240,7 @@ describe('handleResponse', () => {
         expect(mockRes.res.setHeader).toHaveBeenCalledWith('x-request-id', 'req-xyz');
     });
 
-    it('should filter hop-by-hop and CORS headers on the streamed path when the flag is on', () => {
+    it('should filter hop-by-hop and CORS headers on the streamed path', () => {
         const mockRes = createMockResponse();
         const mockResponseStream = createMockResponseStream('raw binary content', {
             contentType: 'application/pdf',
@@ -276,7 +253,7 @@ describe('handleResponse', () => {
             }
         });
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: true });
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
 
         const [, headersArg] = vi.mocked(mockRes.res.writeHead).mock.calls[0]!;
         expect(headersArg).toHaveProperty('content-length', '18');
@@ -297,7 +274,7 @@ describe('handleResponse', () => {
             wasCompressed: true
         });
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: true });
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
 
         const [, headersArg] = vi.mocked(mockRes.res.writeHead).mock.calls[0]!;
         expect(headersArg).not.toHaveProperty('content-length');
@@ -313,7 +290,7 @@ describe('handleResponse', () => {
             }
         });
 
-        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx, forwardAllResponseHeaders: true });
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
 
         const [, headersArg] = vi.mocked(mockRes.res.writeHead).mock.calls[0]!;
         expect(headersArg).toHaveProperty('content-length', '18');


### PR DESCRIPTION
NAN-6922

`proxy-forward-all-response-headers` has been at 100% in development, staging and production since NAN-6514, so it only gated dead code. The flag and its off branch are gone, along with the buffered-path header allowlist that existed for the off case.

Proxy responses now always forward the provider headers minus the hop-by-hop and CORS ones, on the buffered, streamed and error paths.

Removing the flag from `nango-environments` is [a separate PR](https://github.com/NangoHQ/nango-environments/pull/201). Land this one first.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

