### PR TITLE
fix(proxy): don't crash on a bare '%' in the request body for providers that don't need canonical params

### DIFF
--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -610,6 +610,14 @@ export function buildCanonicalParams(method: string, data: unknown, queryString:
             .replace(/[!'()*]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase())
             .replace(/%[0-9a-f]{2}/g, (m) => m.toUpperCase());
 
+    const safeDecodeURIComponent = (s: string): string => {
+        try {
+            return decodeURIComponent(s);
+        } catch {
+            return s;
+        }
+    };
+
     const fromQueryString = (qs: string) =>
         qs
             .split('&')
@@ -617,8 +625,8 @@ export function buildCanonicalParams(method: string, data: unknown, queryString:
             .map((pair) => {
                 const i = pair.indexOf('=');
                 return {
-                    k: decodeURIComponent((i === -1 ? pair : pair.slice(0, i)).replace(/\+/g, '%20')),
-                    v: decodeURIComponent((i === -1 ? '' : pair.slice(i + 1)).replace(/\+/g, '%20'))
+                    k: safeDecodeURIComponent((i === -1 ? pair : pair.slice(0, i)).replace(/\+/g, '%20')),
+                    v: safeDecodeURIComponent((i === -1 ? '' : pair.slice(i + 1)).replace(/\+/g, '%20'))
                 };
             })
             .sort((a, b) => a.k.localeCompare(b.k))
@@ -787,13 +795,18 @@ export function buildProxyHeaders({
         const endpointQuery = parsedUrl.search.slice(1);
         const contentTypeHeader = Object.entries(config.headers ?? {}).find(([k]) => k.toLowerCase() === 'content-type');
         const contentType = contentTypeHeader ? String(contentTypeHeader[1]) : '';
+
+        // These exist for Duo's signing spec; only compute them when a header template actually
+        // uses them, since `params` parses the body as query-string-shaped and can throw otherwise.
+        const needsCanonicalParams = headerValues.some((value) => value.includes('${awsSigV4('));
+        const usesReplacer = (name: string) => needsCanonicalParams || headerValues.some((value) => value.includes(`\${${name}}`));
         const baseReplacers = {
             endpoint: config.endpoint,
             host: parsedUrl.host,
             path: endpointPath,
-            params: buildCanonicalParams(config.method, config.data, endpointQuery),
-            urlCanonicalParams: buildCanonicalParams('GET', undefined, endpointQuery),
-            bodyCanonicalParams: getRawBody(config.method, config.data),
+            ...(usesReplacer('params') && { params: buildCanonicalParams(config.method, config.data, endpointQuery) }),
+            ...(usesReplacer('urlCanonicalParams') && { urlCanonicalParams: buildCanonicalParams('GET', undefined, endpointQuery) }),
+            ...(usesReplacer('bodyCanonicalParams') && { bodyCanonicalParams: getRawBody(config.method, config.data) }),
             contentType
         };
 

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'node:crypto';
 
 import FormData from 'form-data';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getProvider } from '@nangohq/providers';
 
@@ -780,6 +780,171 @@ describe('buildProxyHeaders', () => {
         expect(result['authorization']).toMatch(/SignedHeaders=[^,]*\bcontent-type\b/);
         expect(result['x-amz-target']).toBe('DynamoDB_20120810.GetItem');
         expect(result['content-type']).toBe('application/x-amz-json-1.0');
+    });
+
+    it('does not throw on a request body containing a bare "%" for a provider whose header templates never reference the canonical-params replacers', () => {
+        const config = getDefaultProxy({
+            method: 'PUT',
+            baseUrlOverride: 'https://s3.us-east-1.amazonaws.com',
+            data: JSON.stringify({ text: 'We closed 50% of the pipeline this quarter, up from 30% last quarter.' }),
+            provider: {
+                auth_mode: 'API_KEY',
+                proxy: {
+                    base_url: 'https://api.fireflies.ai',
+                    headers: { authorization: 'Bearer ${apiKey}' }
+                }
+            }
+        });
+
+        expect(() =>
+            buildProxyHeaders({
+                config,
+                url: 'https://s3.us-east-1.amazonaws.com/some-bucket/some-key.json',
+                connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'fireflies-key' } })
+            })
+        ).not.toThrow();
+    });
+
+    it('still computes params from the request body for a provider whose header template references ${params}', () => {
+        const config = getDefaultProxy({
+            method: 'POST',
+            data: 'name=My%20Group',
+            provider: {
+                auth_mode: 'API_KEY',
+                proxy: {
+                    base_url: 'https://api.duosecurity.com',
+                    headers: { 'x-duo-params': '${params}' }
+                }
+            }
+        });
+
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api.duosecurity.com/admin/v1/groups',
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'duo-key' } })
+        });
+
+        expect(result['x-duo-params']).toBe('name=My%20Group');
+    });
+
+    it('resolves ${params} for the real cisco-duo-admin provider config, not just a synthetic one', () => {
+        const provider = getProvider('cisco-duo-admin');
+        if (!provider) {
+            throw new Error('cisco-duo-admin provider is missing');
+        }
+
+        const config = getDefaultProxy({
+            method: 'POST',
+            data: 'realname=Test%20User',
+            provider
+        });
+
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://api-test.duosecurity.com/admin/v1/users',
+            connection: getTestConnection({
+                credentials: { type: 'BASIC', username: 'ikey', password: 'skey' },
+                connection_config: { hostname: 'api-test.duosecurity.com' }
+            })
+        });
+
+        expect(result['authorization']).not.toContain('${');
+        expect(result['authorization']).toMatch(/^Basic [A-Za-z0-9+/=]+$/);
+    });
+
+    it('resolves ${bodyCanonicalParams} for the real streamline-ai provider config end-to-end through buildProxyHeaders', () => {
+        const provider = getProvider('streamline-ai');
+        if (!provider) {
+            throw new Error('streamline-ai provider is missing');
+        }
+
+        const body = JSON.stringify({ requestFormId: 'requestform_1', status: 'submitted' });
+        const config = getDefaultProxy({
+            method: 'POST',
+            data: body,
+            provider
+        });
+
+        const result = buildProxyHeaders({
+            config,
+            url: 'https://acme.streamline.ai/api/v0/requests',
+            connection: getTestConnection({ credentials: { type: 'BASIC', username: 'slak_test123', password: 'test-ed25519-key' } })
+        });
+
+        expect(result['content-digest']).not.toContain('${');
+        expect(result['content-digest']).toBe(`sha-256=:${crypto.createHash('sha256').update(body, 'utf8').digest('base64')}:`);
+    });
+
+    describe('${awsSigV4(...)} (real aws-iam provider config)', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('signs the actual request body, not an empty one (regression: awsSigV4 does not literally contain "${bodyCanonicalParams}")', () => {
+            const provider = getProvider('aws-iam');
+            if (!provider) {
+                throw new Error('aws-iam provider is missing');
+            }
+            const connection = getTestConnection({ credentials: { type: 'BASIC', username: 'AKIAEXAMPLE', password: 'secretkeyexample' } });
+
+            const withBody = buildProxyHeaders({
+                config: getDefaultProxy({ method: 'POST', data: 'Action=ListUsers&Version=2010-05-08', provider }),
+                url: 'https://iam.amazonaws.com/',
+                connection
+            });
+            const withoutBody = buildProxyHeaders({
+                config: getDefaultProxy({ method: 'POST', provider }),
+                url: 'https://iam.amazonaws.com/',
+                connection
+            });
+
+            expect(withBody['authorization']).not.toContain('${');
+            expect(withBody['authorization']).not.toBe(withoutBody['authorization']);
+        });
+
+        it('signs the actual request body for aws-inspector2 too, whose header template also matches the connectionConfig branch', () => {
+            const provider = getProvider('aws-inspector2');
+            if (!provider) {
+                throw new Error('aws-inspector2 provider is missing');
+            }
+            const connection = getTestConnection({
+                credentials: { type: 'BASIC', username: 'AKIAEXAMPLE', password: 'secretkeyexample' },
+                connection_config: { region: 'us-east-1' }
+            });
+
+            const withBody = buildProxyHeaders({
+                config: getDefaultProxy({ method: 'POST', data: 'findingArns=arn:aws:inspector2:us-east-1:123456789012:finding/abc', provider }),
+                url: 'https://inspector2.us-east-1.amazonaws.com/',
+                connection
+            });
+            const withoutBody = buildProxyHeaders({
+                config: getDefaultProxy({ method: 'POST', provider }),
+                url: 'https://inspector2.us-east-1.amazonaws.com/',
+                connection
+            });
+
+            expect(withBody['authorization']).not.toContain('${');
+            expect(withBody['authorization']).not.toBe(withoutBody['authorization']);
+        });
+    });
+});
+
+describe('buildCanonicalParams (malformed percent-encoding)', () => {
+    it('falls back to the raw value instead of throwing on a bare "%" in a POST body', () => {
+        expect(() => buildCanonicalParams('POST', '50% of users', '')).not.toThrow();
+    });
+
+    it('falls back to the raw value instead of throwing on a bare "%" in a Buffer body', () => {
+        expect(() => buildCanonicalParams('POST', Buffer.from('50% of users'), '')).not.toThrow();
+    });
+
+    it('falls back to the raw value instead of throwing on a bare "%" in a GET query string', () => {
+        expect(() => buildCanonicalParams('GET', undefined, 'q=50% off')).not.toThrow();
     });
 });
 


### PR DESCRIPTION
## Describe the problem and your solution

- This pr fixes a crash in the proxy's canonical-params builder when a request body contains a bare `%` (invalid percent-encoding), which threw on `decodeURIComponent` for any provider whose data happened to include a literal `%` (e.g. "50% of the pipeline").  Both `buildCanonicalParams` and `fromQueryString` now fall back to the raw value on a decode failure, and canonical params (params, urlCanonicalParams, bodyCanonicalParams) are only computed when a provider's header templates actually reference them, so providers that don't use them (most of them) skip that parsing entirely.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

