### PR TITLE
fix(billing): show discounted metrics as billed

### DIFF
--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -96,13 +96,13 @@ interface OrbCostBucket {
 }
 
 /**
- * A plan minimum raises `total` above `subtotal`, spreading itself across unused prices too.
- * A discount lowers it. The lower figure is what the metric earned in both cases.
+ * A plan minimum spreads itself over every price, pushing `total` above `subtotal`.
+ * A discount pulls it below. Either way, the lower number is what the customer is billed.
  */
 function chargeInCents(priceCost: { subtotal: string; total?: string | null }): number | null {
     const subtotal = orbAmountToCents(priceCost.subtotal);
-    // An absent `total` carries no adjustment to read, so the subtotal is the whole charge. An
-    // unparseable one does carry an adjustment, and reading past it would overstate the charge.
+    // No `total` at all means there is no adjustment, so `subtotal` is the whole charge. A `total`
+    // we cannot parse hides a real adjustment, so falling back would overstate what is owed.
     if (priceCost.total === undefined || priceCost.total === null) {
         return subtotal;
     }

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -20,8 +20,8 @@ import type Orb from 'orb-billing';
  * Orb money as an integer number of cents, read off the decimal string rather than via
  * `Number(x) * 100` — that is lossy, giving 1998.9999999999998 for '19.99' instead of 1999.
  */
-export function orbAmountToCents(amount: string): number | null {
-    const match = /^(-?)(\d+)(?:\.(\d*))?$/.exec(amount.trim());
+export function orbAmountToCents(amount: string | null | undefined): number | null {
+    const match = typeof amount === 'string' ? /^(-?)(\d+)(?:\.(\d*))?$/.exec(amount.trim()) : null;
     if (!match) {
         return null;
     }
@@ -90,8 +90,22 @@ interface OrbCostBucket {
     per_price_costs: {
         price_id: string;
         subtotal: string;
+        total?: string | null;
         price: { price_type: string; name: string; currency?: string | null; billable_metric?: { id: string } | null };
     }[];
+}
+
+/**
+ * A plan minimum raises `total` above `subtotal`, spreading itself across unused prices too.
+ * A discount lowers it. The lower figure is what the metric earned in both cases.
+ */
+function chargeInCents(priceCost: { subtotal: string; total?: string | null }): number | null {
+    const subtotal = orbAmountToCents(priceCost.subtotal);
+    const total = orbAmountToCents(priceCost.total);
+    if (subtotal === null || total === null) {
+        return subtotal ?? total;
+    }
+    return Math.min(subtotal, total);
 }
 
 export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, opts: { explicitTimeframe?: boolean } = {}): BillingPeriodCosts | null {
@@ -116,8 +130,7 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
 
     for (const priceCost of period.per_price_costs) {
         const { price } = priceCost;
-        // Orb spreads minimum charges and discounts across price totals. Read usage charges from `subtotal`.
-        const amountInCents = orbAmountToCents(priceCost.subtotal);
+        const amountInCents = chargeInCents(priceCost);
         const priceCurrency = normalizeIsoCurrency(price.currency);
 
         if (price.price_type === 'fixed_price') {

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -101,9 +101,15 @@ interface OrbCostBucket {
  */
 function chargeInCents(priceCost: { subtotal: string; total?: string | null }): number | null {
     const subtotal = orbAmountToCents(priceCost.subtotal);
+    // An absent `total` carries no adjustment to read, so the subtotal is the whole charge. An
+    // unparseable one does carry an adjustment, and reading past it would overstate the charge.
+    if (priceCost.total === undefined || priceCost.total === null) {
+        return subtotal;
+    }
+
     const total = orbAmountToCents(priceCost.total);
     if (subtotal === null || total === null) {
-        return subtotal ?? total;
+        return null;
     }
     return Math.min(subtotal, total);
 }

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -446,10 +446,40 @@ describe('fromOrbPeriodCosts', () => {
         expect(fromOrbPeriodCosts(costs, NOW)?.fixedInCents).toBe(25_000);
     });
 
-    it('falls back to the readable figure when only one of the two parses', () => {
+    it('rejects a total it cannot parse rather than billing the pre-adjustment subtotal', () => {
         const costs = { data: [bucket([usagePrice(RECORDS_PROD, '23.17', 'Sync records', 'price_1', 'not-a-number')])] };
 
-        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 2317 });
+        expect(fromOrbPeriodCosts(costs, NOW)).toBeNull();
+    });
+
+    it('scopes an unreadable total to its own metric, the same as an unreadable subtotal', () => {
+        const costs = {
+            data: [bucket([usagePrice(RECORDS_PROD, '1.00'), usagePrice(COMPUTE_HOURS_PROD, '23.17', 'Function compute time (h)', 'price_2', 'not-a-number')])]
+        };
+
+        const result = fromOrbPeriodCosts(costs, NOW);
+        expect(result?.metrics).toEqual({ records: 100 });
+        expect(result?.malformedMetrics).toEqual(['function_duration_seconds']);
+    });
+
+    it('flags a fixed price whose total is unreadable instead of adding the subtotal to fixed charges', () => {
+        const costs = {
+            data: [
+                bucket([
+                    usagePrice(RECORDS_PROD, '23.17'),
+                    {
+                        price_id: 'price_fixed',
+                        subtotal: '500.00',
+                        total: 'not-a-number',
+                        price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null }
+                    }
+                ])
+            ]
+        };
+
+        const result = fromOrbPeriodCosts(costs, NOW);
+        expect(result?.fixedInCents).toBe(0);
+        expect(result?.flagged).toEqual([{ priceId: 'price_fixed', priceName: 'Base fee', metric: null, amountInCents: null }]);
     });
 
     it('reads the subtotal when the payload carries no total', () => {

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -292,6 +292,11 @@ describe('orbAmountToCents', () => {
         expect(orbAmountToCents('-5.00')).toBe(-500);
     });
 
+    it('returns null when there is no amount at all, rather than throwing', () => {
+        expect(orbAmountToCents(undefined)).toBeNull();
+        expect(orbAmountToCents(null)).toBeNull();
+    });
+
     it('returns null for anything that is not a plain decimal', () => {
         expect(orbAmountToCents('')).toBeNull();
         expect(orbAmountToCents('abc')).toBeNull();
@@ -369,7 +374,14 @@ const COMPUTE_HOURS_PROD = 'ZrAoynYimCwtmFSP';
 const DATA_TRANSFER_PROD = 'RNskBsYUvTYLsjV2';
 const CONNECTIONS_PROD = '8aAyMTG6HafmZpqJ';
 
-function usagePrice(metricId: string | null, subtotal: string, name = 'Some price', priceId = 'price_1', total = subtotal) {
+interface PriceCostFixture {
+    price_id: string;
+    subtotal: string;
+    total?: string;
+    price: { price_type: string; currency: string | null; name: string; billable_metric: { id: string } | null };
+}
+
+function usagePrice(metricId: string | null, subtotal: string, name = 'Some price', priceId = 'price_1', total = subtotal): PriceCostFixture {
     return {
         price_id: priceId,
         subtotal,
@@ -378,7 +390,7 @@ function usagePrice(metricId: string | null, subtotal: string, name = 'Some pric
     };
 }
 
-function bucket(perPriceCosts: ReturnType<typeof usagePrice>[], timeframeEnd = '2026-09-01T00:00:00+00:00') {
+function bucket(perPriceCosts: PriceCostFixture[], timeframeEnd = '2026-09-01T00:00:00+00:00') {
     return { timeframe_end: timeframeEnd, per_price_costs: perPriceCosts };
 }
 
@@ -402,6 +414,58 @@ describe('fromOrbPeriodCosts', () => {
         const costs = { data: [bucket([usagePrice(CONNECTIONS_PROD, '0.29', 'Connections', 'price_1', '16.86')])] };
 
         expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ connections: 29 });
+    });
+
+    it('charges a discounted metric what was billed, not what the usage earned', () => {
+        const costs = { data: [bucket([usagePrice(COMPUTE_HOURS_PROD, '4894.88', 'Function compute time (h)', 'price_1', '4483.63')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ function_duration_seconds: 448_363 });
+    });
+
+    it('charges nothing for a metric whose usage is fully waived', () => {
+        const costs = { data: [bucket([usagePrice(COMPUTE_HOURS_PROD, '1133.53', 'Function compute time (h)', 'price_1', '0.00')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ function_duration_seconds: 0 });
+    });
+
+    it('discounts a fixed price too, so the base fee reads what was billed', () => {
+        const costs = {
+            data: [
+                bucket([
+                    usagePrice(RECORDS_PROD, '23.17'),
+                    {
+                        price_id: 'price_fixed',
+                        subtotal: '500.00',
+                        total: '250.00',
+                        price: { price_type: 'fixed_price', currency: 'USD', name: 'Base fee', billable_metric: null }
+                    }
+                ])
+            ]
+        };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.fixedInCents).toBe(25_000);
+    });
+
+    it('falls back to the readable figure when only one of the two parses', () => {
+        const costs = { data: [bucket([usagePrice(RECORDS_PROD, '23.17', 'Sync records', 'price_1', 'not-a-number')])] };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 2317 });
+    });
+
+    it('reads the subtotal when the payload carries no total', () => {
+        const costs = {
+            data: [
+                bucket([
+                    {
+                        price_id: 'price_1',
+                        subtotal: '23.17',
+                        price: { price_type: 'usage_price', currency: 'USD', name: 'Sync records', billable_metric: { id: RECORDS_PROD } }
+                    }
+                ])
+            ]
+        };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 2317 });
     });
 
     it('maps a price to its metric and converts the amount to cents', () => {


### PR DESCRIPTION
## Problem

The Charges column reads Orb's `subtotal`, which is what usage earns *before* adjustments. On an account with a discount that isn't the amount billed, so the figure shown for a month is wrong.

Reading `subtotal` was the deliberate fix for the opposite problem in [NAN-6874](https://linear.app/nango/issue/NAN-6874): a plan minimum is spread across every usage price, so `total` showed unused metrics a share of the minimum. A minimum raises `total`, a discount lowers it — one field can't be right for both.

## Solution

- Read the lower of `subtotal` and `total` per price, which is the billed figure whichever adjustment applies.
- Apply it to fixed prices too, since a discount can hit the base fee.
- Stop `orbAmountToCents` throwing on an absent amount, which turned one missing field into a 500 for the whole billing page.

Fixes [NAN-6874](https://linear.app/nango/issue/NAN-6874)

## Testing

Checked against live prod Orb. Pay-as-you-go accounts still read `subtotal`, so NAN-6874's outcome is unchanged, and every account carrying an adjustment now reads what it was billed.

Unit tests cover a discounted metric, a fully waived metric, a discounted fixed price, a payload with no `total`, and the two pre-existing minimum cases.

## Follow-ups

- If an account ever carries both a minimum and a discount, `min` picks the lower rather than composing them. None exists in prod today.
