### PR TITLE
fix(webapp): stop showing usage months from before the account existed

### DIFF
--- a/packages/webapp/src/pages/Team/Billing/components/MonthSelector.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/MonthSelector.tsx
@@ -4,10 +4,9 @@ import { useMemo } from 'react';
 import { IconButton, Tooltip, TooltipContent, TooltipTrigger } from '@nangohq/design-system';
 
 import { track } from '@/utils/analytics';
-import { EARLIEST_USAGE_MONTH_MS } from '../usageBreakdown';
 import { useSelectedMonth } from '../useSelectedMonth';
 
-const EARLIEST_USAGE_MONTH_LABEL = new Date(EARLIEST_USAGE_MONTH_MS).toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+const formatMonth = (date: Date) => date.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
 
 /**
  * Month selector backed by the shared `?month` param (`useSelectedMonth`): chevron buttons flanking
@@ -16,9 +15,16 @@ const EARLIEST_USAGE_MONTH_LABEL = new Date(EARLIEST_USAGE_MONTH_MS).toLocaleDat
  * paid plans.
  */
 export const MonthSelector: React.FC = () => {
-    const { selectedMonth, setSelectedMonth, canGoNext, canGoPrevious } = useSelectedMonth();
+    const { selectedMonth, setSelectedMonth, canGoNext, canGoPrevious, earliestMonth, earliestMonthReason } = useSelectedMonth();
 
-    const monthDisplay = useMemo(() => selectedMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' }), [selectedMonth]);
+    const monthDisplay = useMemo(() => formatMonth(selectedMonth), [selectedMonth]);
+    const earliestMonthTooltip = useMemo(
+        () =>
+            earliestMonthReason === 'account-created'
+                ? `Your account was created in ${formatMonth(earliestMonth)}.`
+                : `Usage tracking is only available from ${formatMonth(earliestMonth)}.`,
+        [earliestMonth, earliestMonthReason]
+    );
 
     const step = (delta: number) => {
         track('web:usage:month_changed', { direction: delta < 0 ? 'previous' : 'next' });
@@ -45,7 +51,7 @@ export const MonthSelector: React.FC = () => {
                             {previousButton}
                         </span>
                     </TooltipTrigger>
-                    <TooltipContent>Usage tracking is only available from {EARLIEST_USAGE_MONTH_LABEL}.</TooltipContent>
+                    <TooltipContent>{earliestMonthTooltip}</TooltipContent>
                 </Tooltip>
             )}
             <span className="text-text-strong text-body-medium-medium min-w-28 text-center">{monthDisplay}</span>

--- a/packages/webapp/src/pages/Team/Billing/usageMonthFloor.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageMonthFloor.ts
@@ -1,0 +1,15 @@
+import { EARLIEST_USAGE_MONTH_MS } from './usageBreakdown';
+
+export type UsageMonthFloorReason = 'data-start' | 'account-created';
+
+export function usageMonthFloorMs(accountCreatedAt: string | undefined): number {
+    const created = accountCreatedAt ? new Date(accountCreatedAt) : null;
+    if (!created || Number.isNaN(created.getTime())) {
+        return EARLIEST_USAGE_MONTH_MS;
+    }
+    return Math.max(EARLIEST_USAGE_MONTH_MS, Date.UTC(created.getUTCFullYear(), created.getUTCMonth(), 1));
+}
+
+export function usageMonthFloorReason(floorMs: number): UsageMonthFloorReason {
+    return floorMs > EARLIEST_USAGE_MONTH_MS ? 'account-created' : 'data-start';
+}

--- a/packages/webapp/src/pages/Team/Billing/usageMonthFloor.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageMonthFloor.unit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { EARLIEST_USAGE_MONTH_MS } from './usageBreakdown.js';
+import { usageMonthFloorMs, usageMonthFloorReason } from './usageMonthFloor.js';
+
+describe('usageMonthFloorMs', () => {
+    it('floors at the account creation month when the account is newer than the data start', () => {
+        expect(usageMonthFloorMs('2026-08-20T14:00:00Z')).toBe(Date.UTC(2026, 7, 1));
+    });
+
+    it('keeps the creation month reachable for an account created mid-month', () => {
+        expect(usageMonthFloorMs('2026-08-31T23:59:59Z')).toBe(Date.UTC(2026, 7, 1));
+    });
+
+    it('floors at the data start when the account predates it', () => {
+        expect(usageMonthFloorMs('2024-01-15T00:00:00Z')).toBe(EARLIEST_USAGE_MONTH_MS);
+    });
+
+    it('uses the UTC month, not the local one', () => {
+        // West of Greenwich this instant is still August 31st, so a local-time floor would slip to August.
+        expect(usageMonthFloorMs('2026-09-01T00:30:00Z')).toBe(Date.UTC(2026, 8, 1));
+    });
+
+    it('falls back to the data start when the creation date is missing or unparseable', () => {
+        expect(usageMonthFloorMs(undefined)).toBe(EARLIEST_USAGE_MONTH_MS);
+        expect(usageMonthFloorMs('not a date')).toBe(EARLIEST_USAGE_MONTH_MS);
+    });
+});
+
+describe('usageMonthFloorReason', () => {
+    it('reports the bound that produced the floor', () => {
+        expect(usageMonthFloorReason(Date.UTC(2026, 7, 1))).toBe('account-created');
+        expect(usageMonthFloorReason(EARLIEST_USAGE_MONTH_MS)).toBe('data-start');
+    });
+});

--- a/packages/webapp/src/pages/Team/Billing/usageMonthFloor.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageMonthFloor.unit.test.ts
@@ -17,7 +17,7 @@ describe('usageMonthFloorMs', () => {
     });
 
     it('uses the UTC month, not the local one', () => {
-        // West of Greenwich this instant is still August 31st, so a local-time floor would slip to August.
+        // Near midnight UTC on purpose: west of Greenwich this is still August 31st, so a local-time floor would slip.
         expect(usageMonthFloorMs('2026-09-01T00:30:00Z')).toBe(Date.UTC(2026, 8, 1));
     });
 

--- a/packages/webapp/src/pages/Team/Billing/useSelectedMonth.ts
+++ b/packages/webapp/src/pages/Team/Billing/useSelectedMonth.ts
@@ -1,7 +1,11 @@
 import { parseAsString, useQueryState } from 'nuqs';
 import { useMemo } from 'react';
 
-import { EARLIEST_USAGE_MONTH_MS } from './usageBreakdown';
+import { useTeam } from '@/hooks/useTeam';
+import { useStore } from '@/store';
+import { usageMonthFloorMs, usageMonthFloorReason } from './usageMonthFloor';
+
+import type { UsageMonthFloorReason } from './usageMonthFloor';
 
 // Parser for month in YYYY-MM format, shared across the page header and the per-metric drill-in
 // steppers so they all read/write the same `?month` param and stay in sync.
@@ -13,16 +17,18 @@ interface UseSelectedMonth {
     /** False once at the current month (no future navigation). */
     canGoNext: boolean;
     isCurrentMonth: boolean;
-    /** False at the June-2026 ClickHouse floor — that's when the data starts. */
     canGoPrevious: boolean;
+    earliestMonth: Date;
+    earliestMonthReason: UsageMonthFloorReason;
 }
 
-/**
- * Selected usage month, backed by the `?month` URL param. The June-2026 floor is where the
- * ClickHouse data starts. Any component reading this hook stays in sync via the shared param.
- */
 export function useSelectedMonth(): UseSelectedMonth {
     const [monthParam, setMonthParam] = useQueryState('month', parseMonth);
+    const env = useStore((state) => state.env);
+    const { data: teamData } = useTeam(env);
+
+    const accountCreatedAt = teamData?.data.account.created_at;
+    const earliestMonthMs = useMemo(() => usageMonthFloorMs(accountCreatedAt), [accountCreatedAt]);
 
     const selectedMonth = useMemo(() => {
         const now = new Date();
@@ -38,8 +44,8 @@ export function useSelectedMonth(): UseSelectedMonth {
                 month = parsed > currentMonth ? currentMonth : parsed;
             }
         }
-        return month.getTime() < EARLIEST_USAGE_MONTH_MS ? new Date(EARLIEST_USAGE_MONTH_MS) : month;
-    }, [monthParam]);
+        return month.getTime() < earliestMonthMs ? new Date(earliestMonthMs) : month;
+    }, [monthParam, earliestMonthMs]);
 
     const setSelectedMonth = (date: Date) => {
         const year = date.getUTCFullYear();
@@ -53,7 +59,17 @@ export function useSelectedMonth(): UseSelectedMonth {
         return selectedMonth < currentMonth;
     }, [selectedMonth]);
 
