### PR TITLE
feat(mcp): support static server URL and configurable scopes for MCP_OAUTH2_GENERIC

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1063,6 +1063,7 @@ class OAuthController {
     }
 
     private async mcpGenericRequest({
+        provider,
         config,
         session,
         req,
@@ -1087,7 +1088,7 @@ class OAuthController {
         const connectionId = session.connectionId;
 
         try {
-            const mcpServerUrl = connectionConfig['mcp_server_url'];
+            const mcpServerUrl = provider.mcp_server_url || connectionConfig['mcp_server_url'];
             if (!mcpServerUrl) {
                 const error = WSErrBuilder.InvalidConnectionConfig('mcp_server_url', JSON.stringify(connectionConfig));
                 void logCtx.error(error.message);
@@ -1105,7 +1106,14 @@ class OAuthController {
                 return;
             }
 
-            const { metadata, resourceMetadata, scopes } = discoveryResult;
+            const { metadata, resourceMetadata } = discoveryResult;
+
+            const configuredScopes = config.oauth_scopes
+                ?.split(',')
+                .map((s) => s.trim())
+                .filter(Boolean)
+                .join(' ');
+            const scopes = configuredScopes || discoveryResult.scopes;
 
             const clientMetadata: OAuthClientMetadata = {
                 redirect_uris: [callbackUrl],

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1112,7 +1112,7 @@ class OAuthController {
                 ?.split(',')
                 .map((s) => s.trim())
                 .filter(Boolean)
-                .join(' ');
+                .join(provider.scope_separator || ' ');
             const scopes = configuredScopes || discoveryResult.scopes;
 
             const clientMetadata: OAuthClientMetadata = {

--- a/packages/server/lib/controllers/v1/integrations/buildIntegrationConfig.ts
+++ b/packages/server/lib/controllers/v1/integrations/buildIntegrationConfig.ts
@@ -80,6 +80,7 @@ export async function buildIntegrationConfig(body: PostIntegration['Body'], envi
                 ...(clientUri && { oauth_client_uri: clientUri }),
                 ...(clientLogoUri && { oauth_client_logo_uri: clientLogoUri })
             };
+            config.oauth_scopes = auth.scopes ?? null;
         } else if (auth.authType === 'INSTALL_PLUGIN') {
             config.app_link = auth.appLink ?? null;
             config.custom = {

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -165,6 +165,9 @@ export const patchIntegration = asyncWrapperWithEnvironment<PatchIntegration>(as
                     ...(clientLogoUri && { oauth_client_logo_uri: clientLogoUri })
                 };
             }
+            if (body.scopes !== undefined) {
+                integration.oauth_scopes = body.scopes || '';
+            }
         } else if (body.authType === 'INSTALL_PLUGIN') {
             const { username, password, appLink } = body;
             integration = {

--- a/packages/server/lib/controllers/v1/integrations/validation.ts
+++ b/packages/server/lib/controllers/v1/integrations/validation.ts
@@ -56,7 +56,8 @@ export const integrationAuthTypeMcpOAuth2GenericSchema = z
         authType: z.enum(['MCP_OAUTH2_GENERIC']),
         clientName: z.string().min(1).max(255).optional(),
         clientUri: z.url().max(255).or(z.literal('')).optional(),
-        clientLogoUri: z.url().max(255).optional()
+        clientLogoUri: z.url().max(255).optional(),
+        scopes: scopesSchema
     })
     .strict();
 

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -229,6 +229,7 @@ export interface MCPOAuth2GenericAuthBody {
     clientName?: string | undefined;
     clientUri?: string | undefined;
     clientLogoUri?: string | undefined;
+    scopes?: string | undefined;
 }
 
 export interface InstallPluginAuthBody {

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -160,6 +160,7 @@ export interface ProviderMcpOAUTH2 extends Omit<BaseProvider, 'body_format'> {
 
 export interface ProviderMcpOAuth2Generic extends Omit<BaseProvider, 'body_format'> {
     auth_mode: 'MCP_OAUTH2_GENERIC';
+    mcp_server_url?: string;
 }
 
 export interface ProviderJwt extends BaseProvider {

--- a/packages/webapp/src/pages/Integrations/components/forms/McpGenericCreateForm.tsx
+++ b/packages/webapp/src/pages/Integrations/components/forms/McpGenericCreateForm.tsx
@@ -5,6 +5,7 @@ import z from 'zod';
 
 import { Button, InputGroup, InputGroupInput } from '@nangohq/design-system';
 
+import { ScopesInput } from '@/components/patterns/ScopesInput';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
 
 import type { ApiProviderListItem, PostIntegration } from '@nangohq/types';
@@ -12,7 +13,8 @@ import type { ApiProviderListItem, PostIntegration } from '@nangohq/types';
 const formSchema = z.object({
     clientName: z.string().optional(),
     clientUri: z.string().optional(),
-    clientLogoUri: z.string().url('Must be a valid URL (e.g., https://example.com/logo.png)').optional()
+    clientLogoUri: z.string().url('Must be a valid URL (e.g., https://example.com/logo.png)').optional(),
+    scopes: z.string().optional()
 });
 
 type FormData = z.infer<typeof formSchema>;
@@ -37,7 +39,8 @@ export const McpGenericCreateForm: React.FC<{ provider: ApiProviderListItem; onS
                     authType: provider.authMode as Extract<typeof provider.authMode, 'MCP_OAUTH2_GENERIC'>,
                     clientName: formData.clientName,
                     clientUri: formData.clientUri,
-                    clientLogoUri: formData.clientLogoUri
+                    clientLogoUri: formData.clientLogoUri,
+                    scopes: formData.scopes
                 }
             });
         } finally {
@@ -94,6 +97,19 @@ export const McpGenericCreateForm: React.FC<{ provider: ApiProviderListItem; onS
                                         </InputGroup>
                                     </FormControl>
                                     <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="scopes"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Scopes</FormLabel>
+                                    <FormControl>
+                                        <ScopesInput scopesString={field.value} onChange={(scopes) => Promise.resolve(field.onChange(scopes))} />
+                                    </FormControl>
                                 </FormItem>
                             )}
                         />

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpGenericSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpGenericSettings.tsx
@@ -4,6 +4,7 @@ import { EditableInput } from '@/components/patterns/EditableInput';
 import { ScopesInput } from '@/components/patterns/ScopesInput';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { usePatchIntegration } from '@/hooks/useIntegration';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
@@ -18,6 +19,8 @@ export const McpGenericSettings: React.FC<{ data: GetIntegration['Success']['dat
 }) => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
+    const { can } = usePermissions();
+    const canEdit = can('environment:integrations:update', environment);
     const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
 
     const callbackUrl = environment.callback_url || defaultCallback();
@@ -46,13 +49,15 @@ export const McpGenericSettings: React.FC<{ data: GetIntegration['Success']['dat
                 const plural = countDifference > 1 ? 'scopes' : 'scope';
                 toast({ title: `Added ${countDifference} new ${plural}`, variant: 'success' });
             } else {
-                toast({ title: `Scope successfully removed`, variant: 'success' });
+                const plural = countDifference < -1 ? 'Scopes' : 'Scope';
+                toast({ title: `${plural} successfully removed`, variant: 'success' });
             }
         } catch (err) {
             let errorMessage = 'Failed to update scopes';
             if (err instanceof APIError && err.json.error.message) {
                 errorMessage = err.json.error.message;
             }
+            toast({ title: errorMessage, variant: 'error' });
             throw new Error(errorMessage);
         }
     };
@@ -77,6 +82,7 @@ export const McpGenericSettings: React.FC<{ data: GetIntegration['Success']['dat
                     initialValue={integration.custom?.oauth_client_name || ''}
                     onSave={(value) => onSave({ clientName: value })}
                     validate={validateNotEmpty}
+                    canEdit={canEdit}
                 />
             </div>
 
@@ -87,6 +93,7 @@ export const McpGenericSettings: React.FC<{ data: GetIntegration['Success']['dat
                     initialValue={integration.custom?.oauth_client_uri || ''}
                     onSave={(value) => onSave({ clientUri: value })}
                     validate={validateNotEmpty}
+                    canEdit={canEdit}
                 />
             </div>
 
@@ -98,13 +105,14 @@ export const McpGenericSettings: React.FC<{ data: GetIntegration['Success']['dat
                     onSave={(value) => onSave({ clientLogoUri: value })}
                     placeholder="e.g., https://example.com/logo.png"
                     validate={validateUrl}
+                    canEdit={canEdit}
                 />
             </div>
 
             {/* Scopes */}
             <div className="flex flex-col gap-2">
                 <FieldLabel htmlFor="scopes">Scopes</FieldLabel>
-                <ScopesInput scopesString={integration.oauth_scopes || ''} onChange={handleScopesChange} />
+                <ScopesInput scopesString={integration.oauth_scopes || ''} onChange={handleScopesChange} readOnly={!canEdit} />
             </div>
         </div>
     );

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpGenericSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/McpGenericSettings.tsx
@@ -1,11 +1,13 @@
 import { FieldLabel, InputGroup, InputGroupAddon, InputGroupInput } from '@nangohq/design-system';
 
 import { EditableInput } from '@/components/patterns/EditableInput';
+import { ScopesInput } from '@/components/patterns/ScopesInput';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { usePatchIntegration } from '@/hooks/useIntegration';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty, validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
+import { APIError } from '@/utils/api';
 import { defaultCallback } from '@/utils/cloud';
 
 import type { ApiEnvironment, GetIntegration, PatchIntegration } from '@nangohq/types';
@@ -31,6 +33,27 @@ export const McpGenericSettings: React.FC<{ data: GetIntegration['Success']['dat
             const message = 'Failed to update, an error occurred';
             toast({ title: message, variant: 'error' });
             throw new Error(message);
+        }
+    };
+
+    const handleScopesChange = async (scopes: string, countDifference: number) => {
+        try {
+            await patchIntegration({
+                authType: template.auth_mode,
+                scopes
+            } as PatchIntegration['Body']);
+            if (countDifference > 0) {
+                const plural = countDifference > 1 ? 'scopes' : 'scope';
+                toast({ title: `Added ${countDifference} new ${plural}`, variant: 'success' });
+            } else {
+                toast({ title: `Scope successfully removed`, variant: 'success' });
+            }
+        } catch (err) {
+            let errorMessage = 'Failed to update scopes';
+            if (err instanceof APIError && err.json.error.message) {
+                errorMessage = err.json.error.message;
+            }
+            throw new Error(errorMessage);
         }
     };
 
@@ -76,6 +99,12 @@ export const McpGenericSettings: React.FC<{ data: GetIntegration['Success']['dat
                     placeholder="e.g., https://example.com/logo.png"
                     validate={validateUrl}
                 />
+            </div>
+
+            {/* Scopes */}
+            <div className="flex flex-col gap-2">
+                <FieldLabel htmlFor="scopes">Scopes</FieldLabel>
+                <ScopesInput scopesString={integration.oauth_scopes || ''} onChange={handleScopesChange} />
             </div>
         </div>
     );

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -498,6 +498,9 @@
                 "registration_url": {
                     "type": "string"
                 },
+                "mcp_server_url": {
+                    "type": "string"
+                },
                 "registration_params": {
                     "type": "object",
                     "additionalProperties": {


### PR DESCRIPTION
## Describe the problem and your solution

- This pr adds configurable OAuth scopes and a static `mcp_server_url` provider override for `MCP_OAUTH2_GENERIC` integrations, with a settings UI to add/remove scopes and a create-form field for setting them upfront. Scope-joining now respects the provider's configured `scope_separator` instead of always using a space, and the settings page correctly gates all editable fields (scopes, client name/URI/logo URI) behind `environment:integrations:update` with proper feedback on failed scope updates.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

