### PR TITLE
feat(logs): stamp the session actor on action runs (NAN-6949)

### DIFF
--- a/packages/server/lib/controllers/agent/mcp/execute/execute.ts
+++ b/packages/server/lib/controllers/agent/mcp/execute/execute.ts
@@ -99,7 +99,8 @@ export async function executeSessionTool({
             input,
             isAsync: false,
             retryMax: RETRY_MAX,
-            span
+            span,
+            actor: { kind: 'session', id: session.id }
         });
 
         if (result.isErr()) {

--- a/packages/server/lib/controllers/agent/mcp/execute/execute.unit.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/execute/execute.unit.test.ts
@@ -87,6 +87,12 @@ describe('executeSessionTool', () => {
         );
     });
 
+    it('stamps the session as the actor of the run', async () => {
+        await execute('read_doc');
+
+        expect(executeAction).toHaveBeenCalledWith(expect.objectContaining({ actor: { kind: 'session', id: 'session-1' } }));
+    });
+
     it('runs a searchable tool, which is callable without being listed', async () => {
         const result = await execute('upsert_doc');
 

--- a/packages/server/lib/services/action.service.ts
+++ b/packages/server/lib/services/action.service.ts
@@ -7,7 +7,7 @@ import { getOrchestrator } from '../utils/utils.js';
 
 import type { LogContextOrigin } from '@nangohq/logs';
 import type { NangoError } from '@nangohq/shared';
-import type { AsyncActionResponse, DBEnvironment, DBTeam, Result } from '@nangohq/types';
+import type { AsyncActionResponse, DBEnvironment, DBTeam, OperationActor, Result } from '@nangohq/types';
 import type { Span } from 'dd-trace';
 
 export type ActionExecutionSuccess = AsyncActionResponse | { data: unknown };
@@ -48,7 +48,8 @@ export async function executeAction({
     input,
     isAsync,
     retryMax,
-    span
+    span,
+    actor
 }: {
     account: DBTeam;
     environment: DBEnvironment;
@@ -59,6 +60,7 @@ export async function executeAction({
     isAsync: boolean;
     retryMax: number;
     span: Span;
+    actor?: OperationActor | undefined;
 }): Promise<ActionExecution> {
     let logCtx: LogContextOrigin | undefined;
     try {
@@ -87,7 +89,7 @@ export async function executeAction({
             .setTag('nango.providerConfigKey', providerConfigKey);
 
         logCtx = await logContextGetter.create(
-            { operation: { type: 'action', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
+            { operation: { type: 'action', action: 'run' }, expiresAt: defaultOperationExpiration.action(), actor },
             {
                 account,
                 environment,


### PR DESCRIPTION
NAN-6949

Stamps the actor on the `action:run` operations an agent session triggers, so the agent session filter on the logs page returns the work the agent did and not just the session create and terminate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

