### PR TITLE
feat(orch): add support for scheduled functions

### DIFF
--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -9,7 +9,7 @@ import { Ok, stringifyError } from '@nangohq/utils';
 import { envs } from '../env.js';
 import { handleSyncSuccess, startSync } from './sync.js';
 
-import type { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
+import type { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskScheduleFunction, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
 import type { ReturnedRecord, UnencryptedRecordData } from '@nangohq/records';
 import type { Sync, Job as SyncJob } from '@nangohq/shared';
 import type { ConnectionJobs, DBSyncConfig, SyncResult } from '@nangohq/types';
@@ -212,7 +212,8 @@ const runJob = async (
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false,
-        isFunction: (): this is TaskFunction => false
+        isFunction: (): this is TaskFunction => false,
+        isScheduleFunction: (): this is TaskScheduleFunction => false
     };
     const nangoProps = await startSync(task, mockStartScript);
     if (nangoProps.isErr()) {

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -53,7 +53,6 @@ describe('OrchestratorClient', async () => {
                     type: 'sync',
                     syncId: 'sync-a',
                     syncName: nanoid(),
-                    syncJobId: 5678,
                     connection: {
                         id: 123,
                         connection_id: 'C',
@@ -79,7 +78,6 @@ describe('OrchestratorClient', async () => {
                     type: 'sync',
                     syncId: 'sync-a',
                     syncName: nanoid(),
-                    syncJobId: 5678,
                     connection: {
                         id: 123,
                         connection_id: 'C',
@@ -107,7 +105,6 @@ describe('OrchestratorClient', async () => {
                     type: 'sync',
                     syncId: 'sync-a',
                     syncName: nanoid(),
-                    syncJobId: 5678,
                     connection: {
                         id: 123,
                         connection_id: 'C',
@@ -138,7 +135,6 @@ describe('OrchestratorClient', async () => {
                     type: 'sync',
                     syncId: 'sync-a',
                     syncName: nanoid(),
-                    syncJobId: 5678,
                     connection: {
                         id: 123,
                         connection_id: 'C',
@@ -170,7 +166,6 @@ describe('OrchestratorClient', async () => {
                     type: 'sync',
                     syncId: 'sync-a',
                     syncName: nanoid(),
-                    syncJobId: 5678,
                     connection: {
                         id: 123,
                         connection_id: 'C',

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -102,7 +102,15 @@ export class OrchestratorClient {
     }
 
     public async recurring(props: RecurringProps): Promise<Result<{ scheduleId: string }, ClientError>> {
-        const res = await this.routeFetch(postRecurringRoute)({
+        const res = await this.routeFetch(postRecurringRoute, {
+            // A duplicate schedule is a terminal answer, not a transient failure.
+            retryConfig: {
+                maxAttempts: 3,
+                maxWaitMs: Infinity,
+                delayMs: 50,
+                retryIf: (res) => 'error' in res && getErrorMessageForCode(res.error.payload, 'duplicate_schedule_name') === null
+            }
+        })({
             body: {
                 name: props.name,
                 state: props.state,
@@ -115,11 +123,19 @@ export class OrchestratorClient {
             }
         });
         if ('error' in res) {
+            const duplicateMessage = getErrorMessageForCode(res.error.payload, 'duplicate_schedule_name');
+            if (duplicateMessage !== null) {
+                return Err({
+                    name: 'duplicate_schedule_name',
+                    message: duplicateMessage || 'Schedule with this name already exists',
+                    payload: {}
+                });
+            }
             const startsAt = props.startsAt.toISOString();
             return Err({
                 name: res.error.code,
                 message: res.error.message || `Error creating recurring schedule`,
-                payload: { ...props, startsAt, response: res.error.payload as any }
+                payload: { ...props, startsAt, response: res.error.payload as any } as JsonValue
             });
         } else {
             return Ok(res);
@@ -744,6 +760,15 @@ export function isDuplicateTaskNameClientError(err: unknown): boolean {
 
     const error = err as { name?: string };
     return error.name === 'duplicate_task_name';
+}
+
+export function isDuplicateScheduleNameClientError(err: unknown): boolean {
+    if (!err || typeof err !== 'object') {
+        return false;
+    }
+
+    const error = err as { name?: string };
+    return error.name === 'duplicate_schedule_name';
 }
 
 export type ExecuteBatchEntryResult = Result<{ taskId: string; retryKey: string }, ClientError>;

--- a/packages/orchestrator/lib/clients/client.unit.test.ts
+++ b/packages/orchestrator/lib/clients/client.unit.test.ts
@@ -99,6 +99,43 @@ describe('OrchestratorClient immediate', () => {
     });
 });
 
+describe('OrchestratorClient recurring', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('fails when duplicate schedule', async () => {
+        const fetchMock = vi.fn().mockImplementation(
+            () =>
+                new Response(JSON.stringify({ error: { code: 'duplicate_schedule_name', message: 'schedule already exists' } }), {
+                    status: 409,
+                    headers: { 'content-type': 'application/json' }
+                })
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const client = new OrchestratorClient({ baseUrl: 'http://orchestrator.test' });
+        const res = await client.recurring({
+            name: 'schedule-1',
+            state: 'STARTED',
+            startsAt: new Date(),
+            frequencyMs: 300_000,
+            group: { key: 'function:environment:1', maxConcurrency: 0 },
+            retry: { max: 0 },
+            timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
+            args: { type: 'function', instanceId: 1 }
+        });
+
+        expect(res.isErr()).toBe(true);
+        if (res.isErr()) {
+            expect(res.error.name).toBe('duplicate_schedule_name');
+            expect(res.error.payload).toEqual({});
+        }
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});
+
 function buildWebhookProps(name: string): ExecuteWebhookProps {
     return {
         name,

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -58,6 +58,9 @@ interface FunctionArgs {
     trigger: FunctionTrigger;
     async: boolean;
 }
+interface ScheduleFunctionArgs {
+    instanceId: number;
+}
 export type SchedulesReturn = Result<OrchestratorSchedule[]>;
 export type VoidReturn = Result<void, ClientError>;
 export type ExecuteProps = SetOptional<ImmediateProps, 'retry' | 'timeoutSettingsInSecs'>;
@@ -81,7 +84,7 @@ export interface OrchestratorSchedule {
     nextDueDate: Date | null;
 }
 
-export type OrchestratorTask = TaskSync | TaskSyncAbort | TaskAction | TaskWebhook | TaskOnEvent | TaskAbort | TaskFunction;
+export type OrchestratorTask = TaskSync | TaskSyncAbort | TaskAction | TaskWebhook | TaskOnEvent | TaskAbort | TaskFunction | TaskScheduleFunction;
 
 interface TaskCommonFields {
     id: string;
@@ -103,6 +106,7 @@ interface TaskCommon extends TaskCommonFields {
     isSyncAbort(this: OrchestratorTask): this is TaskSyncAbort;
     isAbort(this: OrchestratorTask): this is TaskAbort;
     isFunction(this: OrchestratorTask): this is TaskFunction;
+    isScheduleFunction(this: OrchestratorTask): this is TaskScheduleFunction;
 }
 export interface TaskAbort extends TaskCommon, AbortArgs {}
 export function TaskAbort(props: TaskCommonFields & AbortArgs): TaskAbort {
@@ -126,7 +130,8 @@ export function TaskAbort(props: TaskCommonFields & AbortArgs): TaskAbort {
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => true,
-        isFunction: (): this is TaskFunction => false
+        isFunction: (): this is TaskFunction => false,
+        isScheduleFunction: (): this is TaskScheduleFunction => false
     };
 }
 
@@ -155,7 +160,8 @@ export function TaskSync(props: TaskCommonFields & SyncArgs & SyncExecutionArgs)
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false,
-        isFunction: (): this is TaskFunction => false
+        isFunction: (): this is TaskFunction => false,
+        isScheduleFunction: (): this is TaskScheduleFunction => false
     };
 }
 
@@ -185,7 +191,8 @@ export function TaskSyncAbort(props: TaskCommonFields & SyncArgs & AbortArgs): T
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => true,
         isAbort: (): this is TaskAbort => false,
-        isFunction: (): this is TaskFunction => false
+        isFunction: (): this is TaskFunction => false,
+        isScheduleFunction: (): this is TaskScheduleFunction => false
     };
 }
 
@@ -213,7 +220,8 @@ export function TaskAction(props: TaskCommonFields & ActionArgs): TaskAction {
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false,
-        isFunction: (): this is TaskFunction => false
+        isFunction: (): this is TaskFunction => false,
+        isScheduleFunction: (): this is TaskScheduleFunction => false
     };
 }
 
@@ -241,7 +249,8 @@ export function TaskWebhook(props: TaskCommonFields & WebhookArgs): TaskWebhook 
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false,
-        isFunction: (): this is TaskFunction => false
+        isFunction: (): this is TaskFunction => false,
+        isScheduleFunction: (): this is TaskScheduleFunction => false
     };
 }
 
@@ -270,7 +279,8 @@ export function TaskOnEvent(props: TaskCommonFields & OnEventArgs): TaskOnEvent 
         isOnEvent: (): this is TaskOnEvent => true,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false,
-        isFunction: (): this is TaskFunction => false
+        isFunction: (): this is TaskFunction => false,
+        isScheduleFunction: (): this is TaskScheduleFunction => false
     };
 }
 
@@ -298,7 +308,33 @@ export function TaskFunction(props: TaskCommonFields & FunctionArgs): TaskFuncti
         isOnEvent: (): this is TaskOnEvent => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false,
-        isFunction: (): this is TaskFunction => true
+        isFunction: (): this is TaskFunction => true,
+        isScheduleFunction: (): this is TaskScheduleFunction => false
+    };
+}
+
+export interface TaskScheduleFunction extends TaskCommon, ScheduleFunctionArgs {}
+export function TaskScheduleFunction(props: TaskCommonFields & ScheduleFunctionArgs): TaskScheduleFunction {
+    return {
+        id: props.id,
+        name: props.name,
+        state: props.state,
+        attempt: props.attempt,
+        retryKey: props.retryKey,
+        attemptMax: props.attemptMax,
+        instanceId: props.instanceId,
+        groupKey: props.groupKey,
+        groupMaxConcurrency: props.groupMaxConcurrency,
+        ownerKey: props.ownerKey,
+        heartbeatTimeoutSecs: props.heartbeatTimeoutSecs,
+        isSync: (): this is TaskSync => false,
+        isWebhook: (): this is TaskWebhook => false,
+        isAction: (): this is TaskAction => false,
+        isOnEvent: (): this is TaskOnEvent => false,
+        isSyncAbort: (): this is TaskSyncAbort => false,
+        isAbort: (): this is TaskAbort => false,
+        isFunction: (): this is TaskFunction => false,
+        isScheduleFunction: (): this is TaskScheduleFunction => true
     };
 }
 

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -4,7 +4,7 @@ import { taskStates } from '@nangohq/scheduler';
 import { Err, Ok } from '@nangohq/utils';
 
 import { jsonSchema } from '../utils/validation.js';
-import { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from './types.js';
+import { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskScheduleFunction, TaskSync, TaskSyncAbort, TaskWebhook } from './types.js';
 
 import type { OrchestratorSchedule, OrchestratorTask } from './types.js';
 import type { Schedule, Task } from '@nangohq/scheduler';
@@ -73,44 +73,64 @@ export const onEventArgsSchema = z.object({
     activityLogId: z.string(),
     ...commonSchemaArgsFields
 });
-export const functionArgsSchema = z.object({
+
+const functionBaseFields = {
     type: z.literal('function'),
-    functionName: z.string().min(1),
+    functionName: z.string().min(1)
+};
+
+const functionTriggerConnectionSchema = z.object({
+    connectionId: z.string().min(1),
+    integrationId: z.string().min(1)
+});
+
+const scheduleFunctionTriggerSchema = z.object({
+    kind: z.literal('schedule'),
+    input: z.null(),
+    connection: functionTriggerConnectionSchema
+});
+
+const functionTriggerSchema = z.discriminatedUnion('kind', [
+    z.object({
+        kind: z.literal('invoke'),
+        input: jsonSchema,
+        connection: functionTriggerConnectionSchema
+    }),
+    z.object({
+        kind: z.literal('http'),
+        input: jsonSchema.optional().default(null),
+        request: z.object({
+            method: z.enum(['GET', 'POST', 'PATCH', 'PUT', 'DELETE']),
+            path: z.string(),
+            headers: z.record(z.string(), z.string()),
+            query: z.record(z.string(), z.string()),
+            body: jsonSchema.optional().default(null)
+        }),
+        subscriptions: z.array(z.string()).default([]),
+        connection: functionTriggerConnectionSchema
+    }),
+    z.object({
+        kind: z.literal('event'),
+        input: z.object({ event: z.enum(['post-connection-creation', 'pre-connection-deletion', 'validate-connection']) }),
+        connection: functionTriggerConnectionSchema
+    }),
+    scheduleFunctionTriggerSchema
+]);
+
+export const functionArgsSchema = z.object({
+    ...functionBaseFields,
     activityLogId: z.string(),
-    // TODO: add support for connection-less functions
-    trigger: z.discriminatedUnion('kind', [
-        z.object({
-            kind: z.literal('invoke'),
-            input: jsonSchema,
-            connection: z.object({ connectionId: z.string().min(1), integrationId: z.string().min(1) })
-        }),
-        z.object({
-            kind: z.literal('schedule'),
-            input: z.null(),
-            connection: z.object({ connectionId: z.string().min(1), integrationId: z.string().min(1) })
-        }),
-        z.object({
-            kind: z.literal('http'),
-            input: jsonSchema.optional().default(null),
-            request: z.object({
-                method: z.enum(['GET', 'POST', 'PATCH', 'PUT', 'DELETE']),
-                path: z.string(),
-                headers: z.record(z.string(), z.string()),
-                query: z.record(z.string(), z.string()),
-                body: jsonSchema.optional().default(null)
-            }),
-            subscriptions: z.array(z.string()).default([]),
-            connection: z.object({ connectionId: z.string().min(1), integrationId: z.string().min(1) })
-        }),
-        z.object({
-            kind: z.literal('event'),
-            input: z.object({ event: z.enum(['post-connection-creation', 'pre-connection-deletion', 'validate-connection']) }),
-            connection: z.object({ connectionId: z.string().min(1), integrationId: z.string().min(1) })
-        })
-    ]),
+    trigger: functionTriggerSchema,
     async: z.boolean().optional().default(false),
     ...commonSchemaArgsFields
 });
+
+export const scheduleFunctionArgsSchema = z
+    .object({
+        type: z.literal('function'),
+        instanceId: z.number().int().positive()
+    })
+    .strict();
 
 const commonSchemaFields = {
     id: z.string().uuid(),
@@ -151,6 +171,10 @@ const onEventSchema = z.object({
 const functionSchema = z.object({
     ...commonSchemaFields,
     payload: functionArgsSchema
+});
+const scheduleFunctionSchema = z.object({
+    ...commonSchemaFields,
+    payload: scheduleFunctionArgsSchema
 });
 
 export function validateTask(task: Task): Result<OrchestratorTask> {
@@ -287,6 +311,24 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 ownerKey: func.data.ownerKey,
                 retryKey: func.data.retryKey,
                 heartbeatTimeoutSecs: func.data.heartbeatTimeoutSecs
+            })
+        );
+    }
+    const scheduleFunction = scheduleFunctionSchema.safeParse(task);
+    if (scheduleFunction.success) {
+        return Ok(
+            TaskScheduleFunction({
+                id: scheduleFunction.data.id,
+                state: scheduleFunction.data.state,
+                name: scheduleFunction.data.name,
+                attempt: scheduleFunction.data.retryCount + 1,
+                attemptMax: scheduleFunction.data.retryMax + 1,
+                instanceId: scheduleFunction.data.payload.instanceId,
+                groupKey: scheduleFunction.data.groupKey,
+                groupMaxConcurrency: scheduleFunction.data.groupMaxConcurrency,
+                ownerKey: scheduleFunction.data.ownerKey,
+                retryKey: scheduleFunction.data.retryKey,
+                heartbeatTimeoutSecs: scheduleFunction.data.heartbeatTimeoutSecs
             })
         );
     }

--- a/packages/orchestrator/lib/clients/validate.unit.test.ts
+++ b/packages/orchestrator/lib/clients/validate.unit.test.ts
@@ -5,6 +5,44 @@ import { validateTask } from './validate.js';
 import type { Task } from '@nangohq/scheduler';
 
 describe('validateTask', () => {
+    it('deserializes a dequeued scheduled function task', () => {
+        const result = validateTask({
+            id: '4a14038c-3a57-4a4d-bb9e-c8a5e85474ae',
+            name: 'scheduled-function-task',
+            groupKey: 'function:instance:123',
+            groupMaxConcurrency: 1,
+            state: 'STARTED',
+            retryKey: null,
+            retryCount: 0,
+            retryMax: 0,
+            ownerKey: null,
+            heartbeatTimeoutSecs: 60,
+            startsAfter: new Date(),
+            createdToStartedTimeoutSecs: 30,
+            startedToCompletedTimeoutSecs: 120,
+            createdAt: new Date(),
+            lastStateTransitionAt: new Date(),
+            lastHeartbeatAt: new Date(),
+            output: null,
+            terminated: false,
+            scheduleId: 'c1952e1f-b385-4db0-b4ef-a7ad52a034c9',
+            payload: {
+                type: 'function',
+                instanceId: 123
+            }
+        } as Task);
+
+        const task = result.unwrap();
+        expect(task.isScheduleFunction()).toBe(true);
+        if (task.isScheduleFunction()) {
+            expect(task).toMatchObject({
+                instanceId: 123,
+                attempt: 1,
+                attemptMax: 1
+            });
+        }
+    });
+
     it('deserializes a dequeued function task', () => {
         const result = validateTask({
             id: '4a14038c-3a57-4a4d-bb9e-c8a5e85474ae',

--- a/packages/orchestrator/lib/routes/v1/postRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/postRecurring.ts
@@ -1,8 +1,9 @@
 import * as z from 'zod';
 
+import { isDuplicateScheduleNameError } from '@nangohq/scheduler';
 import { validateRequest } from '@nangohq/utils';
 
-import { syncArgsSchema } from '../../clients/validate.js';
+import { scheduleFunctionArgsSchema, syncArgsSchema } from '../../clients/validate.js';
 
 import type { Scheduler } from '@nangohq/scheduler';
 import type { ApiError, Endpoint } from '@nangohq/types';
@@ -11,6 +12,7 @@ import type { JsonObject } from 'type-fest';
 
 const path = '/v1/recurring';
 const method = 'POST';
+const recurringArgsSchema = z.discriminatedUnion('type', [syncArgsSchema, scheduleFunctionArgsSchema]);
 
 export type PostRecurring = Endpoint<{
     Method: typeof method;
@@ -32,9 +34,9 @@ export type PostRecurring = Endpoint<{
             startedToCompleted: number;
             heartbeat: number;
         };
-        args: JsonObject & { type: 'sync' };
+        args: z.input<typeof recurringArgsSchema>;
     };
-    Error: ApiError<'recurring_failed'>;
+    Error: ApiError<'recurring_failed' | 'duplicate_schedule_name'>;
     Success: { scheduleId: string };
 }>;
 
@@ -56,7 +58,7 @@ const bodySchemaBase = z
             startedToCompleted: z.number().int().positive(),
             heartbeat: z.number().int().positive()
         }),
-        args: syncArgsSchema
+        args: recurringArgsSchema
     })
     .strict();
 
@@ -78,7 +80,7 @@ const handler = (scheduler: Scheduler) => {
         const schedule = await scheduler.recurring({
             name: res.locals.parsedBody.name,
             state: res.locals.parsedBody.state,
-            payload: res.locals.parsedBody.args,
+            payload: res.locals.parsedBody.args as JsonObject, // Validation has applied Zod defaults, so we can safely cast to JsonObject
             startsAt: res.locals.parsedBody.startsAt,
             frequencyMs: res.locals.parsedBody.frequencyMs,
             groupKey: res.locals.parsedBody.group.key,
@@ -90,6 +92,10 @@ const handler = (scheduler: Scheduler) => {
             lastScheduledTaskState: null
         });
         if (schedule.isErr()) {
+            if (isDuplicateScheduleNameError(schedule.error)) {
+                res.status(409).json({ error: { code: 'duplicate_schedule_name', message: schedule.error.message } });
+                return;
+            }
             res.status(500).json({ error: { code: 'recurring_failed', message: schedule.error.message } });
             return;
         }

--- a/packages/orchestrator/lib/routes/v1/postRecurring.unit.test.ts
+++ b/packages/orchestrator/lib/routes/v1/postRecurring.unit.test.ts
@@ -1,0 +1,166 @@
+import { EventEmitter } from 'node:events';
+
+import getPort from 'get-port';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InMemorySlidingWindowRateLimiter } from '@nangohq/kvstore';
+import { DuplicateScheduleNameError } from '@nangohq/scheduler';
+import { Err, Ok } from '@nangohq/utils';
+
+import { getServer } from '../../server.js';
+
+import type { Scheduler } from '@nangohq/scheduler';
+import type { Server } from 'node:http';
+
+const scheduleId = '01994dc2-b6a7-7e46-964d-5f520e57a082';
+const recurring = vi.fn(() => Promise.resolve(Ok({ id: scheduleId })));
+const scheduler = { recurring } as unknown as Scheduler;
+const rateLimiter = new InMemorySlidingWindowRateLimiter({ keyPrefix: 'recurring-route-test', limit: 100, windowMs: 60_000 });
+const port = await getPort();
+let api: Server;
+
+async function post(body: unknown): Promise<Response> {
+    return await fetch(`http://localhost:${port}/v1/recurring`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+}
+
+describe('POST /v1/recurring', () => {
+    beforeAll(() => {
+        api = getServer(scheduler, new EventEmitter(), rateLimiter).listen(port);
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterAll(async () => {
+        await new Promise<void>((resolve, reject) => api.close((err) => (err ? reject(err) : resolve())));
+        await rateLimiter.destroy();
+    });
+
+    it('creates recurring sync schedules', async () => {
+        const body = {
+            name: 'environment:789:sync:123',
+            state: 'STARTED' as const,
+            startsAt: new Date().toISOString(),
+            frequencyMs: 300_000,
+            group: { key: 'sync:environment:789', maxConcurrency: 0 },
+            retry: { max: 0 },
+            timeoutSettingsInSecs: { createdToStarted: 3600, startedToCompleted: 86_400, heartbeat: 300 },
+            args: {
+                type: 'sync',
+                syncId: '123',
+                syncName: 'fetchIssues',
+                syncVariant: 'base',
+                debug: false,
+                connection: {
+                    id: 456,
+                    connection_id: 'customer-connection',
+                    provider_config_key: 'github',
+                    environment_id: 789
+                }
+            }
+        };
+        const response = await post(body);
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({ scheduleId });
+        expect(recurring).toHaveBeenCalledWith({
+            name: body.name,
+            state: body.state,
+            startsAt: new Date(body.startsAt),
+            frequencyMs: body.frequencyMs,
+            groupKey: body.group.key,
+            retryMax: body.retry.max,
+            createdToStartedTimeoutSecs: body.timeoutSettingsInSecs.createdToStarted,
+            startedToCompletedTimeoutSecs: body.timeoutSettingsInSecs.startedToCompleted,
+            heartbeatTimeoutSecs: body.timeoutSettingsInSecs.heartbeat,
+            lastScheduledTaskId: null,
+            lastScheduledTaskState: null,
+            payload: { ...body.args, emptyCache: false }
+        });
+    });
+
+    it('creates recurring function schedules', async () => {
+        const body = {
+            name: 'environment:789:function:123',
+            state: 'STARTED' as const,
+            startsAt: new Date().toISOString(),
+            frequencyMs: 300_000,
+            group: { key: 'function:environment:789:connection:456:function:fetchIssues', maxConcurrency: 1 },
+            retry: { max: 0 },
+            timeoutSettingsInSecs: { createdToStarted: 86_400, startedToCompleted: 900, heartbeat: 120 },
+            args: {
+                type: 'function',
+                instanceId: 123
+            }
+        };
+        const response = await post(body);
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({ scheduleId });
+        expect(recurring).toHaveBeenCalledWith({
+            name: body.name,
+            state: body.state,
+            startsAt: new Date(body.startsAt),
+            frequencyMs: body.frequencyMs,
+            groupKey: body.group.key,
+            retryMax: body.retry.max,
+            createdToStartedTimeoutSecs: body.timeoutSettingsInSecs.createdToStarted,
+            startedToCompletedTimeoutSecs: body.timeoutSettingsInSecs.startedToCompleted,
+            heartbeatTimeoutSecs: body.timeoutSettingsInSecs.heartbeat,
+            lastScheduledTaskId: null,
+            lastScheduledTaskState: null,
+            payload: body.args
+        });
+    });
+
+    it('returns a conflict when the schedule already exists', async () => {
+        const body = {
+            name: 'environment:789:function:123',
+            state: 'STARTED' as const,
+            startsAt: new Date().toISOString(),
+            frequencyMs: 300_000,
+            group: { key: 'function:environment:789', maxConcurrency: 0 },
+            retry: { max: 0 },
+            timeoutSettingsInSecs: { createdToStarted: 3600, startedToCompleted: 86_400, heartbeat: 300 },
+            args: { type: 'function', instanceId: 123 }
+        };
+        recurring.mockResolvedValueOnce(Err(new DuplicateScheduleNameError(body.name)) as never);
+
+        const response = await post(body);
+
+        expect(response.status).toBe(409);
+        await expect(response.json()).resolves.toStrictEqual({
+            error: { code: 'duplicate_schedule_name', message: `Schedule '${body.name}' already exists` }
+        });
+    });
+
+    it('rejects unexpected recurring function fields', async () => {
+        const body = {
+            name: 'environment:789:function:123',
+            state: 'STARTED' as const,
+            startsAt: new Date().toISOString(),
+            frequencyMs: 300_000,
+            group: { key: 'function:environment:789:connection:456:function:fetchIssues', maxConcurrency: 1 },
+            retry: { max: 0 },
+            timeoutSettingsInSecs: { createdToStarted: 86_400, startedToCompleted: 900, heartbeat: 120 },
+            args: {
+                type: 'function',
+                instanceId: 123,
+                trigger: {
+                    kind: 'schedule',
+                    input: null,
+                    connection: { connectionId: 'customer-connection', integrationId: 'github' }
+                }
+            }
+        };
+        const response = await post(body);
+
+        expect(response.status).toBe(400);
+        expect(recurring).not.toHaveBeenCalled();
+    });
+});

--- a/packages/scheduler/lib/errors.ts
+++ b/packages/scheduler/lib/errors.ts
@@ -9,6 +9,17 @@ export function isDuplicateTaskNameError(err: unknown): boolean {
     return err instanceof DuplicateTaskNameError;
 }
 
+export class DuplicateScheduleNameError extends Error {
+    constructor(scheduleName: string) {
+        super(`Schedule '${scheduleName}' already exists`);
+        this.name = 'DuplicateScheduleNameError';
+    }
+}
+
+export function isDuplicateScheduleNameError(err: unknown): boolean {
+    return err instanceof DuplicateScheduleNameError;
+}
+
 export class ScheduleTaskAlreadyRunningError extends Error {
     constructor() {
         super('A task for this schedule is already running');

--- a/packages/scheduler/lib/models/schedules.integration.test.ts
+++ b/packages/scheduler/lib/models/schedules.integration.test.ts
@@ -4,6 +4,7 @@ import { uuidv7 } from 'uuidv7';
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDbClient } from '../db/helpers.test.js';
+import { isDuplicateScheduleNameError } from '../errors.js';
 import * as schedules from './schedules.js';
 
 import type { Schedule } from '../types.js';
@@ -39,6 +40,69 @@ describe('Schedules', () => {
             deletedAt: null,
             lastScheduledTaskId: null
         });
+    });
+    it('should fail to create a schedule when it already exists', async () => {
+        const schedule = await createSchedule(db);
+
+        const duplicate = await schedules.create(db, {
+            name: schedule.name,
+            state: 'PAUSED',
+            payload: { foo: 'updated' },
+            startsAt: new Date(),
+            frequencyMs: 600_000,
+            groupKey: 'updated-group-key',
+            retryMax: 2,
+            createdToStartedTimeoutSecs: 2,
+            startedToCompletedTimeoutSecs: 3,
+            heartbeatTimeoutSecs: 4,
+            lastScheduledTaskId: null,
+            lastScheduledTaskState: null
+        });
+
+        expect(duplicate.isErr()).toBe(true);
+        expect(duplicate.isErr() && isDuplicateScheduleNameError(duplicate.error)).toBe(true);
+        const existing = (await schedules.get(db, schedule.id)).unwrap();
+        expect(existing.payload).toEqual({ foo: 'bar' });
+    });
+    it('should resurrect a soft-deleted schedule', async () => {
+        const schedule = await createSchedule(db);
+        const taskId = uuidv7();
+        await schedules.setLastScheduledTask(db, [{ id: schedule.id, taskId, taskState: 'SUCCEEDED' }]);
+        await schedules.remove(db, schedule.id);
+
+        const resurrected = (
+            await schedules.create(db, {
+                name: schedule.name,
+                state: 'PAUSED',
+                payload: { foo: 'restored' },
+                startsAt: new Date(),
+                frequencyMs: 600_000,
+                groupKey: 'restored-group-key',
+                retryMax: 2,
+                createdToStartedTimeoutSecs: 2,
+                startedToCompletedTimeoutSecs: 3,
+                heartbeatTimeoutSecs: 4,
+                lastScheduledTaskId: null,
+                lastScheduledTaskState: null
+            })
+        ).unwrap();
+
+        expect(resurrected).toMatchObject({
+            id: schedule.id,
+            name: schedule.name,
+            state: 'PAUSED',
+            payload: { foo: 'restored' },
+            frequencyMs: 600_000,
+            groupKey: 'restored-group-key',
+            retryMax: 2,
+            createdToStartedTimeoutSecs: 2,
+            startedToCompletedTimeoutSecs: 3,
+            heartbeatTimeoutSecs: 4,
+            deletedAt: null,
+            lastScheduledTaskId: null,
+            lastScheduledTaskState: null
+        });
+        expect(resurrected.createdAt).toEqual(schedule.createdAt);
     });
     it('should be successfully retrieved', async () => {
         const schedule = await createSchedule(db);

--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -2,7 +2,7 @@ import { uuidv7 } from 'uuidv7';
 
 import { Err, Ok, stringifyError } from '@nangohq/utils';
 
-import { isPgLockNotAvailableError, ScheduleLockedError } from '../errors.js';
+import { DuplicateScheduleNameError, isPgLockNotAvailableError, ScheduleLockedError } from '../errors.js';
 
 import type { Schedule, ScheduleProps, ScheduleState, TaskState } from '../types.js';
 import type { Result } from '@nangohq/utils';
@@ -117,6 +117,7 @@ export const DbSchedule = {
     })
 };
 
+/** Create a schedule, or resurrect the existing schedule when its state is DELETED. */
 export async function create(db: knex.Knex, props: ScheduleProps): Promise<Result<Schedule>> {
     const now = new Date();
     const newSchedule: Schedule = {
@@ -131,10 +132,32 @@ export async function create(db: knex.Knex, props: ScheduleProps): Promise<Resul
         lastScheduledTaskId: null,
         nextExecutionAt: now
     };
+    const values = DbSchedule.to(newSchedule);
     try {
-        const inserted = await db.from<DbSchedule>(SCHEDULES_TABLE).insert(DbSchedule.to(newSchedule)).returning('*');
+        const inserted = await db
+            .from<DbSchedule>(SCHEDULES_TABLE)
+            .insert(values)
+            .onConflict('name')
+            .merge({
+                state: values.state,
+                starts_at: values.starts_at,
+                frequency: values.frequency,
+                payload: values.payload,
+                group_key: values.group_key,
+                retry_max: values.retry_max,
+                created_to_started_timeout_secs: values.created_to_started_timeout_secs,
+                started_to_completed_timeout_secs: values.started_to_completed_timeout_secs,
+                heartbeat_timeout_secs: values.heartbeat_timeout_secs,
+                updated_at: values.updated_at,
+                deleted_at: null,
+                last_scheduled_task_id: null,
+                last_scheduled_task_state: null,
+                next_execution_at: values.next_execution_at
+            })
+            .where(`${SCHEDULES_TABLE}.state`, 'DELETED')
+            .returning('*');
         if (!inserted?.[0]) {
-            return Err(new Error(`Error: no schedule '${props.name}' created`));
+            return Err(new DuplicateScheduleNameError(props.name));
         }
         return Ok(DbSchedule.from(inserted[0]));
     } catch (err) {

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -470,7 +470,7 @@ async function at(
     ).unwrap();
 }
 
-async function recurring({ scheduler, state = 'PAUSED' }: { scheduler: Scheduler; state?: ScheduleState }): Promise<Schedule> {
+async function recurring({ scheduler, state = 'PAUSED' }: { scheduler: Scheduler; state?: Exclude<ScheduleState, 'DELETED'> }): Promise<Schedule> {
     const recurringProps = {
         name: nanoid(),
         state,

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -36,7 +36,9 @@ export interface FromScheduleProps {
     scheduleName: string;
     extra: JsonObject;
 }
-export type ScheduleProps = Omit<Schedule, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt' | 'nextExecutionAt'>;
+export type ScheduleProps = Omit<Schedule, 'id' | 'state' | 'createdAt' | 'updatedAt' | 'deletedAt' | 'nextExecutionAt'> & {
+    state: Exclude<ScheduleState, 'DELETED'>;
+};
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const scheduleStates = ['PAUSED', 'STARTED', 'DELETED'] as const;


### PR DESCRIPTION
Not used yet since function with 'schedule' trigger isn't supported yet.

- `POST/ recurring` is now accepting payload { type: 'function', instance: 123} Note: The behavior of the POST /recurring endpoint has been altered to resurrect a schedule if it already exists with state=DELETED
- Add validation logic for schedule function so they can be dequeued

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

