### PR TITLE
refactor(shared): coalesce customer key lookups

### DIFF
--- a/packages/server/lib/controllers/environment/deleteApiKey.ts
+++ b/packages/server/lib/controllers/environment/deleteApiKey.ts
@@ -43,16 +43,17 @@ export const deletePublicEnvironmentApiKey = asyncWrapper<DeletePublicApiKey>(as
         return;
     }
 
-    const key = await customerKeyService.getApiKeyByUuidWithoutSecrets(db.knex, keyUuid, environment.id, account.id);
+    const key = await customerKeyService.search(db.knex, { type: 'environment', environmentId: environment.id, accountId: account.id, keyUuid });
     if (key.isErr()) {
         report(key.error, { accountId: account.id, environmentId: environment.id });
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to delete API key' } });
         return;
     }
-    if (!key.value) {
+    const found = key.value[0];
+    if (!found) {
         res.status(404).send({ error: { code: 'not_found', message: 'API key not found' } });
         return;
     }
 
-    await handleDeleteApiKey({ res, environmentId: environment.id, keyId: key.value.id });
+    await handleDeleteApiKey({ res, environmentId: environment.id, keyId: found.id });
 });

--- a/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/environment/environmentApiKeys.integration.test.ts
@@ -501,7 +501,7 @@ describe('Public environment API key management', () => {
             isError(res.json);
             expect(res.json.error).toEqual({ code: 'not_found', message: 'Environment not found' });
 
-            const remaining = (await customerKeyService.getApiKeysByEnv(db.knex, second.env.id)).unwrap();
+            const remaining = (await customerKeyService.search(db.knex, { type: 'environment', environmentId: second.env.id })).unwrap();
             expect(remaining.map((key) => key.id)).toContain(created.id);
         });
 

