### PR TITLE
fix(server): return 500 when secret key auth hits an unexpected error (NAN-4668)

### DIFF
--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -148,7 +148,7 @@ export class AccessMiddleware {
         } catch (err) {
             logger.error(`failed_get_env_by_secret_key ${stringifyError(err)}`);
             span.setTag('error', err);
-            errorManager.errRes(res, 'malformed_auth_header');
+            res.status(500).send({ error: { code: 'server_error' } });
             return;
         } finally {
             metrics.duration(metrics.Types.AUTH_GET_ENV_BY_SECRET_KEY, Date.now() - start, { accountId: res.locals['account']?.id || 'unknown' });

--- a/packages/server/lib/middleware/access.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/access.middleware.unit.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { accountService } from '@nangohq/shared';
+
+import accessMiddleware from './access.middleware.js';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { ApiKeyContext, DBEnvironment, DBTeam } from '@nangohq/types';
+import type { NextFunction, Request, Response } from 'express';
+
+const secretKey = '00000000-0000-4000-8000-000000000000';
+
+const context: ApiKeyContext = {
+    account: { id: 1 } as DBTeam,
+    environment: { id: 10 } as DBEnvironment,
+    plan: null,
+    principal: { type: 'api_key', source: 'customer_key', accountId: 1, scopes: ['environment:*'], environmentIds: [10] },
+    auth: { source: 'customer_key' }
+};
+
+async function runSecretKeyAuth(authorization: string | undefined) {
+    const req = { get: (name: string) => (name.toLowerCase() === 'authorization' ? authorization : undefined) } as unknown as Request;
+    const res = {
+        locals: {} as Partial<RequestLocals>,
+        status: vi.fn().mockReturnThis(),
+        send: vi.fn().mockReturnThis()
+    };
+    const next = vi.fn();
+
+    await accessMiddleware.secretKeyAuth(req, res as unknown as Response<any, Partial<RequestLocals>>, next as unknown as NextFunction);
+
+    const sent = res.send.mock.lastCall?.[0] as { error: { code: string } } | undefined;
+
+    return { next, status: res.status, code: sent?.error.code, locals: res.locals };
+}
+
+describe('secretKeyAuth', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('responds 500 when the account lookup throws', async () => {
+        const lookup = vi
+            .spyOn(accountService, 'getAccountContextByApiKey')
+            .mockRejectedValue(new Error('KnexTimeoutError: Knex: Timeout acquiring a connection'));
+
+        const { next, status, code } = await runSecretKeyAuth(`Bearer ${secretKey}`);
+
+        expect(lookup).toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(500);
+        expect(code).toBe('server_error');
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('authenticates a known key', async () => {
+        vi.spyOn(accountService, 'getAccountContextByApiKey').mockResolvedValue(context);
+
+        const { next, status, locals } = await runSecretKeyAuth(`Bearer ${secretKey}`);
+
+        expect(next).toHaveBeenCalled();
+        expect(status).not.toHaveBeenCalled();
+        expect(locals.authType).toBe('secretKey');
+        expect(locals.account).toStrictEqual(context.account);
+        expect(locals.environment).toStrictEqual(context.environment);
+        expect(locals.apiKeyPrincipal).toStrictEqual(context.principal);
+    });
+
+    it('responds 401 when the key matches no account', async () => {
+        vi.spyOn(accountService, 'getAccountContextByApiKey').mockResolvedValue(null);
+
+        const { next, status, code } = await runSecretKeyAuth(`Bearer ${secretKey}`);
+
+        expect(status).toHaveBeenCalledWith(401);
+        expect(code).toBe('unknown_account');
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        { header: undefined, expected: 'missing_auth_header' },
+        { header: 'Bearer ', expected: 'malformed_auth_header' },
+        { header: 'Bearer not-a-uuid', expected: 'invalid_secret_key_format' }
+    ])('responds 401 $expected without looking up the key', async ({ header, expected }) => {
+        const lookup = vi.spyOn(accountService, 'getAccountContextByApiKey');
+
+        const { next, status, code } = await runSecretKeyAuth(header);
+
+        expect(status).toHaveBeenCalledWith(401);
+        expect(code).toBe(expected);
+        expect(lookup).not.toHaveBeenCalled();
+        expect(next).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
- `secretKeyAuth` now answers `500 server_error` when the key lookup throws, instead of `401 malformed_auth_header`. A transient database failure (pool exhaustion, `KnexTimeoutError`) was indistinguishable from a bad credential, so API consumers treated it as a permanently invalid key — the reporter's app disables a connection on 401, and a customer hit the same thing again on 0.71.4.
- New unit test for the middleware's status ladder: an unexpected error is 500, every genuine authentication failure is still 401 (missing header, empty bearer, non-UUID token, unknown key) and a valid key still authenticates.

## No error classification

The linked issue suggests an `isInfrastructureError(err)` allowlist. That isn't needed: every expected failure returns before the catch — missing and empty headers early, and bad format / unknown account / missing plan through `validateApiKey`'s `Result`. The only paths that throw out of that call are the database query and the `pbkdf2` hash, neither of which a caller can trigger, so the catch is already the unexpected-error branch. `server_error` is the code the repo already uses for that (`asyncWrapper`, `noAuth` in the same file) and it is part of `ResDefaultErrors`.

## Scope

Five other auth middlewares (`connectSessionAuth`, `connectSessionAuthBody`, `agentSessionAuth`, `connectSessionOrSecretKeyAuth`, `connectSessionOrPublicKeyAuth`) share the pattern and still answer `401 unknown_account` on a database failure; sandbox API keys also still 401, because `getAccountContextBySandboxApiKey` catches its own error and `getAccountContextByApiKey` flattens it to `null`. Both are deliberately left out of this PR, which fixes only the reported path, and are tracked on NAN-4668.

Fixes #5338

## Test plan

- [x] `vitest run packages/server/lib/middleware/access.middleware.unit.test.ts` — 6 passing
- [x] Confirmed the tests fail when the code regresses: restoring the 401 in the catch fails the 500 test; answering 500 from the client-error branches fails the four 401 tests
- [x] Rebased on master and re-ran; `prettier --check` and `oxlint` clean on both files
- [ ] After deploy: confirm a database incident shows up as 5xx on the API error-rate dashboard rather than as authentication failures

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

