### PR TITLE
chore(mfa): retire the mfa rollout flag (NAN-6921)

### DIFF
--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -22,9 +22,6 @@ export function buildFlags(client: FeatureFlagsClient) {
             // accountUuid is exposed as a property so strategies can allow/exclude specific accounts.
             return client.isEnabled('oauth-state-cookie-enforcement', { targetingKey: accountUuid, accountUuid }, false);
         },
-        isMFAEnabled(accountUuid: string) {
-            return client.isEnabled('mfa', { targetingKey: accountUuid, accountUuid }, false);
-        },
         isAttioWebhookDedupeEnabled(accountUuid: string) {
             return client.isEnabled('attio-webhook-dedupe', { targetingKey: accountUuid, accountUuid }, false);
         },

--- a/packages/server/lib/controllers/v1/account/managed/verification.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/managed/verification.integration.test.ts
@@ -5,7 +5,6 @@ import { mfaService, seeders, userService } from '@nangohq/shared';
 import { nanoid, normalizeEmail } from '@nangohq/utils';
 
 import type { runServer as runServerType } from '../../../../utils/tests.js';
-import type * as featureFlagsType from '@nangohq/feature-flags';
 
 const workosMocks = vi.hoisted(() => {
     process.env['FLAG_MANAGED_AUTH_ENABLED'] = 'true';
@@ -40,13 +39,11 @@ type RunServer = typeof runServerType;
 
 let api: Awaited<ReturnType<RunServer>>;
 let runServer: RunServer;
-let featureFlags: typeof featureFlagsType;
 
 describe(`POST ${route}`, () => {
     beforeAll(async () => {
         vi.resetModules();
         ({ runServer } = await import('../../../../utils/tests.js'));
-        featureFlags = await import('@nangohq/feature-flags');
         api = await runServer();
     });
 
@@ -204,8 +201,6 @@ describe(`POST ${route}`, () => {
     });
 
     it('should challenge MFA before completing a managed auth login', async () => {
-        vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
-
         const { user } = await seeders.seedAccountEnvAndUser();
         const enrollment = (await mfaService.startEnrollment(user.id, user.email)).unwrap();
         const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
@@ -241,8 +236,6 @@ describe(`POST ${route}`, () => {
     });
 
     it('should not challenge MFA when the user has no active factor', async () => {
-        vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
-
         const { user } = await seeders.seedAccountEnvAndUser();
 
         workosMocks.authenticateWithCode.mockResolvedValue({

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -1,5 +1,4 @@
 import db from '@nangohq/database';
-import { getFlags } from '@nangohq/feature-flags';
 import { accountService, mfaService, recordMFALoginRefused, recordMFAVerifyFailure, userService } from '@nangohq/shared';
 
 import { safeReturnTo } from '../returnTo.js';
@@ -75,7 +74,7 @@ async function loadEligibleUser(userId: number): Promise<DBUser | null> {
 
 export async function isMFAEnabled(user: DBUser, trx: Knex = db.knex): Promise<boolean> {
     const account = await accountService.getAccountById(trx, user.account_id);
-    return Boolean(account && (await getFlags().isMFAEnabled(account.uuid)));
+    return Boolean(account);
 }
 
 async function loginUser(req: Request, user: DBUser): Promise<void> {

--- a/packages/server/lib/controllers/v1/account/mfa/mfa-audit.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/mfa-audit.integration.test.ts
@@ -1,7 +1,6 @@
 import * as OTPAuth from 'otpauth';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as featureFlags from '@nangohq/feature-flags';
 import { mfaService, userService } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
@@ -65,8 +64,6 @@ describe('MFA verify audit — pending-login session (private API)', () => {
     beforeAll(async () => {
         api = await runServer();
         auditSpy = vi.spyOn(audit, 'record');
-        // getFlags() returns the stable noop facade in tests; force the MFA feature on.
-        vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
     });
 
     afterAll(() => {

--- a/packages/server/lib/controllers/v1/account/mfa/mfa.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/mfa.integration.test.ts
@@ -1,22 +1,17 @@
 import * as OTPAuth from 'otpauth';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import * as featureFlags from '@nangohq/feature-flags';
 import { seeders } from '@nangohq/shared';
 
 import { authenticateUser, isError, isSuccess, runServer } from '../../../../utils/tests.js';
 
-import type { MockInstance } from 'vitest';
-
 const mfaRoute = '/api/v1/account/mfa';
 
 let api: Awaited<ReturnType<typeof runServer>>;
-let mfaFlagSpy: MockInstance<ReturnType<typeof featureFlags.getFlags>['isMFAEnabled']>;
 
 describe('MFA settings', () => {
     beforeAll(async () => {
         api = await runServer();
-        mfaFlagSpy = vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
     });
 
     afterAll(() => {
@@ -69,18 +64,6 @@ describe('MFA settings', () => {
         expect(activation.res.status).toBe(400);
         isError(activation.json);
         expect(activation.json.error.code).toBe('invalid_mfa_code');
-    });
-
-    it('returns feature disabled when MFA is not enabled for the account', async () => {
-        const { user } = await seeders.seedAccountEnvAndUser();
-        const cookie = await authenticateUser(api, user);
-        mfaFlagSpy.mockResolvedValueOnce(false);
-
-        const status = await api.fetch(mfaRoute, { method: 'GET', session: cookie });
-
-        expect(status.res.status).toBe(400);
-        isError(status.json);
-        expect(status.json.error.code).toBe('feature_disabled');
     });
 
     it('disables MFA with a valid code', async () => {

--- a/packages/server/lib/controllers/v1/account/mfa/mfa.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/mfa.ts
@@ -1,6 +1,5 @@
 import * as z from 'zod';
 
-import { getFlags } from '@nangohq/feature-flags';
 import { MFAError, mfaService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -49,20 +48,8 @@ function getAuthenticatedUser<T>(res: Response<T, RequestLocals>) {
     return user;
 }
 
-async function isMFAEnabled<T>(res: Response<T, RequestLocals>): Promise<boolean> {
-    return await getFlags().isMFAEnabled(res.locals['account'].uuid);
-}
-
-function rejectDisabledFeature<T>(res: Response<T, RequestLocals>) {
-    res.status(400).send({ error: { code: 'feature_disabled' } } as T);
-}
-
 export const getMFAStatus = asyncWrapper<GetMFAStatus>(async (req, res) => {
     if (!validateQuery(req, res)) {
-        return;
-    }
-    if (!(await isMFAEnabled(res))) {
-        rejectDisabledFeature(res);
         return;
     }
 
@@ -72,10 +59,6 @@ export const getMFAStatus = asyncWrapper<GetMFAStatus>(async (req, res) => {
 
 export const postMFAEnrollment = asyncWrapper<PostMFAEnrollment>(async (req, res) => {
     if (!validateQuery(req, res)) {
-        return;
-    }
-    if (!(await isMFAEnabled(res))) {
-        rejectDisabledFeature(res);
         return;
     }
 
@@ -93,10 +76,6 @@ export const postMFAEnrollment = asyncWrapper<PostMFAEnrollment>(async (req, res
 
 export const postMFAActivation = asyncWrapper<PostMFAActivation>(async (req, res) => {
     if (!validateQuery(req, res)) {
-        return;
-    }
-    if (!(await isMFAEnabled(res))) {
-        rejectDisabledFeature(res);
         return;
     }
 
@@ -123,10 +102,6 @@ export const postMFAActivation = asyncWrapper<PostMFAActivation>(async (req, res
 
 export const postMFARecoveryCodes = asyncWrapper<PostMFARecoveryCodes>(async (req, res) => {
     if (!validateQuery(req, res)) {
-        return;
-    }
-    if (!(await isMFAEnabled(res))) {
-        rejectDisabledFeature(res);
         return;
     }
 
@@ -158,10 +133,6 @@ export const postMFARecoveryCodes = asyncWrapper<PostMFARecoveryCodes>(async (re
 
 export const deleteMFA = asyncWrapper<DeleteMFA>(async (req, res) => {
     if (!validateQuery(req, res)) {
-        return;
-    }
-    if (!(await isMFAEnabled(res))) {
-        rejectDisabledFeature(res);
         return;
     }
 

--- a/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
@@ -2,14 +2,11 @@ import jwt from 'jsonwebtoken';
 import * as OTPAuth from 'otpauth';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import * as featureFlags from '@nangohq/feature-flags';
 import { userService } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
 import { isError, isSuccess, runServer } from '../../../utils/tests.js';
 import { resetPasswordSecret } from '../../../utils/utils.js';
-
-import type { MockInstance } from 'vitest';
 
 const signupRoute = '/api/v1/account/signup';
 const signinRoute = '/api/v1/account/signin';
@@ -19,7 +16,6 @@ const accountDiscoveryRoute = '/api/v1/account/onboarding/account-discovery';
 const mfaRoute = '/api/v1/account/mfa';
 
 let api: Awaited<ReturnType<typeof runServer>>;
-let mfaFlagSpy: MockInstance<ReturnType<typeof featureFlags.getFlags>['isMFAEnabled']>;
 
 async function signupVerifiedUser(): Promise<{ email: string; password: string }> {
     const email = `${nanoid()}@example.com`;
@@ -68,7 +64,6 @@ async function issueResetToken(email: string): Promise<string> {
 describe(`PUT ${resetPasswordRoute}`, () => {
     beforeAll(async () => {
         api = await runServer();
-        mfaFlagSpy = vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
     });
 
     afterAll(() => {
@@ -196,15 +191,11 @@ describe(`PUT ${resetPasswordRoute}`, () => {
         isSuccess(retry.json);
     });
 
-    it('should skip the second factor when the feature is off for the account', async () => {
-        const { email, password } = await signupVerifiedUser();
-        const session = await signin(email, password);
-        await enrollMfa(session);
+    it('should skip the second factor when the user has no factor enrolled', async () => {
+        const { email } = await signupVerifiedUser();
 
         const token = await issueResetToken(email);
-        mfaFlagSpy.mockResolvedValue(false);
         const { res, json } = await api.fetch(resetPasswordRoute, { method: 'PUT', body: { token, password: 'aZ1-newpass!?' } });
-        mfaFlagSpy.mockResolvedValue(true);
 
         expect(res.status).toBe(200);
         isSuccess(json);

--- a/packages/server/lib/controllers/v1/account/signin.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/signin.integration.test.ts
@@ -1,7 +1,6 @@
 import * as OTPAuth from 'otpauth';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import * as featureFlags from '@nangohq/feature-flags';
 import { mfaService, userService } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
@@ -50,7 +49,6 @@ async function enrollMfaUser(): Promise<{ email: string; password: string; user:
 describe(`POST ${signinRoute}`, () => {
     beforeAll(async () => {
         api = await runServer();
-        vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
     });
 
     afterAll(() => {

--- a/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.integration.test.ts
+++ b/packages/server/lib/controllers/v1/admin/impersonate/postImpersonate.integration.test.ts
@@ -1,14 +1,11 @@
 import * as OTPAuth from 'otpauth';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import * as featureFlags from '@nangohq/feature-flags';
 import { seeders } from '@nangohq/shared';
 import { flags } from '@nangohq/utils';
 
 import { envs } from '../../../../env.js';
 import { authenticateUser, isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
-
-import type { MockInstance } from 'vitest';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -166,11 +163,8 @@ describe(`POST ${endpoint}`, () => {
 });
 
 describe(`POST ${endpoint} with a dashboard session`, () => {
-    let mfaFlagSpy: MockInstance<ReturnType<typeof featureFlags.getFlags>['isMFAEnabled']>;
-
     beforeAll(async () => {
         api = await runServer();
-        mfaFlagSpy = vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
     });
     afterAll(() => {
         api.server.close();
@@ -179,7 +173,6 @@ describe(`POST ${endpoint} with a dashboard session`, () => {
     afterEach(() => {
         flags.hasAdminCapabilities = false;
         envs.NANGO_IMPERSONATION_MFA_REQUIRED = true;
-        mfaFlagSpy.mockResolvedValue(true);
     });
 
     async function enrollAndActivate(session: string) {
@@ -340,30 +333,6 @@ describe(`POST ${endpoint} with a dashboard session`, () => {
             body: { accountUUID, loginReason: 'support' }
         });
 
-        isSuccess(res.json);
-        expect(res.res.status).toBe(200);
-    });
-
-    it('should challenge even when the account MFA feature flag is off', async () => {
-        const { session, totp } = await seedAdmin({ withFactor: true });
-        const accountUUID = await seedTarget();
-        mfaFlagSpy.mockResolvedValue(false);
-
-        const refused = await api.fetch(endpoint, {
-            method: 'POST',
-            query: { env: 'dev' },
-            session,
-            body: { accountUUID, loginReason: 'support', code: '000000' }
-        });
-        isError(refused.json);
-        expect(refused.json).toStrictEqual<typeof refused.json>({ error: { code: 'invalid_mfa_code' } });
-
-        const res = await api.fetch(endpoint, {
-            method: 'POST',
-            query: { env: 'dev' },
-            session,
-            body: { accountUUID, loginReason: 'support', code: nextCode(totp!) }
-        });
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
     });

--- a/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
+++ b/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
@@ -46,7 +46,6 @@ describe(`GET ${route}`, () => {
             data: {
                 invitedUsers: [],
                 isAdminTeam: false,
-                mfaFeatureEnabled: false,
                 account: {
                     id: account.id,
                     name: account.name,

--- a/packages/server/lib/controllers/v1/team/getTeam.ts
+++ b/packages/server/lib/controllers/v1/team/getTeam.ts
@@ -1,4 +1,3 @@
-import { getFlags } from '@nangohq/feature-flags';
 import { listInvitations, mfaService, userService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -22,8 +21,7 @@ export const getTeam = asyncWrapper<GetTeam>(async (req, res) => {
     const users = await userService.getUsersByAccountId(account.id);
     const invitedUsers = await listInvitations({ accountId: account.id });
 
-    const mfaFeatureEnabled = await getFlags().isMFAEnabled(account.uuid);
-    const mfaEnabledUserIds = mfaFeatureEnabled ? await mfaService.getEnabledUserIds(users.map((user) => user.id)) : new Set<number>();
+    const mfaEnabledUserIds = await mfaService.getEnabledUserIds(users.map((user) => user.id));
 
     const usersFormatted = users.map((user) => ({ ...userToAPI(user), mfaEnabled: mfaEnabledUserIds.has(user.id) }));
 
@@ -32,8 +30,7 @@ export const getTeam = asyncWrapper<GetTeam>(async (req, res) => {
             account: teamToApi(account),
             users: usersFormatted,
             invitedUsers: invitedUsers.map(invitationToApi),
-            isAdminTeam: account.uuid === envs.NANGO_ADMIN_UUID,
-            mfaFeatureEnabled
+            isAdminTeam: account.uuid === envs.NANGO_ADMIN_UUID
         }
     });
 });

--- a/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
@@ -1,13 +1,10 @@
 import * as OTPAuth from 'otpauth';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import * as featureFlags from '@nangohq/feature-flags';
 import { userService } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
 import { isError, isSuccess, runServer } from '../../../../utils/tests.js';
-
-import type { MockInstance } from 'vitest';
 
 const signupRoute = '/api/v1/account/signup';
 const signinRoute = '/api/v1/account/signin';
@@ -17,7 +14,6 @@ const mfaRoute = '/api/v1/account/mfa';
 const STEP_MS = 30 * 1000;
 
 let api: Awaited<ReturnType<typeof runServer>>;
-let mfaFlagSpy: MockInstance<ReturnType<typeof featureFlags.getFlags>['isMFAEnabled']>;
 
 async function signupVerifiedUser(): Promise<{ email: string; password: string }> {
     const email = `${nanoid()}@example.com`;
@@ -59,7 +55,6 @@ async function enrollMfa(session: string): Promise<{ totp: OTPAuth.TOTP; recover
 describe(`PUT ${passwordRoute}`, () => {
     beforeAll(async () => {
         api = await runServer();
-        mfaFlagSpy = vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
     });
 
     afterAll(() => {
@@ -273,18 +268,15 @@ describe(`PUT ${passwordRoute}`, () => {
         expect(json).toStrictEqual({ error: { code: 'invalid_mfa_code' } });
     });
 
-    it('should skip the second factor when the feature is off for the account', async () => {
+    it('should skip the second factor when the user has no factor enrolled', async () => {
         const { email, password } = await signupVerifiedUser();
         const session = await signin(email, password);
-        await enrollMfa(session);
 
-        mfaFlagSpy.mockResolvedValue(false);
         const { res, json } = await api.fetch(passwordRoute, {
             method: 'PUT',
             session,
             body: { oldPassword: password, newPassword: 'aZ1-newpass!?' }
         });
-        mfaFlagSpy.mockResolvedValue(true);
 
         expect(res.status).toBe(200);
         isSuccess(json);

--- a/packages/server/lib/middleware/audit.auth.private.integration.test.ts
+++ b/packages/server/lib/middleware/audit.auth.private.integration.test.ts
@@ -2,7 +2,6 @@ import jwt from 'jsonwebtoken';
 import * as OTPAuth from 'otpauth';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as featureFlags from '@nangohq/feature-flags';
 import { mfaService, userService } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
@@ -111,8 +110,6 @@ describe('audit — auth flows', () => {
     beforeAll(async () => {
         api = await runServer();
         auditSpy = vi.spyOn(audit, 'record');
-        // MFA is forced on so an enrolled user's sign-in takes the pending-MFA path.
-        vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
     });
 
     afterAll(() => {

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -17,8 +17,6 @@ export type GetTeam = ApiEndpoint<{
             users: ApiTeamUser[];
             invitedUsers: ApiInvitation[];
             isAdminTeam: boolean;
-            // Whether MFA is available for this account. When false the dashboard hides per-member 2FA state.
-            mfaFeatureEnabled: boolean;
         };
     };
 }>;

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -115,8 +115,6 @@ export const TeamMembers: React.FC = () => {
 
     const [editingUser, setEditingUser] = useState<ApiUser | null>(null);
 
-    const mfaFeatureEnabled = data?.data.mfaFeatureEnabled ?? false;
-
     const allUsers: ((ApiTeamUser & { is_invitation: false }) | (ApiInvitation & { is_invitation: true }))[] = useMemo(
         () =>
             [
@@ -165,7 +163,7 @@ export const TeamMembers: React.FC = () => {
                                 </IconButton>
                             </div>
                         </TableHead>
-                        {mfaFeatureEnabled && <TableHead>2FA</TableHead>}
+                        <TableHead>2FA</TableHead>
                         <TableHead>Status</TableHead>
                         <TableHead className="text-right">{/* Actions */}</TableHead>
                     </TableRow>
@@ -200,17 +198,15 @@ export const TeamMembers: React.FC = () => {
                                 </div>
                             </TableCell>
 
-                            {mfaFeatureEnabled && (
-                                <TableCell>
-                                    {user.is_invitation ? (
-                                        <span className="text-text-secondary">—</span>
-                                    ) : user.mfaEnabled ? (
-                                        <Badge variant="success">Enabled</Badge>
-                                    ) : (
-                                        <Badge variant="ghost">Disabled</Badge>
-                                    )}
-                                </TableCell>
-                            )}
+                            <TableCell>
+                                {user.is_invitation ? (
+                                    <span className="text-text-secondary">—</span>
+                                ) : user.mfaEnabled ? (
+                                    <Badge variant="success">Enabled</Badge>
+                                ) : (
+                                    <Badge variant="ghost">Disabled</Badge>
+                                )}
+                            </TableCell>
 
                             <TableCell>
                                 {user.is_invitation ? (


### PR DESCRIPTION
NAN-6921

MFA is at 100% in prod and stable, so the `mfa` rollout flag is gone along with every check that read it.

`GET /api/v1/team` no longer returns `mfaFeatureEnabled`. The field only existed to pass the flag to the dashboard, so the 2FA column now always renders.

Paired with NangoHQ/nango-environments#NAN-6921, which drops the flag definition. Deploy this first.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