--- a/packages/server/lib/controllers/environment/getApiKey.ts
+++ b/packages/server/lib/controllers/environment/getApiKey.ts
@@ -35,18 +35,23 @@ export const getPublicEnvironmentApiKey = asyncWrapper<GetPublicApiKey>(async (r
         return;
     }
 
-    const key = await customerKeyService.getApiKeyByUuid(db.knex, params.data.keyUuid, environment.id, account.id);
+    const key = await customerKeyService.search(
+        db.knex,
+        { type: 'environment', environmentId: environment.id, accountId: account.id, keyUuid: params.data.keyUuid },
+        { withSecrets: true }
+    );
     if (key.isErr()) {
         report(key.error, { accountId: account.id, environmentId: environment.id, keyUuid: params.data.keyUuid });
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to retrieve API key' } });
         return;
     }
-    if (!key.value) {
+    const found = key.value[0];
+    if (!found) {
         res.status(404).send({ error: { code: 'not_found', message: 'API key not found' } });
         return;
     }
 
-    const { id, uuid, display_name, scopes, secret, last_used_at, created_at } = key.value;
+    const { id, uuid, display_name, scopes, secret, last_used_at, created_at } = found;
     res.status(200).send({
         data: {
             id,

--- a/packages/server/lib/controllers/environment/getApiKeys.ts
+++ b/packages/server/lib/controllers/environment/getApiKeys.ts
@@ -36,7 +36,7 @@ export const getPublicEnvironmentApiKeys = asyncWrapper<GetPublicApiKeys>(async 
         return;
     }
 
-    const keys = await customerKeyService.getApiKeysByEnvWithoutSecrets(db.knex, environment.id, query.data.display_name);
+    const keys = await customerKeyService.search(db.knex, { type: 'environment', environmentId: environment.id, displayName: query.data.display_name });
     if (keys.isErr()) {
         report(keys.error, { accountId: account.id, environmentId: environment.id });
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to retrieve API keys' } });

--- a/packages/server/lib/controllers/v1/account/apiKeys/listApiKeys.ts
+++ b/packages/server/lib/controllers/v1/account/apiKeys/listApiKeys.ts
@@ -13,7 +13,7 @@ export const listAccountApiKeys = asyncWrapper<ListAccountApiKeys>(async (req, r
         return;
     }
 
-    const result = await customerKeyService.getAccountApiKeys(db.knex, res.locals.account.id);
+    const result = await customerKeyService.search(db.knex, { type: 'account', accountId: res.locals.account.id }, { withSecrets: true });
     if (result.isErr()) {
         report(result.error);
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to retrieve account API keys' } });

--- a/packages/server/lib/controllers/v1/environment/listApiKeys.ts
+++ b/packages/server/lib/controllers/v1/environment/listApiKeys.ts
@@ -18,7 +18,7 @@ export const listApiKeys = asyncWrapperWithEnvironment<ListApiKeys>(async (req, 
 
     const canReadSecret = principalCan(res.locals, 'environment:settings:read_secret');
 
-    const keysResult = await customerKeyService.getApiKeysByEnv(db.knex, environment.id);
+    const keysResult = await customerKeyService.search(db.knex, { type: 'environment', environmentId: environment.id }, { withSecrets: true });
     if (keysResult.isErr()) {
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to retrieve API keys' } });
         return;

--- a/packages/server/lib/middleware/audit/apiKey.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/apiKey.middleware.unit.test.ts
@@ -4,10 +4,9 @@ import { metrics, Ok } from '@nangohq/utils';
 
 import { auditAccountApiKeyCreated, auditApiKeyCreated, auditApiKeyDeleted, auditPublicApiKeyCreated, auditPublicApiKeyDeleted } from './apiKey.middleware.js';
 import {
+    customerKeySearchMock,
     fakeReq,
     fakeRes,
-    getApiKeyByIdMock,
-    getApiKeyByUuidWithoutSecretsMock,
     getEnvironmentByIdMock,
     getEnvironmentByUuidMock,
     installAuditMockDefaults,
@@ -18,6 +17,8 @@ import {
     secretKeyLocals
 } from './testing.js';
 
+import type { CustomerKeySearch } from '@nangohq/shared';
+
 vi.mock('../../audit.js', async (importOriginal) => (await import('./testing.js')).auditModuleMock(importOriginal as never));
 vi.mock('@nangohq/shared', async (importOriginal) => (await import('./testing.js')).sharedModuleMock(importOriginal as never));
 
@@ -26,8 +27,15 @@ describe('apiKey audit middleware (unit)', () => {
         installAuditMockDefaults();
         getEnvironmentByIdMock.mockReset().mockResolvedValue({ id: 12, name: 'prod' });
         getEnvironmentByUuidMock.mockReset().mockResolvedValue({ id: 12, uuid: '00000000-0000-4000-8000-000000000012', name: 'prod' });
-        getApiKeyByIdMock.mockReset().mockResolvedValue(Ok({ uuid: 'a2f1c0de-0000-4000-8000-000000000001', display_name: 'ci-key' }));
-        getApiKeyByUuidWithoutSecretsMock.mockReset().mockResolvedValue(Ok({ id: 2551, display_name: 'ci-key' }));
+        customerKeySearchMock.mockReset().mockImplementation((_trx: unknown, filter: CustomerKeySearch) => {
+            if (filter.type === 'environment' && filter.keyId !== undefined) {
+                return Ok([{ uuid: 'a2f1c0de-0000-4000-8000-000000000001', display_name: 'ci-key' }]);
+            }
+            if (filter.type === 'environment' && filter.keyUuid !== undefined) {
+                return Ok([{ id: 2551, display_name: 'ci-key' }]);
+            }
+            return Ok([]);
+        });
     });
 
     afterEach(() => {
@@ -44,13 +52,13 @@ describe('apiKey audit middleware (unit)', () => {
             targets: [{ type: 'api_key', id: 'a2f1c0de-0000-4000-8000-000000000001', display: 'ci-key' }]
         });
         // Scoped by account and environment, so one customer's key id can never name another's key.
-        expect(getApiKeyByIdMock).toHaveBeenCalledWith(expect.anything(), 2551, 9, 42);
+        expect(customerKeySearchMock).toHaveBeenCalledWith(expect.anything(), { type: 'environment', environmentId: 9, accountId: 42, keyId: 2551 });
     });
 
     it('api key delete: a malformed key id records the attempt without a lookup', async () => {
         const event = await runAudit(auditApiKeyDeleted, fakeReq({ params: { keyId: '-1' } }), fakeRes(locals));
         expect(event).toMatchObject({ resource: 'api_key', action: 'deleted', accountId: 42 });
-        expect(getApiKeyByIdMock).not.toHaveBeenCalled();
+        expect(customerKeySearchMock).not.toHaveBeenCalled();
     });
 
     it('public api key create: names the environment the key was made in, not the one it authenticated against', async () => {
@@ -88,7 +96,12 @@ describe('apiKey audit middleware (unit)', () => {
             environment: { id: '00000000-0000-4000-8000-000000000012', display: 'prod' },
             targets: [{ type: 'api_key', id: '00000000-0000-4000-8000-000000002551', display: 'ci-key' }]
         });
-        expect(getApiKeyByUuidWithoutSecretsMock).toHaveBeenCalledWith(expect.anything(), '00000000-0000-4000-8000-000000002551', 12, 42);
+        expect(customerKeySearchMock).toHaveBeenCalledWith(expect.anything(), {
+            type: 'environment',
+            environmentId: 12,
+            accountId: 42,
+            keyUuid: '00000000-0000-4000-8000-000000002551'
+        });
         expect(accountKey?.environment).toBeNull();
     });
 
@@ -153,7 +166,7 @@ describe('apiKey audit middleware (unit)', () => {
         );
         expect(event).toMatchObject({ resource: 'api_key', action: 'deleted', accountId: 42, environment: null, targets: [] });
         expect(getEnvironmentByUuidMock).not.toHaveBeenCalled();
-        expect(getApiKeyByUuidWithoutSecretsMock).not.toHaveBeenCalled();
+        expect(customerKeySearchMock).not.toHaveBeenCalled();
     });
 
     it("public api key create: another account's environment is never named", async () => {

--- a/packages/server/lib/middleware/audit/lookups.ts
+++ b/packages/server/lib/middleware/audit/lookups.ts
@@ -8,7 +8,7 @@ import { nonEmptyString, omitUndefined, positiveInt, uuid } from './input.js';
 import type { RequestLocals } from '../../utils/express.js';
 import type { AuditTarget, AuditTargetType } from '@nangohq/audit';
 import type { ApiKeyRef } from '@nangohq/shared';
-import type { IntegrationProviderMetadata } from '@nangohq/types';
+import type { DBCustomerKey, IntegrationProviderMetadata } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { Request } from 'express';
 
@@ -65,13 +65,14 @@ export async function integrationProviderMeta(value: unknown, locals: Partial<Re
     }
 }
 
-async function apiKeyRef(lookup: () => Promise<Result<ApiKeyRef | undefined>>): Promise<ApiKeyRef | undefined> {
+async function apiKeyRef(lookup: () => Promise<Result<DBCustomerKey[]>>): Promise<ApiKeyRef | undefined> {
     try {
         const result = await lookup();
         if (result.isErr()) {
             throw result.error;
         }
-        return result.value;
+        const key = result.value[0];
+        return key ? { uuid: key.uuid, display_name: key.display_name } : undefined;
     } catch (err) {
         auditEnrichmentFailed('display', 'api_key', err);
         return undefined;
@@ -90,7 +91,7 @@ export async function apiKeyTarget(value: unknown, locals: Partial<RequestLocals
     }
     const environmentId = locals.environment.id;
     const accountId = locals.account.id;
-    return apiKeyTargetFrom(await apiKeyRef(() => customerKeyService.getApiKeyById(db.knex, numericId, environmentId, accountId)));
+    return apiKeyTargetFrom(await apiKeyRef(() => customerKeyService.search(db.knex, { type: 'environment', environmentId, accountId, keyId: numericId })));
 }
 
 export async function accountApiKeyTarget(value: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
@@ -101,7 +102,7 @@ export async function accountApiKeyTarget(value: unknown, locals: Partial<Reques
         return undefined;
     }
     const accountId = locals.account.id;
-    return apiKeyTargetFrom(await apiKeyRef(() => customerKeyService.getAccountApiKeyById(db.knex, numericId, accountId)));
+    return apiKeyTargetFrom(await apiKeyRef(() => customerKeyService.search(db.knex, { type: 'account', accountId, keyId: numericId })));
 }
 
 export function publicEnvApiKeyTarget(keyUuid: unknown, environmentUuid: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
@@ -117,11 +118,11 @@ export function publicEnvApiKeyTarget(keyUuid: unknown, environmentUuid: unknown
         if (!environment) {
             return undefined;
         }
-        const result = await customerKeyService.getApiKeyByUuidWithoutSecrets(db.knex, id, environment.id, account.id);
+        const result = await customerKeyService.search(db.knex, { type: 'environment', environmentId: environment.id, accountId: account.id, keyUuid: id });
         if (result.isErr()) {
             throw result.error;
         }
-        return result.value?.display_name;
+        return result.value[0]?.display_name;
     });
 }
 

--- a/packages/server/lib/middleware/audit/testing.ts
+++ b/packages/server/lib/middleware/audit/testing.ts
@@ -17,9 +17,7 @@ export const getAccountByIdMock: Mock = vi.fn();
 export const getPlanSafeMock: Mock = vi.fn();
 export const getEnvironmentByIdMock: Mock = vi.fn();
 export const getEnvironmentByUuidMock: Mock = vi.fn();
-export const getApiKeyByIdMock: Mock = vi.fn();
-export const getAccountApiKeyByIdMock: Mock = vi.fn();
-export const getApiKeyByUuidWithoutSecretsMock: Mock = vi.fn();
+export const customerKeySearchMock: Mock = vi.fn();
 export const getIntegrationSummaryMock: Mock = vi.fn();
 export const getConnectionByIdMock: Mock = vi.fn();
 export const getUserByIdMock: Mock = vi.fn();
@@ -36,12 +34,7 @@ export async function sharedModuleMock(importOriginal: () => Promise<typeof Nang
         getInvitation: getInvitationMock,
         getPlanSafe: getPlanSafeMock,
         environmentService: { ...actual.environmentService, getByIdWithoutSecrets: getEnvironmentByIdMock, getByUuidWithoutSecrets: getEnvironmentByUuidMock },
-        customerKeyService: {
-            ...actual.customerKeyService,
-            getApiKeyById: getApiKeyByIdMock,
-            getAccountApiKeyById: getAccountApiKeyByIdMock,
-            getApiKeyByUuidWithoutSecrets: getApiKeyByUuidWithoutSecretsMock
-        },
+        customerKeyService: { ...actual.customerKeyService, search: customerKeySearchMock },
         configService: { ...actual.configService, getIntegrationSummary: getIntegrationSummaryMock },
         accountService: { ...actual.accountService, getAccountById: getAccountByIdMock },
         connectionService: { ...actual.connectionService, getConnectionById: getConnectionByIdMock },

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -43,7 +43,7 @@ export * from './services/tags/schema.js';
 export * as gettingStartedService from './services/getting-started.service.js';
 export { MFAError, recordMFALoginRefused, recordMFAVerifyFailure, recordMFAVerifySuccess } from './services/mfa.service.js';
 export { CustomerKeyError, MAX_API_KEYS_PER_ACCOUNT } from './services/customerKey.service.js';
-export type { ApiKeyRef } from './services/customerKey.service.js';
+export type { ApiKeyRef, CustomerKeySearch } from './services/customerKey.service.js';
 export {
     GetConnectionError,
     type ConnectionIntegrationMatchRow,

--- a/packages/shared/lib/seeders/global.seeder.ts
+++ b/packages/shared/lib/seeders/global.seeder.ts
@@ -20,7 +20,7 @@ export async function seedAccountEnvAndUser({ plan: planOverride }: { plan?: Par
     const account = await createAccount();
     const env = await createEnvironmentSeed(account.id, 'dev');
     const secret = (await secretService.getDefaultSecretForEnv(db.knex, env)).unwrap();
-    const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, env.id)).unwrap();
+    const apiKeys = (await customerKeyService.search(db.knex, { type: 'environment', environmentId: env.id }, { withSecrets: true })).unwrap();
     const apiKey = apiKeys[0]!;
     const plan = (await createPlan(db.knex, { account_id: account.id, name: 'free', ...planOverride })).unwrap();
     const user = await seedUser(account.id);

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -221,7 +221,7 @@ describe('Account service', () => {
         const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.search(db.knex, { type: 'environment', environmentId: environment!.id }, { withSecrets: true })).unwrap();
 
         const bySecretKey = await accountService.getAccountContext({ secretKey: apiKeys[0]!.secret });
 
@@ -298,7 +298,9 @@ describe('Account service', () => {
         const firstEnvironment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         const secondEnvironment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
-        const [apiKey] = (await customerKeyService.getApiKeysByEnv(db.knex, firstEnvironment.id)).unwrap();
+        const [apiKey] = (
+            await customerKeyService.search(db.knex, { type: 'environment', environmentId: firstEnvironment.id }, { withSecrets: true })
+        ).unwrap();
 
         await db.knex('customer_keys_relations').insert({
             customer_key_id: apiKey!.id,
@@ -319,7 +321,9 @@ describe('Account service', () => {
         await plans.createPlan(db.knex, { account_id: firstAccount.id, name: 'free' });
         const secondAccount = await createTestAccount();
         const secondEnvironment = (await environmentService.createEnvironment(db.knex, { accountId: secondAccount.id, name: uuid() })).unwrap();
-        const [apiKey] = (await customerKeyService.getApiKeysByEnv(db.knex, firstEnvironment.id)).unwrap();
+        const [apiKey] = (
+            await customerKeyService.search(db.knex, { type: 'environment', environmentId: firstEnvironment.id }, { withSecrets: true })
+        ).unwrap();
 
         await db.knex('customer_keys_relations').where({ customer_key_id: apiKey!.id }).update({ entity_id: secondEnvironment.id });
 
@@ -347,7 +351,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.search(db.knex, { type: 'environment', environmentId: environment!.id }, { withSecrets: true })).unwrap();
 
         await db
             .knex('customer_keys')
@@ -410,7 +414,7 @@ describe('Account service', () => {
         const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.search(db.knex, { type: 'environment', environmentId: environment!.id }, { withSecrets: true })).unwrap();
         const apiKey = apiKeys[0]!;
         const signingSecret = decryptSandboxSigningSecret(apiKey)!;
         const dryrunId = '00000000-0000-4000-8000-000000000001';
@@ -514,7 +518,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.search(db.knex, { type: 'environment', environmentId: environment!.id }, { withSecrets: true })).unwrap();
         const signingSecret = decryptSandboxSigningSecret(apiKeys[0]!)!;
         const now = Date.now();
         const sandboxToken = createSandboxApiKeyToken({
@@ -535,7 +539,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.search(db.knex, { type: 'environment', environmentId: environment!.id }, { withSecrets: true })).unwrap();
         const apiKey = apiKeys[0]!;
         const signingSecret = decryptSandboxSigningSecret(apiKey)!;
 
@@ -596,7 +600,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.search(db.knex, { type: 'environment', environmentId: environment!.id }, { withSecrets: true })).unwrap();
         const customerKeySecret = apiKeys[0]!.secret;
 
         const initial = await accountService.getAccountContext({ secretKey: customerKeySecret });

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -34,7 +34,23 @@ export class CustomerKeyError extends Error {
 /** What the audit trail needs to name a key: the public identifier and its label, never its secret. */
 export type ApiKeyRef = Pick<DBCustomerKey, 'uuid' | 'display_name'>;
 
-type AccountApiKeyRecord = Pick<DBCustomerKey, 'id' | 'uuid' | 'display_name' | 'scopes' | 'secret' | 'iv' | 'tag' | 'last_used_at' | 'created_at'>;
+type EnvironmentKeySearch = {
+    type: 'environment';
+    environmentId: number;
+    accountId?: number;
+    keyId?: number;
+    keyUuid?: string;
+    displayName?: string | undefined;
+};
+
+type AccountKeySearch = {
+    type: 'account';
+    accountId: number;
+    keyId?: number;
+    keyUuid?: string;
+};
+
+export type CustomerKeySearch = EnvironmentKeySearch | AccountKeySearch;
 
 class CustomerKeyService {
     private async acquireNameLock(trx: Knex, accountId: number, keyType: string): Promise<void> {
@@ -42,12 +58,40 @@ class CustomerKeyService {
         await trx.raw(`SELECT pg_advisory_xact_lock(?) as "lock_customer_key_name_${keyType}"`, [lockKey]);
     }
 
-    private activeAccountApiKeys(trx: Knex, accountId: number) {
-        return trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
-            .where(`${CUSTOMER_KEYS_TABLE}.account_id`, accountId)
-            .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
-            .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
-            .whereRaw(`EXISTS (SELECT 1 FROM unnest(COALESCE(${CUSTOMER_KEYS_TABLE}.scopes, ARRAY[]::TEXT[])) AS scope WHERE scope LIKE 'account:%')`);
+    private customerKeysQuery(trx: Knex, filter: CustomerKeySearch) {
+        let query = trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE).where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api').whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`);
+
+        switch (filter.type) {
+            case 'environment': {
+                query = query
+                    .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
+                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
+                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, filter.environmentId);
+                if (filter.accountId !== undefined) {
+                    query = query.where(`${CUSTOMER_KEYS_TABLE}.account_id`, filter.accountId);
+                }
+                if (filter.displayName !== undefined) {
+                    query = query.where(`${CUSTOMER_KEYS_TABLE}.display_name`, filter.displayName);
+                }
+                break;
+            }
+
+            case 'account': {
+                query = query
+                    .where(`${CUSTOMER_KEYS_TABLE}.account_id`, filter.accountId)
+                    .whereRaw(`EXISTS (SELECT 1 FROM unnest(COALESCE(${CUSTOMER_KEYS_TABLE}.scopes, ARRAY[]::TEXT[])) AS scope WHERE scope LIKE 'account:%')`);
+                break;
+            }
+        }
+
+        if (filter.keyId !== undefined) {
+            query = query.where(`${CUSTOMER_KEYS_TABLE}.id`, filter.keyId);
+        }
+        if (filter.keyUuid !== undefined) {
+            query = query.where(`${CUSTOMER_KEYS_TABLE}.uuid`, filter.keyUuid);
+        }
+
+        return query;
     }
 
     /**
@@ -139,13 +183,14 @@ class CustomerKeyService {
             const created = await trx.transaction(async (innerTrx) => {
                 await this.acquireNameLock(innerTrx, accountId, 'api');
 
-                const existing = await this.activeAccountApiKeys(innerTrx, accountId).select('id').where('display_name', displayName).first();
+                const accountKeyQuery = this.customerKeysQuery(innerTrx, { type: 'account', accountId });
 
+                const existing = await accountKeyQuery.clone().select('id').where('display_name', displayName).first();
                 if (existing) {
                     throw new CustomerKeyError('duplicate_api_key', { display_name: displayName });
                 }
 
-                const count = await this.activeAccountApiKeys(innerTrx, accountId).count<{ total: string }[]>('* as total').first();
+                const count = await accountKeyQuery.clone().count<{ total: string }[]>('* as total').first();
                 if (count && Number(count.total) >= MAX_API_KEYS_PER_ACCOUNT) {
                     throw new CustomerKeyError('resource_capped', { max: MAX_API_KEYS_PER_ACCOUNT });
                 }
@@ -228,74 +273,28 @@ class CustomerKeyService {
         }
     }
 
-    public async getAccountApiKeys(trx: Knex, accountId: number): Promise<Result<AccountApiKeyRecord[]>> {
+    /**
+     * Looks up customer keys by account or environment scope, optionally narrowed to a specific
+     * key (`keyId`/`keyUuid`) or display name (environment scope only). Secrets stay encrypted
+     * unless `withSecrets` is set.
+     */
+    public async search(
+        trx: Knex,
+        filter: CustomerKeySearch,
+        { withSecrets }: { withSecrets: boolean } = { withSecrets: false }
+    ): Promise<Result<DBCustomerKey[]>> {
         try {
-            const rows = await this.activeAccountApiKeys(trx, accountId)
-                .select('id', 'uuid', 'display_name', 'scopes', 'secret', 'iv', 'tag', 'last_used_at', 'created_at')
-                .orderBy('display_name', 'asc');
+            const rows = await this.customerKeysQuery(trx, filter)
+                .select<DBCustomerKey[]>(`${CUSTOMER_KEYS_TABLE}.*`)
+                .orderBy(`${CUSTOMER_KEYS_TABLE}.display_name`, 'asc');
 
-            const decrypted = rows.map(
-                (row) => getEncryptionManager().decryptAPISecret(row as Parameters<EncryptionManager['decryptAPISecret']>[0]) as AccountApiKeyRecord
-            );
-            return Ok(decrypted);
+            const result = withSecrets
+                ? rows.map((row) => getEncryptionManager().decryptAPISecret(row as Parameters<EncryptionManager['decryptAPISecret']>[0]) as DBCustomerKey)
+                : rows;
+            return Ok(result);
         } catch (err) {
             return Err(err);
         }
-    }
-
-    public async getAccountApiKeyById(trx: Knex, keyId: number, accountId: number): Promise<Result<ApiKeyRef | undefined>> {
-        try {
-            const row = await this.activeAccountApiKeys(trx, accountId)
-                .select(`${CUSTOMER_KEYS_TABLE}.uuid`, `${CUSTOMER_KEYS_TABLE}.display_name`)
-                .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
-                .first();
-            return Ok(row ? { uuid: row.uuid, display_name: row.display_name } : undefined);
-        } catch (err) {
-            return Err(err);
-        }
-    }
-
-    public async getApiKeyById(trx: Knex, keyId: number, envId: number, accountId: number): Promise<Result<ApiKeyRef | undefined>> {
-        try {
-            const row = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
-                .select(`${CUSTOMER_KEYS_TABLE}.uuid`, `${CUSTOMER_KEYS_TABLE}.display_name`)
-                .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
-                .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
-                .where(`${CUSTOMER_KEYS_TABLE}.account_id`, accountId)
-                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
-                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
-                .first();
-            return Ok(row ? { uuid: row.uuid, display_name: row.display_name } : undefined);
-        } catch (err) {
-            return Err(err);
-        }
-    }
-
-    public async getApiKeyByUuidWithoutSecrets(trx: Knex, keyUuid: string, envId: number, accountId: number): Promise<Result<DBCustomerKey | null>> {
-        try {
-            const row = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
-                .select(`${CUSTOMER_KEYS_TABLE}.*`)
-                .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
-                .where(`${CUSTOMER_KEYS_TABLE}.uuid`, keyUuid)
-                .where(`${CUSTOMER_KEYS_TABLE}.account_id`, accountId)
-                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
-                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
-                .first();
-            return Ok(row ?? null);
-        } catch (err) {
-            return Err(err);
-        }
-    }
-
-    public async getApiKeyByUuid(trx: Knex, keyUuid: string, envId: number, accountId: number): Promise<Result<DBCustomerKey | null>> {
-        const encryptedKey = await this.getApiKeyByUuidWithoutSecrets(trx, keyUuid, envId, accountId);
-        return encryptedKey.map((key) => {
-            return key !== null ? getEncryptionManager().decryptAPISecret(key) : null;
-        });
     }
 
     public async createWebhookSigningKey(
@@ -349,57 +348,6 @@ class CustomerKeyService {
         } catch (err) {
             return Err(err);
         }
-    }
-
-    public async getApiKeysByEnv(trx: Knex, envId: number): Promise<Result<DBCustomerKey[]>> {
-        try {
-            const rows = await this.apiKeysByEnvironmentQuery(trx, envId).select<DBCustomerKey[]>(`${CUSTOMER_KEYS_TABLE}.*`);
-
-            const decrypted = rows.map(
-                (row) => getEncryptionManager().decryptAPISecret(row as Parameters<EncryptionManager['decryptAPISecret']>[0]) as DBCustomerKey
-            );
-            return Ok(decrypted);
-        } catch (err) {
-            return Err(err);
-        }
-    }
-
-    public async getApiKeysByEnvWithoutSecrets(
-        trx: Knex,
-        envId: number,
-        displayName?: string
-    ): Promise<Result<Pick<DBCustomerKey, 'id' | 'uuid' | 'display_name' | 'scopes' | 'last_used_at' | 'created_at'>[]>> {
-        try {
-            const rows = await this.apiKeysByEnvironmentQuery(trx, envId, { displayName }).select<
-                Pick<DBCustomerKey, 'id' | 'uuid' | 'display_name' | 'scopes' | 'last_used_at' | 'created_at'>[]
-            >(
-                `${CUSTOMER_KEYS_TABLE}.id`,
-                `${CUSTOMER_KEYS_TABLE}.uuid`,
-                `${CUSTOMER_KEYS_TABLE}.display_name`,
-                `${CUSTOMER_KEYS_TABLE}.scopes`,
-                `${CUSTOMER_KEYS_TABLE}.last_used_at`,
-                `${CUSTOMER_KEYS_TABLE}.created_at`
-            );
-
-            return Ok(rows);
-        } catch (err) {
-            return Err(err);
-        }
-    }
-
-    private apiKeysByEnvironmentQuery(trx: Knex, environmentId: number, { displayName }: { displayName?: string | undefined } = {}) {
-        return trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
-            .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
-            .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
-            .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, environmentId)
-            .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
-            .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
-            .modify((query) => {
-                if (displayName !== undefined) {
-                    query.where(`${CUSTOMER_KEYS_TABLE}.display_name`, displayName);
-                }
-            })
-            .orderBy(`${CUSTOMER_KEYS_TABLE}.display_name`, 'asc');
     }
 
     private webhookSigningKeyForEnv(trx: Knex, envId: number) {
@@ -588,9 +536,7 @@ class CustomerKeyService {
 
     public async deleteAccountApiKey(trx: Knex, keyId: number, accountId: number): Promise<Result<void>> {
         try {
-            const updated = await this.activeAccountApiKeys(trx, accountId)
-                .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
-                .update({ deleted_at: trx.fn.now() as unknown as Date });
+            const updated = await this.customerKeysQuery(trx, { type: 'account', accountId, keyId }).update({ deleted_at: trx.fn.now() as unknown as Date });
             if (updated === 0) {
                 return Err(new CustomerKeyError('no_such_api_secret', { id: keyId }));
             }

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -52,6 +52,24 @@ type AccountKeySearch = {
 
 export type CustomerKeySearch = EnvironmentKeySearch | AccountKeySearch;
 
+type SafeCustomerKey = Omit<
+    DBCustomerKey,
+    'secret' | 'iv' | 'tag' | 'hashed' | 'sandbox_signing_secret' | 'sandbox_signing_secret_iv' | 'sandbox_signing_secret_tag'
+>;
+
+const SAFE_CUSTOMER_KEY_COLUMNS = [
+    'id',
+    'uuid',
+    'account_id',
+    'key_type',
+    'display_name',
+    'scopes',
+    'last_used_at',
+    'deleted_at',
+    'created_at',
+    'updated_at'
+] as const satisfies readonly (keyof SafeCustomerKey)[];
+
 class CustomerKeyService {
     private async acquireNameLock(trx: Knex, accountId: number, keyType: string): Promise<void> {
         const lockKey = stringToHash(`customer_key_name:${accountId}:${keyType}`);
@@ -275,8 +293,7 @@ class CustomerKeyService {
 
     /**
      * Looks up customer keys by account or environment scope, optionally narrowed to a specific
-     * key (`keyId`/`keyUuid`) or display name (environment scope only). Secrets stay encrypted
-     * unless `withSecrets` is set.
+     * key (`keyId`/`keyUuid`) or display name. Sensitive fields are replaced with placeholders unless `withSecrets` is set.
      */
     public async search(
         trx: Knex,
@@ -284,14 +301,28 @@ class CustomerKeyService {
         { withSecrets }: { withSecrets: boolean } = { withSecrets: false }
     ): Promise<Result<DBCustomerKey[]>> {
         try {
-            const rows = await this.customerKeysQuery(trx, filter)
-                .select<DBCustomerKey[]>(`${CUSTOMER_KEYS_TABLE}.*`)
-                .orderBy(`${CUSTOMER_KEYS_TABLE}.display_name`, 'asc');
+            const query = this.customerKeysQuery(trx, filter).orderBy(`${CUSTOMER_KEYS_TABLE}.display_name`, 'asc');
 
-            const result = withSecrets
-                ? rows.map((row) => getEncryptionManager().decryptAPISecret(row as Parameters<EncryptionManager['decryptAPISecret']>[0]) as DBCustomerKey)
-                : rows;
-            return Ok(result);
+            if (withSecrets) {
+                const rows = await query.select<DBCustomerKey[]>(`${CUSTOMER_KEYS_TABLE}.*`);
+                const decrypted = rows.map(
+                    (row) => getEncryptionManager().decryptAPISecret(row as Parameters<EncryptionManager['decryptAPISecret']>[0]) as DBCustomerKey
+                );
+                return Ok(decrypted);
+            }
+
+            const rows = await query.select<SafeCustomerKey[]>(SAFE_CUSTOMER_KEY_COLUMNS.map((column) => `${CUSTOMER_KEYS_TABLE}.${column}`));
+            const withPlaceholders = rows.map((row) => ({
+                ...row,
+                secret: '',
+                iv: '',
+                tag: '',
+                hashed: '',
+                sandbox_signing_secret: null,
+                sandbox_signing_secret_iv: null,
+                sandbox_signing_secret_tag: null
+            }));
+            return Ok(withPlaceholders);
         } catch (err) {
             return Err(err);
         }


### PR DESCRIPTION
Coalesces 7 near-duplicate read methods in `customerKey.service` into one: 

`search(trx, filter, { withSecrets } = { withSecrets: false })`

Introduces a private query builder (`customerKeysQuery`) that handles both account and environment key lookups, thus replacing two near-duplicate ones that achieved the same thing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

