### PR TITLE
feat(webapp): show existing customers what they'd pay on the new pricing

### DIFF
--- a/packages/billing/lib/index.ts
+++ b/packages/billing/lib/index.ts
@@ -18,3 +18,5 @@ export const billing = new Billing(orbConfigured ? new OrbClient() : new NoopBil
 
 export { getStripe } from './stripe.js';
 export { growthAddonStateFromOrb } from './clients/orb/adapters.js';
+export { PAY_AS_YOU_GO_METRICS, projectPayAsYouGo } from './pricing/payAsYouGo.js';
+export type { PayAsYouGoMetric, PayAsYouGoProjection, PayAsYouGoQuantities } from './pricing/payAsYouGo.js';

--- a/packages/billing/lib/pricing/payAsYouGo.ts
+++ b/packages/billing/lib/pricing/payAsYouGo.ts
@@ -4,13 +4,11 @@ export type PayAsYouGoMetric = Extract<UsageMetric, 'connections' | 'function_du
 
 export const PAY_AS_YOU_GO_METRICS: readonly PayAsYouGoMetric[] = ['connections', 'function_duration_seconds', 'data_transfer'];
 
-// Keep rates here: `planToApi` exposes plan fields, and `@nangohq/types` ships in the webapp.
 const CENTS_PER_CONNECTION = 29;
 const CENTS_PER_COMPUTE_HOUR = 72;
 const CENTS_PER_TRANSFER_GB = 50;
 
 const SECONDS_PER_HOUR = 3600;
-/** Decimal GB, not GiB; this matches the published rate and Orb metric. */
 const BYTES_PER_GB = 1_000_000_000;
 
 const MINIMUM_IN_CENTS = 5_000;

--- a/packages/billing/lib/pricing/payAsYouGo.ts
+++ b/packages/billing/lib/pricing/payAsYouGo.ts
@@ -1,26 +1,22 @@
 import type { UsageMetric } from '@nangohq/types';
 
-/**
- * Rates stay in this package. `planToApi` copies every plan column into its response, and
- * `@nangohq/types` ships inside the webapp bundle.
- */
-
 export type PayAsYouGoMetric = Extract<UsageMetric, 'connections' | 'function_duration_seconds' | 'data_transfer'>;
 
 export const PAY_AS_YOU_GO_METRICS: readonly PayAsYouGoMetric[] = ['connections', 'function_duration_seconds', 'data_transfer'];
 
+// Keep rates here: `planToApi` exposes plan fields, and `@nangohq/types` ships in the webapp.
 const CENTS_PER_CONNECTION = 29;
 const CENTS_PER_COMPUTE_HOUR = 72;
 const CENTS_PER_TRANSFER_GB = 50;
 
 const SECONDS_PER_HOUR = 3600;
-/** Decimal GB, not GiB — the unit the published rate and Orb's metric both use. */
+/** Decimal GB, not GiB; this matches the published rate and Orb metric. */
 const BYTES_PER_GB = 1_000_000_000;
 
 const MINIMUM_IN_CENTS = 5_000;
 const GROWTH_ADD_ON_IN_CENTS = 45_000;
 
-/** Each metric in its stored unit: a running average, whole seconds, bytes. */
+/** Quantities use their stored units: average connections, whole seconds, and bytes. */
 export type PayAsYouGoQuantities = Record<PayAsYouGoMetric, number>;
 
 export interface PayAsYouGoProjection {
@@ -34,7 +30,6 @@ export interface PayAsYouGoProjection {
 }
 
 function quantity(value: number, metric: PayAsYouGoMetric): number {
-    // Zero is a real quantity. A non-finite one means the usage read failed.
     if (!Number.isFinite(value) || value < 0) {
         throw new Error(`unusable_quantity_for_${metric}`);
     }
@@ -42,7 +37,6 @@ function quantity(value: number, metric: PayAsYouGoMetric): number {
 }
 
 export function projectPayAsYouGo(quantities: PayAsYouGoQuantities, { isGrowth }: { isGrowth: boolean }): PayAsYouGoProjection {
-    // Round per metric, so the rows add up to the subtotal.
     const metrics: Record<PayAsYouGoMetric, number> = {
         connections: Math.round(quantity(quantities.connections, 'connections') * CENTS_PER_CONNECTION),
         function_duration_seconds: Math.round(
@@ -60,7 +54,6 @@ export function projectPayAsYouGo(quantities: PayAsYouGoQuantities, { isGrowth }
         minimumInCents: MINIMUM_IN_CENTS,
         minimumApplied: subtotalInCents < MINIMUM_IN_CENTS,
         growthAddOnInCents,
-        // The minimum covers the three usage prices only. The add-on sits outside it.
         totalInCents: Math.max(subtotalInCents, MINIMUM_IN_CENTS) + growthAddOnInCents
     };
 }

--- a/packages/billing/lib/pricing/payAsYouGo.ts
+++ b/packages/billing/lib/pricing/payAsYouGo.ts
@@ -1,0 +1,74 @@
+import type { UsageMetric } from '@nangohq/types';
+
+/**
+ * What a period of usage would cost on Pay-as-you-go.
+ *
+ * The rates live here rather than anywhere reachable from the frontend: `planToApi` spreads every
+ * `DBPlan` column to the browser, and `@nangohq/types` is bundled into the webapp. Callers get
+ * computed cents; nothing ships a rate.
+ */
+
+export type PayAsYouGoMetric = Extract<UsageMetric, 'connections' | 'function_duration_seconds' | 'data_transfer'>;
+
+export const PAY_AS_YOU_GO_METRICS: readonly PayAsYouGoMetric[] = ['connections', 'function_duration_seconds', 'data_transfer'];
+
+const CENTS_PER_CONNECTION = 29;
+const CENTS_PER_COMPUTE_HOUR = 72;
+const CENTS_PER_TRANSFER_GB = 50;
+
+const SECONDS_PER_HOUR = 3600;
+/** Decimal GB, matching both the published rate and Orb's own billable metric. */
+const BYTES_PER_GB = 1_000_000_000;
+
+const MINIMUM_IN_CENTS = 5_000;
+const GROWTH_ADD_ON_IN_CENTS = 45_000;
+
+/** Metered quantities in each metric's own stored unit: an average, whole seconds, and bytes. */
+export type PayAsYouGoQuantities = Record<PayAsYouGoMetric, number>;
+
+export interface PayAsYouGoProjection {
+    /** Integer cents per metric, before the minimum. */
+    metrics: Record<PayAsYouGoMetric, number>;
+    subtotalInCents: number;
+    minimumInCents: number;
+    /** True when usage came in under the minimum, so the total is the floor rather than the subtotal. */
+    minimumApplied: boolean;
+    growthAddOnInCents: number;
+    totalInCents: number;
+}
+
+function quantity(value: number, metric: PayAsYouGoMetric): number {
+    // A metric with no rows reaches us as 0 already, so anything unusable here is a broken read.
+    // Refusing beats quoting a number we can't stand behind.
+    if (!Number.isFinite(value) || value < 0) {
+        throw new Error(`unusable_quantity_for_${metric}`);
+    }
+    return value;
+}
+
+export function projectPayAsYouGo(quantities: PayAsYouGoQuantities, { isGrowth }: { isGrowth: boolean }): PayAsYouGoProjection {
+    // Each charge converts to the unit its rate is published in before multiplying, and rounds once,
+    // so the rows always add up to the subtotal shown beneath them.
+    const metrics: Record<PayAsYouGoMetric, number> = {
+        connections: Math.round(quantity(quantities.connections, 'connections') * CENTS_PER_CONNECTION),
+        function_duration_seconds: Math.round(
+            (quantity(quantities.function_duration_seconds, 'function_duration_seconds') / SECONDS_PER_HOUR) * CENTS_PER_COMPUTE_HOUR
+        ),
+        data_transfer: Math.round((quantity(quantities.data_transfer, 'data_transfer') / BYTES_PER_GB) * CENTS_PER_TRANSFER_GB)
+    };
+
+    const subtotalInCents = metrics.connections + metrics.function_duration_seconds + metrics.data_transfer;
+    const growthAddOnInCents = isGrowth ? GROWTH_ADD_ON_IN_CENTS : 0;
+
+    return {
+        metrics,
+        subtotalInCents,
+        minimumInCents: MINIMUM_IN_CENTS,
+        minimumApplied: subtotalInCents < MINIMUM_IN_CENTS,
+        growthAddOnInCents,
+        // The minimum covers the three usage prices only; the add-on sits outside it. Verified
+        // against a live Orb invoice, where a $0.18 usage period billed $46.67 of minimum plus the
+        // add-on in full rather than $50 all-in.
+        totalInCents: Math.max(subtotalInCents, MINIMUM_IN_CENTS) + growthAddOnInCents
+    };
+}

--- a/packages/billing/lib/pricing/payAsYouGo.ts
+++ b/packages/billing/lib/pricing/payAsYouGo.ts
@@ -1,11 +1,8 @@
 import type { UsageMetric } from '@nangohq/types';
 
 /**
- * What a period of usage would cost on Pay-as-you-go.
- *
- * The rates live here rather than anywhere reachable from the frontend: `planToApi` spreads every
- * `DBPlan` column to the browser, and `@nangohq/types` is bundled into the webapp. Callers get
- * computed cents; nothing ships a rate.
+ * What a period of usage would cost on Pay-as-you-go. The rates stay in this package: `planToApi`
+ * spreads every `DBPlan` column to the browser, and `@nangohq/types` is bundled into the webapp.
  */
 
 export type PayAsYouGoMetric = Extract<UsageMetric, 'connections' | 'function_duration_seconds' | 'data_transfer'>;
@@ -23,7 +20,7 @@ const BYTES_PER_GB = 1_000_000_000;
 const MINIMUM_IN_CENTS = 5_000;
 const GROWTH_ADD_ON_IN_CENTS = 45_000;
 
-/** Metered quantities in each metric's own stored unit: an average, whole seconds, and bytes. */
+/** Each metric in its stored unit: a running average, whole seconds, bytes. */
 export type PayAsYouGoQuantities = Record<PayAsYouGoMetric, number>;
 
 export interface PayAsYouGoProjection {
@@ -31,15 +28,13 @@ export interface PayAsYouGoProjection {
     metrics: Record<PayAsYouGoMetric, number>;
     subtotalInCents: number;
     minimumInCents: number;
-    /** True when usage came in under the minimum, so the total is the floor rather than the subtotal. */
     minimumApplied: boolean;
     growthAddOnInCents: number;
     totalInCents: number;
 }
 
 function quantity(value: number, metric: PayAsYouGoMetric): number {
-    // A metric with no rows reaches us as 0 already, so anything unusable here is a broken read.
-    // Refusing beats quoting a number we can't stand behind.
+    // A metric with no rows already reads as 0, so a non-finite value here means a broken read.
     if (!Number.isFinite(value) || value < 0) {
         throw new Error(`unusable_quantity_for_${metric}`);
     }
@@ -47,8 +42,7 @@ function quantity(value: number, metric: PayAsYouGoMetric): number {
 }
 
 export function projectPayAsYouGo(quantities: PayAsYouGoQuantities, { isGrowth }: { isGrowth: boolean }): PayAsYouGoProjection {
-    // Each charge converts to the unit its rate is published in before multiplying, and rounds once,
-    // so the rows always add up to the subtotal shown beneath them.
+    // Convert to each rate's published unit and round per metric, so the rows sum to the subtotal.
     const metrics: Record<PayAsYouGoMetric, number> = {
         connections: Math.round(quantity(quantities.connections, 'connections') * CENTS_PER_CONNECTION),
         function_duration_seconds: Math.round(
@@ -66,9 +60,7 @@ export function projectPayAsYouGo(quantities: PayAsYouGoQuantities, { isGrowth }
         minimumInCents: MINIMUM_IN_CENTS,
         minimumApplied: subtotalInCents < MINIMUM_IN_CENTS,
         growthAddOnInCents,
-        // The minimum covers the three usage prices only; the add-on sits outside it. Verified
-        // against a live Orb invoice, where a $0.18 usage period billed $46.67 of minimum plus the
-        // add-on in full rather than $50 all-in.
+        // The minimum covers the three usage prices only. The add-on sits outside it.
         totalInCents: Math.max(subtotalInCents, MINIMUM_IN_CENTS) + growthAddOnInCents
     };
 }

--- a/packages/billing/lib/pricing/payAsYouGo.ts
+++ b/packages/billing/lib/pricing/payAsYouGo.ts
@@ -1,8 +1,8 @@
 import type { UsageMetric } from '@nangohq/types';
 
 /**
- * What a period of usage would cost on Pay-as-you-go. The rates stay in this package: `planToApi`
- * spreads every `DBPlan` column to the browser, and `@nangohq/types` is bundled into the webapp.
+ * What a period of usage would cost on Pay-as-you-go. Keep the rates here: `planToApi` copies every
+ * plan column into its response, and `@nangohq/types` ships inside the webapp bundle.
  */
 
 export type PayAsYouGoMetric = Extract<UsageMetric, 'connections' | 'function_duration_seconds' | 'data_transfer'>;
@@ -14,7 +14,7 @@ const CENTS_PER_COMPUTE_HOUR = 72;
 const CENTS_PER_TRANSFER_GB = 50;
 
 const SECONDS_PER_HOUR = 3600;
-/** Decimal GB, matching both the published rate and Orb's own billable metric. */
+/** Decimal GB, not GiB. Matches the published rate and Orb's own billable metric. */
 const BYTES_PER_GB = 1_000_000_000;
 
 const MINIMUM_IN_CENTS = 5_000;

--- a/packages/billing/lib/pricing/payAsYouGo.ts
+++ b/packages/billing/lib/pricing/payAsYouGo.ts
@@ -1,8 +1,8 @@
 import type { UsageMetric } from '@nangohq/types';
 
 /**
- * What a period of usage would cost on Pay-as-you-go. Keep the rates here: `planToApi` copies every
- * plan column into its response, and `@nangohq/types` ships inside the webapp bundle.
+ * Rates stay in this package. `planToApi` copies every plan column into its response, and
+ * `@nangohq/types` ships inside the webapp bundle.
  */
 
 export type PayAsYouGoMetric = Extract<UsageMetric, 'connections' | 'function_duration_seconds' | 'data_transfer'>;
@@ -14,7 +14,7 @@ const CENTS_PER_COMPUTE_HOUR = 72;
 const CENTS_PER_TRANSFER_GB = 50;
 
 const SECONDS_PER_HOUR = 3600;
-/** Decimal GB, not GiB. Matches the published rate and Orb's own billable metric. */
+/** Decimal GB, not GiB — the unit the published rate and Orb's metric both use. */
 const BYTES_PER_GB = 1_000_000_000;
 
 const MINIMUM_IN_CENTS = 5_000;
@@ -34,7 +34,7 @@ export interface PayAsYouGoProjection {
 }
 
 function quantity(value: number, metric: PayAsYouGoMetric): number {
-    // A metric with no rows already reads as 0, so a non-finite value here means a broken read.
+    // Zero is a real quantity. A non-finite one means the usage read failed.
     if (!Number.isFinite(value) || value < 0) {
         throw new Error(`unusable_quantity_for_${metric}`);
     }
@@ -42,7 +42,7 @@ function quantity(value: number, metric: PayAsYouGoMetric): number {
 }
 
 export function projectPayAsYouGo(quantities: PayAsYouGoQuantities, { isGrowth }: { isGrowth: boolean }): PayAsYouGoProjection {
-    // Convert to each rate's published unit and round per metric, so the rows sum to the subtotal.
+    // Round per metric, so the rows add up to the subtotal.
     const metrics: Record<PayAsYouGoMetric, number> = {
         connections: Math.round(quantity(quantities.connections, 'connections') * CENTS_PER_CONNECTION),
         function_duration_seconds: Math.round(

--- a/packages/billing/lib/pricing/payAsYouGo.unit.test.ts
+++ b/packages/billing/lib/pricing/payAsYouGo.unit.test.ts
@@ -44,7 +44,6 @@ describe('projectPayAsYouGo', () => {
         expect(projection.totalInCents).toBe(5000);
     });
 
-    // The add-on is outside the minimum, so a Growth account under the floor pays both in full.
     it('adds the Growth add-on on top of the minimum, not inside it', () => {
         const projection = projectPayAsYouGo(quantities({ connections: 10 }), { isGrowth: true });
 

--- a/packages/billing/lib/pricing/payAsYouGo.unit.test.ts
+++ b/packages/billing/lib/pricing/payAsYouGo.unit.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { projectPayAsYouGo } from './payAsYouGo.js';
+
+import type { PayAsYouGoQuantities } from './payAsYouGo.js';
+
+function quantities(overrides: Partial<PayAsYouGoQuantities> = {}): PayAsYouGoQuantities {
+    return { connections: 0, function_duration_seconds: 0, data_transfer: 0, ...overrides };
+}
+
+describe('projectPayAsYouGo', () => {
+    it('prices each metric in the unit its rate is published in', () => {
+        const projection = projectPayAsYouGo(
+            quantities({
+                connections: 34,
+                function_duration_seconds: 231_480, // 64.3 hours
+                data_transfer: 12_400_000_000 // 12.4 GB
+            }),
+            { isGrowth: false }
+        );
+
+        expect(projection.metrics).toEqual({
+            connections: 986, // 34 x $0.29
+            function_duration_seconds: 4630, // 64.3h x $0.72
+            data_transfer: 620 // 12.4GB x $0.50
+        });
+        expect(projection.subtotalInCents).toBe(6236);
+    });
+
+    it('bills the subtotal once it clears the minimum', () => {
+        const projection = projectPayAsYouGo(quantities({ connections: 1000 }), { isGrowth: false });
+
+        expect(projection.subtotalInCents).toBe(29_000);
+        expect(projection.minimumApplied).toBe(false);
+        expect(projection.totalInCents).toBe(29_000);
+    });
+
+    it('floors a light period at the minimum without touching the per-metric rows', () => {
+        const projection = projectPayAsYouGo(quantities({ connections: 10 }), { isGrowth: false });
+
+        expect(projection.metrics.connections).toBe(290);
+        expect(projection.subtotalInCents).toBe(290);
+        expect(projection.minimumApplied).toBe(true);
+        expect(projection.totalInCents).toBe(5000);
+    });
+
+    // The add-on is outside the minimum, so a Growth account under the floor pays both in full.
+    it('adds the Growth add-on on top of the minimum, not inside it', () => {
+        const projection = projectPayAsYouGo(quantities({ connections: 10 }), { isGrowth: true });
+
+        expect(projection.growthAddOnInCents).toBe(45_000);
+        expect(projection.totalInCents).toBe(50_000);
+    });
+
+    it('leaves the add-on out for a plan that does not carry it', () => {
+        expect(projectPayAsYouGo(quantities({ connections: 1000 }), { isGrowth: false }).growthAddOnInCents).toBe(0);
+    });
+
+    it('keeps the rows adding up to the subtotal even when each one rounds', () => {
+        const projection = projectPayAsYouGo(
+            quantities({
+                connections: 3.456,
+                function_duration_seconds: 1234,
+                data_transfer: 987_654_321
+            }),
+            { isGrowth: false }
+        );
+
+        const summed = projection.metrics.connections + projection.metrics.function_duration_seconds + projection.metrics.data_transfer;
+        expect(projection.subtotalInCents).toBe(summed);
+    });
+
+    it('reports zero usage as a real $0 rather than a gap', () => {
+        const projection = projectPayAsYouGo(quantities(), { isGrowth: false });
+
+        expect(projection.subtotalInCents).toBe(0);
+        expect(projection.minimumApplied).toBe(true);
+        expect(projection.totalInCents).toBe(5000);
+    });
+
+    it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])('refuses to quote a bill from an unusable quantity (%s)', (value) => {
+        expect(() => projectPayAsYouGo(quantities({ function_duration_seconds: value }), { isGrowth: false })).toThrow(
+            'unusable_quantity_for_function_duration_seconds'
+        );
+    });
+});

--- a/packages/billing/lib/pricing/payAsYouGo.unit.test.ts
+++ b/packages/billing/lib/pricing/payAsYouGo.unit.test.ts
@@ -13,16 +13,16 @@ describe('projectPayAsYouGo', () => {
         const projection = projectPayAsYouGo(
             quantities({
                 connections: 34,
-                function_duration_seconds: 231_480, // 64.3 hours
-                data_transfer: 12_400_000_000 // 12.4 GB
+                function_duration_seconds: 231_480,
+                data_transfer: 12_400_000_000
             }),
             { isGrowth: false }
         );
 
         expect(projection.metrics).toEqual({
-            connections: 986, // 34 x $0.29
-            function_duration_seconds: 4630, // 64.3h x $0.72
-            data_transfer: 620 // 12.4GB x $0.50
+            connections: 986,
+            function_duration_seconds: 4630,
+            data_transfer: 620
         });
         expect(projection.subtotalInCents).toBe(6236);
     });

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
@@ -37,7 +37,6 @@ const LAST_MONTH = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 
 async function seedPlan(planName: DBPlan['name'], { futurePlan, futurePlanAt }: { futurePlan?: string | null; futurePlanAt?: Date | null } = {}) {
     const seed = await seeders.seedAccountEnvAndUser();
-    // A silently failed update would test the seeded default plan and pass for the wrong reason.
     const updated = await updatePlan(db.knex, {
         id: seed.plan.id,
         name: planName,

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
@@ -26,7 +26,6 @@ const NOT_APPLICABLE = {
     notApplicable: true
 };
 
-// 34 connections, 64.3 hours of compute, 12.4 GB — the figures the design frame is drawn with.
 const USAGE = {
     connections: { total: 34 },
     function_duration_seconds: { total: 231_480 },
@@ -124,7 +123,6 @@ describe(`GET ${route}`, () => {
             isSuccess(res.json);
             expect(res.res.status).toBe(200);
             expect(res.json.data).toStrictEqual(NOT_APPLICABLE);
-            // No migration means no projection to make, so the read must not happen at all.
             expect(getBillingUsageSpy).not.toHaveBeenCalled();
         });
 
@@ -139,8 +137,7 @@ describe(`GET ${route}`, () => {
         });
 
         it('should not open the staff preview to an ordinary signed-in session', async () => {
-            // The preview turns on `debugMode`, which only `postImpersonate` sets and only for the
-            // admin account. An account logging in normally must not reach its own projection.
+            // Only `postImpersonate` sets `debugMode`, and only for the admin account.
             const seed = await seedPlan('growth-v2');
             const session = await authenticateUser(api, seed.user);
 
@@ -161,8 +158,7 @@ describe(`GET ${route}`, () => {
             expect(getBillingUsageSpy).not.toHaveBeenCalled();
         });
 
-        // The retired plans fail both `isSpendPlan` and the old plan-name allowlist, yet they are
-        // exactly who is being migrated — 7 starter-legacy accounts in the first batch.
+        // The retired plans fail `isSpendPlan`, yet they are exactly who is being migrated.
         it.each(['starter-v2', 'growth-v2', 'starter-legacy', 'scale-legacy', 'growth-legacy'] as const)(
             'should project for a scheduled %s account',
             async (planName) => {

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
@@ -236,10 +236,10 @@ describe(`GET ${route}`, () => {
                 expect.any(Number),
                 expect.objectContaining({
                     granularity: 'day',
-                    avgPerDay: true,
                     timeframe: { start: new Date('2026-08-01T00:00:00.000Z'), end: new Date('2026-09-01T00:00:00.000Z') }
                 })
             );
+            expect(getBillingUsageSpy.mock.calls[0]?.[2]).not.toHaveProperty('avgPerDay');
         });
 
         it('should fail loudly when the usage read fails, rather than quoting a wrong bill', async () => {

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
@@ -137,7 +137,6 @@ describe(`GET ${route}`, () => {
         });
 
         it('should not open the staff preview to an ordinary signed-in session', async () => {
-            // Only `postImpersonate` sets `debugMode`, and only for the admin account.
             const seed = await seedPlan('growth-v2');
             const session = await authenticateUser(api, seed.user);
 

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
@@ -157,7 +157,6 @@ describe(`GET ${route}`, () => {
             expect(getBillingUsageSpy).not.toHaveBeenCalled();
         });
 
-        // The retired plans fail `isSpendPlan`, yet they are exactly who is being migrated.
         it.each(['starter-v2', 'growth-v2', 'starter-legacy', 'scale-legacy', 'growth-legacy'] as const)(
             'should project for a scheduled %s account',
             async (planName) => {

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
@@ -1,0 +1,247 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders, updatePlan } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import { authenticateUser, isError, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../utils/tests.js';
+import { usageTracker } from '../../../../utils/usage.js';
+
+import type { DBPlan } from '@nangohq/types';
+
+const route = '/api/v1/plans/billing/projected-costs';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+let getBillingUsageSpy: any;
+
+const NOT_APPLICABLE = {
+    metrics: {},
+    subtotalInCents: 0,
+    minimumInCents: 0,
+    minimumApplied: false,
+    growthAddOnInCents: 0,
+    totalInCents: 0,
+    periodComplete: false,
+    currency: 'USD',
+    notApplicable: true
+};
+
+// 34 connections, 64.3 hours of compute, 12.4 GB — the figures the design frame is drawn with.
+const USAGE = {
+    connections: { total: 34 },
+    function_duration_seconds: { total: 231_480 },
+    data_transfer: { total: 12_400_000_000 }
+};
+
+const IN_A_MONTH = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+const LAST_MONTH = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+async function seedPlan(planName: DBPlan['name'], { futurePlan, futurePlanAt }: { futurePlan?: string | null; futurePlanAt?: Date | null } = {}) {
+    const seed = await seeders.seedAccountEnvAndUser();
+    // A silently failed update would test the seeded default plan and pass for the wrong reason.
+    const updated = await updatePlan(db.knex, {
+        id: seed.plan.id,
+        name: planName,
+        orb_future_plan: futurePlan ?? null,
+        orb_future_plan_at: futurePlanAt ?? null
+    });
+    if (updated.isErr()) {
+        throw updated.error;
+    }
+    return seed;
+}
+
+function scheduled(planName: DBPlan['name']) {
+    return seedPlan(planName, { futurePlan: 'pay-as-you-go', futurePlanAt: IN_A_MONTH });
+}
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+        getBillingUsageSpy = vi.spyOn(usageTracker, 'getBillingUsage');
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getBillingUsageSpy.mockResolvedValue(Ok(USAGE));
+    });
+
+    describe('Authentication & Authorization', () => {
+        it('should be protected', async () => {
+            const res = await api.fetch(route, { method: 'GET', query: { env: 'dev' } });
+
+            shouldBeProtected(res);
+        });
+
+        it('should enforce env query param', async () => {
+            const { apiKey } = await seeders.seedAccountEnvAndUser();
+            const res = await api.fetch(route, {
+                method: 'GET',
+                token: apiKey.secret,
+                // @ts-expect-error missing env on purpose
+                query: {}
+            });
+
+            shouldRequireQueryEnv(res);
+        });
+
+        it('should reject a timeframe that runs backwards', async () => {
+            const { apiKey } = await scheduled('growth-v2');
+            const res = await api.fetch(route, {
+                method: 'GET',
+                token: apiKey.secret,
+                query: { env: 'dev', from: '2026-09-01T00:00:00.000Z', to: '2026-08-01T00:00:00.000Z' }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_query_params');
+        });
+    });
+
+    describe('Gating on the Orb schedule', () => {
+        it('should not read usage for an account with nothing scheduled', async () => {
+            const { apiKey } = await seedPlan('growth-v2');
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+            expect(res.json.data).toStrictEqual(NOT_APPLICABLE);
+            // No migration means no projection to make, so the read must not happen at all.
+            expect(getBillingUsageSpy).not.toHaveBeenCalled();
+        });
+
+        it('should ignore a past-dated schedule, which nothing clears once the date passes', async () => {
+            const { apiKey } = await seedPlan('growth-v2', { futurePlan: 'pay-as-you-go', futurePlanAt: LAST_MONTH });
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data).toStrictEqual(NOT_APPLICABLE);
+            expect(getBillingUsageSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not open the staff preview to an ordinary signed-in session', async () => {
+            // The preview turns on `debugMode`, which only `postImpersonate` sets and only for the
+            // admin account. An account logging in normally must not reach its own projection.
+            const seed = await seedPlan('growth-v2');
+            const session = await authenticateUser(api, seed.user);
+
+            const res = await api.fetch(route, { method: 'GET', session, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data).toStrictEqual(NOT_APPLICABLE);
+            expect(getBillingUsageSpy).not.toHaveBeenCalled();
+        });
+
+        it('should ignore a schedule that lands somewhere other than Pay-as-you-go', async () => {
+            const { apiKey } = await seedPlan('growth-v2', { futurePlan: 'free', futurePlanAt: IN_A_MONTH });
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data).toStrictEqual(NOT_APPLICABLE);
+            expect(getBillingUsageSpy).not.toHaveBeenCalled();
+        });
+
+        // The retired plans fail both `isSpendPlan` and the old plan-name allowlist, yet they are
+        // exactly who is being migrated — 7 starter-legacy accounts in the first batch.
+        it.each(['starter-v2', 'growth-v2', 'starter-legacy', 'scale-legacy', 'growth-legacy'] as const)(
+            'should project for a scheduled %s account',
+            async (planName) => {
+                const { apiKey } = await scheduled(planName);
+
+                const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+                isSuccess(res.json);
+                expect(res.res.status).toBe(200);
+                expect(res.json.data.notApplicable).toBe(false);
+                expect(res.json.data.metrics).toEqual({ connections: 986, function_duration_seconds: 4630, data_transfer: 620 });
+                expect(res.json.data.subtotalInCents).toBe(6236);
+                expect(getBillingUsageSpy).toHaveBeenCalled();
+            }
+        );
+    });
+
+    describe('The projected bill', () => {
+        it('should carry the Growth add-on for growth-v2', async () => {
+            const { apiKey } = await scheduled('growth-v2');
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data.growthAddOnInCents).toBe(45_000);
+            expect(res.json.data.totalInCents).toBe(51_236);
+        });
+
+        it('should leave the add-on out for starter-v2', async () => {
+            const { apiKey } = await scheduled('starter-v2');
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data.growthAddOnInCents).toBe(0);
+            expect(res.json.data.totalInCents).toBe(6236);
+        });
+
+        it('should floor a light period at the minimum, leaving the rows alone', async () => {
+            const { apiKey } = await scheduled('starter-v2');
+            getBillingUsageSpy.mockResolvedValue(Ok({ connections: { total: 10 }, function_duration_seconds: { total: 0 }, data_transfer: { total: 0 } }));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data.metrics.connections).toBe(290);
+            expect(res.json.data.subtotalInCents).toBe(290);
+            expect(res.json.data.minimumApplied).toBe(true);
+            expect(res.json.data.totalInCents).toBe(5000);
+        });
+
+        it('should keep a genuine zero as zero rather than a gap', async () => {
+            const { apiKey } = await scheduled('starter-v2');
+            getBillingUsageSpy.mockResolvedValue(Ok({}));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isSuccess(res.json);
+            expect(res.json.data.metrics).toEqual({ connections: 0, function_duration_seconds: 0, data_transfer: 0 });
+            expect(res.json.data.subtotalInCents).toBe(0);
+            expect(res.json.data.totalInCents).toBe(5000);
+        });
+
+        it('should pass the requested timeframe through to the usage read', async () => {
+            const { apiKey } = await scheduled('growth-v2');
+
+            await api.fetch(route, {
+                method: 'GET',
+                token: apiKey.secret,
+                query: { env: 'dev', from: '2026-08-01T00:00:00.000Z', to: '2026-09-01T00:00:00.000Z' }
+            });
+
+            expect(getBillingUsageSpy).toHaveBeenCalledWith(
+                '',
+                expect.any(Number),
+                expect.objectContaining({
+                    granularity: 'day',
+                    avgPerDay: true,
+                    timeframe: { start: new Date('2026-08-01T00:00:00.000Z'), end: new Date('2026-09-01T00:00:00.000Z') }
+                })
+            );
+        });
+
+        it('should fail loudly when the usage read fails, rather than quoting a wrong bill', async () => {
+            const { apiKey } = await scheduled('growth-v2');
+            getBillingUsageSpy.mockResolvedValue(Err(new Error('clickhouse_down')));
+
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev' } });
+
+            isError(res.json);
+            expect(res.res.status).toBe(500);
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.integration.test.ts
@@ -89,6 +89,18 @@ describe(`GET ${route}`, () => {
             shouldRequireQueryEnv(res);
         });
 
+        it.each([
+            ['from', { from: '2026-08-01T00:00:00.000Z' }],
+            ['to', { to: '2026-09-01T00:00:00.000Z' }]
+        ])('should reject %s without its pair, rather than projecting the current period', async (_name, half) => {
+            const { apiKey } = await scheduled('growth-v2');
+            const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, query: { env: 'dev', ...half } });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(getBillingUsageSpy).not.toHaveBeenCalled();
+        });
+
         it('should reject a timeframe that runs backwards', async () => {
             const { apiKey } = await scheduled('growth-v2');
             const res = await api.fetch(route, {

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
@@ -1,0 +1,116 @@
+import z from 'zod';
+
+import { PAY_AS_YOU_GO_METRICS, projectPayAsYouGo } from '@nangohq/billing';
+import { getPlanDefinition } from '@nangohq/shared';
+import { report, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { usageTracker } from '../../../../utils/usage.js';
+
+import type { GetProjectedCosts } from '@nangohq/types';
+
+const TARGET_PLAN = 'pay-as-you-go';
+
+const NOT_APPLICABLE: GetProjectedCosts['Success']['data'] = {
+    metrics: {},
+    subtotalInCents: 0,
+    minimumInCents: 0,
+    minimumApplied: false,
+    growthAddOnInCents: 0,
+    totalInCents: 0,
+    periodComplete: false,
+    currency: 'USD',
+    notApplicable: true
+};
+
+const querySchema = z
+    .strictObject({
+        env: z.string(),
+        from: z.iso.datetime().optional(),
+        to: z.iso.datetime().optional()
+    })
+    .refine((data) => !data.from || !data.to || new Date(data.from) <= new Date(data.to), {
+        message: 'From date must be before to date',
+        path: ['from']
+    });
+
+export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res) => {
+    const val = querySchema.safeParse(req.query);
+    if (!val.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(val.error) } });
+        return;
+    }
+    const query = val.data;
+
+    const { plan, account } = res.locals;
+    if (!plan) {
+        res.status(400).send({ error: { code: 'feature_disabled' } });
+        return;
+    }
+
+    // Gated on Orb's schedule alone, matching the client's `planTransition` predicate — not on the
+    // current plan or on `isSpendPlan`, since the retired plans being migrated fail both.
+    const changeAt = plan.orb_future_plan_at ? new Date(plan.orb_future_plan_at) : null;
+    const scheduled = plan.orb_future_plan === TARGET_PLAN && changeAt !== null && !Number.isNaN(changeAt.getTime()) && changeAt > new Date();
+    // Nango staff impersonating an account also get the projection, so the transition view can be
+    // checked against real data before anything is scheduled in Orb — where the customer would see
+    // it. Read off the session, which only `postImpersonate` sets and only for the admin account, so
+    // an account cannot ask for its own projection this way.
+    const previewing = req.session?.debugMode === true;
+    if (!scheduled && !previewing) {
+        res.status(200).send({ data: NOT_APPLICABLE });
+        return;
+    }
+
+    const timeframe = query.from && query.to ? { start: new Date(query.from), end: new Date(query.to) } : null;
+
+    // Same opts the usage table's own query uses, so a charge divided by the quantity on screen
+    // comes back to the published rate.
+    const usage = await usageTracker.getBillingUsage('', account.id, {
+        granularity: 'day',
+        ...(timeframe ? { timeframe } : {}),
+        metrics: [...PAY_AS_YOU_GO_METRICS],
+        avgPerDay: true
+    });
+    if (usage.isErr()) {
+        report(usage.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to get usage' } });
+        return;
+    }
+
+    const isGrowth = getPlanDefinition(plan.name)?.keepsGrowthAddOnOnMigration === true;
+
+    let projection: ReturnType<typeof projectPayAsYouGo>;
+    try {
+        projection = projectPayAsYouGo(
+            {
+                connections: usage.value.connections?.total ?? 0,
+                function_duration_seconds: usage.value.function_duration_seconds?.total ?? 0,
+                data_transfer: usage.value.data_transfer?.total ?? 0
+            },
+            { isGrowth }
+        );
+    } catch (err) {
+        report(err);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to project costs' } });
+        return;
+    }
+
+    // The current-plan side of the comparison comes from `period-costs` for the same window, so both
+    // columns are Orb's own figures for one usage set and the rows sum to each total.
+    const periodComplete = timeframe !== null && timeframe.end <= new Date();
+
+    res.status(200).send({
+        data: {
+            metrics: projection.metrics,
+            subtotalInCents: projection.subtotalInCents,
+            minimumInCents: projection.minimumInCents,
+            minimumApplied: projection.minimumApplied,
+            growthAddOnInCents: projection.growthAddOnInCents,
+            totalInCents: projection.totalInCents,
+            periodComplete,
+            currency: 'USD',
+            notApplicable: false
+        }
+    });
+});

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
@@ -66,12 +66,21 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
         return;
     }
 
-    const timeframe = query.from && query.to ? { start: new Date(query.from), end: new Date(query.to) } : null;
+    // Named explicitly when the caller gives no window: the fallback walks counter metrics only,
+    // and `connections` is not one, so it would be projected as zero.
+    const now = new Date();
+    const timeframe =
+        query.from && query.to
+            ? { start: new Date(query.from), end: new Date(query.to) }
+            : {
+                  start: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)),
+                  end: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1))
+              };
 
     // The same opts the usage table requests, so charge ÷ displayed quantity equals the rate.
     const usage = await usageTracker.getBillingUsage('', account.id, {
         granularity: 'day',
-        ...(timeframe ? { timeframe } : {}),
+        timeframe,
         metrics: [...PAY_AS_YOU_GO_METRICS],
         avgPerDay: true
     });
@@ -99,7 +108,7 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
         return;
     }
 
-    const periodComplete = timeframe !== null && timeframe.end <= new Date();
+    const periodComplete = timeframe.end <= now;
 
     res.status(200).send({
         data: {

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
@@ -55,20 +55,17 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
         return;
     }
 
-    // Gate on Orb's schedule only. The retired plans being migrated all fail `isSpendPlan`.
     const changeAt = plan.orb_future_plan_at ? new Date(plan.orb_future_plan_at) : null;
     const scheduled = plan.orb_future_plan === TARGET_PLAN && changeAt !== null && !Number.isNaN(changeAt.getTime()) && changeAt > new Date();
-    // Staff previewing an impersonated account get it too. Only `postImpersonate` sets `debugMode`,
-    // so an account cannot ask for itself.
+    // Only `postImpersonate` can set `debugMode`, so an account cannot enable its own preview.
     const previewing = req.session?.debugMode === true;
     if (!scheduled && !previewing) {
         res.status(200).send({ data: NOT_APPLICABLE });
         return;
     }
 
-    // Name the current month explicitly. Given no window, `getBillingUsage` returns only counter
-    // metrics, and `connections` is not one, so it would project as zero.
     const now = new Date();
+    // Without a window, `getBillingUsage` returns only counter metrics. Connections would project as zero.
     const timeframe =
         query.from && query.to
             ? { start: new Date(query.from), end: new Date(query.to) }
@@ -77,8 +74,7 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
                   end: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1))
               };
 
-    // Connections must be the period's running average: that is what Orb meters, and what the
-    // migration email quotes. Do not add `avgPerDay` — it reports each day's own count instead.
+    // Orb meters the period's running average. `avgPerDay` would return each day's count instead.
     const usage = await usageTracker.getBillingUsage('', account.id, {
         granularity: 'day',
         timeframe,

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
@@ -58,8 +58,8 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
     // Gate on Orb's schedule only. The retired plans being migrated all fail `isSpendPlan`.
     const changeAt = plan.orb_future_plan_at ? new Date(plan.orb_future_plan_at) : null;
     const scheduled = plan.orb_future_plan === TARGET_PLAN && changeAt !== null && !Number.isNaN(changeAt.getTime()) && changeAt > new Date();
-    // Staff impersonating an account also get the projection, to check the view on real data before
-    // scheduling anything. Only `postImpersonate` sets `debugMode`, so an account cannot ask itself.
+    // Staff previewing an impersonated account get it too. Only `postImpersonate` sets `debugMode`,
+    // so an account cannot ask for itself.
     const previewing = req.session?.debugMode === true;
     if (!scheduled && !previewing) {
         res.status(200).send({ data: NOT_APPLICABLE });

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
@@ -77,12 +77,12 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
                   end: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1))
               };
 
-    // The same opts the usage table requests, so charge ÷ displayed quantity equals the rate.
+    // No `avgPerDay`: connections must be the period's running average, which is the quantity Orb
+    // meters and the quantity the migration email is generated from.
     const usage = await usageTracker.getBillingUsage('', account.id, {
         granularity: 'day',
         timeframe,
-        metrics: [...PAY_AS_YOU_GO_METRICS],
-        avgPerDay: true
+        metrics: [...PAY_AS_YOU_GO_METRICS]
     });
     if (usage.isErr()) {
         report(usage.error);

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
@@ -55,7 +55,7 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
         return;
     }
 
-    // Orb's schedule alone. An `isSpendPlan` check would exclude the retired plans being migrated.
+    // Gate on Orb's schedule only. The retired plans being migrated all fail `isSpendPlan`.
     const changeAt = plan.orb_future_plan_at ? new Date(plan.orb_future_plan_at) : null;
     const scheduled = plan.orb_future_plan === TARGET_PLAN && changeAt !== null && !Number.isNaN(changeAt.getTime()) && changeAt > new Date();
     // Staff impersonating an account also get the projection, to check the view on real data before
@@ -66,8 +66,8 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
         return;
     }
 
-    // Named explicitly when the caller gives no window: the fallback walks counter metrics only,
-    // and `connections` is not one, so it would be projected as zero.
+    // Name the current month explicitly. Given no window, `getBillingUsage` returns only counter
+    // metrics, and `connections` is not one, so it would project as zero.
     const now = new Date();
     const timeframe =
         query.from && query.to
@@ -77,8 +77,8 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
                   end: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1))
               };
 
-    // No `avgPerDay`: connections must be the period's running average, which is the quantity Orb
-    // meters and the quantity the migration email is generated from.
+    // Connections must be the period's running average: that is what Orb meters, and what the
+    // migration email quotes. Do not add `avgPerDay` — it reports each day's own count instead.
     const usage = await usageTracker.getBillingUsage('', account.id, {
         granularity: 'day',
         timeframe,

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
@@ -57,7 +57,6 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
 
     const changeAt = plan.orb_future_plan_at ? new Date(plan.orb_future_plan_at) : null;
     const scheduled = plan.orb_future_plan === TARGET_PLAN && changeAt !== null && !Number.isNaN(changeAt.getTime()) && changeAt > new Date();
-    // Only `postImpersonate` can set `debugMode`, so an account cannot enable its own preview.
     const previewing = req.session?.debugMode === true;
     if (!scheduled && !previewing) {
         res.status(200).send({ data: NOT_APPLICABLE });

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
@@ -32,8 +32,6 @@ const querySchema = z
         from: z.iso.datetime().optional(),
         to: z.iso.datetime().optional()
     })
-    // Both or neither: one half of a window would otherwise fall through to the current period,
-    // projecting a different month than the caller asked for.
     .refine((data) => (data.from === undefined) === (data.to === undefined), {
         message: 'from and to must be provided together',
         path: ['from']
@@ -57,14 +55,11 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
         return;
     }
 
-    // Gated on Orb's schedule alone, matching the client's `planTransition` predicate — not on the
-    // current plan or on `isSpendPlan`, since the retired plans being migrated fail both.
+    // Orb's schedule alone. An `isSpendPlan` check would exclude the retired plans being migrated.
     const changeAt = plan.orb_future_plan_at ? new Date(plan.orb_future_plan_at) : null;
     const scheduled = plan.orb_future_plan === TARGET_PLAN && changeAt !== null && !Number.isNaN(changeAt.getTime()) && changeAt > new Date();
-    // Nango staff impersonating an account also get the projection, so the transition view can be
-    // checked against real data before anything is scheduled in Orb — where the customer would see
-    // it. Read off the session, which only `postImpersonate` sets and only for the admin account, so
-    // an account cannot ask for its own projection this way.
+    // Staff impersonating an account also get the projection, to check the view on real data before
+    // scheduling anything. Only `postImpersonate` sets `debugMode`, so an account cannot ask itself.
     const previewing = req.session?.debugMode === true;
     if (!scheduled && !previewing) {
         res.status(200).send({ data: NOT_APPLICABLE });
@@ -73,8 +68,7 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
 
     const timeframe = query.from && query.to ? { start: new Date(query.from), end: new Date(query.to) } : null;
 
-    // Same opts the usage table's own query uses, so a charge divided by the quantity on screen
-    // comes back to the published rate.
+    // The same opts the usage table requests, so charge ÷ displayed quantity equals the rate.
     const usage = await usageTracker.getBillingUsage('', account.id, {
         granularity: 'day',
         ...(timeframe ? { timeframe } : {}),
@@ -105,8 +99,6 @@ export const getProjectedCosts = asyncWrapper<GetProjectedCosts>(async (req, res
         return;
     }
 
-    // The current-plan side of the comparison comes from `period-costs` for the same window, so both
-    // columns are Orb's own figures for one usage set and the rows sum to each total.
     const periodComplete = timeframe !== null && timeframe.end <= new Date();
 
     res.status(200).send({

--- a/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/getProjectedCosts.ts
@@ -25,11 +25,20 @@ const NOT_APPLICABLE: GetProjectedCosts['Success']['data'] = {
 
 const querySchema = z
     .strictObject({
-        env: z.string(),
+        env: z
+            .string()
+            .regex(/^[a-zA-Z0-9_-]+$/)
+            .max(255),
         from: z.iso.datetime().optional(),
         to: z.iso.datetime().optional()
     })
-    .refine((data) => !data.from || !data.to || new Date(data.from) <= new Date(data.to), {
+    // Both or neither: one half of a window would otherwise fall through to the current period,
+    // projecting a different month than the caller asked for.
+    .refine((data) => (data.from === undefined) === (data.to === undefined), {
+        message: 'from and to must be provided together',
+        path: ['from']
+    })
+    .refine((data) => !data.from || !data.to || new Date(data.from) < new Date(data.to), {
         message: 'From date must be before to date',
         path: ['from']
     });

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -105,6 +105,7 @@ import { getPlainHmac } from './controllers/v1/plain/getHmac.js';
 import { deleteSpendAlert } from './controllers/v1/plans/billing/deleteSpendAlert.js';
 import { getBillingPeriodCosts } from './controllers/v1/plans/billing/getBillingPeriodCosts.js';
 import { getOverdueInvoices } from './controllers/v1/plans/billing/getOverdueInvoices.js';
+import { getProjectedCosts } from './controllers/v1/plans/billing/getProjectedCosts.js';
 import { getSpendAlert } from './controllers/v1/plans/billing/getSpendAlert.js';
 import { getUpcomingInvoice } from './controllers/v1/plans/billing/getUpcomingInvoice.js';
 import { putInvoicingDetails } from './controllers/v1/plans/billing/putInvoicingDetails.js';
@@ -297,6 +298,7 @@ web.route('/plans/billing/invoicing').put(webAuth, auditBillingDetailsChanged, c
 web.route('/plans/billing/overdue').get(webAuth, getOverdueInvoices);
 web.route('/plans/billing/upcoming-invoice').get(webAuth, getUpcomingInvoice);
 web.route('/plans/billing/period-costs').get(webAuth, getBillingPeriodCosts);
+web.route('/plans/billing/projected-costs').get(webAuth, getProjectedCosts);
 web.route('/plans/billing/spend-alert').get(webAuth, can('account:billing:spend_alert:read'), getSpendAlert);
 web.route('/plans/billing/spend-alert').put(webAuth, auditBillingSpendAlertChanged, can('account:billing:spend_alert:update'), putSpendAlert);
 web.route('/plans/billing/spend-alert').delete(webAuth, auditBillingSpendAlertRemoved, can('account:billing:spend_alert:update'), deleteSpendAlert);

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -354,6 +354,7 @@ export const growthLegacyPlan: PlanDefinition = {
     nextPlan: [],
     canChange: false,
     hidden: true,
+    keepsGrowthAddOnOnMigration: true,
     flags: {
         api_rate_limit_size: 'l',
         environments_max: 3,

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -97,6 +97,7 @@ export const growthV1Plan: PlanDefinition = {
     canChange: true,
     hidden: true,
     basePrice: 500,
+    keepsGrowthAddOnOnMigration: true,
     flags: {
         api_rate_limit_size: 'xl',
         environments_max: 10,
@@ -155,6 +156,7 @@ export const growthV2Plan: PlanDefinition = {
     nextPlan: ['enterprise'],
     canChange: true,
     basePrice: 500,
+    keepsGrowthAddOnOnMigration: true,
     flags: growthV1Plan.flags
 };
 

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -133,6 +133,7 @@ import type {
     GetBillingUsage,
     GetBillingUsageTopDimensionValues,
     GetOverdueInvoices,
+    GetProjectedCosts,
     GetSpendAlert,
     GetUpcomingInvoice,
     PostPlanChange,
@@ -261,6 +262,7 @@ export type PrivateApiEndpoints =
     | GetBillingUsageTopDimensionValues
     | GetUpcomingInvoice
     | GetBillingPeriodCosts
+    | GetProjectedCosts
     | GetSpendAlert
     | PutSpendAlert
     | DeleteSpendAlert

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -206,7 +206,8 @@ export type GetProjectedCosts = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing/projected-costs';
-    Querystring: { env: string; from?: string; to?: string };
+    /** A window is both dates or neither; one on its own is rejected. */
+    Querystring: { env: string } | { env: string; from: string; to: string };
     Success: {
         data: {
             metrics: Partial<Record<UsageMetric, number>>;

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -28,7 +28,6 @@ export interface PlanDefinition {
     nextPlan: string[] | null;
     prevPlan: string[] | null;
     basePrice?: number;
-    /** Source-plan rule for migrations; `DBPlan.has_growth_features` records the add-on on Pay-as-you-go. */
     keepsGrowthAddOnOnMigration?: boolean;
 
     cta?: string;
@@ -197,7 +196,6 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
     };
 }>;
 
-/** Includes the Pay-as-you-go minimum; `GetBillingPeriodCosts` excludes plan minimums. */
 export type GetProjectedCosts = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -28,8 +28,7 @@ export interface PlanDefinition {
     nextPlan: string[] | null;
     prevPlan: string[] | null;
     basePrice?: number;
-    /** Carries the Growth add-on across a migration. Not `DBPlan.has_growth_features`, which tracks
-     *  an add-on bought *on* Pay-as-you-go. */
+    /** Source-plan rule for migrations; `DBPlan.has_growth_features` records the add-on on Pay-as-you-go. */
     keepsGrowthAddOnOnMigration?: boolean;
 
     cta?: string;
@@ -198,8 +197,7 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
     };
 }>;
 
-/** `totalInCents` applies the Pay-as-you-go floor, so it does not line up with
- *  `GetBillingPeriodCosts`, which excludes plan minimums. */
+/** Includes the Pay-as-you-go minimum; `GetBillingPeriodCosts` excludes plan minimums. */
 export type GetProjectedCosts = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
@@ -215,7 +213,7 @@ export type GetProjectedCosts = ApiEndpoint<{
             totalInCents: number;
             periodComplete: boolean;
             currency: string;
-            /** Nothing scheduled, so every figure is 0. */
+            /** True when no Pay-as-you-go migration is scheduled. */
             notApplicable: boolean;
         };
     };

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -206,7 +206,6 @@ export type GetProjectedCosts = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing/projected-costs';
-    /** A window is both dates or neither; one on its own is rejected. */
     Querystring: { env: string } | { env: string; from: string; to: string };
     Success: {
         data: {

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -198,10 +198,8 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
     };
 }>;
 
-/**
- * What a period would cost on Pay-as-you-go. `totalInCents` applies the Pay-as-you-go floor, so it
- * is not comparable line-by-line with `GetBillingPeriodCosts`, which excludes plan minimums.
- */
+/** `totalInCents` applies the Pay-as-you-go floor, so it does not line up with
+ *  `GetBillingPeriodCosts`, which excludes plan minimums. */
 export type GetProjectedCosts = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -28,10 +28,8 @@ export interface PlanDefinition {
     nextPlan: string[] | null;
     prevPlan: string[] | null;
     basePrice?: number;
-    /**
-     * Whether an account on this plan carries the Growth add-on across a migration to Pay-as-you-go.
-     * Distinct from `DBPlan.has_growth_features`, which tracks an add-on bought *on* Pay-as-you-go.
-     */
+    /** Carries the Growth add-on across a migration. Not `DBPlan.has_growth_features`, which tracks
+     *  an add-on bought *on* Pay-as-you-go. */
     keepsGrowthAddOnOnMigration?: boolean;
 
     cta?: string;
@@ -201,11 +199,8 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
 }>;
 
 /**
- * What a period would cost on Pay-as-you-go, for an account Orb has scheduled to move there.
- *
- * Carries computed cents only: the rates live server-side in `@nangohq/billing` and never ship.
- * Not comparable line-by-line with `GetBillingPeriodCosts` — that one reports what Orb charged and
- * excludes plan minimums, while `totalInCents` here applies the Pay-as-you-go floor.
+ * What a period would cost on Pay-as-you-go. `totalInCents` applies the Pay-as-you-go floor, so it
+ * is not comparable line-by-line with `GetBillingPeriodCosts`, which excludes plan minimums.
  */
 export type GetProjectedCosts = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
@@ -214,18 +209,15 @@ export type GetProjectedCosts = ApiEndpoint<{
     Querystring: { env: string; from?: string; to?: string };
     Success: {
         data: {
-            /** Integer cents per metric, before the minimum. Only the metrics Pay-as-you-go bills on. */
             metrics: Partial<Record<UsageMetric, number>>;
             subtotalInCents: number;
             minimumInCents: number;
-            /** True when usage came in under the minimum, so the total is the floor not the subtotal. */
             minimumApplied: boolean;
             growthAddOnInCents: number;
             totalInCents: number;
-            /** False while the period is still running, so the comparison is not yet like-for-like. */
             periodComplete: boolean;
             currency: string;
-            /** True when nothing is scheduled, so there is no migration to project. Every figure is 0. */
+            /** Nothing scheduled, so every figure is 0. */
             notApplicable: boolean;
         };
     };

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -28,6 +28,11 @@ export interface PlanDefinition {
     nextPlan: string[] | null;
     prevPlan: string[] | null;
     basePrice?: number;
+    /**
+     * Whether an account on this plan carries the Growth add-on across a migration to Pay-as-you-go.
+     * Distinct from `DBPlan.has_growth_features`, which tracks an add-on bought *on* Pay-as-you-go.
+     */
+    keepsGrowthAddOnOnMigration?: boolean;
 
     cta?: string;
     hidden?: boolean;
@@ -191,6 +196,37 @@ export type GetBillingPeriodCosts = ApiEndpoint<{
             /** True when there's no billing period to report costs for — a free plan, no linked
              *  subscription, or an ended one. `metrics`/`currency` are otherwise never empty/null. */
             noCosts: boolean;
+        };
+    };
+}>;
+
+/**
+ * What a period would cost on Pay-as-you-go, for an account Orb has scheduled to move there.
+ *
+ * Carries computed cents only: the rates live server-side in `@nangohq/billing` and never ship.
+ * Not comparable line-by-line with `GetBillingPeriodCosts` — that one reports what Orb charged and
+ * excludes plan minimums, while `totalInCents` here applies the Pay-as-you-go floor.
+ */
+export type GetProjectedCosts = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
+    Method: 'GET';
+    Path: '/api/v1/plans/billing/projected-costs';
+    Querystring: { env: string; from?: string; to?: string };
+    Success: {
+        data: {
+            /** Integer cents per metric, before the minimum. Only the metrics Pay-as-you-go bills on. */
+            metrics: Partial<Record<UsageMetric, number>>;
+            subtotalInCents: number;
+            minimumInCents: number;
+            /** True when usage came in under the minimum, so the total is the floor not the subtotal. */
+            minimumApplied: boolean;
+            growthAddOnInCents: number;
+            totalInCents: number;
+            /** False while the period is still running, so the comparison is not yet like-for-like. */
+            periodComplete: boolean;
+            currency: string;
+            /** True when nothing is scheduled, so there is no migration to project. Every figure is 0. */
+            notApplicable: boolean;
         };
     };
 }>;

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -9,7 +9,7 @@ import { Switch } from '@/components/ui/Switch';
 import { Tag } from '@/components/ui/Tag';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { useApiGetPlans, useCurrentPlan } from '@/hooks/usePlan';
-import { hasMonthlySpend, migratesToPayAsYouGo } from '@/pages/Team/Billing/planVisibility';
+import { hasMonthlySpend, isRetiredPlan } from '@/pages/Team/Billing/planVisibility';
 import { useStore } from '@/store';
 import { cn } from '@/utils/utils';
 import { DEFAULTS, usePlanOverrideStore } from './planOverride';
@@ -32,7 +32,7 @@ function scheduledChangeKind(target: PlanDefinition['code'], from: PlanDefinitio
         return 'cancellation';
     }
     // Enterprise lists Pay-as-you-go as an ordinary downgrade, so the source plan decides.
-    if (target === 'pay-as-you-go' && from && migratesToPayAsYouGo(from)) {
+    if (target === 'pay-as-you-go' && from && isRetiredPlan(from)) {
         return 'migration';
     }
     return 'downgrade';
@@ -86,25 +86,26 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
         return duplicated;
     }, [plansList]);
 
+    // `useCurrentPlan` already has the override applied, so the real plan has to come from the
+    // un-overridden query or the caption would name whatever is being previewed.
+    const realPlanName = useEnvironment(env).data?.plan?.name;
+
     const scheduledChangeOptions = useMemo(() => {
         const definitions = plansList?.data ?? [];
-        const current = definitions.find((plan) => plan.code === overrideCode);
+        // Falls back to the real plan, so previewing a schedule needs no override of the plan itself.
+        const current = definitions.find((plan) => plan.code === (overrideCode ?? realPlanName));
         if (!current) {
             return [];
         }
 
         const targets = new Set(current.prevPlan);
-        if (migratesToPayAsYouGo(current.code)) {
+        if (isRetiredPlan(current.code)) {
             // We schedule the migration onto these plans, so `prevPlan` never lists it.
             targets.add('pay-as-you-go');
         }
 
         return definitions.filter((plan) => targets.has(plan.code));
-    }, [plansList, overrideCode]);
-
-    // `useCurrentPlan` already has the override applied, so the real plan has to come from the
-    // un-overridden query or the caption would name whatever is being previewed.
-    const realPlanName = useEnvironment(env).data?.plan?.name;
+    }, [plansList, overrideCode, realPlanName]);
     const realPlanTitle = plansList?.data.find((plan) => plan.code === realPlanName)?.title;
     const overrides = Object.entries(DEFAULTS).filter(([key, value]) => store[key as keyof typeof DEFAULTS] !== value).length;
 
@@ -165,7 +166,7 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
                                     <SelectItem value={NO_SCHEDULED_CHANGE_VALUE}>None</SelectItem>
                                     {scheduledChangeOptions.map((plan) => (
                                         <SelectItem key={plan.code} value={plan.code}>
-                                            {plan.title} ({scheduledChangeKind(plan.code, overrideCode)})
+                                            {plan.title} ({scheduledChangeKind(plan.code, overrideCode ?? realPlanName ?? null)})
                                         </SelectItem>
                                     ))}
                                 </SelectContent>

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -86,13 +86,11 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
         return duplicated;
     }, [plansList]);
 
-    // `useCurrentPlan` already has the override applied, so the real plan has to come from the
-    // un-overridden query or the caption would name whatever is being previewed.
+    // `useCurrentPlan` already has the override applied, so the real plan comes from here.
     const realPlanName = useEnvironment(env).data?.plan?.name;
 
     const scheduledChangeOptions = useMemo(() => {
         const definitions = plansList?.data ?? [];
-        // Falls back to the real plan, so previewing a schedule needs no override of the plan itself.
         const current = definitions.find((plan) => plan.code === (overrideCode ?? realPlanName));
         if (!current) {
             return [];

--- a/packages/webapp/src/features/PlanOverrideOverlay.tsx
+++ b/packages/webapp/src/features/PlanOverrideOverlay.tsx
@@ -86,7 +86,6 @@ export const PlanOverrideContent: React.FC<PlanOverrideContentProps> = ({ onBack
         return duplicated;
     }, [plansList]);
 
-    // `useCurrentPlan` already has the override applied, so the real plan comes from here.
     const realPlanName = useEnvironment(env).data?.plan?.name;
 
     const scheduledChangeOptions = useMemo(() => {

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -162,7 +162,6 @@ export function applyPlanOverride(
               // plan definitions only ever set those fields to `null`, never an actual Date.
               ...(overridePlan.flags as Partial<ApiPlan>),
               name: overridePlan.code,
-              // Null so an overridden plan does not inherit the real account's scheduled date.
               orb_future_plan: null,
               orb_future_plan_at: null
           }

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -150,11 +150,11 @@ export function applyPlanOverride(
         addonState
     }: { overridePlan?: PlanDefinition | null; scheduledTarget?: PlanDefinition | null; addonState?: GrowthAddonState | null }
 ): ApiPlan | null | undefined {
-    if (!realPlan || (!overridePlan && !addonState)) {
+    if (!realPlan || (!overridePlan && !addonState && !scheduledTarget)) {
         return realPlan;
     }
 
-    const withPlan: ApiPlan = overridePlan
+    const onPlan: ApiPlan = overridePlan
         ? {
               ...realPlan,
               // `flags` is typed against `DBPlan` (pre-serialization), so its never-set Date fields
@@ -162,10 +162,18 @@ export function applyPlanOverride(
               // plan definitions only ever set those fields to `null`, never an actual Date.
               ...(overridePlan.flags as Partial<ApiPlan>),
               name: overridePlan.code,
-              orb_future_plan: scheduledTarget?.code ?? null,
-              orb_future_plan_at: scheduledTarget ? nextUsageResetDate(new Date()).toISOString() : null
+              // An overridden plan must not inherit the real one's schedule, so this clears rather
+              // than leaves it.
+              orb_future_plan: null,
+              orb_future_plan_at: null
           }
         : realPlan;
+
+    // Applied whether or not the plan itself is overridden, so a migration can be previewed on an
+    // account already sitting on a retired plan.
+    const withPlan: ApiPlan = scheduledTarget
+        ? { ...onPlan, orb_future_plan: scheduledTarget.code, orb_future_plan_at: nextUsageResetDate(new Date()).toISOString() }
+        : onPlan;
 
     if (!addonState) {
         return withPlan;

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -167,7 +167,7 @@ export function applyPlanOverride(
           }
         : realPlan;
 
-    // Runs whether or not a plan is overridden, so a real retired-plan account can be previewed.
+    // Apply scheduled changes without a plan override, so real retired plans can be previewed.
     const withPlan: ApiPlan = scheduledTarget
         ? { ...onPlan, orb_future_plan: scheduledTarget.code, orb_future_plan_at: nextUsageResetDate(new Date()).toISOString() }
         : onPlan;

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -167,7 +167,6 @@ export function applyPlanOverride(
           }
         : realPlan;
 
-    // Apply scheduled changes without a plan override, so real retired plans can be previewed.
     const withPlan: ApiPlan = scheduledTarget
         ? { ...onPlan, orb_future_plan: scheduledTarget.code, orb_future_plan_at: nextUsageResetDate(new Date()).toISOString() }
         : onPlan;

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -162,15 +162,13 @@ export function applyPlanOverride(
               // plan definitions only ever set those fields to `null`, never an actual Date.
               ...(overridePlan.flags as Partial<ApiPlan>),
               name: overridePlan.code,
-              // An overridden plan must not inherit the real one's schedule, so this clears rather
-              // than leaves it.
+              // Cleared, so an overridden plan does not inherit the real one's date.
               orb_future_plan: null,
               orb_future_plan_at: null
           }
         : realPlan;
 
-    // Applied whether or not the plan itself is overridden, so a migration can be previewed on an
-    // account already sitting on a retired plan.
+    // Applied with or without a plan override, so a retired-plan account can be previewed as-is.
     const withPlan: ApiPlan = scheduledTarget
         ? { ...onPlan, orb_future_plan: scheduledTarget.code, orb_future_plan_at: nextUsageResetDate(new Date()).toISOString() }
         : onPlan;

--- a/packages/webapp/src/features/planOverride.ts
+++ b/packages/webapp/src/features/planOverride.ts
@@ -162,13 +162,13 @@ export function applyPlanOverride(
               // plan definitions only ever set those fields to `null`, never an actual Date.
               ...(overridePlan.flags as Partial<ApiPlan>),
               name: overridePlan.code,
-              // Cleared, so an overridden plan does not inherit the real one's date.
+              // Null so an overridden plan does not inherit the real account's scheduled date.
               orb_future_plan: null,
               orb_future_plan_at: null
           }
         : realPlan;
 
-    // Applied with or without a plan override, so a retired-plan account can be previewed as-is.
+    // Runs whether or not a plan is overridden, so a real retired-plan account can be previewed.
     const withPlan: ApiPlan = scheduledTarget
         ? { ...onPlan, orb_future_plan: scheduledTarget.code, orb_future_plan_at: nextUsageResetDate(new Date()).toISOString() }
         : onPlan;

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -18,6 +18,7 @@ import type {
     GetOverdueInvoices,
     GetPlan,
     GetPlans,
+    GetProjectedCosts,
     GetSpendAlert,
     GetUpcomingInvoice,
     GetUsage,
@@ -52,10 +53,10 @@ function usePlanOverride(env: string, realPlan: ApiPlan | null | undefined): Api
     const scheduledTargetCode = usePlanOverrideStore((s) => s.scheduledTargetCode);
     const addonState = usePlanOverrideStore((s) => s.addonState);
     // Only fetch when an override is set, to avoid an extra /plans request on every load.
-    const { data: plansList } = useApiGetPlans(env, { enabled: Boolean(overrideCode) });
+    const { data: plansList } = useApiGetPlans(env, { enabled: Boolean(overrideCode || scheduledTargetCode) });
 
     return useMemo(() => {
-        if (!overrideCode && !addonState) {
+        if (!overrideCode && !addonState && !scheduledTargetCode) {
             return realPlan;
         }
         const overridePlan = plansList?.data.find((p) => p.code === overrideCode) ?? null;
@@ -254,6 +255,33 @@ export function useApiGetBillingPeriodCosts(
             });
 
             const json = (await res.json()) as GetBillingPeriodCosts['Reply'];
+            if (res.status !== 200 || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        }
+    });
+}
+
+export const GetProjectedCostsQueryKey = ['plans', 'billing', 'projected-costs'];
+
+/**
+ * What the selected period would cost on Pay-as-you-go. Keyed on the timeframe rather than the
+ * current month: this is ClickHouse-backed, so unlike the Orb figures above any month can be asked
+ * for. `enabled` is the caller's call - only an account with a scheduled migration has an answer.
+ */
+export function useApiGetProjectedCosts(env: string, timeframe: { start: string; end: string }, options?: { enabled?: boolean }) {
+    return useQuery<GetProjectedCosts['Success'], APIError>({
+        enabled: Boolean(env) && (options?.enabled ?? false),
+        staleTime: UPCOMING_INVOICE_STALE_TIME,
+        queryKey: [...GetProjectedCostsQueryKey, env, timeframe.start, timeframe.end],
+        queryFn: async (): Promise<GetProjectedCosts['Success']> => {
+            const res = await apiFetch(`/api/v1/plans/billing/projected-costs?env=${env}&from=${timeframe.start}&to=${timeframe.end}`, {
+                method: 'GET'
+            });
+
+            const json = (await res.json()) as GetProjectedCosts['Reply'];
             if (res.status !== 200 || 'error' in json) {
                 throw new APIError({ res, json });
             }

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -270,8 +270,6 @@ export function useApiGetProjectedCosts(env: string, timeframe: { start: string;
     return useQuery<GetProjectedCosts['Success'], APIError>({
         enabled: Boolean(env) && (options?.enabled ?? false),
         staleTime: UPCOMING_INVOICE_STALE_TIME,
-        // Keyed on the timeframe, not just the env: ClickHouse answers for any month, so stepping
-        // the month must not reuse the previous answer.
         queryKey: [...GetProjectedCostsQueryKey, env, timeframe.start, timeframe.end],
         queryFn: async (): Promise<GetProjectedCosts['Success']> => {
             const res = await apiFetch(`/api/v1/plans/billing/projected-costs?env=${env}&from=${timeframe.start}&to=${timeframe.end}`, {

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -266,11 +266,7 @@ export function useApiGetBillingPeriodCosts(
 
 export const GetProjectedCostsQueryKey = ['plans', 'billing', 'projected-costs'];
 
-/**
- * What the selected period would cost on Pay-as-you-go. Keyed on the timeframe rather than the
- * current month: this is ClickHouse-backed, so unlike the Orb figures above any month can be asked
- * for. `enabled` is the caller's call - only an account with a scheduled migration has an answer.
- */
+/** Keyed on the timeframe, not the current month: ClickHouse answers for any month. */
 export function useApiGetProjectedCosts(env: string, timeframe: { start: string; end: string }, options?: { enabled?: boolean }) {
     return useQuery<GetProjectedCosts['Success'], APIError>({
         enabled: Boolean(env) && (options?.enabled ?? false),

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -266,11 +266,12 @@ export function useApiGetBillingPeriodCosts(
 
 export const GetProjectedCostsQueryKey = ['plans', 'billing', 'projected-costs'];
 
-/** Keyed on the timeframe, not the current month: ClickHouse answers for any month. */
 export function useApiGetProjectedCosts(env: string, timeframe: { start: string; end: string }, options?: { enabled?: boolean }) {
     return useQuery<GetProjectedCosts['Success'], APIError>({
         enabled: Boolean(env) && (options?.enabled ?? false),
         staleTime: UPCOMING_INVOICE_STALE_TIME,
+        // Keyed on the timeframe, not just the env: ClickHouse answers for any month, so stepping
+        // the month must not reuse the previous answer.
         queryKey: [...GetProjectedCostsQueryKey, env, timeframe.start, timeframe.end],
         queryFn: async (): Promise<GetProjectedCosts['Success']> => {
             const res = await apiFetch(`/api/v1/plans/billing/projected-costs?env=${env}&from=${timeframe.start}&to=${timeframe.end}`, {

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -42,9 +42,9 @@ export const TeamBilling: React.FC = () => {
     // Plan titles come from `/api/v1/plans`; with no titles the strip can only show raw Orb codes,
     // so a failed load hides the section rather than leaking them or holding a skeleton forever.
     const { isError: didPlanListFail } = useApiGetPlans(env);
-    const showSummary = !didPlanListFail && (isPlanPending || showsSummaryStrip(environmentData?.plan));
 
     const transition = usePlanTransition();
+    const showSummary = !didPlanListFail && (isPlanPending || showsSummaryStrip(environmentData?.plan, transition !== null));
 
     // A failed refetch keeps the previous plan cached, so the error is checked rather than trusting stale data.
     const showSpendAlerts = canManageBilling && !didPlanFail && hasMonthlySpend(environmentData?.plan) && !!environmentData?.plan?.orb_subscription_id;

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -55,9 +55,10 @@ export const Summary: React.FC = () => {
         return buildSummaryState({ plan, plans: plansList?.data, paymentMethod, canManageBilling, spend, onS26Pricing, transition, now: new Date() });
     }, [plan, plansList, arePlansPending, isSpendResolving, paymentMethod, canManageBilling, spend, onS26Pricing, transition]);
 
-    // Legacy, enterprise and free-uncapped accounts get no strip at all — their terms are negotiated
-    // per customer or nothing is billable, so every field would be empty or untrue.
-    if (plan && !showsSummaryStrip(plan)) {
+    // Legacy, enterprise and free-uncapped accounts get no strip — their terms are negotiated per
+    // customer or nothing is billable. A scheduled migration is the exception: the date has to land
+    // somewhere.
+    if (plan && !showsSummaryStrip(plan, transition !== null)) {
         return null;
     }
 

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -55,9 +55,8 @@ export const Summary: React.FC = () => {
         return buildSummaryState({ plan, plans: plansList?.data, paymentMethod, canManageBilling, spend, onS26Pricing, transition, now: new Date() });
     }, [plan, plansList, arePlansPending, isSpendResolving, paymentMethod, canManageBilling, spend, onS26Pricing, transition]);
 
-    // Legacy, enterprise and free-uncapped accounts get no strip — their terms are negotiated per
-    // customer or nothing is billable. A scheduled migration is the exception: the date has to land
-    // somewhere.
+    // Legacy, enterprise and free-uncapped terms are negotiated per customer, so no strip. A
+    // scheduled migration is the exception: its date has to land somewhere.
     if (plan && !showsSummaryStrip(plan, transition !== null)) {
         return null;
     }

--- a/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Summary.tsx
@@ -55,8 +55,6 @@ export const Summary: React.FC = () => {
         return buildSummaryState({ plan, plans: plansList?.data, paymentMethod, canManageBilling, spend, onS26Pricing, transition, now: new Date() });
     }, [plan, plansList, arePlansPending, isSpendResolving, paymentMethod, canManageBilling, spend, onS26Pricing, transition]);
 
-    // Legacy, enterprise and free-uncapped terms are negotiated per customer, so no strip. A
-    // scheduled migration is the exception: its date has to land somewhere.
     if (plan && !showsSummaryStrip(plan, transition !== null)) {
         return null;
     }

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -54,11 +54,8 @@ export const Usage: React.FC = () => {
     } = useApiGetBillingPeriodCosts(env, plan, { enabled: orbChargesEnabled, ...(isCurrentMonth ? {} : { timeframe }) });
     const chargeArgs = { enabled: orbChargesEnabled, isPending: costsPending, isError: costsError, data: periodCosts };
     const orbCharges = buildUsageRowCharges(chargeArgs);
-    // Same figures, but beside the Pay-as-you-go column an unpriced meter reads as a dash rather
-    // than a $0.00 that looks like a comparable number.
     const orbCurrentPlanCharges = buildUsageRowCharges({ ...chargeArgs, unpriced: 'dash' });
 
-    // The projection is computed from ClickHouse, so unlike the Orb figures it answers for any month.
     const { data: projected, isPending: projectedPending, isError: projectedError } = useApiGetProjectedCosts(env, timeframe, { enabled: isMigrating });
     const projectedCharges = buildProjectedCharges({ enabled: isMigrating, isPending: projectedPending, isError: projectedError, data: projected });
 
@@ -94,14 +91,12 @@ export const Usage: React.FC = () => {
 
     const charges = isMigrating ? projectedCharges : orbCharges;
 
-    // One table, two pricing models. `connections` is the only meter both charge on, so it is the
-    // one row that can carry a figure in each column; every other meter belongs to one side only.
+    // `connections` is the only meter both models charge on, so a metric-keyed lookup collides.
     const legacyOnlyMetrics = LEGACY_USAGE_METRICS.filter((metric) => !S26_USAGE_METRICS.includes(metric));
     const rows: UsageTableRow[] = isMigrating
         ? [
               ...metrics.map((metric) =>
                   rowFor(metric, {
-                      // Headings earn their keep only once there are two sets of rows to tell apart.
                       ...(showOld ? { group: 'New metrics' } : {}),
                       charge: projectedCharges?.(metric),
                       ...(orbCurrentPlanCharges ? { currentPlanCharge: orbCurrentPlanCharges(metric) } : {})
@@ -111,8 +106,6 @@ export const Usage: React.FC = () => {
                   ? legacyOnlyMetrics.map((metric) =>
                         rowFor(metric, {
                             group: 'Old metrics',
-                            // A dash, matching how the other column states a meter its plan does not
-                            // price — Pay-as-you-go has no price for any of these.
                             charge: { formatted: null, pending: false },
                             ...(orbCharges ? { currentPlanCharge: orbCharges(metric) } : {})
                         })
@@ -203,11 +196,8 @@ export const Usage: React.FC = () => {
     );
 };
 
-/**
- * The current plan's own side of the comparison, summed from the same Orb figures the metric rows
- * show so the column adds up. Null when Orb has nothing to state, which reads as a blank column
- * rather than a row of dashes.
- */
+/** Summed from the same Orb figures the rows show, so the column adds up. Null, not 0, when Orb
+ *  has nothing to state — 0 would render $0.00 for an account that has no figures at all. */
 function currentPlanTotals(
     periodCosts: GetBillingPeriodCosts['Success'] | undefined
 ): { usageInCents: number; fixedInCents: number; totalInCents: number } | null {

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -2,7 +2,7 @@ import { ExternalLink, Info } from 'lucide-react';
 import { parseAsBoolean, useQueryState } from 'nuqs';
 import { useMemo } from 'react';
 
-import { Alert, AlertActions, AlertDescription, AlertTitle, Badge, Button } from '@nangohq/design-system';
+import { Alert, AlertActions, AlertDescription, AlertTitle, Button } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { Switch } from '@/components/ui/Switch';
@@ -134,10 +134,7 @@ export const Usage: React.FC = () => {
             )}
 
             <div className="flex justify-between items-center">
-                <div className="flex items-center gap-2">
-                    <span className="text-text-strong text-body-medium-medium">Usage</span>
-                    {isMigrating && <Badge variant="brand">New pricing</Badge>}
-                </div>
+                <span className="text-text-strong text-body-medium-medium">Usage</span>
                 <MonthSelector />
             </div>
 

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -147,7 +147,8 @@ export const Usage: React.FC = () => {
                 variant={isMigrating ? 'comparison' : charges ? 'charges' : 'usage'}
                 charges={charges}
                 currentPlanTitle={transition?.fromTitle}
-                extraColumnTooltip={isMigrating ? 'Estimated amount based on new rates.' : undefined}
+                currentPlanTooltip={transition ? `Plan active until ${transition.at}.` : undefined}
+                projectedTooltip={isMigrating ? 'Estimated amount based on new rates.' : undefined}
             />
 
             {isMigrating && (

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -91,7 +91,6 @@ export const Usage: React.FC = () => {
 
     const charges = isMigrating ? projectedCharges : orbCharges;
 
-    // Drop the meter both pricings charge on: one lookup key cannot serve two `connections` rows.
     const legacyOnlyMetrics = LEGACY_USAGE_METRICS.filter((metric) => !S26_USAGE_METRICS.includes(metric));
     const rows: UsageTableRow[] = isMigrating
         ? metrics.map((metric) =>
@@ -106,7 +105,7 @@ export const Usage: React.FC = () => {
     const legacyRows: UsageTableRow[] = legacyOnlyMetrics.map((metric) => rowFor(metric, orbCharges ? { currentPlanCharge: orbCharges(metric) } : {}));
     return (
         <div className="w-full flex flex-col gap-4">
-            {/* A migrating account already has the migration banner. An unscheduled one has nothing else. */}
+            {/* A migrating account already has the transition banner. */}
             {isLegacy && !isMigrating && (
                 <Alert variant="info">
                     <Info />

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -20,9 +20,9 @@ import { USAGE_METRIC_LABELS } from './usageMetrics';
 import { UsageTable } from './UsageTable';
 
 import type { UsageTableRow } from './UsageTable';
-import type { GetBillingPeriodCosts, UsageMetric } from '@nangohq/types';
+import type { UsageMetric } from '@nangohq/types';
 
-const showOldParam = parseAsBoolean.withDefault(false).withOptions({ history: 'replace' });
+const showLegacyParam = parseAsBoolean.withDefault(false).withOptions({ history: 'replace' });
 
 export const Usage: React.FC = () => {
     const env = useStore((state) => state.env);
@@ -30,7 +30,7 @@ export const Usage: React.FC = () => {
     const { data: environmentData } = useCurrentPlan(env);
     const plan = environmentData?.plan;
     const isFree = plan?.name === 'free';
-    const [showOld, setShowOld] = useQueryState('oldMetrics', showOldParam);
+    const [showLegacy, setShowLegacy] = useQueryState('legacyMetrics', showLegacyParam);
     const transition = usePlanTransition();
     const isMigrating = transition !== null;
     const metrics = billedUsageMetrics(plan, isMigrating);
@@ -94,39 +94,16 @@ export const Usage: React.FC = () => {
     // Drop the meter both pricings charge on: one lookup key cannot serve two `connections` rows.
     const legacyOnlyMetrics = LEGACY_USAGE_METRICS.filter((metric) => !S26_USAGE_METRICS.includes(metric));
     const rows: UsageTableRow[] = isMigrating
-        ? [
-              ...metrics.map((metric) =>
-                  rowFor(metric, {
-                      ...(showOld ? { group: 'New metrics' } : {}),
-                      charge: projectedCharges?.(metric),
-                      ...(orbCurrentPlanCharges ? { currentPlanCharge: orbCurrentPlanCharges(metric) } : {})
-                  })
-              ),
-              ...(showOld
-                  ? legacyOnlyMetrics.map((metric) =>
-                        rowFor(metric, {
-                            group: 'Old metrics',
-                            charge: { formatted: null, pending: false },
-                            ...(orbCharges ? { currentPlanCharge: orbCharges(metric) } : {})
-                        })
-                    )
-                  : [])
-          ]
+        ? metrics.map((metric) =>
+              rowFor(metric, {
+                  charge: projectedCharges?.(metric),
+                  ...(orbCurrentPlanCharges ? { currentPlanCharge: orbCurrentPlanCharges(metric) } : {})
+              })
+          )
         : metrics.map((metric) => rowFor(metric));
-    const totals =
-        isMigrating && projected && !projected.data.notApplicable
-            ? {
-                  subtotalInCents: projected.data.subtotalInCents,
-                  minimumInCents: projected.data.minimumInCents,
-                  minimumApplied: projected.data.minimumApplied,
-                  growthAddOnInCents: projected.data.growthAddOnInCents,
-                  totalInCents: projected.data.totalInCents,
-                  currency: projected.data.currency,
-                  currentPlanTitle: transition.fromTitle,
-                  currentPlan: currentPlanTotals(periodCosts, projected.data.currency)
-              }
-            : undefined;
 
+    // No `charge`: Pay-as-you-go does not price these meters, so that column states nothing.
+    const legacyRows: UsageTableRow[] = legacyOnlyMetrics.map((metric) => rowFor(metric, orbCharges ? { currentPlanCharge: orbCharges(metric) } : {}));
     return (
         <div className="w-full flex flex-col gap-4">
             {/* A migrating account already has the migration banner. An unscheduled one has nothing else. */}
@@ -172,47 +149,41 @@ export const Usage: React.FC = () => {
                 chartMode="daily"
                 variant={isMigrating ? 'comparison' : charges ? 'charges' : 'usage'}
                 charges={charges}
-                totals={totals}
+                currentPlanTitle={transition?.fromTitle}
                 extraColumnTooltip={isMigrating ? 'Estimated amount based on new rates.' : undefined}
             />
 
             {isMigrating && (
                 <div className="flex items-center gap-2 px-1">
                     <Switch
-                        id="old-metrics"
-                        checked={showOld}
+                        id="legacy-metrics"
+                        checked={showLegacy}
                         onCheckedChange={(checked) => {
-                            void setShowOld(checked);
-                            track('web:usage:old_metrics_toggled', { shown: checked });
+                            void setShowLegacy(checked);
+                            track('web:usage:legacy_metrics_toggled', { shown: checked });
                         }}
                     />
-                    <label htmlFor="old-metrics" className="cursor-pointer text-text-secondary text-body-small-regular">
-                        Show old metrics
+                    <label htmlFor="legacy-metrics" className="cursor-pointer text-text-secondary text-body-small-regular">
+                        Show legacy billing metrics
                     </label>
                 </div>
+            )}
+
+            {isMigrating && showLegacy && (
+                <UsageTable
+                    rows={legacyRows}
+                    isLoading={isLoading}
+                    env={env}
+                    timeframe={timeframe}
+                    chartMode="daily"
+                    variant="comparison"
+                    currentPlanTitle={transition?.fromTitle}
+                    legacy
+                />
             )}
         </div>
     );
 };
-
-/** Summed from the same Orb figures the rows show, so the column adds up. Returns null, not 0:
- *  0 would show $0.00 as the bill for an account Orb has no figures for. */
-function currentPlanTotals(
-    periodCosts: GetBillingPeriodCosts['Success'] | undefined,
-    currency: string
-): { usageInCents: number; fixedInCents: number; totalInCents: number } | null {
-    if (!periodCosts || periodCosts.data.noCosts) {
-        return null;
-    }
-    // Both columns are formatted with the projection's currency, so a current plan billed in
-    // another one would print a fabricated figure. Withhold it rather than convert.
-    if (periodCosts.data.currency !== currency) {
-        return null;
-    }
-    const { metrics, fixedInCents } = periodCosts.data;
-    const usageInCents = Object.values(metrics).reduce<number>((sum, cents) => sum + cents, 0);
-    return { usageInCents, fixedInCents, totalInCents: usageInCents + fixedInCents };
-}
 
 function monthTimeframe(month: Date, offset: number): { start: string; end: string } {
     const start = new Date(Date.UTC(month.getUTCFullYear(), month.getUTCMonth() + offset, 1));

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -1,20 +1,28 @@
 import { ExternalLink, Info } from 'lucide-react';
+import { parseAsBoolean, useQueryState } from 'nuqs';
 import { useMemo } from 'react';
 
-import { Alert, AlertActions, AlertDescription, AlertTitle, Button } from '@nangohq/design-system';
+import { Alert, AlertActions, AlertDescription, AlertTitle, Badge, Button } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
-import { useApiGetBillingPeriodCosts, useApiGetBillingUsage, useCurrentPlan } from '@/hooks/usePlan';
+import { Switch } from '@/components/ui/Switch';
+import { useApiGetBillingPeriodCosts, useApiGetBillingUsage, useApiGetProjectedCosts, useCurrentPlan } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
-import { billedUsageMetrics } from '@/utils/usage';
+import { billedUsageMetrics, LEGACY_USAGE_METRICS, S26_USAGE_METRICS } from '@/utils/usage';
 import { hasMonthlySpend, isLegacyPlan } from '../planVisibility';
-import { buildUsageRowCharges } from '../usageCharges';
+import { buildProjectedCharges, buildUsageRowCharges } from '../usageCharges';
+import { usePlanTransition } from '../usePlanTransition';
 import { useSelectedMonth } from '../useSelectedMonth';
 import { FreeUsage } from './FreeUsage';
 import { MonthSelector } from './MonthSelector';
 import { USAGE_METRIC_LABELS } from './usageMetrics';
 import { UsageTable } from './UsageTable';
+
+import type { UsageTableRow } from './UsageTable';
+import type { GetBillingPeriodCosts, UsageMetric } from '@nangohq/types';
+
+const showOldParam = parseAsBoolean.withDefault(false).withOptions({ history: 'replace' });
 
 export const Usage: React.FC = () => {
     const env = useStore((state) => state.env);
@@ -22,17 +30,13 @@ export const Usage: React.FC = () => {
     const { data: environmentData } = useCurrentPlan(env);
     const plan = environmentData?.plan;
     const isFree = plan?.name === 'free';
-    const metrics = billedUsageMetrics(plan);
+    const [showOld, setShowOld] = useQueryState('oldMetrics', showOldParam);
+    const transition = usePlanTransition();
+    const isMigrating = transition !== null;
+    const metrics = billedUsageMetrics(plan, isMigrating);
 
     // Calculate timeframe for the selected month
-    const timeframe = useMemo(() => {
-        const start = new Date(Date.UTC(selectedMonth.getUTCFullYear(), selectedMonth.getUTCMonth(), 1));
-        const end = new Date(Date.UTC(selectedMonth.getUTCFullYear(), selectedMonth.getUTCMonth() + 1, 1));
-        return {
-            start: start.toISOString(),
-            end: end.toISOString()
-        };
-    }, [selectedMonth]);
+    const timeframe = useMemo(() => monthTimeframe(selectedMonth, 0), [selectedMonth]);
 
     // Free renders <FreeUsage/> (which fetches its own ClickHouse data), so skip this query for
     // Free — it would double-fetch. Gate on `plan` being resolved too: until it loads `isFree` is
@@ -42,13 +46,21 @@ export const Usage: React.FC = () => {
     // billing running-average, matching what each row's drill-in chart also requests.
     const { data: usage, isLoading, error: usageError } = useApiGetBillingUsage(env, timeframe, { avgPerDay: true, enabled: plan != null && !isFree });
 
-    const chargesEnabled = hasMonthlySpend(plan);
+    const orbChargesEnabled = hasMonthlySpend(plan);
     const {
         data: periodCosts,
         isPending: costsPending,
         isError: costsError
-    } = useApiGetBillingPeriodCosts(env, plan, { enabled: chargesEnabled, ...(isCurrentMonth ? {} : { timeframe }) });
-    const charges = buildUsageRowCharges({ enabled: chargesEnabled, isPending: costsPending, isError: costsError, data: periodCosts });
+    } = useApiGetBillingPeriodCosts(env, plan, { enabled: orbChargesEnabled, ...(isCurrentMonth ? {} : { timeframe }) });
+    const chargeArgs = { enabled: orbChargesEnabled, isPending: costsPending, isError: costsError, data: periodCosts };
+    const orbCharges = buildUsageRowCharges(chargeArgs);
+    // Same figures, but beside the Pay-as-you-go column an unpriced meter reads as a dash rather
+    // than a $0.00 that looks like a comparable number.
+    const orbCurrentPlanCharges = buildUsageRowCharges({ ...chargeArgs, unpriced: 'dash' });
+
+    // The projection is computed from ClickHouse, so unlike the Orb figures it answers for any month.
+    const { data: projected, isPending: projectedPending, isError: projectedError } = useApiGetProjectedCosts(env, timeframe, { enabled: isMigrating });
+    const projectedCharges = buildProjectedCharges({ enabled: isMigrating, isPending: projectedPending, isError: projectedError, data: projected });
 
     if (usageError) {
         return (
@@ -70,18 +82,63 @@ export const Usage: React.FC = () => {
 
     const isLegacy = isLegacyPlan(plan);
     // Paid/legacy plans are uncapped (only `freePlan` sets real limits in `plans/definitions.ts`).
-    const rows = metrics.map((metric) => ({
+    const rowFor = (metric: UsageMetric, extra: Partial<UsageTableRow> = {}): UsageTableRow => ({
         metric,
         label: USAGE_METRIC_LABELS[metric],
         usage: usage?.data.usage[metric]?.total ?? 0,
         limit: null,
         capsLoading: isLoading,
-        data: usage?.data.usage[metric]
-    }));
+        data: usage?.data.usage[metric],
+        ...extra
+    });
+
+    const charges = isMigrating ? projectedCharges : orbCharges;
+
+    // One table, two pricing models. `connections` is the only meter both charge on, so it is the
+    // one row that can carry a figure in each column; every other meter belongs to one side only.
+    const legacyOnlyMetrics = LEGACY_USAGE_METRICS.filter((metric) => !S26_USAGE_METRICS.includes(metric));
+    const rows: UsageTableRow[] = isMigrating
+        ? [
+              ...metrics.map((metric) =>
+                  rowFor(metric, {
+                      // Headings earn their keep only once there are two sets of rows to tell apart.
+                      ...(showOld ? { group: 'New metrics' } : {}),
+                      charge: projectedCharges?.(metric),
+                      ...(orbCurrentPlanCharges ? { currentPlanCharge: orbCurrentPlanCharges(metric) } : {})
+                  })
+              ),
+              ...(showOld
+                  ? legacyOnlyMetrics.map((metric) =>
+                        rowFor(metric, {
+                            group: 'Old metrics',
+                            // A dash, matching how the other column states a meter its plan does not
+                            // price — Pay-as-you-go has no price for any of these.
+                            charge: { formatted: null, pending: false },
+                            ...(orbCharges ? { currentPlanCharge: orbCharges(metric) } : {})
+                        })
+                    )
+                  : [])
+          ]
+        : metrics.map((metric) => rowFor(metric));
+    const totals =
+        isMigrating && projected && !projected.data.notApplicable
+            ? {
+                  subtotalInCents: projected.data.subtotalInCents,
+                  minimumInCents: projected.data.minimumInCents,
+                  minimumApplied: projected.data.minimumApplied,
+                  growthAddOnInCents: projected.data.growthAddOnInCents,
+                  totalInCents: projected.data.totalInCents,
+                  currency: projected.data.currency,
+                  currentPlanTitle: transition.fromTitle,
+                  currentPlan: currentPlanTotals(periodCosts)
+              }
+            : undefined;
 
     return (
         <div className="w-full flex flex-col gap-4">
-            {isLegacy && (
+            {/* The banner above the page already announces the migration, so this only explains why
+                the metrics changed — but an unscheduled legacy account still needs the old notice. */}
+            {isLegacy && !isMigrating && (
                 <Alert variant="info">
                     <Info />
                     <AlertTitle>Legacy plan</AlertTitle>
@@ -108,7 +165,10 @@ export const Usage: React.FC = () => {
             )}
 
             <div className="flex justify-between items-center">
-                <span className="text-text-strong text-body-medium-medium">Usage</span>
+                <div className="flex items-center gap-2">
+                    <span className="text-text-strong text-body-medium-medium">Usage</span>
+                    {isMigrating && <Badge variant="brand">New pricing</Badge>}
+                </div>
                 <MonthSelector />
             </div>
 
@@ -118,9 +178,49 @@ export const Usage: React.FC = () => {
                 env={env}
                 timeframe={timeframe}
                 chartMode="daily"
-                variant={charges ? 'charges' : 'usage'}
+                variant={isMigrating ? 'comparison' : charges ? 'charges' : 'usage'}
                 charges={charges}
+                totals={totals}
+                extraColumnTooltip={isMigrating ? 'Estimated amount based on new rates.' : undefined}
             />
+
+            {isMigrating && (
+                <div className="flex items-center gap-2 px-1">
+                    <Switch
+                        id="old-metrics"
+                        checked={showOld}
+                        onCheckedChange={(checked) => {
+                            void setShowOld(checked);
+                            track('web:usage:old_metrics_toggled', { shown: checked });
+                        }}
+                    />
+                    <label htmlFor="old-metrics" className="cursor-pointer text-text-secondary text-body-small-regular">
+                        Show old metrics
+                    </label>
+                </div>
+            )}
         </div>
     );
 };
+
+/**
+ * The current plan's own side of the comparison, summed from the same Orb figures the metric rows
+ * show so the column adds up. Null when Orb has nothing to state, which reads as a blank column
+ * rather than a row of dashes.
+ */
+function currentPlanTotals(
+    periodCosts: GetBillingPeriodCosts['Success'] | undefined
+): { usageInCents: number; fixedInCents: number; totalInCents: number } | null {
+    if (!periodCosts || periodCosts.data.noCosts) {
+        return null;
+    }
+    const { metrics, fixedInCents } = periodCosts.data;
+    const usageInCents = Object.values(metrics).reduce<number>((sum, cents) => sum + cents, 0);
+    return { usageInCents, fixedInCents, totalInCents: usageInCents + fixedInCents };
+}
+
+function monthTimeframe(month: Date, offset: number): { start: string; end: string } {
+    const start = new Date(Date.UTC(month.getUTCFullYear(), month.getUTCMonth() + offset, 1));
+    const end = new Date(Date.UTC(month.getUTCFullYear(), month.getUTCMonth() + offset + 1, 1));
+    return { start: start.toISOString(), end: end.toISOString() };
+}

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -107,7 +107,7 @@ export const Usage: React.FC = () => {
     );
     return (
         <div className="w-full flex flex-col gap-4">
-            {/* A migrating account already has the transition banner. */}
+            {/* Migrating accounts already have the transition banner. */}
             {isLegacy && !isMigrating && (
                 <Alert variant="info">
                     <Info />

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -91,7 +91,7 @@ export const Usage: React.FC = () => {
 
     const charges = isMigrating ? projectedCharges : orbCharges;
 
-    // `connections` is the only meter both models charge on, so a metric-keyed lookup collides.
+    // Drop the meter both pricings charge on: one lookup key cannot serve two `connections` rows.
     const legacyOnlyMetrics = LEGACY_USAGE_METRICS.filter((metric) => !S26_USAGE_METRICS.includes(metric));
     const rows: UsageTableRow[] = isMigrating
         ? [
@@ -129,8 +129,7 @@ export const Usage: React.FC = () => {
 
     return (
         <div className="w-full flex flex-col gap-4">
-            {/* The banner above the page already announces the migration, so this only explains why
-                the metrics changed — but an unscheduled legacy account still needs the old notice. */}
+            {/* A migrating account already has the migration banner. An unscheduled one has nothing else. */}
             {isLegacy && !isMigrating && (
                 <Alert variant="info">
                     <Info />
@@ -196,8 +195,8 @@ export const Usage: React.FC = () => {
     );
 };
 
-/** Summed from the same Orb figures the rows show, so the column adds up. Null, not 0, when Orb
- *  has nothing to state — 0 would render $0.00 for an account that has no figures at all. */
+/** Summed from the same Orb figures the rows show, so the column adds up. Returns null, not 0:
+ *  0 would show $0.00 as the bill for an account Orb has no figures for. */
 function currentPlanTotals(
     periodCosts: GetBillingPeriodCosts['Success'] | undefined,
     currency: string

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -102,7 +102,9 @@ export const Usage: React.FC = () => {
         : metrics.map((metric) => rowFor(metric));
 
     // No `charge`: Pay-as-you-go does not price these meters, so that column states nothing.
-    const legacyRows: UsageTableRow[] = legacyOnlyMetrics.map((metric) => rowFor(metric, orbCharges ? { currentPlanCharge: orbCharges(metric) } : {}));
+    const legacyRows: UsageTableRow[] = legacyOnlyMetrics.map((metric) =>
+        rowFor(metric, orbCurrentPlanCharges ? { currentPlanCharge: orbCurrentPlanCharges(metric) } : {})
+    );
     return (
         <div className="w-full flex flex-col gap-4">
             {/* A migrating account already has the transition banner. */}

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -123,7 +123,7 @@ export const Usage: React.FC = () => {
                   totalInCents: projected.data.totalInCents,
                   currency: projected.data.currency,
                   currentPlanTitle: transition.fromTitle,
-                  currentPlan: currentPlanTotals(periodCosts)
+                  currentPlan: currentPlanTotals(periodCosts, projected.data.currency)
               }
             : undefined;
 
@@ -199,9 +199,15 @@ export const Usage: React.FC = () => {
 /** Summed from the same Orb figures the rows show, so the column adds up. Null, not 0, when Orb
  *  has nothing to state — 0 would render $0.00 for an account that has no figures at all. */
 function currentPlanTotals(
-    periodCosts: GetBillingPeriodCosts['Success'] | undefined
+    periodCosts: GetBillingPeriodCosts['Success'] | undefined,
+    currency: string
 ): { usageInCents: number; fixedInCents: number; totalInCents: number } | null {
     if (!periodCosts || periodCosts.data.noCosts) {
+        return null;
+    }
+    // Both columns are formatted with the projection's currency, so a current plan billed in
+    // another one would print a fabricated figure. Withhold it rather than convert.
+    if (periodCosts.data.currency !== currency) {
         return null;
     }
     const { metrics, fixedInCents } = periodCosts.data;

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -19,7 +19,6 @@ export function usageRowGrid(variant: UsageRowVariant): string {
         return 'grid grid-cols-[minmax(0,2fr)_minmax(0,2.2fr)_124px_20px] items-center gap-4 px-6';
     }
     if (variant === 'comparison') {
-        // A second money column for the current plan, so old and new sit side by side on one row.
         return 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_124px_180px_20px] items-center gap-4 px-6';
     }
     return 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_124px_20px] items-center gap-4 px-6';
@@ -47,8 +46,7 @@ interface UsageRowProps {
     chartMode: 'daily' | 'cumulative';
     variant: UsageRowVariant;
     charge?: UsageRowCharge;
-    /** What the current plan charged for this metric. Only the legacy meters and `connections` have
-     *  one; everything else is new under Pay-as-you-go. */
+    /** Only the legacy meters and `connections` have one. */
     currentPlanCharge?: UsageRowCharge;
 }
 
@@ -107,8 +105,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                     ) : (
                         <div />
                     )}
-                    {/* The current plan's column, left of Pay-as-you-go. A dash means the plan has no
-                        price for this meter; blank means the row states nothing here at all. */}
+                    {/* Dash = the plan has no price for this meter. Blank = the row states nothing. */}
                     {variant === 'comparison' && (
                         <div className="text-text-default type-text-regular-sm">{currentPlanCharge ? (currentPlanCharge.formatted ?? '—') : ''}</div>
                     )}

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -13,8 +13,8 @@ import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 export type UsageRowVariant = 'caps' | 'usage' | 'charges' | 'comparison';
 
 export function usageRowGrid(variant: UsageRowVariant): string {
-    // Tailwind's scanner needs the full bracketed class literally in source to generate it, so this
-    // picks between complete strings rather than assembling one from a variable.
+    // Tailwind only generates a class it can see written out in source. Return whole strings here;
+    // never build one by interpolation.
     if (variant === 'caps') {
         return 'grid grid-cols-[minmax(0,2fr)_minmax(0,2.2fr)_124px_20px] items-center gap-4 px-6';
     }
@@ -46,7 +46,6 @@ interface UsageRowProps {
     chartMode: 'daily' | 'cumulative';
     variant: UsageRowVariant;
     charge?: UsageRowCharge;
-    /** Only the legacy meters and `connections` have one. */
     currentPlanCharge?: UsageRowCharge;
 }
 

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -123,7 +123,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                         </div>
                     ) : (
                         // On an uncapped plan a charge is what was billed, not a threshold crossed.
-                        <div className="text-text-default type-text-regular-sm">{charge?.formatted ?? '—'}</div>
+                        <div className="text-text-default type-text-regular-sm">{charge ? (charge.formatted ?? '—') : ''}</div>
                     )}
                     <ChevronDown className="size-5 text-text-muted transition-transform group-data-[state=open]:rotate-180" />
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -78,7 +78,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
     const figures = showLimits && limit != null ? formatMetricPair(metric, usage, limit) : { usage: formatMetricUsage(metric, usage), limit: null };
     const exactFigure = formatMetricUsageExact(metric, usage) + (figures.limit != null ? ` / ${figures.limit}` : '');
     // The charge and usage queries resolve independently.
-    const isPending = variant === 'charges' ? charge?.pending : capsLoading;
+    const isPending = variant === 'charges' || variant === 'comparison' ? charge?.pending : capsLoading;
 
     return (
         <Collapsible open={open} onOpenChange={onOpenChange} className="border-b border-border-muted last:border-b-0 data-[state=open]:bg-surface-panel">
@@ -106,9 +106,12 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                         <div />
                     )}
                     {/* Dash = the plan has no price for this meter. Blank = the row states nothing. */}
-                    {variant === 'comparison' && (
-                        <div className="text-text-default type-text-regular-sm">{currentPlanCharge ? (currentPlanCharge.formatted ?? '—') : ''}</div>
-                    )}
+                    {variant === 'comparison' &&
+                        (currentPlanCharge?.pending ? (
+                            <Skeleton className="h-4 w-12" />
+                        ) : (
+                            <div className="text-text-default type-text-regular-sm">{currentPlanCharge ? (currentPlanCharge.formatted ?? '—') : ''}</div>
+                        ))}
                     {isPending ? (
                         <Skeleton className="h-4 w-12" />
                     ) : showLimits ? (

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -10,12 +10,19 @@ import { UsageChartCard } from './UsageChartCard';
 import type { UsageRowCharge } from '../usageCharges';
 import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 
-export function usageRowGrid(variant: 'caps' | 'usage' | 'charges'): string {
+export type UsageRowVariant = 'caps' | 'usage' | 'charges' | 'comparison';
+
+export function usageRowGrid(variant: UsageRowVariant): string {
     // Tailwind's scanner needs the full bracketed class literally in source to generate it, so this
-    // picks between two complete strings rather than assembling one from a variable.
-    return variant === 'caps'
-        ? 'grid grid-cols-[minmax(0,2fr)_minmax(0,2.2fr)_124px_20px] items-center gap-4 px-6'
-        : 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_124px_20px] items-center gap-4 px-6';
+    // picks between complete strings rather than assembling one from a variable.
+    if (variant === 'caps') {
+        return 'grid grid-cols-[minmax(0,2fr)_minmax(0,2.2fr)_124px_20px] items-center gap-4 px-6';
+    }
+    if (variant === 'comparison') {
+        // A second money column for the current plan, so old and new sit side by side on one row.
+        return 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_124px_180px_20px] items-center gap-4 px-6';
+    }
+    return 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_124px_20px] items-center gap-4 px-6';
 }
 
 interface UsageRowProps {
@@ -38,8 +45,11 @@ interface UsageRowProps {
     onOpenChange?: (open: boolean) => void;
     /** 'cumulative' for Free (progress toward the cap), 'daily' for paid. */
     chartMode: 'daily' | 'cumulative';
-    variant: 'caps' | 'usage' | 'charges';
+    variant: UsageRowVariant;
     charge?: UsageRowCharge;
+    /** What the current plan charged for this metric. Only the legacy meters and `connections` have
+     *  one; everything else is new under Pay-as-you-go. */
+    currentPlanCharge?: UsageRowCharge;
 }
 
 /**
@@ -61,7 +71,8 @@ export const UsageRow: React.FC<UsageRowProps> = ({
     onOpenChange,
     chartMode,
     variant,
-    charge
+    charge,
+    currentPlanCharge
 }) => {
     const state = getUsageState(usage, limit);
     const percent = limit ? Math.round((usage / limit) * 100) : null;
@@ -95,6 +106,11 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                         </div>
                     ) : (
                         <div />
+                    )}
+                    {/* The current plan's column, left of Pay-as-you-go. A dash means the plan has no
+                        price for this meter; blank means the row states nothing here at all. */}
+                    {variant === 'comparison' && (
+                        <div className="text-text-default type-text-regular-sm">{currentPlanCharge ? (currentPlanCharge.formatted ?? '—') : ''}</div>
                     )}
                     {isPending ? (
                         <Skeleton className="h-4 w-12" />

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -12,9 +12,8 @@ import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 
 export type UsageRowVariant = 'caps' | 'usage' | 'charges' | 'comparison';
 
+// Tailwind only generates classes it sees in source. This helper must return whole strings.
 export function usageRowGrid(variant: UsageRowVariant): string {
-    // Tailwind only generates a class it can see written out in source. Return whole strings here;
-    // never build one by interpolation.
     if (variant === 'caps') {
         return 'grid grid-cols-[minmax(0,2fr)_minmax(0,2.2fr)_124px_20px] items-center gap-4 px-6';
     }
@@ -104,7 +103,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
                     ) : (
                         <div />
                     )}
-                    {/* Dash = the plan has no price for this meter. Blank = the row states nothing. */}
+                    {/* A dash means unpriced. Blank means this row has no applicable figure. */}
                     {variant === 'comparison' &&
                         (currentPlanCharge?.pending ? (
                             <Skeleton className="h-4 w-12" />

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -15,10 +15,8 @@ import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 export interface UsageTableRow {
     metric: UsageMetric;
     label: string;
-    /** Heading this row sits under. Rows sharing one are grouped in order. */
     group?: string;
-    /** Overrides the table's `charges` lookup — needed once one table holds two pricing models,
-     *  since `connections` appears in both and a metric-keyed lookup cannot tell them apart. */
+    /** Overrides the table's lookup, which cannot tell one model's `connections` from the other's. */
     charge?: UsageRowCharge;
     currentPlanCharge?: UsageRowCharge;
     usage: number;
@@ -27,7 +25,6 @@ export interface UsageTableRow {
     data?: ApiBillingUsageMetric;
 }
 
-/** What the rows add up to, when the table is showing a bill rather than bare usage. */
 export interface UsageTableTotals {
     subtotalInCents: number;
     minimumInCents: number;
@@ -35,8 +32,6 @@ export interface UsageTableTotals {
     growthAddOnInCents: number;
     totalInCents: number;
     currency: string;
-    /** The current plan's name and its own charges for the same window, for the comparison. Null
-     *  when Orb can't state them — a plan without per-period spend, or an unlinked subscription. */
     currentPlanTitle?: string;
     currentPlan?: { usageInCents: number; fixedInCents: number; totalInCents: number } | null;
 }
@@ -54,9 +49,7 @@ interface UsageTableProps {
      *  (each row manages its own open state) when omitted. */
     isRowOpen?: (metric: UsageMetric) => boolean;
     onRowOpenChange?: (metric: UsageMetric, open: boolean) => void;
-    /** Footer lines under the rows. Omitted when the table isn't stating a bill. */
     totals?: UsageTableTotals;
-    /** Caveat for the rightmost comparison column, shown on an info icon beside its header. */
     extraColumnTooltip?: string;
 }
 
@@ -146,23 +139,19 @@ export const UsageTable: React.FC<UsageTableProps> = ({
     );
 };
 
-/** One footer line: label on the left, amounts in the same columns the per-metric charges sit in. */
 const TotalsLine: React.FC<{
     variant: UsageTableProps['variant'];
     label: string;
     amount: string | null;
     currentPlanAmount?: string | null;
-    /** Caveat on the Pay-as-you-go figure, shown on an info icon beside it. */
     tooltip?: string;
     strong?: boolean;
 }> = ({ variant, label, amount, currentPlanAmount, tooltip, strong }) => {
-    // Sized like a metric row: these lines continue the column rather than annotate it.
     const text = cn('tabular-nums', strong ? 'text-text-strong text-body-medium-medium' : 'text-text-default type-text-regular-sm');
     return (
         <div className={cn(usageRowGrid(variant), 'py-2.5')}>
             <span className={cn('truncate', strong ? 'text-text-strong text-body-medium-medium' : 'text-text-secondary type-text-regular-sm')}>{label}</span>
             <span />
-            {/* Blank rather than a dash: the current plan simply has no figure of this kind. */}
             {variant === 'comparison' && <span className={text}>{currentPlanAmount ?? ''}</span>}
             <span className="flex items-center gap-1.5">
                 <span className={text}>{amount ?? '—'}</span>
@@ -173,19 +162,16 @@ const TotalsLine: React.FC<{
     );
 };
 
-/** Why the usage line reads higher than the metrics above it add up to. */
 function minimumNote(totals: UsageTableTotals, money: (cents: number) => string | null): string {
     const minimum = money(totals.minimumInCents);
     return minimum ? `Accrued usage is below the ${minimum} monthly minimum.` : 'Accrued usage is below the monthly minimum.';
 }
 
-/** The difference between the two bills, as a badge variant. Null when there is nothing to compare. */
 function billDifference(totals: UsageTableTotals): { text: string; variant: BadgeProps['variant'] } | null {
     if (!totals.currentPlan) {
         return null;
     }
     const delta = totals.totalInCents - totals.currentPlan.totalInCents;
-    // Two identical totals say it themselves; a badge would only add noise.
     if (delta === 0) {
         return null;
     }
@@ -198,16 +184,10 @@ const UsageTotals: React.FC<{ variant: UsageTableProps['variant']; totals: Usage
     const comparing = variant === 'comparison';
     const difference = comparing ? billDifference(totals) : null;
 
-    // Both columns split the same way — what usage cost, then what is charged regardless of it —
-    // so the two bills are read the same way and each column's lines add up to its own total.
-    // One shared background across the block, so the summed lines read as one unit rather than
-    // leaving the total looking like another metric row.
-    // No top border of its own: the last metric row already draws one, and the shared background is
-    // what actually marks the block off.
+    // No top border: the last metric row already draws one, and two would show as a double line.
     return (
         <div className="bg-surface-input-muted">
-            {/* Under the minimum, the floor *is* the usage charge — it replaces the subtotal rather
-                than adding to it, so it goes on this line with the arithmetic explained on hover. */}
+            {/* The floor replaces the subtotal rather than adding to it, so it goes on this line. */}
             <TotalsLine
                 variant={variant}
                 label={comparing ? 'Usage charges' : 'Subtotal'}
@@ -230,14 +210,11 @@ const UsageTotals: React.FC<{ variant: UsageTableProps['variant']; totals: Usage
                     <span className="tabular-nums text-text-default text-body-medium-medium">
                         {totals.currentPlan ? (money(totals.currentPlan.totalInCents) ?? '—') : ''}
                     </span>
-                    {/* The difference is the answer the page exists to give, so it carries the same
-                        weight as the total it comes from rather than trailing it as a footnote. */}
                     <span className="flex items-baseline gap-2">
                         <span className="tabular-nums text-text-strong text-body-medium-medium">{money(totals.totalInCents) ?? '—'}</span>
                         {difference && (
-                            // Matches the total beside it in size and weight, which the Badge's own
-                            // `type-code-regular-xs` otherwise wins — the token stylesheet is
-                            // imported unlayered, so it outranks the utility without `!`.
+                            // The token stylesheet is imported unlayered, so the Badge's own
+                            // `type-code-regular-xs` wins without the `!`.
                             // eslint-disable-next-line react/forbid-component-props -- deliberate: this comparison view is short-lived, so the weight is not worth a design-system variant
                             <Badge variant={difference.variant} className="text-body-medium-medium!">
                                 {difference.text}

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -1,18 +1,44 @@
-import { Info } from 'lucide-react';
+import { Fragment } from 'react';
 
+import { Badge } from '@nangohq/design-system';
+
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { cn } from '@/utils/utils';
+import { formatMoneyFromCents } from '../money';
 import { UsageRow, usageRowGrid } from './UsageRow';
 
-import type { UsageChargeLookup } from '../usageCharges';
+import type { UsageChargeLookup, UsageRowCharge } from '../usageCharges';
+import type { UsageRowVariant } from './UsageRow';
+import type { BadgeProps } from '@nangohq/design-system';
 import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 
 export interface UsageTableRow {
     metric: UsageMetric;
     label: string;
+    /** Heading this row sits under. Rows sharing one are grouped in order. */
+    group?: string;
+    /** Overrides the table's `charges` lookup — needed once one table holds two pricing models,
+     *  since `connections` appears in both and a metric-keyed lookup cannot tell them apart. */
+    charge?: UsageRowCharge;
+    currentPlanCharge?: UsageRowCharge;
     usage: number;
     limit: number | null;
     capsLoading?: boolean;
     data?: ApiBillingUsageMetric;
+}
+
+/** What the rows add up to, when the table is showing a bill rather than bare usage. */
+export interface UsageTableTotals {
+    subtotalInCents: number;
+    minimumInCents: number;
+    minimumApplied: boolean;
+    growthAddOnInCents: number;
+    totalInCents: number;
+    currency: string;
+    /** The current plan's name and its own charges for the same window, for the comparison. Null
+     *  when Orb can't state them — a plan without per-period spend, or an unlinked subscription. */
+    currentPlanTitle?: string;
+    currentPlan?: { usageInCents: number; fixedInCents: number; totalInCents: number } | null;
 }
 
 interface UsageTableProps {
@@ -22,21 +48,27 @@ interface UsageTableProps {
     timeframe: { start: string; end: string };
     /** 'cumulative' for Free (progress toward the cap), 'daily' for paid. */
     chartMode: 'daily' | 'cumulative';
-    variant: 'caps' | 'usage' | 'charges';
+    variant: UsageRowVariant;
     charges?: UsageChargeLookup;
     /** Controlled expand state, keyed by metric — Free persists this in the URL. Uncontrolled
      *  (each row manages its own open state) when omitted. */
     isRowOpen?: (metric: UsageMetric) => boolean;
     onRowOpenChange?: (metric: UsageMetric, open: boolean) => void;
+    /** Footer lines under the rows. Omitted when the table isn't stating a bill. */
+    totals?: UsageTableTotals;
+    /** Caveat for the rightmost comparison column, shown on an info icon beside its header. */
+    extraColumnTooltip?: string;
 }
 
 /** The two right-hand column headers, which differ by variant. */
-function usageColumnHeaders(variant: UsageTableProps['variant']): { thisPeriod: string; rightmost: string } {
+function usageColumnHeaders(variant: UsageTableProps['variant'], currentPlanTitle?: string): { thisPeriod: string; rightmost: string; extra?: string } {
     switch (variant) {
         case 'caps':
             return { thisPeriod: 'Used / Limit', rightmost: '% of limit' };
         case 'charges':
             return { thisPeriod: 'This period', rightmost: 'Charges' };
+        case 'comparison':
+            return { thisPeriod: 'This period', rightmost: `${currentPlanTitle ?? 'Current'} plan`, extra: 'Pay-as-you-go plan' };
         case 'usage':
             return { thisPeriod: '', rightmost: 'This period' };
     }
@@ -46,20 +78,51 @@ function usageColumnHeaders(variant: UsageTableProps['variant']): { thisPeriod: 
  * The bordered per-metric usage table shared by Free and paid: a header row, then one collapsible
  * {@link UsageRow} per metric.
  */
-export const UsageTable: React.FC<UsageTableProps> = ({ rows, isLoading, env, timeframe, chartMode, variant, charges, isRowOpen, onRowOpenChange }) => {
-    const { thisPeriod, rightmost } = usageColumnHeaders(variant);
+export const UsageTable: React.FC<UsageTableProps> = ({
+    rows,
+    isLoading,
+    env,
+    timeframe,
+    chartMode,
+    variant,
+    charges,
+    isRowOpen,
+    onRowOpenChange,
+    totals,
+    extraColumnTooltip
+}) => {
+    const { thisPeriod, rightmost, extra } = usageColumnHeaders(variant, totals?.currentPlanTitle);
     return (
-        <div className="w-full flex flex-col gap-4">
-            <div className="rounded border border-border-default overflow-hidden">
-                <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
-                    <span>Metric</span>
-                    <span>{thisPeriod}</span>
-                    <span>{rightmost}</span>
-                    <span />
-                </div>
-                {rows.map((row) => (
+        <div className="w-full rounded border border-border-default overflow-hidden">
+            <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
+                <span>Metric</span>
+                <span>{thisPeriod}</span>
+                <span>{rightmost}</span>
+                {extra && (
+                    <span className="flex items-center gap-1.5">
+                        {extra}
+                        {extraColumnTooltip && (
+                            <InfoTooltip side="top" align="end">
+                                {extraColumnTooltip}
+                            </InfoTooltip>
+                        )}
+                    </span>
+                )}
+                <span />
+            </div>
+            {rows.map((row, index) => (
+                <Fragment key={row.group ? `${row.group}:${row.metric}` : row.metric}>
+                    {row.group && row.group !== rows[index - 1]?.group && (
+                        <div
+                            className={cn(
+                                usageRowGrid(variant),
+                                'py-2 bg-surface-panel-inset border-b border-border-muted text-text-secondary type-label-xxs uppercase'
+                            )}
+                        >
+                            <span>{row.group}</span>
+                        </div>
+                    )}
                     <UsageRow
-                        key={row.metric}
                         metric={row.metric}
                         label={row.label}
                         usage={row.usage}
@@ -73,14 +136,119 @@ export const UsageTable: React.FC<UsageTableProps> = ({ rows, isLoading, env, ti
                         onOpenChange={onRowOpenChange ? (open) => onRowOpenChange(row.metric, open) : undefined}
                         chartMode={chartMode}
                         variant={variant}
-                        charge={charges?.(row.metric)}
+                        charge={row.charge ?? charges?.(row.metric)}
+                        currentPlanCharge={row.currentPlanCharge}
                     />
-                ))}
-            </div>
-            <span className="flex items-center gap-1.5 text-text-muted text-body-small-regular px-1">
-                <Info className="size-3.5 shrink-0" />
-                Click any row to see its trend and breakdown.
+                </Fragment>
+            ))}
+            {totals && <UsageTotals variant={variant} totals={totals} />}
+        </div>
+    );
+};
+
+/** One footer line: label on the left, amounts in the same columns the per-metric charges sit in. */
+const TotalsLine: React.FC<{
+    variant: UsageTableProps['variant'];
+    label: string;
+    amount: string | null;
+    currentPlanAmount?: string | null;
+    /** Caveat on the Pay-as-you-go figure, shown on an info icon beside it. */
+    tooltip?: string;
+    strong?: boolean;
+}> = ({ variant, label, amount, currentPlanAmount, tooltip, strong }) => {
+    // Sized like a metric row: these lines continue the column rather than annotate it.
+    const text = cn('tabular-nums', strong ? 'text-text-strong text-body-medium-medium' : 'text-text-default type-text-regular-sm');
+    return (
+        <div className={cn(usageRowGrid(variant), 'py-2.5')}>
+            <span className={cn('truncate', strong ? 'text-text-strong text-body-medium-medium' : 'text-text-secondary type-text-regular-sm')}>{label}</span>
+            <span />
+            {/* Blank rather than a dash: the current plan simply has no figure of this kind. */}
+            {variant === 'comparison' && <span className={text}>{currentPlanAmount ?? ''}</span>}
+            <span className="flex items-center gap-1.5">
+                <span className={text}>{amount ?? '—'}</span>
+                {tooltip && <InfoTooltip side="top">{tooltip}</InfoTooltip>}
             </span>
+            <span />
+        </div>
+    );
+};
+
+/** Why the usage line reads higher than the metrics above it add up to. */
+function minimumNote(totals: UsageTableTotals, money: (cents: number) => string | null): string {
+    const minimum = money(totals.minimumInCents);
+    return minimum ? `Accrued usage is below the ${minimum} monthly minimum.` : 'Accrued usage is below the monthly minimum.';
+}
+
+/** The difference between the two bills, as a badge variant. Null when there is nothing to compare. */
+function billDifference(totals: UsageTableTotals): { text: string; variant: BadgeProps['variant'] } | null {
+    if (!totals.currentPlan) {
+        return null;
+    }
+    const delta = totals.totalInCents - totals.currentPlan.totalInCents;
+    // Two identical totals say it themselves; a badge would only add noise.
+    if (delta === 0) {
+        return null;
+    }
+    const formatted = formatMoneyFromCents(Math.abs(delta), totals.currency) ?? '';
+    return delta > 0 ? { text: `+${formatted}`, variant: 'warning' } : { text: `−${formatted}`, variant: 'success' };
+}
+
+const UsageTotals: React.FC<{ variant: UsageTableProps['variant']; totals: UsageTableTotals }> = ({ variant, totals }) => {
+    const money = (cents: number) => formatMoneyFromCents(cents, totals.currency);
+    const comparing = variant === 'comparison';
+    const difference = comparing ? billDifference(totals) : null;
+
+    // Both columns split the same way — what usage cost, then what is charged regardless of it —
+    // so the two bills are read the same way and each column's lines add up to its own total.
+    // One shared background across the block, so the summed lines read as one unit rather than
+    // leaving the total looking like another metric row.
+    // No top border of its own: the last metric row already draws one, and the shared background is
+    // what actually marks the block off.
+    return (
+        <div className="bg-surface-input-muted">
+            {/* Under the minimum, the floor *is* the usage charge — it replaces the subtotal rather
+                than adding to it, so it goes on this line with the arithmetic explained on hover. */}
+            <TotalsLine
+                variant={variant}
+                label={comparing ? 'Usage charges' : 'Subtotal'}
+                amount={money(totals.minimumApplied ? totals.minimumInCents : totals.subtotalInCents)}
+                currentPlanAmount={totals.currentPlan ? money(totals.currentPlan.usageInCents) : null}
+                {...(comparing && totals.minimumApplied ? { tooltip: minimumNote(totals, money) } : {})}
+            />
+            {(totals.growthAddOnInCents > 0 || (totals.currentPlan?.fixedInCents ?? 0) > 0) && (
+                <TotalsLine
+                    variant={variant}
+                    label={comparing ? 'Fixed charges' : 'Growth add-on'}
+                    amount={money(totals.growthAddOnInCents)}
+                    currentPlanAmount={totals.currentPlan ? money(totals.currentPlan.fixedInCents) : null}
+                />
+            )}
+            {comparing ? (
+                <div className={cn(usageRowGrid(variant), 'py-3')}>
+                    <span className="text-text-strong text-body-medium-medium truncate">Total</span>
+                    <span />
+                    <span className="tabular-nums text-text-default text-body-medium-medium">
+                        {totals.currentPlan ? (money(totals.currentPlan.totalInCents) ?? '—') : ''}
+                    </span>
+                    {/* The difference is the answer the page exists to give, so it carries the same
+                        weight as the total it comes from rather than trailing it as a footnote. */}
+                    <span className="flex items-baseline gap-2">
+                        <span className="tabular-nums text-text-strong text-body-medium-medium">{money(totals.totalInCents) ?? '—'}</span>
+                        {difference && (
+                            // Matches the total beside it in size and weight, which the Badge's own
+                            // `type-code-regular-xs` otherwise wins — the token stylesheet is
+                            // imported unlayered, so it outranks the utility without `!`.
+                            // eslint-disable-next-line react/forbid-component-props -- deliberate: this comparison view is short-lived, so the weight is not worth a design-system variant
+                            <Badge variant={difference.variant} className="text-body-medium-medium!">
+                                {difference.text}
+                            </Badge>
+                        )}
+                    </span>
+                    <span />
+                </div>
+            ) : (
+                <TotalsLine variant={variant} label="Projected total" amount={money(totals.totalInCents)} strong />
+            )}
         </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -17,7 +17,7 @@ export interface UsageTableRow {
     metric: UsageMetric;
     label: string;
     group?: string;
-    /** Overrides the table's lookup, which cannot tell one model's `connections` from the other's. */
+    /** Overrides the metric-keyed lookup. Both pricings meter `connections`, so the key picks the wrong row. */
     charge?: UsageRowCharge;
     currentPlanCharge?: UsageRowCharge;
     usage: number;
@@ -191,7 +191,6 @@ const UsageTotals: React.FC<{ variant: UsageTableProps['variant']; totals: Usage
     const comparing = variant === 'comparison';
     const difference = comparing ? billDifference(totals) : null;
 
-    // No top border: the last metric row already draws one, and two would show as a double line.
     return (
         <div className="bg-surface-input-muted">
             {/* The floor replaces the subtotal rather than adding to it, so it goes on this line. */}

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -31,7 +31,6 @@ interface UsageTableProps {
     isRowOpen?: (metric: UsageMetric) => boolean;
     onRowOpenChange?: (metric: UsageMetric, open: boolean) => void;
     currentPlanTitle?: string;
-    /** Keeps the comparison grid so the two tables line up, and blanks the Pay-as-you-go header. */
     legacy?: boolean;
     currentPlanTooltip?: string;
     projectedTooltip?: string;

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -1,4 +1,3 @@
-import { Info } from 'lucide-react';
 import { Fragment } from 'react';
 
 import { Badge } from '@nangohq/design-system';
@@ -87,61 +86,55 @@ export const UsageTable: React.FC<UsageTableProps> = ({
 }) => {
     const { thisPeriod, rightmost, extra } = usageColumnHeaders(variant, totals?.currentPlanTitle);
     return (
-        <div className="flex flex-col gap-2">
-            <div className="w-full rounded border border-border-default overflow-hidden">
-                <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
-                    <span>Metric</span>
-                    <span>{thisPeriod}</span>
-                    <span>{rightmost}</span>
-                    {extra && (
-                        <span className="flex items-center gap-1.5">
-                            {extra}
-                            {extraColumnTooltip && (
-                                <InfoTooltip side="top" align="end">
-                                    {extraColumnTooltip}
-                                </InfoTooltip>
-                            )}
-                        </span>
-                    )}
-                    <span />
-                </div>
-                {rows.map((row, index) => (
-                    <Fragment key={row.group ? `${row.group}:${row.metric}` : row.metric}>
-                        {row.group && row.group !== rows[index - 1]?.group && (
-                            <div
-                                className={cn(
-                                    usageRowGrid(variant),
-                                    'py-2 bg-surface-panel-inset border-b border-border-muted text-text-secondary type-label-xxs uppercase'
-                                )}
-                            >
-                                <span>{row.group}</span>
-                            </div>
+        <div className="w-full rounded border border-border-default overflow-hidden">
+            <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
+                <span>Metric</span>
+                <span>{thisPeriod}</span>
+                <span>{rightmost}</span>
+                {extra && (
+                    <span className="flex items-center gap-1.5">
+                        {extra}
+                        {extraColumnTooltip && (
+                            <InfoTooltip side="top" align="end">
+                                {extraColumnTooltip}
+                            </InfoTooltip>
                         )}
-                        <UsageRow
-                            metric={row.metric}
-                            label={row.label}
-                            usage={row.usage}
-                            limit={row.limit}
-                            capsLoading={row.capsLoading}
-                            data={row.data}
-                            isLoading={isLoading}
-                            env={env}
-                            timeframe={timeframe}
-                            open={isRowOpen?.(row.metric)}
-                            onOpenChange={onRowOpenChange ? (open) => onRowOpenChange(row.metric, open) : undefined}
-                            chartMode={chartMode}
-                            variant={variant}
-                            charge={row.charge ?? charges?.(row.metric)}
-                            currentPlanCharge={row.currentPlanCharge}
-                        />
-                    </Fragment>
-                ))}
-                {totals && <UsageTotals variant={variant} totals={totals} />}
+                    </span>
+                )}
+                <span />
             </div>
-            <span className="flex items-center gap-1.5 text-text-muted text-body-small-regular px-1">
-                <Info className="size-3.5 shrink-0" />
-                Click any row to see its trend and breakdown.
-            </span>
+            {rows.map((row, index) => (
+                <Fragment key={row.group ? `${row.group}:${row.metric}` : row.metric}>
+                    {row.group && row.group !== rows[index - 1]?.group && (
+                        <div
+                            className={cn(
+                                usageRowGrid(variant),
+                                'py-2 bg-surface-panel-inset border-b border-border-muted text-text-secondary type-label-xxs uppercase'
+                            )}
+                        >
+                            <span>{row.group}</span>
+                        </div>
+                    )}
+                    <UsageRow
+                        metric={row.metric}
+                        label={row.label}
+                        usage={row.usage}
+                        limit={row.limit}
+                        capsLoading={row.capsLoading}
+                        data={row.data}
+                        isLoading={isLoading}
+                        env={env}
+                        timeframe={timeframe}
+                        open={isRowOpen?.(row.metric)}
+                        onOpenChange={onRowOpenChange ? (open) => onRowOpenChange(row.metric, open) : undefined}
+                        chartMode={chartMode}
+                        variant={variant}
+                        charge={row.charge ?? charges?.(row.metric)}
+                        currentPlanCharge={row.currentPlanCharge}
+                    />
+                </Fragment>
+            ))}
+            {totals && <UsageTotals variant={variant} totals={totals} />}
         </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -9,7 +9,6 @@ import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 export interface UsageTableRow {
     metric: UsageMetric;
     label: string;
-    /** Overrides the metric-keyed lookup. Both pricings meter `connections`, so the key picks the wrong row. */
     charge?: UsageRowCharge;
     currentPlanCharge?: UsageRowCharge;
     usage: number;
@@ -31,14 +30,10 @@ interface UsageTableProps {
      *  (each row manages its own open state) when omitted. */
     isRowOpen?: (metric: UsageMetric) => boolean;
     onRowOpenChange?: (metric: UsageMetric, open: boolean) => void;
-    /** Names the current plan's column. The comparison heads it with the plan the account is on. */
     currentPlanTitle?: string;
-    /** The legacy meters, listed below the toggle. They keep the comparison grid so both tables line
-     *  up, but no legacy meter is priced on Pay-as-you-go, so that column stays empty. */
+    /** Keeps the comparison grid so the two tables line up, and blanks the Pay-as-you-go header. */
     legacy?: boolean;
-    /** Beside the current plan's column header. */
     currentPlanTooltip?: string;
-    /** Beside the Pay-as-you-go column header. */
     projectedTooltip?: string;
 }
 

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -1,3 +1,4 @@
+import { Info } from 'lucide-react';
 import { Fragment } from 'react';
 
 import { Badge } from '@nangohq/design-system';
@@ -86,55 +87,61 @@ export const UsageTable: React.FC<UsageTableProps> = ({
 }) => {
     const { thisPeriod, rightmost, extra } = usageColumnHeaders(variant, totals?.currentPlanTitle);
     return (
-        <div className="w-full rounded border border-border-default overflow-hidden">
-            <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
-                <span>Metric</span>
-                <span>{thisPeriod}</span>
-                <span>{rightmost}</span>
-                {extra && (
-                    <span className="flex items-center gap-1.5">
-                        {extra}
-                        {extraColumnTooltip && (
-                            <InfoTooltip side="top" align="end">
-                                {extraColumnTooltip}
-                            </InfoTooltip>
-                        )}
-                    </span>
-                )}
-                <span />
-            </div>
-            {rows.map((row, index) => (
-                <Fragment key={row.group ? `${row.group}:${row.metric}` : row.metric}>
-                    {row.group && row.group !== rows[index - 1]?.group && (
-                        <div
-                            className={cn(
-                                usageRowGrid(variant),
-                                'py-2 bg-surface-panel-inset border-b border-border-muted text-text-secondary type-label-xxs uppercase'
+        <div className="flex flex-col gap-2">
+            <div className="w-full rounded border border-border-default overflow-hidden">
+                <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
+                    <span>Metric</span>
+                    <span>{thisPeriod}</span>
+                    <span>{rightmost}</span>
+                    {extra && (
+                        <span className="flex items-center gap-1.5">
+                            {extra}
+                            {extraColumnTooltip && (
+                                <InfoTooltip side="top" align="end">
+                                    {extraColumnTooltip}
+                                </InfoTooltip>
                             )}
-                        >
-                            <span>{row.group}</span>
-                        </div>
+                        </span>
                     )}
-                    <UsageRow
-                        metric={row.metric}
-                        label={row.label}
-                        usage={row.usage}
-                        limit={row.limit}
-                        capsLoading={row.capsLoading}
-                        data={row.data}
-                        isLoading={isLoading}
-                        env={env}
-                        timeframe={timeframe}
-                        open={isRowOpen?.(row.metric)}
-                        onOpenChange={onRowOpenChange ? (open) => onRowOpenChange(row.metric, open) : undefined}
-                        chartMode={chartMode}
-                        variant={variant}
-                        charge={row.charge ?? charges?.(row.metric)}
-                        currentPlanCharge={row.currentPlanCharge}
-                    />
-                </Fragment>
-            ))}
-            {totals && <UsageTotals variant={variant} totals={totals} />}
+                    <span />
+                </div>
+                {rows.map((row, index) => (
+                    <Fragment key={row.group ? `${row.group}:${row.metric}` : row.metric}>
+                        {row.group && row.group !== rows[index - 1]?.group && (
+                            <div
+                                className={cn(
+                                    usageRowGrid(variant),
+                                    'py-2 bg-surface-panel-inset border-b border-border-muted text-text-secondary type-label-xxs uppercase'
+                                )}
+                            >
+                                <span>{row.group}</span>
+                            </div>
+                        )}
+                        <UsageRow
+                            metric={row.metric}
+                            label={row.label}
+                            usage={row.usage}
+                            limit={row.limit}
+                            capsLoading={row.capsLoading}
+                            data={row.data}
+                            isLoading={isLoading}
+                            env={env}
+                            timeframe={timeframe}
+                            open={isRowOpen?.(row.metric)}
+                            onOpenChange={onRowOpenChange ? (open) => onRowOpenChange(row.metric, open) : undefined}
+                            chartMode={chartMode}
+                            variant={variant}
+                            charge={row.charge ?? charges?.(row.metric)}
+                            currentPlanCharge={row.currentPlanCharge}
+                        />
+                    </Fragment>
+                ))}
+                {totals && <UsageTotals variant={variant} totals={totals} />}
+            </div>
+            <span className="flex items-center gap-1.5 text-text-muted text-body-small-regular px-1">
+                <Info className="size-3.5 shrink-0" />
+                Click any row to see its trend and breakdown.
+            </span>
         </div>
     );
 };
@@ -190,7 +197,7 @@ const UsageTotals: React.FC<{ variant: UsageTableProps['variant']; totals: Usage
             {/* The floor replaces the subtotal rather than adding to it, so it goes on this line. */}
             <TotalsLine
                 variant={variant}
-                label={comparing ? 'Usage charges' : 'Subtotal'}
+                label="Usage charges"
                 amount={money(totals.minimumApplied ? totals.minimumInCents : totals.subtotalInCents)}
                 currentPlanAmount={totals.currentPlan ? money(totals.currentPlan.usageInCents) : null}
                 {...(comparing && totals.minimumApplied ? { tooltip: minimumNote(totals, money) } : {})}
@@ -198,7 +205,7 @@ const UsageTotals: React.FC<{ variant: UsageTableProps['variant']; totals: Usage
             {(totals.growthAddOnInCents > 0 || (totals.currentPlan?.fixedInCents ?? 0) > 0) && (
                 <TotalsLine
                     variant={variant}
-                    label={comparing ? 'Fixed charges' : 'Growth add-on'}
+                    label="Fixed charges"
                     amount={money(totals.growthAddOnInCents)}
                     currentPlanAmount={totals.currentPlan ? money(totals.currentPlan.fixedInCents) : null}
                 />

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -36,7 +36,10 @@ interface UsageTableProps {
     /** The legacy meters, listed below the toggle. They keep the comparison grid so both tables line
      *  up, but no legacy meter is priced on Pay-as-you-go, so that column stays empty. */
     legacy?: boolean;
-    extraColumnTooltip?: string;
+    /** Beside the current plan's column header. */
+    currentPlanTooltip?: string;
+    /** Beside the Pay-as-you-go column header. */
+    projectedTooltip?: string;
 }
 
 /** The two right-hand column headers, which differ by variant. */
@@ -69,7 +72,8 @@ export const UsageTable: React.FC<UsageTableProps> = ({
     onRowOpenChange,
     currentPlanTitle,
     legacy,
-    extraColumnTooltip
+    currentPlanTooltip,
+    projectedTooltip
 }) => {
     const { thisPeriod, rightmost, extra } = usageColumnHeaders(variant, currentPlanTitle);
     return (
@@ -77,13 +81,20 @@ export const UsageTable: React.FC<UsageTableProps> = ({
             <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
                 <span>{legacy ? 'Legacy metric' : 'Metric'}</span>
                 <span>{thisPeriod}</span>
-                <span>{rightmost}</span>
+                <span className="flex items-center gap-1.5">
+                    {rightmost}
+                    {currentPlanTooltip && (
+                        <InfoTooltip side="top" align="start">
+                            {currentPlanTooltip}
+                        </InfoTooltip>
+                    )}
+                </span>
                 {extra && (
                     <span className="flex items-center gap-1.5">
                         {!legacy && extra}
-                        {!legacy && extraColumnTooltip && (
+                        {!legacy && projectedTooltip && (
                             <InfoTooltip side="top" align="end">
-                                {extraColumnTooltip}
+                                {projectedTooltip}
                             </InfoTooltip>
                         )}
                     </span>

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -1,21 +1,14 @@
-import { Fragment } from 'react';
-
-import { Badge } from '@nangohq/design-system';
-
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { cn } from '@/utils/utils';
-import { formatMoneyFromCents } from '../money';
 import { UsageRow, usageRowGrid } from './UsageRow';
 
 import type { UsageChargeLookup, UsageRowCharge } from '../usageCharges';
 import type { UsageRowVariant } from './UsageRow';
-import type { BadgeProps } from '@nangohq/design-system';
 import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 
 export interface UsageTableRow {
     metric: UsageMetric;
     label: string;
-    group?: string;
     /** Overrides the metric-keyed lookup. Both pricings meter `connections`, so the key picks the wrong row. */
     charge?: UsageRowCharge;
     currentPlanCharge?: UsageRowCharge;
@@ -23,17 +16,6 @@ export interface UsageTableRow {
     limit: number | null;
     capsLoading?: boolean;
     data?: ApiBillingUsageMetric;
-}
-
-export interface UsageTableTotals {
-    subtotalInCents: number;
-    minimumInCents: number;
-    minimumApplied: boolean;
-    growthAddOnInCents: number;
-    totalInCents: number;
-    currency: string;
-    currentPlanTitle?: string;
-    currentPlan?: { usageInCents: number; fixedInCents: number; totalInCents: number } | null;
 }
 
 interface UsageTableProps {
@@ -49,7 +31,11 @@ interface UsageTableProps {
      *  (each row manages its own open state) when omitted. */
     isRowOpen?: (metric: UsageMetric) => boolean;
     onRowOpenChange?: (metric: UsageMetric, open: boolean) => void;
-    totals?: UsageTableTotals;
+    /** Names the current plan's column. The comparison heads it with the plan the account is on. */
+    currentPlanTitle?: string;
+    /** The legacy meters, listed below the toggle. They keep the comparison grid so both tables line
+     *  up, but no legacy meter is priced on Pay-as-you-go, so that column stays empty. */
+    legacy?: boolean;
     extraColumnTooltip?: string;
 }
 
@@ -81,20 +67,21 @@ export const UsageTable: React.FC<UsageTableProps> = ({
     charges,
     isRowOpen,
     onRowOpenChange,
-    totals,
+    currentPlanTitle,
+    legacy,
     extraColumnTooltip
 }) => {
-    const { thisPeriod, rightmost, extra } = usageColumnHeaders(variant, totals?.currentPlanTitle);
+    const { thisPeriod, rightmost, extra } = usageColumnHeaders(variant, currentPlanTitle);
     return (
         <div className="w-full rounded border border-border-default overflow-hidden">
             <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
-                <span>Metric</span>
+                <span>{legacy ? 'Legacy metric' : 'Metric'}</span>
                 <span>{thisPeriod}</span>
                 <span>{rightmost}</span>
                 {extra && (
                     <span className="flex items-center gap-1.5">
-                        {extra}
-                        {extraColumnTooltip && (
+                        {!legacy && extra}
+                        {!legacy && extraColumnTooltip && (
                             <InfoTooltip side="top" align="end">
                                 {extraColumnTooltip}
                             </InfoTooltip>
@@ -103,128 +90,26 @@ export const UsageTable: React.FC<UsageTableProps> = ({
                 )}
                 <span />
             </div>
-            {rows.map((row, index) => (
-                <Fragment key={row.group ? `${row.group}:${row.metric}` : row.metric}>
-                    {row.group && row.group !== rows[index - 1]?.group && (
-                        <div
-                            className={cn(
-                                usageRowGrid(variant),
-                                'py-2 bg-surface-panel-inset border-b border-border-muted text-text-secondary type-label-xxs uppercase'
-                            )}
-                        >
-                            <span>{row.group}</span>
-                        </div>
-                    )}
-                    <UsageRow
-                        metric={row.metric}
-                        label={row.label}
-                        usage={row.usage}
-                        limit={row.limit}
-                        capsLoading={row.capsLoading}
-                        data={row.data}
-                        isLoading={isLoading}
-                        env={env}
-                        timeframe={timeframe}
-                        open={isRowOpen?.(row.metric)}
-                        onOpenChange={onRowOpenChange ? (open) => onRowOpenChange(row.metric, open) : undefined}
-                        chartMode={chartMode}
-                        variant={variant}
-                        charge={row.charge ?? charges?.(row.metric)}
-                        currentPlanCharge={row.currentPlanCharge}
-                    />
-                </Fragment>
-            ))}
-            {totals && <UsageTotals variant={variant} totals={totals} />}
-        </div>
-    );
-};
-
-const TotalsLine: React.FC<{
-    variant: UsageTableProps['variant'];
-    label: string;
-    amount: string | null;
-    currentPlanAmount?: string | null;
-    tooltip?: string;
-    strong?: boolean;
-}> = ({ variant, label, amount, currentPlanAmount, tooltip, strong }) => {
-    const text = cn('tabular-nums', strong ? 'text-text-strong text-body-medium-medium' : 'text-text-default type-text-regular-sm');
-    return (
-        <div className={cn(usageRowGrid(variant), 'py-2.5')}>
-            <span className={cn('truncate', strong ? 'text-text-strong text-body-medium-medium' : 'text-text-secondary type-text-regular-sm')}>{label}</span>
-            <span />
-            {variant === 'comparison' && <span className={text}>{currentPlanAmount ?? ''}</span>}
-            <span className="flex items-center gap-1.5">
-                <span className={text}>{amount ?? '—'}</span>
-                {tooltip && <InfoTooltip side="top">{tooltip}</InfoTooltip>}
-            </span>
-            <span />
-        </div>
-    );
-};
-
-function minimumNote(totals: UsageTableTotals, money: (cents: number) => string | null): string {
-    const minimum = money(totals.minimumInCents);
-    return minimum ? `Accrued usage is below the ${minimum} monthly minimum.` : 'Accrued usage is below the monthly minimum.';
-}
-
-function billDifference(totals: UsageTableTotals): { text: string; variant: BadgeProps['variant'] } | null {
-    if (!totals.currentPlan) {
-        return null;
-    }
-    const delta = totals.totalInCents - totals.currentPlan.totalInCents;
-    if (delta === 0) {
-        return null;
-    }
-    const formatted = formatMoneyFromCents(Math.abs(delta), totals.currency) ?? '';
-    return delta > 0 ? { text: `+${formatted}`, variant: 'warning' } : { text: `−${formatted}`, variant: 'success' };
-}
-
-const UsageTotals: React.FC<{ variant: UsageTableProps['variant']; totals: UsageTableTotals }> = ({ variant, totals }) => {
-    const money = (cents: number) => formatMoneyFromCents(cents, totals.currency);
-    const comparing = variant === 'comparison';
-    const difference = comparing ? billDifference(totals) : null;
-
-    return (
-        <div className="bg-surface-input-muted">
-            {/* The floor replaces the subtotal rather than adding to it, so it goes on this line. */}
-            <TotalsLine
-                variant={variant}
-                label="Usage charges"
-                amount={money(totals.minimumApplied ? totals.minimumInCents : totals.subtotalInCents)}
-                currentPlanAmount={totals.currentPlan ? money(totals.currentPlan.usageInCents) : null}
-                {...(comparing && totals.minimumApplied ? { tooltip: minimumNote(totals, money) } : {})}
-            />
-            {(totals.growthAddOnInCents > 0 || (totals.currentPlan?.fixedInCents ?? 0) > 0) && (
-                <TotalsLine
+            {rows.map((row) => (
+                <UsageRow
+                    key={row.metric}
+                    metric={row.metric}
+                    label={row.label}
+                    usage={row.usage}
+                    limit={row.limit}
+                    capsLoading={row.capsLoading}
+                    data={row.data}
+                    isLoading={isLoading}
+                    env={env}
+                    timeframe={timeframe}
+                    open={isRowOpen?.(row.metric)}
+                    onOpenChange={onRowOpenChange ? (open) => onRowOpenChange(row.metric, open) : undefined}
+                    chartMode={chartMode}
                     variant={variant}
-                    label="Fixed charges"
-                    amount={money(totals.growthAddOnInCents)}
-                    currentPlanAmount={totals.currentPlan ? money(totals.currentPlan.fixedInCents) : null}
+                    charge={row.charge ?? charges?.(row.metric)}
+                    currentPlanCharge={row.currentPlanCharge}
                 />
-            )}
-            {comparing ? (
-                <div className={cn(usageRowGrid(variant), 'py-3')}>
-                    <span className="text-text-strong text-body-medium-medium truncate">Total</span>
-                    <span />
-                    <span className="tabular-nums text-text-default text-body-medium-medium">
-                        {totals.currentPlan ? (money(totals.currentPlan.totalInCents) ?? '—') : ''}
-                    </span>
-                    <span className="flex items-baseline gap-2">
-                        <span className="tabular-nums text-text-strong text-body-medium-medium">{money(totals.totalInCents) ?? '—'}</span>
-                        {difference && (
-                            // The token stylesheet is imported unlayered, so the Badge's own
-                            // `type-code-regular-xs` wins without the `!`.
-                            // eslint-disable-next-line react/forbid-component-props -- deliberate: this comparison view is short-lived, so the weight is not worth a design-system variant
-                            <Badge variant={difference.variant} className="text-body-medium-medium!">
-                                {difference.text}
-                            </Badge>
-                        )}
-                    </span>
-                    <span />
-                </div>
-            ) : (
-                <TotalsLine variant={variant} label="Projected total" amount={money(totals.totalInCents)} strong />
-            )}
+            ))}
         </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/planTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.ts
@@ -31,7 +31,6 @@ export function planTransition({
         return null;
     }
 
-    // Enterprise and Startup deal transitions use their standard plan-change copy.
     if (!isRetiredPlan(plan.name)) {
         return null;
     }

--- a/packages/webapp/src/pages/Team/Billing/planTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.ts
@@ -31,8 +31,7 @@ export function planTransition({
         return null;
     }
 
-    // Enterprise and the startup deal can also be scheduled onto Pay-as-you-go, but that is an
-    // ordinary change and each has its own copy for it. Only a retired plan is migrating.
+    // Enterprise and Startup deal transitions use their standard plan-change copy.
     if (!isRetiredPlan(plan.name)) {
         return null;
     }

--- a/packages/webapp/src/pages/Team/Billing/planTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.ts
@@ -1,3 +1,4 @@
+import { isRetiredPlan } from './planVisibility';
 import { pendingPlanChange } from './summaryState';
 
 import type { ApiPlan, DBPlan, PlanDefinition } from '@nangohq/types';
@@ -27,6 +28,12 @@ export function planTransition({
 
     const change = pendingPlanChange({ plan, plans, now });
     if (!change || change.toCode !== TARGET_CODE) {
+        return null;
+    }
+
+    // Enterprise and the startup deal can also be scheduled onto Pay-as-you-go, but that is an
+    // ordinary change and each has its own copy for it. Only a retired plan is migrating.
+    if (!isRetiredPlan(plan.name)) {
         return null;
     }
 

--- a/packages/webapp/src/pages/Team/Billing/planTransition.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.ts
@@ -1,4 +1,3 @@
-import { migratesToPayAsYouGo } from './planVisibility';
 import { pendingPlanChange } from './summaryState';
 
 import type { ApiPlan, DBPlan, PlanDefinition } from '@nangohq/types';
@@ -22,7 +21,7 @@ export function planTransition({
     plans: PlanDefinition[] | undefined;
     now: Date;
 }): PlanTransition | null {
-    if (!plan || !migratesToPayAsYouGo(plan.name)) {
+    if (!plan) {
         return null;
     }
 
@@ -31,11 +30,13 @@ export function planTransition({
         return null;
     }
 
+    const definition = plans?.find((p) => p.code === plan.name);
+
     return {
         at: change.at,
         toPlanTitle: change.toPlanTitle,
         fromCode: plan.name,
-        fromTitle: plans?.find((p) => p.code === plan.name)?.title ?? plan.name,
-        keepsGrowthAddOn: plan.name === 'growth-v2'
+        fromTitle: definition?.title ?? plan.name,
+        keepsGrowthAddOn: definition?.keepsGrowthAddOnOnMigration ?? false
     };
 }

--- a/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
@@ -5,14 +5,18 @@ import { planTransition } from './planTransition.js';
 import type { ApiPlan, PlanDefinition } from '@nangohq/types';
 
 const NOW = new Date('2026-09-03T10:00:00Z');
-const IN_SCOPE = ['starter-v2', 'growth-v2'] as const;
 
 const plans = [
     { code: 'free', title: 'Free' },
     { code: 'pay-as-you-go', title: 'Pay-as-you-go' },
     { code: 'starter-v2', title: 'Starter' },
-    { code: 'growth-v2', title: 'Growth' },
-    { code: 'startup-deal', title: 'Startup deal' }
+    { code: 'growth-v2', title: 'Growth', keepsGrowthAddOnOnMigration: true },
+    { code: 'startup-deal', title: 'Startup deal' },
+    { code: 'starter', title: 'Starter (v1)' },
+    { code: 'growth', title: 'Growth (v1)', keepsGrowthAddOnOnMigration: true },
+    { code: 'starter-legacy', title: 'Starter (legacy)' },
+    { code: 'scale-legacy', title: 'Scale (legacy)' },
+    { code: 'growth-legacy', title: 'Growth (legacy)' }
 ] as PlanDefinition[];
 
 function planOf(name: ApiPlan['name'], overrides: Partial<ApiPlan> = {}): ApiPlan {
@@ -28,32 +32,38 @@ function transitionOf(plan: ApiPlan) {
 }
 
 describe('planTransition', () => {
-    it('announces the migration for both retired v2 plans', () => {
-        for (const name of IN_SCOPE) {
-            expect(transitionOf(scheduled(name))).toEqual({
-                at: 'October 1, 2026',
-                toPlanTitle: 'Pay-as-you-go',
-                fromCode: name,
-                fromTitle: name === 'growth-v2' ? 'Growth' : 'Starter',
-                keepsGrowthAddOn: name === 'growth-v2'
-            });
-        }
+    // Whoever Orb has scheduled, whatever they are on now. An earlier version allowlisted
+    // starter-v2 and growth-v2, which left the legacy plans in the migration seeing nothing.
+    it.each([
+        ['starter-v2', 'Starter'],
+        ['growth-v2', 'Growth'],
+        ['starter-legacy', 'Starter (legacy)'],
+        ['scale-legacy', 'Scale (legacy)'],
+        ['growth-legacy', 'Growth (legacy)'],
+        ['growth', 'Growth (v1)'],
+        ['starter', 'Starter (v1)'],
+        ['startup-deal', 'Startup deal']
+    ] as const)('announces the migration for a scheduled %s account', (name, fromTitle) => {
+        expect(transitionOf(scheduled(name))).toMatchObject({
+            at: 'October 1, 2026',
+            toPlanTitle: 'Pay-as-you-go',
+            fromCode: name,
+            fromTitle
+        });
     });
 
-    it('carries the add-on across for Growth only, since Pay-as-you-go matches Starter otherwise', () => {
-        expect(transitionOf(scheduled('growth-v2'))?.keepsGrowthAddOn).toBe(true);
-        expect(transitionOf(scheduled('starter-v2'))?.keepsGrowthAddOn).toBe(false);
+    it.each(['growth-v2', 'growth'] as const)('carries the Growth add-on across for %s', (name) => {
+        expect(transitionOf(scheduled(name))?.keepsGrowthAddOn).toBe(true);
+    });
+
+    // Pay-as-you-go matches Starter without the add-on, so these carry nothing.
+    it.each(['starter-v2', 'starter-legacy', 'scale-legacy', 'growth-legacy'] as const)('carries no add-on for %s', (name) => {
+        expect(transitionOf(scheduled(name))?.keepsGrowthAddOn).toBe(false);
     });
 
     it('stays silent for an account with nothing scheduled', () => {
-        for (const name of IN_SCOPE) {
+        for (const name of ['starter-v2', 'growth-v2', 'starter-legacy'] as const) {
             expect(transitionOf(planOf(name))).toBeNull();
-        }
-    });
-
-    it('stays silent for plans out of scope, whatever is scheduled', () => {
-        for (const name of ['free', 'startup-deal', 'growth', 'starter', 'growth-legacy', 'enterprise'] as const) {
-            expect(transitionOf(scheduled(name))).toBeNull();
         }
     });
 

--- a/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
@@ -16,7 +16,8 @@ const plans = [
     { code: 'growth', title: 'Growth (v1)', keepsGrowthAddOnOnMigration: true },
     { code: 'starter-legacy', title: 'Starter (legacy)' },
     { code: 'scale-legacy', title: 'Scale (legacy)' },
-    { code: 'growth-legacy', title: 'Growth (legacy)' }
+    { code: 'growth-legacy', title: 'Growth (legacy)' },
+    { code: 'enterprise', title: 'Enterprise' }
 ] as PlanDefinition[];
 
 function planOf(name: ApiPlan['name'], overrides: Partial<ApiPlan> = {}): ApiPlan {
@@ -39,8 +40,7 @@ describe('planTransition', () => {
         ['scale-legacy', 'Scale (legacy)'],
         ['growth-legacy', 'Growth (legacy)'],
         ['growth', 'Growth (v1)'],
-        ['starter', 'Starter (v1)'],
-        ['startup-deal', 'Startup deal']
+        ['starter', 'Starter (v1)']
     ] as const)('announces the migration for a scheduled %s account', (name, fromTitle) => {
         expect(transitionOf(scheduled(name))).toMatchObject({
             at: 'October 1, 2026',
@@ -48,6 +48,12 @@ describe('planTransition', () => {
             fromCode: name,
             fromTitle
         });
+    });
+
+    // Both can be scheduled onto Pay-as-you-go as an ordinary change, and each has its own copy
+    // for it. Neither is in the migration population.
+    it.each(['enterprise', 'startup-deal'] as const)('stays silent for a scheduled %s account', (name) => {
+        expect(transitionOf(scheduled(name))).toBeNull();
     });
 
     it.each(['growth-v2', 'growth'] as const)('carries the Growth add-on across for %s', (name) => {

--- a/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
@@ -32,8 +32,7 @@ function transitionOf(plan: ApiPlan) {
 }
 
 describe('planTransition', () => {
-    // Whoever Orb has scheduled, whatever they are on now. An earlier version allowlisted
-    // starter-v2 and growth-v2, which left the legacy plans in the migration seeing nothing.
+    // Whoever Orb has scheduled, whatever plan they are on now.
     it.each([
         ['starter-v2', 'Starter'],
         ['growth-v2', 'Growth'],

--- a/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
@@ -50,8 +50,6 @@ describe('planTransition', () => {
         });
     });
 
-    // Both can be scheduled onto Pay-as-you-go as an ordinary change, and each has its own copy
-    // for it. Neither is in the migration population.
     it.each(['enterprise', 'startup-deal'] as const)('stays silent for a scheduled %s account', (name) => {
         expect(transitionOf(scheduled(name))).toBeNull();
     });

--- a/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
@@ -32,7 +32,6 @@ function transitionOf(plan: ApiPlan) {
 }
 
 describe('planTransition', () => {
-    // Whoever Orb has scheduled, whatever plan they are on now.
     it.each([
         ['starter-v2', 'Starter'],
         ['growth-v2', 'Growth'],
@@ -55,7 +54,7 @@ describe('planTransition', () => {
         expect(transitionOf(scheduled(name))?.keepsGrowthAddOn).toBe(true);
     });
 
-    // Pay-as-you-go matches Starter without the add-on, so these carry nothing.
+    // Only `growth` and `growth-v2` set `keepsGrowthAddOnOnMigration`, so `growth-legacy` carries nothing.
     it.each(['starter-v2', 'starter-legacy', 'scale-legacy', 'growth-legacy'] as const)('carries no add-on for %s', (name) => {
         expect(transitionOf(scheduled(name))?.keepsGrowthAddOn).toBe(false);
     });

--- a/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/planTransition.unit.test.ts
@@ -16,7 +16,7 @@ const plans = [
     { code: 'growth', title: 'Growth (v1)', keepsGrowthAddOnOnMigration: true },
     { code: 'starter-legacy', title: 'Starter (legacy)' },
     { code: 'scale-legacy', title: 'Scale (legacy)' },
-    { code: 'growth-legacy', title: 'Growth (legacy)' },
+    { code: 'growth-legacy', title: 'Growth (legacy)', keepsGrowthAddOnOnMigration: true },
     { code: 'enterprise', title: 'Enterprise' }
 ] as PlanDefinition[];
 
@@ -56,12 +56,11 @@ describe('planTransition', () => {
         expect(transitionOf(scheduled(name))).toBeNull();
     });
 
-    it.each(['growth-v2', 'growth'] as const)('carries the Growth add-on across for %s', (name) => {
+    it.each(['growth-v2', 'growth', 'growth-legacy'] as const)('carries the Growth add-on across for %s', (name) => {
         expect(transitionOf(scheduled(name))?.keepsGrowthAddOn).toBe(true);
     });
 
-    // Only `growth` and `growth-v2` set `keepsGrowthAddOnOnMigration`, so `growth-legacy` carries nothing.
-    it.each(['starter-v2', 'starter-legacy', 'scale-legacy', 'growth-legacy'] as const)('carries no add-on for %s', (name) => {
+    it.each(['starter-v2', 'starter-legacy', 'scale-legacy'] as const)('carries no add-on for %s', (name) => {
         expect(transitionOf(scheduled(name))?.keepsGrowthAddOn).toBe(false);
     });
 

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -116,7 +116,6 @@ const PLAN_IS_RETIRED: Record<DBPlan['name'], boolean> = {
     'enterprise-cloud-hosted': false
 };
 
-/** Scheduled migrations need the strip even when the plan map hides it. */
 export function showsSummaryStrip(plan: ApiPlan | null | undefined, hasScheduledTransition = false): boolean {
     if (!plan) {
         return false;

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -116,17 +116,12 @@ const PLAN_IS_RETIRED: Record<DBPlan['name'], boolean> = {
     'enterprise-cloud-hosted': false
 };
 
-const MIGRATES_TO_PAY_AS_YOU_GO: readonly DBPlan['name'][] = ['starter-v2', 'growth-v2'];
-
-export function migratesToPayAsYouGo(code: DBPlan['name']): boolean {
-    return MIGRATES_TO_PAY_AS_YOU_GO.includes(code);
-}
-
-export function showsSummaryStrip(plan: ApiPlan | null | undefined): boolean {
+/** A scheduled migration overrides the map: the account needs somewhere to read its date. */
+export function showsSummaryStrip(plan: ApiPlan | null | undefined, hasScheduledTransition = false): boolean {
     if (!plan) {
         return false;
     }
-    return SHOWS_SUMMARY_STRIP[plan.name];
+    return SHOWS_SUMMARY_STRIP[plan.name] || hasScheduledTransition;
 }
 
 export function isLegacyPlan(plan: ApiPlan | null | undefined): boolean {

--- a/packages/webapp/src/pages/Team/Billing/planVisibility.ts
+++ b/packages/webapp/src/pages/Team/Billing/planVisibility.ts
@@ -116,7 +116,7 @@ const PLAN_IS_RETIRED: Record<DBPlan['name'], boolean> = {
     'enterprise-cloud-hosted': false
 };
 
-/** A scheduled migration overrides the map: the account needs somewhere to read its date. */
+/** Scheduled migrations need the strip even when the plan map hides it. */
 export function showsSummaryStrip(plan: ApiPlan | null | undefined, hasScheduledTransition = false): boolean {
     if (!plan) {
         return false;

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.ts
@@ -15,8 +15,7 @@ interface BuildArgs {
     isPending: boolean;
     isError: boolean;
     data: GetBillingPeriodCosts['Success'] | undefined;
-    /** How a metric the subscription has no price for reads. Use `dash` in the comparison: $0.00
-     *  beside a real charge reads as "free" rather than "not priced". */
+    /** Use `dash` in the comparison: $0.00 beside a real charge reads as "free", not "not priced". */
     unpriced?: 'zero' | 'dash';
 }
 

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.ts
@@ -1,6 +1,6 @@
 import { formatMoneyFromCents } from './money';
 
-import type { GetBillingPeriodCosts, UsageMetric } from '@nangohq/types';
+import type { GetBillingPeriodCosts, GetProjectedCosts, UsageMetric } from '@nangohq/types';
 
 export interface UsageRowCharge {
     formatted: string | null;
@@ -15,6 +15,12 @@ interface BuildArgs {
     isPending: boolean;
     isError: boolean;
     data: GetBillingPeriodCosts['Success'] | undefined;
+    /**
+     * What a metric the subscription carries no price for should read as. On its own a plan bills
+     * $0.00 for an unpriced meter, which is true. Side by side with a plan that does price it, that
+     * $0.00 invites the reader to compare two numbers where only one exists, so it reads as a dash.
+     */
+    unpriced?: 'zero' | 'dash';
 }
 
 const NO_FIGURE: UsageRowCharge = { formatted: null, pending: false };
@@ -48,8 +54,43 @@ export function buildUsageRowCharges(args: BuildArgs): UsageChargeLookup {
         if (amountInCents === undefined) {
             // No price for this metric reads as zero, unless some other price went unattributed — that
             // money could belong to this metric, so it states no figure rather than claiming zero.
-            return fullyAttributed ? { formatted: formatMoneyFromCents(0, currency), pending: false } : NO_FIGURE;
+            return fullyAttributed && args.unpriced !== 'dash' ? { formatted: formatMoneyFromCents(0, currency), pending: false } : NO_FIGURE;
         }
         return { formatted: formatMoneyFromCents(amountInCents, currency), pending: false };
     };
+}
+
+interface BuildProjectedArgs {
+    enabled: boolean;
+    isPending: boolean;
+    isError: boolean;
+    data: GetProjectedCosts['Success'] | undefined;
+}
+
+/**
+ * Charges an account would pay on Pay-as-you-go, in the same lookup shape as
+ * {@link buildUsageRowCharges} so the table renders either without knowing which it got.
+ *
+ * Unlike the Orb figures, every metric here is priced, so an absent one is a real $0 rather than a
+ * gap — there is no unattributed money to worry about.
+ */
+export function buildProjectedCharges(args: BuildProjectedArgs): UsageChargeLookup {
+    if (!args.enabled) {
+        return null;
+    }
+
+    if (args.isPending) {
+        return () => PENDING;
+    }
+
+    if (args.isError || !args.data) {
+        return () => NO_FIGURE;
+    }
+
+    const { metrics, currency, notApplicable } = args.data.data;
+    if (notApplicable) {
+        return null;
+    }
+
+    return (metric) => ({ formatted: formatMoneyFromCents(metrics[metric] ?? 0, currency), pending: false });
 }

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.ts
@@ -15,8 +15,8 @@ interface BuildArgs {
     isPending: boolean;
     isError: boolean;
     data: GetBillingPeriodCosts['Success'] | undefined;
-    /** How a metric the subscription has no price for reads. Beside a plan that does price it,
-     *  $0.00 invites a comparison of two numbers where only one exists, so `dash` suppresses it. */
+    /** How a metric the subscription has no price for reads. Use `dash` in the comparison: $0.00
+     *  beside a real charge reads as "free" rather than "not priced". */
     unpriced?: 'zero' | 'dash';
 }
 
@@ -64,10 +64,7 @@ interface BuildProjectedArgs {
     data: GetProjectedCosts['Success'] | undefined;
 }
 
-/**
- * Same lookup shape as {@link buildUsageRowCharges}, so the table renders either. Every metric here
- * is priced, so an absent one is a real $0 rather than money that went unattributed.
- */
+/** Every metric here is priced, so an absent one is a real $0 rather than money left unattributed. */
 export function buildProjectedCharges(args: BuildProjectedArgs): UsageChargeLookup {
     if (!args.enabled) {
         return null;

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.ts
@@ -15,7 +15,7 @@ interface BuildArgs {
     isPending: boolean;
     isError: boolean;
     data: GetBillingPeriodCosts['Success'] | undefined;
-    /** Use `dash` in the comparison: $0.00 beside a real charge reads as "free", not "not priced". */
+    /** Use `dash` when $0.00 could be mistaken for a free price. */
     unpriced?: 'zero' | 'dash';
 }
 

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.ts
@@ -15,11 +15,8 @@ interface BuildArgs {
     isPending: boolean;
     isError: boolean;
     data: GetBillingPeriodCosts['Success'] | undefined;
-    /**
-     * What a metric the subscription carries no price for should read as. On its own a plan bills
-     * $0.00 for an unpriced meter, which is true. Side by side with a plan that does price it, that
-     * $0.00 invites the reader to compare two numbers where only one exists, so it reads as a dash.
-     */
+    /** How a metric the subscription has no price for reads. Beside a plan that does price it,
+     *  $0.00 invites a comparison of two numbers where only one exists, so `dash` suppresses it. */
     unpriced?: 'zero' | 'dash';
 }
 
@@ -68,11 +65,8 @@ interface BuildProjectedArgs {
 }
 
 /**
- * Charges an account would pay on Pay-as-you-go, in the same lookup shape as
- * {@link buildUsageRowCharges} so the table renders either without knowing which it got.
- *
- * Unlike the Orb figures, every metric here is priced, so an absent one is a real $0 rather than a
- * gap — there is no unattributed money to worry about.
+ * Same lookup shape as {@link buildUsageRowCharges}, so the table renders either. Every metric here
+ * is priced, so an absent one is a real $0 rather than money that went unattributed.
  */
 export function buildProjectedCharges(args: BuildProjectedArgs): UsageChargeLookup {
     if (!args.enabled) {

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.ts
@@ -15,7 +15,6 @@ interface BuildArgs {
     isPending: boolean;
     isError: boolean;
     data: GetBillingPeriodCosts['Success'] | undefined;
-    /** Use `dash` when $0.00 could be mistaken for a free price. */
     unpriced?: 'zero' | 'dash';
 }
 
@@ -63,7 +62,6 @@ interface BuildProjectedArgs {
     data: GetProjectedCosts['Success'] | undefined;
 }
 
-/** Every metric here is priced, so an absent one is a real $0 rather than money left unattributed. */
 export function buildProjectedCharges(args: BuildProjectedArgs): UsageChargeLookup {
     if (!args.enabled) {
         return null;

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.unit.test.ts
@@ -77,7 +77,6 @@ describe('buildUsageRowCharges', () => {
 
         expect(buildUsageRowCharges({ ...settled, data: success(costs) })?.('data_transfer').formatted).toBe('$0.00');
         expect(buildUsageRowCharges({ ...settled, data: success(costs), unpriced: 'dash' })?.('data_transfer').formatted).toBeNull();
-        // A metric the plan does price keeps its figure either way.
         expect(buildUsageRowCharges({ ...settled, data: success(costs), unpriced: 'dash' })?.('records').formatted).toBe('$1.00');
     });
 

--- a/packages/webapp/src/pages/Team/Billing/usageCharges.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageCharges.unit.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildUsageRowCharges } from './usageCharges';
+import { buildProjectedCharges, buildUsageRowCharges } from './usageCharges';
 
-import type { GetBillingPeriodCosts } from '@nangohq/types';
+import type { GetBillingPeriodCosts, GetProjectedCosts } from '@nangohq/types';
 
 function success(data: GetBillingPeriodCosts['Success']['data']): GetBillingPeriodCosts['Success'] {
     return { data };
@@ -72,6 +72,15 @@ describe('buildUsageRowCharges', () => {
         expect(charges?.('proxy').formatted).toBe('$1.00');
     });
 
+    it('states an unpriced metric as a dash when asked, so it is not read as a comparable $0.00', () => {
+        const costs = { metrics: { records: 100 }, malformedMetrics: [], fullyAttributed: true, fixedInCents: 0, currency: 'USD', noCosts: false };
+
+        expect(buildUsageRowCharges({ ...settled, data: success(costs) })?.('data_transfer').formatted).toBe('$0.00');
+        expect(buildUsageRowCharges({ ...settled, data: success(costs), unpriced: 'dash' })?.('data_transfer').formatted).toBeNull();
+        // A metric the plan does price keeps its figure either way.
+        expect(buildUsageRowCharges({ ...settled, data: success(costs), unpriced: 'dash' })?.('records').formatted).toBe('$1.00');
+    });
+
     it('states no figure for a currency it cannot format', () => {
         const charges = buildUsageRowCharges({
             ...settled,
@@ -105,5 +114,60 @@ describe('buildUsageRowCharges', () => {
         });
 
         expect(charges?.('records')).toEqual({ formatted: null, pending: false });
+    });
+});
+
+function projection({
+    metrics = {},
+    notApplicable = false
+}: { metrics?: GetProjectedCosts['Success']['data']['metrics']; notApplicable?: boolean } = {}): GetProjectedCosts['Success'] {
+    return {
+        data: {
+            metrics,
+            subtotalInCents: 0,
+            minimumInCents: 5000,
+            minimumApplied: false,
+            growthAddOnInCents: 0,
+            totalInCents: 0,
+            periodComplete: true,
+            currency: 'USD',
+            notApplicable
+        }
+    };
+}
+
+describe('buildProjectedCharges', () => {
+    it('returns null when there is no migration to project', () => {
+        expect(buildProjectedCharges({ ...settled, enabled: false, data: undefined })).toBeNull();
+        expect(buildProjectedCharges({ ...settled, data: projection({ notApplicable: true }) })).toBeNull();
+    });
+
+    it('formats each projected charge in the response currency', () => {
+        const charges = buildProjectedCharges({
+            ...settled,
+            data: projection({ metrics: { connections: 986, function_duration_seconds: 4630, data_transfer: 620 } })
+        });
+
+        expect(charges?.('connections')).toEqual({ formatted: '$9.86', pending: false });
+        expect(charges?.('function_duration_seconds')).toEqual({ formatted: '$46.30', pending: false });
+        expect(charges?.('data_transfer')).toEqual({ formatted: '$6.20', pending: false });
+    });
+
+    it('reads an absent metric as a real zero', () => {
+        const charges = buildProjectedCharges({ ...settled, data: projection({ metrics: {} }) });
+
+        expect(charges?.('connections')).toEqual({ formatted: '$0.00', pending: false });
+    });
+
+    it('shows a skeleton while loading rather than a stale figure', () => {
+        const charges = buildProjectedCharges({ ...settled, isPending: true, data: undefined });
+
+        expect(charges?.('connections')).toEqual({ formatted: null, pending: true });
+    });
+
+    it('states no figure on error, since react-query keeps the last success', () => {
+        const charges = buildProjectedCharges({ ...settled, isError: true, data: projection({ metrics: { connections: 986 } }) });
+
+        expect(charges?.('connections')).toEqual({ formatted: null, pending: false });
     });
 });

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -27,6 +27,7 @@ export interface AnalyticsEvents {
     'web:usage:value_opened': { metric: UsageMetric; dimension: AnyBreakdownDimension };
     'web:usage:invoice_details_clicked': Record<string, never>;
     'web:usage:billing_portal_clicked': Record<string, never>;
+    'web:usage:old_metrics_toggled': { shown: boolean };
     'web:usage:upgrade_clicked': Record<string, never>;
     'web:usage:addon_action_clicked': { state: GrowthAddonState };
     'web:usage:edit_payment_method_clicked': { source: 'billing_page' };

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -27,7 +27,7 @@ export interface AnalyticsEvents {
     'web:usage:value_opened': { metric: UsageMetric; dimension: AnyBreakdownDimension };
     'web:usage:invoice_details_clicked': Record<string, never>;
     'web:usage:billing_portal_clicked': Record<string, never>;
-    'web:usage:old_metrics_toggled': { shown: boolean };
+    'web:usage:legacy_metrics_toggled': { shown: boolean };
     'web:usage:upgrade_clicked': Record<string, never>;
     'web:usage:addon_action_clicked': { state: GrowthAddonState };
     'web:usage:edit_payment_method_clicked': { source: 'billing_page' };

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -79,8 +79,13 @@ export function isOnS26Pricing(plan: ApiPlan | null | undefined): boolean {
     return !!plan && PLANS_ON_S26_PRICING.includes(plan.name);
 }
 
-export function billedUsageMetrics(plan: ApiPlan | null | undefined): readonly UsageMetric[] {
-    return isOnS26Pricing(plan) ? S26_USAGE_METRICS : LEGACY_USAGE_METRICS;
+/**
+ * The metrics to show an account, which is a different question from what it is billed on today: an
+ * account with a scheduled migration is still billed on the legacy set, but the new one is what it
+ * needs to see. The legacy set stays reachable behind the usage table's toggle.
+ */
+export function billedUsageMetrics(plan: ApiPlan | null | undefined, hasScheduledTransition = false): readonly UsageMetric[] {
+    return isOnS26Pricing(plan) || hasScheduledTransition ? S26_USAGE_METRICS : LEGACY_USAGE_METRICS;
 }
 
 const SECONDS_PER_HOUR = 3600;

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -80,9 +80,8 @@ export function isOnS26Pricing(plan: ApiPlan | null | undefined): boolean {
 }
 
 /**
- * The metrics to show an account, which is a different question from what it is billed on today: an
- * account with a scheduled migration is still billed on the legacy set, but the new one is what it
- * needs to see. The legacy set stays reachable behind the usage table's toggle.
+ * What to *show* an account, not what it is billed on. A scheduled account is still billed on the
+ * legacy set, but needs to see the new one.
  */
 export function billedUsageMetrics(plan: ApiPlan | null | undefined, hasScheduledTransition = false): readonly UsageMetric[] {
     return isOnS26Pricing(plan) || hasScheduledTransition ? S26_USAGE_METRICS : LEGACY_USAGE_METRICS;

--- a/packages/webapp/src/utils/usage.ts
+++ b/packages/webapp/src/utils/usage.ts
@@ -79,10 +79,7 @@ export function isOnS26Pricing(plan: ApiPlan | null | undefined): boolean {
     return !!plan && PLANS_ON_S26_PRICING.includes(plan.name);
 }
 
-/**
- * What to *show* an account, not what it is billed on. A scheduled account is still billed on the
- * legacy set, but needs to see the new one.
- */
+/** Selects displayed metrics. A scheduled migration shows the new set before billing changes. */
 export function billedUsageMetrics(plan: ApiPlan | null | undefined, hasScheduledTransition = false): readonly UsageMetric[] {
     return isOnS26Pricing(plan) || hasScheduledTransition ? S26_USAGE_METRICS : LEGACY_USAGE_METRICS;
 }

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -124,7 +124,6 @@ describe('billedUsageMetrics', () => {
         expect(billedUsageMetrics(undefined)).toEqual(LEGACY_USAGE_METRICS);
     });
 
-    // Includes the retired plans, which is who the first migration batch is.
     it.each(['starter-v2', 'growth-v2', 'starter-legacy', 'growth', 'scale-legacy'] as const)('shows the new metrics to a scheduled %s account', (name) => {
         expect(billedUsageMetrics({ name } as ApiPlan, true)).toEqual(S26_USAGE_METRICS);
     });

--- a/packages/webapp/src/utils/usage.unit.test.ts
+++ b/packages/webapp/src/utils/usage.unit.test.ts
@@ -123,6 +123,15 @@ describe('billedUsageMetrics', () => {
     it('falls back to the legacy set before the plan has loaded', () => {
         expect(billedUsageMetrics(undefined)).toEqual(LEGACY_USAGE_METRICS);
     });
+
+    // Includes the retired plans, which is who the first migration batch is.
+    it.each(['starter-v2', 'growth-v2', 'starter-legacy', 'growth', 'scale-legacy'] as const)('shows the new metrics to a scheduled %s account', (name) => {
+        expect(billedUsageMetrics({ name } as ApiPlan, true)).toEqual(S26_USAGE_METRICS);
+    });
+
+    it('leaves an unscheduled account on its own metrics', () => {
+        expect(billedUsageMetrics({ name: 'growth-v2' } as ApiPlan, false)).toEqual(LEGACY_USAGE_METRICS);
+    });
 });
 
 describe('isOnS26Pricing', () => {


### PR DESCRIPTION
## Context

We're moving about 600 accounts to Pay-as-you-go. The email tells them what they'll pay and links here, but the page couldn't show that number.

**This screen is live until the end of the month. After that most of this code goes, along with the projection endpoint.** So it reuses the existing usage table rather than adding new parts.

## Changes

- The table shows two columns for the month you pick: what the current plan charges per metric, and what Pay-as-you-go would charge.
- The old metrics move to a second table behind a toggle, still showing the current plan's charges.
- The new figures come from ClickHouse, not Orb, which has no data for the new metrics yet. That way any month works, not just this one.
- Connections use the month's running average — what Orb bills on, and what the email uses.
- Rates live in `@nangohq/billing`, not on the plan. `planToApi` copies the whole plan row into its response, so a rate there would reach every browser.
- You see it if you're on a retired plan with a move scheduled in Orb.

Fixes [NAN-6744](https://linear.app/nango/issue/NAN-6744)

## Testing

Checked against a real Orb test account for August and September: connections `$60.00` on Starter against `$23.20` on Pay-as-you-go, with the old metrics showing their own Starter charges.

Tests cover each retired plan, Enterprise and the startup deal staying out, the add-on only applying to Growth, and a normal user refused the staff preview.

Collapsed legacy metrics
<img width="1282" height="303" alt="image" src="https://github.com/user-attachments/assets/eb8c97f4-44d8-428d-b713-783223bca9a1" />

Expanded legacy metrics
<img width="1272" height="668" alt="image" src="https://github.com/user-attachments/assets/f3ef011f-607b-4826-8ba9-ec0fde952cb4" />
