### PR TITLE
fix(webapp): keep dev tools while impersonating customers

### DIFF
--- a/packages/webapp/src/features/DevToolPanel.tsx
+++ b/packages/webapp/src/features/DevToolPanel.tsx
@@ -27,17 +27,11 @@ const isDevToolsEnabledByHostname =
     window.location.hostname.endsWith('.app-development.nango.dev') ||
     window.location.hostname === 'app-staging.nango.dev';
 
-/**
- * Returns true when the dev tool panel should be available — either on a dev
- * hostname or when the signed-in account is the Nango admin team.
- *
- * Defaults to false until the team query resolves, so there is no flash on
- * first paint for non-admin accounts.
- */
 export function useIsDevToolsEnabled(): boolean {
     const env = useStore((s) => s.env);
+    const debugMode = useStore((s) => s.debugMode);
     const { data } = useTeam(env);
-    return isDevToolsEnabledByHostname || (data?.data.isAdminTeam ?? false);
+    return isDevToolsEnabledByHostname || debugMode || (data?.data.isAdminTeam ?? false);
 }
 
 // Toggle with: Ctrl+Shift+D


### PR DESCRIPTION
## Problem

Dev Tools disappear when Nango staff impersonate a customer because the effective account is not the Nango admin account.

## Solution

- Keep Dev Tools available while the existing impersonation debug mode is active.

Fixes [NAN-6945](https://linear.app/nango/issue/NAN-6945/keep-dev-tools-available-while-impersonating-customers)

## Testing

- Ran the webapp Vite typecheck and formatting check.
