### PR TITLE
fix(billing): stop dropping charges when prices change mid-month

### DIFF
--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -86,6 +86,7 @@ const orbBillableMetricToUsageMetric: Record<string, UsageMetric> = {
 };
 
 interface OrbCostBucket {
+    timeframe_start: string;
     timeframe_end: string;
     per_price_costs: {
         price_id: string;
@@ -115,16 +116,29 @@ function chargeInCents(priceCost: { subtotal: string; total?: string | null }): 
 }
 
 export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, opts: { explicitTimeframe?: boolean } = {}): BillingPeriodCosts | null {
-    // Cumulative buckets accumulate over the period, so the one ending last spans all of it.
-    const period = costs.data.reduce<OrbCostBucket | null>(
-        (latest, bucket) => (latest && Date.parse(latest.timeframe_end) >= Date.parse(bucket.timeframe_end) ? latest : bucket),
-        null
-    );
+    // Orb returns a bucket series per price-interval start date, each accumulating only within its
+    // own non-overlapping span. So the period's cost is the last bucket of every series, added up.
+    const lastPerSeries = new Map<string, OrbCostBucket>();
+    let periodEnd = NaN;
+    for (const bucket of costs.data) {
+        const end = Date.parse(bucket.timeframe_end);
+        if (Number.isNaN(end)) {
+            continue;
+        }
+        if (Number.isNaN(periodEnd) || end > periodEnd) {
+            periodEnd = end;
+        }
+        const seen = lastPerSeries.get(bucket.timeframe_start);
+        if (!seen || Date.parse(seen.timeframe_end) < end) {
+            lastPerSeries.set(bucket.timeframe_start, bucket);
+        }
+    }
     // Orb returns its last period after a subscription ends. Accept it only when the request includes dates.
-    const periodEnd = period ? Date.parse(period.timeframe_end) : NaN;
-    if (!period || Number.isNaN(periodEnd) || (!opts.explicitTimeframe && periodEnd <= now.getTime())) {
+    if (Number.isNaN(periodEnd) || (!opts.explicitTimeframe && periodEnd <= now.getTime())) {
         return null;
     }
+
+    const perPriceCosts = [...lastPerSeries.values()].flatMap((bucket) => bucket.per_price_costs);
 
     const metrics: Partial<Record<UsageMetric, number>> = {};
     const malformedMetrics: UsageMetric[] = [];
@@ -134,7 +148,7 @@ export function fromOrbPeriodCosts(costs: { data: OrbCostBucket[] }, now: Date, 
     let fullyAttributed = true;
     let currency: string | null = null;
 
-    for (const priceCost of period.per_price_costs) {
+    for (const priceCost of perPriceCosts) {
         const { price } = priceCost;
         const amountInCents = chargeInCents(priceCost);
         const priceCurrency = normalizeIsoCurrency(price.currency);

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -390,8 +390,8 @@ function usagePrice(metricId: string | null, subtotal: string, name = 'Some pric
     };
 }
 
-function bucket(perPriceCosts: PriceCostFixture[], timeframeEnd = '2026-09-01T00:00:00+00:00') {
-    return { timeframe_end: timeframeEnd, per_price_costs: perPriceCosts };
+function bucket(perPriceCosts: PriceCostFixture[], timeframeEnd = '2026-09-01T00:00:00+00:00', timeframeStart = '2026-08-01T00:00:00+00:00') {
+    return { timeframe_start: timeframeStart, timeframe_end: timeframeEnd, per_price_costs: perPriceCosts };
 }
 
 describe('fromOrbPeriodCosts', () => {
@@ -626,6 +626,67 @@ describe('fromOrbPeriodCosts', () => {
         };
 
         expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 9900 });
+    });
+
+    it('adds up the consecutive segments a mid-period plan change splits the period into', () => {
+        const costs = {
+            data: [
+                bucket([usagePrice(RECORDS_PROD, '40.00', 'Sync records', 'price_old')], '2026-08-31T21:07:31+00:00', '2026-08-01T00:00:00+00:00'),
+                bucket(
+                    [usagePrice(COMPUTE_HOURS_PROD, '4.00', 'Function compute time (h)', 'price_new')],
+                    '2026-09-01T00:00:00+00:00',
+                    '2026-08-31T21:07:31+00:00'
+                )
+            ]
+        };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 4000, function_duration_seconds: 400 });
+    });
+
+    it('reads a fixed price whose series started later than the usage prices', () => {
+        const costs = {
+            data: [
+                bucket([usagePrice(CONNECTIONS_PROD, '12.00', 'Connections', 'price_usage')], '2026-10-01T00:00:00+00:00', '2026-09-03T00:00:00+00:00'),
+                bucket(
+                    [
+                        {
+                            price_id: 'price_addon',
+                            subtotal: '360.00',
+                            total: '360.00',
+                            price: { price_type: 'fixed_price', currency: 'USD', name: 'Growth Add-on', billable_metric: null }
+                        }
+                    ],
+                    '2026-10-01T00:00:00+00:00',
+                    '2026-09-07T00:00:00+00:00'
+                )
+            ]
+        };
+
+        const result = fromOrbPeriodCosts(costs, NOW);
+        expect(result?.metrics).toEqual({ connections: 1200 });
+        expect(result?.fixedInCents).toBe(36_000);
+    });
+
+    it('keeps only the last bucket of each series, since a series accumulates', () => {
+        const costs = {
+            data: [
+                bucket([usagePrice(CONNECTIONS_PROD, '3.00', 'Connections', 'price_a')], '2026-08-15T00:00:00+00:00', '2026-08-01T00:00:00+00:00'),
+                bucket([usagePrice(CONNECTIONS_PROD, '9.00', 'Connections', 'price_a')], '2026-09-01T00:00:00+00:00', '2026-08-01T00:00:00+00:00')
+            ]
+        };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ connections: 900 });
+    });
+
+    it('skips a series whose end cannot be read rather than losing the rest', () => {
+        const costs = {
+            data: [
+                bucket([usagePrice(RECORDS_PROD, '7.00', 'Sync records', 'price_ok')], '2026-09-01T00:00:00+00:00', '2026-08-01T00:00:00+00:00'),
+                bucket([usagePrice(CONNECTIONS_PROD, '3.00', 'Connections', 'price_bad')], 'not-a-date', '2026-08-20T00:00:00+00:00')
+            ]
+        };
+
+        expect(fromOrbPeriodCosts(costs, NOW)?.metrics).toEqual({ records: 700 });
     });
 
     it('returns null for a period that has already closed', () => {


### PR DESCRIPTION
## Context

`fromOrbPeriodCosts` reads one series of Orb cost buckets and throws the rest away, so a month whose prices changed part-way through is costed from only part of itself.

No customer has lost a visible charge over this yet. It would take an immediate change between two paid plans on the same pricing, with usage on both sides of it — the mid-month upgrade path. The prod accounts that do split, like 25153, separate their usage prices from the growth add-on, and the page renders no fixed prices, so the figure on screen is unaffected. Both series also end at the same instant there, so which one the old code keeps is down to Orb's response order.

## Changes

- Take the last bucket of every series, not one bucket overall. Each bucket in a series is a running total, so the last one covers that whole stretch. The stretches don't overlap, so adding them up gives the month.
- Skip a series whose end date can't be read instead of losing the whole month to it, and report the skip so it isn't silent.

Fixes [NAN-6972](https://linear.app/nango/issue/NAN-6972)

## Testing

Backend only, so nothing to click in the preview.

Ran the patched adapter against 25153's real prod payload: both series land, and the $270 add-on is counted instead of discarded.

Tests cover a plan change splitting the month, one metric priced on both sides of it, a fixed price added later, keeping each series' last bucket, and an unreadable end date.
