### PR TITLE
feat(billing): show per-metric charges for past months on the billing page

### DIFF
--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -54,8 +54,8 @@ export class Billing {
         return await this.client.getUpcomingInvoice(subscriptionId);
     }
 
-    async getPeriodCosts(subscriptionId: string): Promise<Result<BillingPeriodCosts | null>> {
-        return await this.client.getPeriodCosts(subscriptionId);
+    async getPeriodCosts(subscriptionId: string, timeframe?: { start: Date; end: Date }): Promise<Result<BillingPeriodCosts | null>> {
+        return await this.client.getPeriodCosts(subscriptionId, timeframe);
     }
 
     async getSpendAlert(subscriptionId: string): Promise<Result<BillingSpendAlert | null>> {

--- a/packages/billing/lib/clients/noop/client.ts
+++ b/packages/billing/lib/clients/noop/client.ts
@@ -78,7 +78,7 @@ export class NoopBillingClient implements BillingClient {
         return Promise.resolve(Ok(null));
     }
 
-    getPeriodCosts(_subscriptionId: string): Promise<Result<BillingPeriodCosts | null>> {
+    getPeriodCosts(_subscriptionId: string, _timeframe?: { start: Date; end: Date }): Promise<Result<BillingPeriodCosts | null>> {
         return Promise.resolve(Ok(null));
     }
 

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -110,16 +110,16 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
     const metrics: Partial<Record<UsageMetric, number>> = {};
     const malformedMetrics: UsageMetric[] = [];
     const flagged: BillingPeriodCosts['flagged'] = [];
-    // Held back so a fixed price can never set the period's currency. If it could, a subscription
-    // carrying only a base fee would start reporting costs where it reports none.
+    // Process fixed prices after usage prices so they cannot set the period currency. A fixed-only
+    // subscription has no metric costs to report.
     const fixedPrices: { priceId: string; priceName: string; amountInCents: number | null; currency: string | null }[] = [];
     let fullyAttributed = true;
     let currency: string | null = null;
 
     for (const priceCost of period.per_price_costs) {
         const { price } = priceCost;
-        // `total` also carries the price's share of any plan-level minimum or discount — a $50 minimum
-        // lands as $16.67 on each of three unused metrics — so only `subtotal` is attributable to usage.
+        // Orb allocates plan-level minimums and discounts across price totals. Only the subtotal
+        // belongs to this usage price.
         const amountInCents = orbAmountToCents(priceCost.subtotal);
         const priceCurrency = normalizeIsoCurrency(price.currency);
 

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -100,9 +100,8 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
         (latest, bucket) => (latest && Date.parse(latest.timeframe_end) >= Date.parse(bucket.timeframe_end) ? latest : bucket),
         null
     );
-    // An ended subscription answers with its stale final period rather than erroring, so without a
-    // named window a closed period is not an answer. NaN must reject explicitly — NaN <= now is
-    // always false, so a malformed timeframe_end would otherwise read as current.
+    // An ended subscription returns its stale final period instead of erroring, so a closed period
+    // counts only when the caller named the window. `NaN <= now` is false, so NaN needs its own check.
     const periodEnd = period ? Date.parse(period.timeframe_end) : NaN;
     if (!period || Number.isNaN(periodEnd) || (!opts.explicitTimeframe && periodEnd <= now.getTime())) {
         return null;
@@ -111,9 +110,8 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
     const metrics: Partial<Record<UsageMetric, number>> = {};
     const malformedMetrics: UsageMetric[] = [];
     const flagged: BillingPeriodCosts['flagged'] = [];
-    // Held back until the usage prices have run: a fixed price must never be what establishes the
-    // period's currency, or a subscription carrying only a base fee would start reporting costs
-    // where it reports none today.
+    // Held back so a fixed price can never set the period's currency. If it could, a subscription
+    // carrying only a base fee would start reporting costs where it reports none.
     const fixedPrices: { priceId: string; priceName: string; amountInCents: number | null; currency: string | null }[] = [];
     let fullyAttributed = true;
     let currency: string | null = null;
@@ -166,9 +164,8 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
     let fixedInCents = 0;
     for (const fixed of fixedPrices) {
         if (fixed.amountInCents === null || fixed.currency !== currency) {
-            // Flagged for alerting but deliberately left out of `fullyAttributed`, which governs only
-            // whether an absent *metric* may read as $0 — money on a fixed price was never a metric's
-            // to claim. So an unreadable one understates `fixedInCents` and changes nothing else.
+            // Deliberately not `fullyAttributed`. That flag only decides whether an absent *metric*
+            // may read as $0.00, so setting it here would turn every real $0.00 usage row into a dash.
             flagged.push({ priceId: fixed.priceId, priceName: fixed.priceName, metric: null, amountInCents: fixed.amountInCents });
             continue;
         }

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -100,8 +100,7 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
         (latest, bucket) => (latest && Date.parse(latest.timeframe_end) >= Date.parse(bucket.timeframe_end) ? latest : bucket),
         null
     );
-    // An ended subscription returns its stale final period instead of erroring, so a closed period
-    // counts only when the caller named the window. `NaN <= now` is false, so NaN needs its own check.
+    // Orb returns its last period after a subscription ends. Accept it only when the request includes dates.
     const periodEnd = period ? Date.parse(period.timeframe_end) : NaN;
     if (!period || Number.isNaN(periodEnd) || (!opts.explicitTimeframe && periodEnd <= now.getTime())) {
         return null;
@@ -110,16 +109,14 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
     const metrics: Partial<Record<UsageMetric, number>> = {};
     const malformedMetrics: UsageMetric[] = [];
     const flagged: BillingPeriodCosts['flagged'] = [];
-    // Process fixed prices after usage prices so they cannot set the period currency. A fixed-only
-    // subscription has no metric costs to report.
+    // Read currency from usage prices. A subscription with only fixed prices has no metric costs.
     const fixedPrices: { priceId: string; priceName: string; amountInCents: number | null; currency: string | null }[] = [];
     let fullyAttributed = true;
     let currency: string | null = null;
 
     for (const priceCost of period.per_price_costs) {
         const { price } = priceCost;
-        // Orb allocates plan-level minimums and discounts across price totals. Only the subtotal
-        // belongs to this usage price.
+        // Orb spreads minimum charges and discounts across price totals. Read usage charges from `subtotal`.
         const amountInCents = orbAmountToCents(priceCost.subtotal);
         const priceCurrency = normalizeIsoCurrency(price.currency);
 
@@ -164,8 +161,7 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
     let fixedInCents = 0;
     for (const fixed of fixedPrices) {
         if (fixed.amountInCents === null || fixed.currency !== currency) {
-            // Deliberately not `fullyAttributed`. That flag only decides whether an absent *metric*
-            // may read as $0.00, so setting it here would turn every real $0.00 usage row into a dash.
+            // Keep `fullyAttributed` unchanged. It describes usage prices, not fixed prices.
             flagged.push({ priceId: fixed.priceId, priceName: fixed.priceName, metric: null, amountInCents: fixed.amountInCents });
             continue;
         }

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -109,7 +109,7 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
     const metrics: Partial<Record<UsageMetric, number>> = {};
     const malformedMetrics: UsageMetric[] = [];
     const flagged: BillingPeriodCosts['flagged'] = [];
-    // Read currency from usage prices. A subscription with only fixed prices has no metric costs.
+    // Store fixed prices until usage prices set the currency. Without a usage price, return null.
     const fixedPrices: { priceId: string; priceName: string; amountInCents: number | null; currency: string | null }[] = [];
     let fullyAttributed = true;
     let currency: string | null = null;
@@ -159,9 +159,9 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
     }
 
     let fixedInCents = 0;
+    // Fixed prices do not change `fullyAttributed`. It reports whether every usage price maps to a metric.
     for (const fixed of fixedPrices) {
         if (fixed.amountInCents === null || fixed.currency !== currency) {
-            // Keep `fullyAttributed` unchanged. It describes usage prices, not fixed prices.
             flagged.push({ priceId: fixed.priceId, priceName: fixed.priceName, metric: null, amountInCents: fixed.amountInCents });
             continue;
         }

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -94,39 +94,43 @@ interface OrbCostBucket {
     }[];
 }
 
-export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date): BillingPeriodCosts | null {
+export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, opts: { explicitTimeframe?: boolean } = {}): BillingPeriodCosts | null {
     // Cumulative buckets accumulate over the period, so the one ending last spans all of it.
     const period = costs.data.reduce<OrbCostBucket | null>(
         (latest, bucket) => (latest && Date.parse(latest.timeframe_end) >= Date.parse(bucket.timeframe_end) ? latest : bucket),
         null
     );
-    // An ended subscription still answers with its final period rather than erroring, and those costs
-    // are not what is being billed now. A NaN from a malformed timeframe_end must reject explicitly —
-    // NaN <= now.getTime() is always false, so it would otherwise read as a current period.
+    // An ended subscription answers with its stale final period rather than erroring, so without a
+    // named window a closed period is not an answer. NaN must reject explicitly — NaN <= now is
+    // always false, so a malformed timeframe_end would otherwise read as current.
     const periodEnd = period ? Date.parse(period.timeframe_end) : NaN;
-    if (!period || Number.isNaN(periodEnd) || periodEnd <= now.getTime()) {
+    if (!period || Number.isNaN(periodEnd) || (!opts.explicitTimeframe && periodEnd <= now.getTime())) {
         return null;
     }
 
     const metrics: Partial<Record<UsageMetric, number>> = {};
     const malformedMetrics: UsageMetric[] = [];
     const flagged: BillingPeriodCosts['flagged'] = [];
+    // Held back until the usage prices have run: a fixed price must never be what establishes the
+    // period's currency, or a subscription carrying only a base fee would start reporting costs
+    // where it reports none today.
+    const fixedPrices: { priceId: string; priceName: string; amountInCents: number | null; currency: string | null }[] = [];
     let fullyAttributed = true;
     let currency: string | null = null;
 
     for (const priceCost of period.per_price_costs) {
         const { price } = priceCost;
-        // Excluded, so the metrics never sum to the period's invoice total — the base fee isn't split
-        // across rows.
+        // `total` also carries the price's share of any plan-level minimum or discount — a $50 minimum
+        // lands as $16.67 on each of three unused metrics — so only `subtotal` is attributable to usage.
+        const amountInCents = orbAmountToCents(priceCost.subtotal);
+        const priceCurrency = normalizeIsoCurrency(price.currency);
+
         if (price.price_type === 'fixed_price') {
+            fixedPrices.push({ priceId: priceCost.price_id, priceName: price.name, amountInCents, currency: priceCurrency });
             continue;
         }
 
         const metric = price.billable_metric ? (orbBillableMetricToUsageMetric[price.billable_metric.id] ?? null) : null;
-        const priceCurrency = normalizeIsoCurrency(price.currency);
-        // `total` also carries the price's share of any plan-level minimum or discount — a $50 minimum
-        // lands as $16.67 on each of three unused metrics — so only `subtotal` is attributable to usage.
-        const amountInCents = orbAmountToCents(priceCost.subtotal);
         const readable = priceCurrency !== null && (currency === null || priceCurrency === currency) && amountInCents !== null;
 
         if (!readable) {
@@ -159,7 +163,19 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date):
         return null;
     }
 
-    return { metrics, malformedMetrics, fullyAttributed, flagged, currency };
+    let fixedInCents = 0;
+    for (const fixed of fixedPrices) {
+        if (fixed.amountInCents === null || fixed.currency !== currency) {
+            // Flagged for alerting but deliberately left out of `fullyAttributed`, which governs only
+            // whether an absent *metric* may read as $0 — money on a fixed price was never a metric's
+            // to claim. So an unreadable one understates `fixedInCents` and changes nothing else.
+            flagged.push({ priceId: fixed.priceId, priceName: fixed.priceName, metric: null, amountInCents: fixed.amountInCents });
+            continue;
+        }
+        fixedInCents += fixed.amountInCents;
+    }
+
+    return { metrics, malformedMetrics, fullyAttributed, flagged, fixedInCents, currency };
 }
 
 /**

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -637,8 +637,6 @@ describe('fromOrbPeriodCosts', () => {
             ]
         };
 
-        // Were a fixed price allowed to establish the currency, an account whose usage prices have
-        // been removed would flip from "no charges" to a row of $0.00s.
         expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
     });
 

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -412,6 +412,7 @@ describe('fromOrbPeriodCosts', () => {
             malformedMetrics: [],
             fullyAttributed: true,
             flagged: [],
+            fixedInCents: 0,
             currency: 'USD'
         });
     });
@@ -475,7 +476,7 @@ describe('fromOrbPeriodCosts', () => {
         expect(fromOrbPeriodCosts(costs, NOW)?.metrics).not.toHaveProperty('records');
     });
 
-    it('excludes fixed prices, so the metrics exclude the base fee', () => {
+    it('reports a fixed price separately, so no metric absorbs the base fee', () => {
         const costs = {
             data: [
                 bucket([
@@ -495,6 +496,7 @@ describe('fromOrbPeriodCosts', () => {
             malformedMetrics: [],
             fullyAttributed: true,
             flagged: [],
+            fixedInCents: 50_000,
             currency: 'USD'
         });
     });
@@ -594,7 +596,34 @@ describe('fromOrbPeriodCosts', () => {
         expect(result?.fullyAttributed).toBe(false);
     });
 
-    it('returns null when every price is fixed, so no currency can be stated', () => {
+    it('leaves every metric figure untouched when a fixed price cannot be read', () => {
+        const withFixed = (fixedCurrency: string, subtotal: string) => ({
+            data: [
+                bucket([
+                    usagePrice(RECORDS_PROD, '23.17'),
+                    {
+                        price_id: 'price_fixed',
+                        subtotal,
+                        total: subtotal,
+                        price: { price_type: 'fixed_price', currency: fixedCurrency, name: 'Base fee', billable_metric: null }
+                    }
+                ])
+            ]
+        });
+
+        const mismatched = fromOrbPeriodCosts(withFixed('EUR', '500.00'), NOW);
+        expect(mismatched?.metrics).toEqual({ records: 2317 });
+        expect(mismatched?.fullyAttributed).toBe(true);
+        expect(mismatched?.fixedInCents).toBe(0);
+        expect(mismatched?.flagged).toHaveLength(1);
+
+        const unparseable = fromOrbPeriodCosts(withFixed('USD', 'n/a'), NOW);
+        expect(unparseable?.metrics).toEqual({ records: 2317 });
+        expect(unparseable?.fullyAttributed).toBe(true);
+        expect(unparseable?.fixedInCents).toBe(0);
+    });
+
+    it('returns null when every price is fixed, so a base fee alone never starts reporting costs', () => {
         const costs = {
             data: [
                 bucket([
@@ -608,6 +637,8 @@ describe('fromOrbPeriodCosts', () => {
             ]
         };
 
+        // Were a fixed price allowed to establish the currency, an account whose usage prices have
+        // been removed would flip from "no charges" to a row of $0.00s.
         expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
     });
 

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -197,7 +197,6 @@ export class OrbClient implements BillingClient {
 
     async getPeriodCosts(subscriptionId: string, timeframe?: { start: Date; end: Date }): Promise<Result<BillingPeriodCosts | null>> {
         try {
-            // Cumulative so the last bucket carries the whole window, not a single day's.
             const costs = await this.orbSDK.subscriptions.fetchCosts(
                 subscriptionId,
                 {

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -195,13 +195,16 @@ export class OrbClient implements BillingClient {
         }
     }
 
-    async getPeriodCosts(subscriptionId: string): Promise<Result<BillingPeriodCosts | null>> {
+    async getPeriodCosts(subscriptionId: string, timeframe?: { start: Date; end: Date }): Promise<Result<BillingPeriodCosts | null>> {
         try {
-            // No timeframe: Orb defaults to the current billing period. Cumulative so the last bucket
-            // carries the period-to-date figure rather than a single day's.
+            // Cumulative so the last bucket carries the whole window, not a single day's. With no
+            // timeframe Orb defaults to the current billing period; a closed month has to be named.
             const costs = await this.orbSDK.subscriptions.fetchCosts(
                 subscriptionId,
-                { view_mode: 'cumulative' },
+                {
+                    view_mode: 'cumulative',
+                    ...(timeframe ? { timeframe_start: timeframe.start.toISOString(), timeframe_end: timeframe.end.toISOString() } : {})
+                },
                 {
                     headers: {
                         'Orb-Cache-Control': 'cache',
@@ -210,7 +213,7 @@ export class OrbClient implements BillingClient {
                 }
             );
 
-            const result = fromOrbPeriodCosts(costs, new Date());
+            const result = fromOrbPeriodCosts(costs, new Date(), { explicitTimeframe: timeframe !== undefined });
             if (result && result.flagged.length > 0) {
                 // A price we couldn't cleanly turn into a metric's charge: nothing else would signal
                 // that a figure is missing, or that another metric's $0 can no longer be trusted.

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -197,8 +197,7 @@ export class OrbClient implements BillingClient {
 
     async getPeriodCosts(subscriptionId: string, timeframe?: { start: Date; end: Date }): Promise<Result<BillingPeriodCosts | null>> {
         try {
-            // Cumulative so the last bucket carries the whole window, not a single day's. With no
-            // timeframe Orb defaults to the current billing period; a closed month has to be named.
+            // Cumulative so the last bucket carries the whole window, not a single day's.
             const costs = await this.orbSDK.subscriptions.fetchCosts(
                 subscriptionId,
                 {

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
@@ -12,11 +12,12 @@ let api: Awaited<ReturnType<typeof runServer>>;
 
 let getPeriodCostsSpy: any;
 
-const NO_COSTS = { metrics: {}, malformedMetrics: [], fullyAttributed: true, currency: null, noCosts: true };
+const NO_COSTS = { metrics: {}, malformedMetrics: [], fullyAttributed: true, fixedInCents: 0, currency: null, noCosts: true };
 const COSTS = {
     metrics: { records: 2317, connections: 0 },
     malformedMetrics: [],
     fullyAttributed: true,
+    fixedInCents: 0,
     currency: 'USD',
     noCosts: false
 };
@@ -102,12 +103,42 @@ describe(`GET ${route}`, () => {
             isSuccess(res.json);
             expect(res.res.status).toBe(200);
             expect(res.json.data).toStrictEqual(COSTS);
-            expect(getPeriodCostsSpy).toHaveBeenCalledWith('orb_sub_123');
+            expect(getPeriodCostsSpy).toHaveBeenCalledWith('orb_sub_123', undefined);
+        });
+
+        it('should pass a named window through to Orb, so a closed month is costed', async () => {
+            const { apiKey } = await seedPlan('growth-v2');
+
+            const res = await api.fetch(route, {
+                method: 'GET',
+                token: apiKey.secret,
+                query: { env: 'dev', from: '2026-08-01T00:00:00.000Z', to: '2026-09-01T00:00:00.000Z' }
+            });
+
+            isSuccess(res.json);
+            expect(getPeriodCostsSpy).toHaveBeenCalledWith('orb_sub_123', {
+                start: new Date('2026-08-01T00:00:00.000Z'),
+                end: new Date('2026-09-01T00:00:00.000Z')
+            });
+        });
+
+        it('should reject a window that runs backwards', async () => {
+            const { apiKey } = await seedPlan('growth-v2');
+
+            const res = await api.fetch(route, {
+                method: 'GET',
+                token: apiKey.secret,
+                query: { env: 'dev', from: '2026-09-01T00:00:00.000Z', to: '2026-08-01T00:00:00.000Z' }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_query_params');
         });
 
         it('should keep a zero charge as zero — the startup deal really does bill $0.00', async () => {
             const { apiKey } = await seedPlan('startup-deal');
-            getPeriodCostsSpy.mockResolvedValue(Ok({ metrics: { records: 0 }, malformedMetrics: [], fullyAttributed: true, currency: 'USD' }));
+            getPeriodCostsSpy.mockResolvedValue(Ok({ metrics: { records: 0 }, malformedMetrics: [], fullyAttributed: true, fixedInCents: 0, currency: 'USD' }));
 
             const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
 
@@ -116,6 +147,7 @@ describe(`GET ${route}`, () => {
                 metrics: { records: 0 },
                 malformedMetrics: [],
                 fullyAttributed: true,
+                fixedInCents: 0,
                 currency: 'USD',
                 noCosts: false
             });
@@ -135,7 +167,9 @@ describe(`GET ${route}`, () => {
 
         it('passes through fullyAttributed and malformedMetrics so the caller knows which figures to trust', async () => {
             const { apiKey } = await seedPlan('growth-v2');
-            getPeriodCostsSpy.mockResolvedValue(Ok({ metrics: { records: 100 }, malformedMetrics: ['proxy'], fullyAttributed: false, currency: 'USD' }));
+            getPeriodCostsSpy.mockResolvedValue(
+                Ok({ metrics: { records: 100 }, malformedMetrics: ['proxy'], fullyAttributed: false, fixedInCents: 0, currency: 'USD' })
+            );
 
             const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
 
@@ -144,6 +178,7 @@ describe(`GET ${route}`, () => {
                 metrics: { records: 100 },
                 malformedMetrics: ['proxy'],
                 fullyAttributed: false,
+                fixedInCents: 0,
                 currency: 'USD',
                 noCosts: false
             });

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.integration.test.ts
@@ -122,6 +122,32 @@ describe(`GET ${route}`, () => {
             });
         });
 
+        it.each([
+            ['from', { from: '2026-08-01T00:00:00.000Z' }],
+            ['to', { to: '2026-09-01T00:00:00.000Z' }]
+        ])('should reject %s without its pair, rather than costing the current period', async (_name, half) => {
+            const { apiKey } = await seedPlan('growth-v2');
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev', ...half } });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(getPeriodCostsSpy).not.toHaveBeenCalled();
+        });
+
+        it('should reject a zero-length window', async () => {
+            const { apiKey } = await seedPlan('growth-v2');
+
+            const res = await api.fetch(route, {
+                method: 'GET',
+                token: apiKey.secret,
+                query: { env: 'dev', from: '2026-08-01T00:00:00.000Z', to: '2026-08-01T00:00:00.000Z' }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+        });
+
         it('should reject a window that runs backwards', async () => {
             const { apiKey } = await seedPlan('growth-v2');
 

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
@@ -26,8 +26,6 @@ const querySchema = z
         from: z.iso.datetime().optional(),
         to: z.iso.datetime().optional()
     })
-    // Both or neither: one half of a window would otherwise fall through to the current period,
-    // answering with a different month's charges than the caller asked for.
     .refine((data) => (data.from === undefined) === (data.to === undefined), {
         message: 'from and to must be provided together',
         path: ['from']

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
@@ -1,19 +1,40 @@
+import z from 'zod';
+
 import { billing } from '@nangohq/billing';
-import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { report, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { isSpendPlan } from '../../../../utils/spendPlans.js';
 
 import type { GetBillingPeriodCosts } from '@nangohq/types';
 
-const NO_COSTS: GetBillingPeriodCosts['Success']['data'] = { metrics: {}, malformedMetrics: [], fullyAttributed: true, currency: null, noCosts: true };
+const NO_COSTS: GetBillingPeriodCosts['Success']['data'] = {
+    metrics: {},
+    malformedMetrics: [],
+    fullyAttributed: true,
+    fixedInCents: 0,
+    currency: null,
+    noCosts: true
+};
+
+const querySchema = z
+    .strictObject({
+        env: z.string(),
+        from: z.iso.datetime().optional(),
+        to: z.iso.datetime().optional()
+    })
+    .refine((data) => !data.from || !data.to || new Date(data.from) <= new Date(data.to), {
+        message: 'From date must be before to date',
+        path: ['from']
+    });
 
 export const getBillingPeriodCosts = asyncWrapper<GetBillingPeriodCosts>(async (req, res) => {
-    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
-    if (emptyQuery) {
-        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+    const val = querySchema.safeParse(req.query);
+    if (!val.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(val.error) } });
         return;
     }
+    const query = val.data;
 
     const { plan } = res.locals;
     if (!plan) {
@@ -33,7 +54,8 @@ export const getBillingPeriodCosts = asyncWrapper<GetBillingPeriodCosts>(async (
         return;
     }
 
-    const costsRes = await billing.getPeriodCosts(plan.orb_subscription_id);
+    const timeframe = query.from && query.to ? { start: new Date(query.from), end: new Date(query.to) } : undefined;
+    const costsRes = await billing.getPeriodCosts(plan.orb_subscription_id, timeframe);
     if (costsRes.isErr()) {
         report(costsRes.error);
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to get period costs' } });
@@ -51,6 +73,7 @@ export const getBillingPeriodCosts = asyncWrapper<GetBillingPeriodCosts>(async (
             metrics: costs.metrics,
             malformedMetrics: costs.malformedMetrics,
             fullyAttributed: costs.fullyAttributed,
+            fixedInCents: costs.fixedInCents,
             currency: costs.currency,
             noCosts: false
         }

--- a/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getBillingPeriodCosts.ts
@@ -19,11 +19,20 @@ const NO_COSTS: GetBillingPeriodCosts['Success']['data'] = {
 
 const querySchema = z
     .strictObject({
-        env: z.string(),
+        env: z
+            .string()
+            .regex(/^[a-zA-Z0-9_-]+$/)
+            .max(255),
         from: z.iso.datetime().optional(),
         to: z.iso.datetime().optional()
     })
-    .refine((data) => !data.from || !data.to || new Date(data.from) <= new Date(data.to), {
+    // Both or neither: one half of a window would otherwise fall through to the current period,
+    // answering with a different month's charges than the caller asked for.
+    .refine((data) => (data.from === undefined) === (data.to === undefined), {
+        message: 'from and to must be provided together',
+        path: ['from']
+    })
+    .refine((data) => !data.from || !data.to || new Date(data.from) < new Date(data.to), {
         message: 'From date must be before to date',
         path: ['from']
     });

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -120,8 +120,7 @@ export interface BillingPeriodCosts {
     /** The individual prices behind `malformedMetrics` and a false `fullyAttributed`, for alerting —
      *  not sent over HTTP. */
     flagged: { priceId: string; priceName: string; metric: UsageMetric | null; amountInCents: number | null }[];
-    /** Integer cents from the fixed prices readable in the period's currency. Kept out of `metrics`
-     *  so no metric absorbs non-usage money; an unreadable one goes to `flagged` and is missing here. */
+    /** Unreadable fixed prices appear only in `flagged`. */
     fixedInCents: number;
     currency: string;
 }

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -120,8 +120,9 @@ export interface BillingPeriodCosts {
     /** The individual prices behind `malformedMetrics` and a false `fullyAttributed`, for alerting —
      *  not sent over HTTP. */
     flagged: { priceId: string; priceName: string; metric: UsageMetric | null; amountInCents: number | null }[];
-    /** Integer cents from every fixed price — a plan's base fee, an add-on. Kept out of `metrics` so
-     *  no metric's charge absorbs money that isn't usage. */
+    /** Integer cents from the fixed prices that could be read in the period's currency — a plan's
+     *  base fee, an add-on. Kept out of `metrics` so no metric's charge absorbs money that isn't
+     *  usage; an unreadable one is reported via `flagged` and left out of this total. */
     fixedInCents: number;
     currency: string;
 }

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -120,7 +120,6 @@ export interface BillingPeriodCosts {
     /** The individual prices behind `malformedMetrics` and a false `fullyAttributed`, for alerting —
      *  not sent over HTTP. */
     flagged: { priceId: string; priceName: string; metric: UsageMetric | null; amountInCents: number | null }[];
-    /** Unreadable fixed prices are recorded in `flagged` and omitted from this total. */
     fixedInCents: number;
     currency: string;
 }

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -10,7 +10,7 @@ export interface BillingClient {
     getSubscription: (accountId: number) => Promise<Result<BillingSubscription>>;
     getOverdueInvoices: (accountId: number) => Promise<Result<BillingOverdueInvoices>>;
     getUpcomingInvoice: (subscriptionId: string) => Promise<Result<BillingUpcomingInvoice | null>>;
-    getPeriodCosts: (subscriptionId: string) => Promise<Result<BillingPeriodCosts | null>>;
+    getPeriodCosts: (subscriptionId: string, timeframe?: { start: Date; end: Date }) => Promise<Result<BillingPeriodCosts | null>>;
     getSpendAlert: (subscriptionId: string) => Promise<Result<BillingSpendAlert | null>>;
     setSpendAlert: (subscriptionId: string, opts: { thresholdInCents: number }) => Promise<Result<BillingSpendAlert>>;
     removeSpendAlert: (subscriptionId: string) => Promise<Result<void>>;
@@ -120,6 +120,9 @@ export interface BillingPeriodCosts {
     /** The individual prices behind `malformedMetrics` and a false `fullyAttributed`, for alerting —
      *  not sent over HTTP. */
     flagged: { priceId: string; priceName: string; metric: UsageMetric | null; amountInCents: number | null }[];
+    /** Integer cents from every fixed price — a plan's base fee, an add-on. Kept out of `metrics` so
+     *  no metric's charge absorbs money that isn't usage. */
+    fixedInCents: number;
     currency: string;
 }
 

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -120,7 +120,7 @@ export interface BillingPeriodCosts {
     /** The individual prices behind `malformedMetrics` and a false `fullyAttributed`, for alerting —
      *  not sent over HTTP. */
     flagged: { priceId: string; priceName: string; metric: UsageMetric | null; amountInCents: number | null }[];
-    /** Unreadable fixed prices appear only in `flagged`. */
+    /** Unreadable fixed prices are recorded in `flagged` and omitted from this total. */
     fixedInCents: number;
     currency: string;
 }

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -120,9 +120,8 @@ export interface BillingPeriodCosts {
     /** The individual prices behind `malformedMetrics` and a false `fullyAttributed`, for alerting —
      *  not sent over HTTP. */
     flagged: { priceId: string; priceName: string; metric: UsageMetric | null; amountInCents: number | null }[];
-    /** Integer cents from the fixed prices that could be read in the period's currency — a plan's
-     *  base fee, an add-on. Kept out of `metrics` so no metric's charge absorbs money that isn't
-     *  usage; an unreadable one is reported via `flagged` and left out of this total. */
+    /** Integer cents from the fixed prices readable in the period's currency. Kept out of `metrics`
+     *  so no metric absorbs non-usage money; an unreadable one goes to `flagged` and is missing here. */
     fixedInCents: number;
     currency: string;
 }

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -176,7 +176,7 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing/period-costs';
-    /** Omit both to get the period being billed now; name a window to cost a closed month. */
+    /** Omit `from` and `to` for the current billing period. Provide both for an explicit date range. */
     Querystring: { env: string; from?: string; to?: string };
     Success: {
         data: {

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -187,7 +187,7 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
             /** False when some usage price mapped to no metric of ours — an absent metric can't safely
              *  read as $0, since the money might be one of theirs. */
             fullyAttributed: boolean;
-            /** Cents from fixed prices — base fee, add-ons — which belong to no metric row. */
+            /** Cents from the readable fixed prices — base fee, add-ons — which belong to no metric row. */
             fixedInCents: number;
             currency: string | null;
             /** True when there's no billing period to report costs for — a free plan, no linked

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -176,7 +176,9 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing/period-costs';
-    Querystring: { env: string };
+    /** Without `from`/`to` this answers for the period being billed now. Naming a window also asks
+     *  for a closed month, which Orb reports with the same per-price breakdown. */
+    Querystring: { env: string; from?: string; to?: string };
     Success: {
         data: {
             metrics: Partial<Record<UsageMetric, number>>;
@@ -185,6 +187,8 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
             /** False when some usage price mapped to no metric of ours — an absent metric can't safely
              *  read as $0, since the money might be one of theirs. */
             fullyAttributed: boolean;
+            /** Cents from fixed prices — base fee, add-ons — which belong to no metric row. */
+            fixedInCents: number;
             currency: string | null;
             /** True when there's no billing period to report costs for — a free plan, no linked
              *  subscription, or an ended one. `metrics`/`currency` are otherwise never empty/null. */

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -176,8 +176,7 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing/period-costs';
-    /** Without `from`/`to` this answers for the period being billed now. Naming a window also asks
-     *  for a closed month, which Orb reports with the same per-price breakdown. */
+    /** Omit both to get the period being billed now; name a window to cost a closed month. */
     Querystring: { env: string; from?: string; to?: string };
     Success: {
         data: {

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -176,7 +176,7 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing/period-costs';
-    /** Omit `from` and `to` for the current billing period. Provide both for an explicit date range. */
+    /** Omitting `from` and `to` uses the current billing period. */
     Querystring: { env: string; from?: string; to?: string };
     Success: {
         data: {

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -186,7 +186,6 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
             /** False when some usage price mapped to no metric of ours — an absent metric can't safely
              *  read as $0, since the money might be one of theirs. */
             fullyAttributed: boolean;
-            /** Cents from the readable fixed prices — base fee, add-ons — which belong to no metric row. */
             fixedInCents: number;
             currency: string | null;
             /** True when there's no billing period to report costs for — a free plan, no linked

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -115,7 +115,7 @@ export function buildSpendOverride(override: SpendOverride): GetUpcomingInvoice[
  */
 export function buildPeriodCostsOverride(override: PeriodCostsOverride): GetBillingPeriodCosts['Success'] {
     if (override === 'unavailable') {
-        return { data: { metrics: {}, malformedMetrics: [], fullyAttributed: true, currency: null, noCosts: true } };
+        return { data: { metrics: {}, malformedMetrics: [], fullyAttributed: true, fixedInCents: 0, currency: null, noCosts: true } };
     }
     if (override === 'zero') {
         return {
@@ -123,6 +123,7 @@ export function buildPeriodCostsOverride(override: PeriodCostsOverride): GetBill
                 metrics: { connections: 0, proxy: 0, function_executions: 0, function_compute_gbms: 0, function_logs: 0, webhook_forwards: 0 },
                 malformedMetrics: [],
                 fullyAttributed: true,
+                fixedInCents: 50_000,
                 currency: 'USD',
                 noCosts: false
             }
@@ -133,6 +134,7 @@ export function buildPeriodCostsOverride(override: PeriodCostsOverride): GetBill
             metrics: { connections: 11352, proxy: 1200, function_executions: 500, function_compute_gbms: 2317, function_logs: 150, webhook_forwards: 0 },
             malformedMetrics: [],
             fullyAttributed: true,
+            fixedInCents: 50_000,
             currency: 'USD',
             noCosts: false
         }

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -231,19 +231,25 @@ export const GetBillingPeriodCostsQueryKey = ['plans', 'billing', 'period-costs'
  * Shares the invoice's stale time deliberately: both read the same Orb figures, and different
  * windows would let two views of them disagree.
  */
-export function useApiGetBillingPeriodCosts(env: string, plan?: { name: string } | null, options?: { enabled?: boolean }) {
+export function useApiGetBillingPeriodCosts(
+    env: string,
+    plan?: { name: string } | null,
+    options?: { enabled?: boolean; timeframe?: { start: string; end: string } }
+) {
     const planName = plan?.name;
+    const timeframe = options?.timeframe;
     const periodCostsOverride = usePlanOverrideStore((s) => s.periodCostsOverride);
     return useQuery<GetBillingPeriodCosts['Success'], APIError>({
         enabled: Boolean(env) && (options?.enabled ?? false),
         staleTime: UPCOMING_INVOICE_STALE_TIME,
-        queryKey: [...GetBillingPeriodCostsQueryKey, env, planName, currentBillingPeriod(), periodCostsOverride],
+        queryKey: [...GetBillingPeriodCostsQueryKey, env, planName, timeframe?.start ?? currentBillingPeriod(), timeframe?.end, periodCostsOverride],
         queryFn: async (): Promise<GetBillingPeriodCosts['Success']> => {
             if (periodCostsOverride !== null) {
                 return buildPeriodCostsOverride(periodCostsOverride);
             }
 
-            const res = await apiFetch(`/api/v1/plans/billing/period-costs?env=${env}`, {
+            const window = timeframe ? `&from=${encodeURIComponent(timeframe.start)}&to=${encodeURIComponent(timeframe.end)}` : '';
+            const res = await apiFetch(`/api/v1/plans/billing/period-costs?env=${env}${window}`, {
                 method: 'GET'
             });
 

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -42,13 +42,13 @@ export const Usage: React.FC = () => {
     // billing running-average, matching what each row's drill-in chart also requests.
     const { data: usage, isLoading, error: usageError } = useApiGetBillingUsage(env, timeframe, { avgPerDay: true, enabled: plan != null && !isFree });
 
-    // Orb answers for any window it is given, so a closed month states its charges too — the
-    // current period is just the case where no window is named.
     const chargesEnabled = hasMonthlySpend(plan);
     const {
         data: periodCosts,
         isPending: costsPending,
         isError: costsError
+        // The current month sends no window on purpose, so Orb uses its own billing period, which
+        // need not start on the 1st. A named window would cost the calendar month instead.
     } = useApiGetBillingPeriodCosts(env, plan, { enabled: chargesEnabled, ...(isCurrentMonth ? {} : { timeframe }) });
     const charges = buildUsageRowCharges({ enabled: chargesEnabled, isPending: costsPending, isError: costsError, data: periodCosts });
 

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -43,12 +43,12 @@ export const Usage: React.FC = () => {
     const { data: usage, isLoading, error: usageError } = useApiGetBillingUsage(env, timeframe, { avgPerDay: true, enabled: plan != null && !isFree });
 
     const chargesEnabled = hasMonthlySpend(plan);
+    // Omit the current-month window so Orb uses the subscription's billing period. Past months use
+    // calendar windows.
     const {
         data: periodCosts,
         isPending: costsPending,
         isError: costsError
-        // The current month sends no window on purpose, so Orb uses its own billing period, which
-        // need not start on the 1st. A named window would cost the calendar month instead.
     } = useApiGetBillingPeriodCosts(env, plan, { enabled: chargesEnabled, ...(isCurrentMonth ? {} : { timeframe }) });
     const charges = buildUsageRowCharges({ enabled: chargesEnabled, isPending: costsPending, isError: costsError, data: periodCosts });
 

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -42,9 +42,14 @@ export const Usage: React.FC = () => {
     // billing running-average, matching what each row's drill-in chart also requests.
     const { data: usage, isLoading, error: usageError } = useApiGetBillingUsage(env, timeframe, { avgPerDay: true, enabled: plan != null && !isFree });
 
-    // Orb only holds costs for the period in progress, so a past month has no charge to state.
-    const chargesEnabled = isCurrentMonth && hasMonthlySpend(plan);
-    const { data: periodCosts, isPending: costsPending, isError: costsError } = useApiGetBillingPeriodCosts(env, plan, { enabled: chargesEnabled });
+    // Orb answers for any window it is given, so a closed month states its charges too — the
+    // current period is just the case where no window is named.
+    const chargesEnabled = hasMonthlySpend(plan);
+    const {
+        data: periodCosts,
+        isPending: costsPending,
+        isError: costsError
+    } = useApiGetBillingPeriodCosts(env, plan, { enabled: chargesEnabled, ...(isCurrentMonth ? {} : { timeframe }) });
     const charges = buildUsageRowCharges({ enabled: chargesEnabled, isPending: costsPending, isError: costsError, data: periodCosts });
 
     if (usageError) {

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -43,8 +43,6 @@ export const Usage: React.FC = () => {
     const { data: usage, isLoading, error: usageError } = useApiGetBillingUsage(env, timeframe, { avgPerDay: true, enabled: plan != null && !isFree });
 
     const chargesEnabled = hasMonthlySpend(plan);
-    // Omit the current-month window so Orb uses the subscription's billing period. Past months use
-    // calendar windows.
     const {
         data: periodCosts,
         isPending: costsPending,

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.unit.test.ts
@@ -18,7 +18,7 @@ describe('buildUsageRowCharges', () => {
     it('formats a charge in the response currency', () => {
         const charges = buildUsageRowCharges({
             ...settled,
-            data: success({ metrics: { records: 2317 }, malformedMetrics: [], fullyAttributed: true, currency: 'USD', noCosts: false })
+            data: success({ metrics: { records: 2317 }, malformedMetrics: [], fullyAttributed: true, fixedInCents: 0, currency: 'USD', noCosts: false })
         });
 
         expect(charges?.('records')).toEqual({ formatted: '$23.17', pending: false });
@@ -27,7 +27,7 @@ describe('buildUsageRowCharges', () => {
     it('states a real zero as zero rather than as no figure', () => {
         const charges = buildUsageRowCharges({
             ...settled,
-            data: success({ metrics: { records: 0 }, malformedMetrics: [], fullyAttributed: true, currency: 'USD', noCosts: false })
+            data: success({ metrics: { records: 0 }, malformedMetrics: [], fullyAttributed: true, fixedInCents: 0, currency: 'USD', noCosts: false })
         });
 
         expect(charges?.('records')).toEqual({ formatted: '$0.00', pending: false });
@@ -37,7 +37,7 @@ describe('buildUsageRowCharges', () => {
         // Real state: some accounts have had a metric's price removed by hand, so they owe nothing on it.
         const charges = buildUsageRowCharges({
             ...settled,
-            data: success({ metrics: { proxy: 100 }, malformedMetrics: [], fullyAttributed: true, currency: 'USD', noCosts: false })
+            data: success({ metrics: { proxy: 100 }, malformedMetrics: [], fullyAttributed: true, fixedInCents: 0, currency: 'USD', noCosts: false })
         });
 
         expect(charges?.('records')).toEqual({ formatted: '$0.00', pending: false });
@@ -46,7 +46,7 @@ describe('buildUsageRowCharges', () => {
     it('refuses to call an unpriced metric zero while another charge went unattributed', () => {
         const charges = buildUsageRowCharges({
             ...settled,
-            data: success({ metrics: { proxy: 100 }, malformedMetrics: [], fullyAttributed: false, currency: 'USD', noCosts: false })
+            data: success({ metrics: { proxy: 100 }, malformedMetrics: [], fullyAttributed: false, fixedInCents: 0, currency: 'USD', noCosts: false })
         });
 
         expect(charges?.('records').formatted).toBeNull();
@@ -62,6 +62,7 @@ describe('buildUsageRowCharges', () => {
                 metrics: { proxy: 100 },
                 malformedMetrics: ['records'],
                 fullyAttributed: true,
+                fixedInCents: 0,
                 currency: 'USD',
                 noCosts: false
             })
@@ -74,7 +75,7 @@ describe('buildUsageRowCharges', () => {
     it('states no figure for a currency it cannot format', () => {
         const charges = buildUsageRowCharges({
             ...settled,
-            data: success({ metrics: { records: 100 }, malformedMetrics: [], fullyAttributed: true, currency: 'credits', noCosts: false })
+            data: success({ metrics: { records: 100 }, malformedMetrics: [], fullyAttributed: true, fixedInCents: 0, currency: 'credits', noCosts: false })
         });
 
         expect(charges?.('records').formatted).toBeNull();
@@ -83,7 +84,7 @@ describe('buildUsageRowCharges', () => {
     it('states no figure when the server reports no billing period to cost', () => {
         const charges = buildUsageRowCharges({
             ...settled,
-            data: success({ metrics: {}, malformedMetrics: [], fullyAttributed: true, currency: null, noCosts: true })
+            data: success({ metrics: {}, malformedMetrics: [], fullyAttributed: true, fixedInCents: 0, currency: null, noCosts: true })
         });
 
         expect(charges?.('records')).toEqual({ formatted: null, pending: false });
@@ -100,7 +101,7 @@ describe('buildUsageRowCharges', () => {
             enabled: true,
             isPending: false,
             isError: true,
-            data: success({ metrics: { records: 2317 }, malformedMetrics: [], fullyAttributed: true, currency: 'USD', noCosts: false })
+            data: success({ metrics: { records: 2317 }, malformedMetrics: [], fullyAttributed: true, fixedInCents: 0, currency: 'USD', noCosts: false })
         });
 
         expect(charges?.('records')).toEqual({ formatted: null, pending: false });


### PR DESCRIPTION
## Problem

Past months showed no per-metric charges even though Orb can return costs for a requested period.

## Solution

- Add paired `from` and `to` dates to the period-cost endpoint and request the selected month from the billing page.
- Accept closed periods only for explicit date ranges, preserving the current-period guard for ended subscriptions.
- Report fixed prices separately so totals include base fees without assigning them to usage metrics.

Fixes [NAN-6935](https://linear.app/nango/issue/NAN-6935)

## Testing

Tested on the local stack against Orb test mode: selecting a past month showed a charge for each usage metric.

Tests cover paired and invalid date ranges, closed periods, and subscriptions with only fixed prices.

<img width="1264" height="473" alt="image" src="https://github.com/user-attachments/assets/cb213810-2a22-46c7-aa8a-4a44c2a5e34a" />