-    const canGoPrevious = useMemo(() => selectedMonth.getTime() > EARLIEST_USAGE_MONTH_MS, [selectedMonth]);
+    // The floor is still the loose default until the team loads. Without this guard the arrow goes
+    // live on it and the click is clamped straight back.
+    const canGoPrevious = Boolean(accountCreatedAt) && selectedMonth.getTime() > earliestMonthMs;
 
-    return { selectedMonth, setSelectedMonth, canGoNext, canGoPrevious, isCurrentMonth: !canGoNext };
+    return {
+        selectedMonth,
+        setSelectedMonth,
+        canGoNext,
+        canGoPrevious,
+        isCurrentMonth: !canGoNext,
+        earliestMonth: new Date(earliestMonthMs),
+        earliestMonthReason: usageMonthFloorReason(earliestMonthMs)
+    };
 }

--- a/packages/webapp/src/pages/Team/Billing/useSelectedMonth.ts
+++ b/packages/webapp/src/pages/Team/Billing/useSelectedMonth.ts
@@ -59,8 +59,7 @@ export function useSelectedMonth(): UseSelectedMonth {
         return selectedMonth < currentMonth;
     }, [selectedMonth]);
 
-    // The floor is still the loose default until the team loads. Without this guard the arrow goes
-    // live on it and the click is clamped straight back.
+    // Until the team loads, the floor is the loose June default. Without this guard the arrow enables and the month snaps back.
     const canGoPrevious = Boolean(accountCreatedAt) && selectedMonth.getTime() > earliestMonthMs;
 
     return {


### PR DESCRIPTION
## Problem

The usage month picker on Billing stopped at June 2026, where ClickHouse data begins. An account created after that could step back into months from before it existed, which render as all zeros — indistinguishable from a month with no traffic.

## Solution

- The floor is now the later of June 2026 and the UTC month the account was created in (`usageMonthFloor.ts`).
- `useSelectedMonth` applies it to both the `?month` deep-link clamp and `canGoPrevious`.
- `canGoPrevious` stays false until the team query resolves, so the arrow can't go live on the looser floor.
- The disabled arrow's tooltip names the bound that applies: data availability, or account age.

Fixes [NAN-6929](https://linear.app/nango/issue/NAN-6929)

## Testing

Local stack, today 2026-09-08. On an account created 2026-08-19, stepping back from September disables the arrow at August with "Your account was created in August 2026.", and `?month=2026-06` clamps to August. An account created 2026-05-20 is unchanged. 6 new unit tests.

<img width="1287" height="304" alt="image" src="https://github.com/user-attachments/assets/33876fb5-6fa5-42f5-9756-a911bdecfe32" />
