### PR TITLE
docs(agent-sessions): tone down beta messaging

### DIFF
--- a/docs/guides/agent-sessions.mdx
+++ b/docs/guides/agent-sessions.mdx
@@ -20,7 +20,7 @@ Example sessions:
 - A developer agent with a team's Linear access and a user's personal GitHub access
 
 <Info>
-    Agent sessions are in public beta. We are quickly expanding agent sessions, follow our [changelog](/updates/changelog) for announcements and improvements!
+    We are quickly expanding agent sessions, follow our [changelog](/updates/changelog) for announcements and improvements!
 </Info>
 
 ## Quickstart

--- a/docs/guides/agent-sessions.mdx
+++ b/docs/guides/agent-sessions.mdx
@@ -19,9 +19,9 @@ Example sessions:
 - A finance agent with a few read-only tools on an org's accounting system, and read & write access to a team's Slack
 - A developer agent with a team's Linear access and a user's personal GitHub access
 
-<Note>
+<Info>
     Agent sessions are in public beta. We are quickly expanding agent sessions, follow our [changelog](/updates/changelog) for announcements and improvements!
-</Note>
+</Info>
 
 ## Quickstart
 

--- a/docs/guides/agent-sessions.mdx
+++ b/docs/guides/agent-sessions.mdx
@@ -4,12 +4,6 @@ sidebarTitle: 'Agent sessions'
 description: 'Optimized interface for AI agents to use integrations'
 ---
 
-<Note>
-    Agent sessions are in public beta.
-    
-    Join our [beta Slack Channel](https://join.slack.com/share/enQtMTE5NDc2MjE1MjI1OTktNWM2OGUwMzI2NWQ2OWJhMzQ5YTA5YzEyNmQzZDVkMzlhOWRlMTBlYTFhYTZlMmU3MGQyOTc1NDljY2FkMzM4NQ) for feedback and notifications of breaking changes.
-</Note>
-
 Agent sessions are an optimized interface for AI agents to use integrations.
 
 Each session has three parts:
@@ -24,6 +18,10 @@ Example sessions:
 - A sales agent with a user's personal Gmail & Google Calendar, and a read-only org-wide Salesforce connection
 - A finance agent with a few read-only tools on an org's accounting system, and read & write access to a team's Slack
 - A developer agent with a team's Linear access and a user's personal GitHub access
+
+<Note>
+    Agent sessions are in public beta. We are quickly expanding agent sessions, follow our [changelog](/updates/changelog) for announcements and improvements!
+</Note>
 
 ## Quickstart
 
@@ -362,7 +360,7 @@ You can also use `pinned` without any `any` selectors, if you already know the e
 An integration that matches no connection does not fail creation. It appears in the toolset as `connected: false`, and its tool calls fail with a missing authorization error.
 
 <Note>
-Currently there is no way for the agent to ask the user to connect an unconnected integration. Let us know on the [Beta Slack channel](https://join.slack.com/share/enQtMTE5NDc2MjE1MjI1OTktNWM2OGUwMzI2NWQ2OWJhMzQ5YTA5YzEyNmQzZDVkMzlhOWRlMTBlYTFhYTZlMmU3MGQyOTc1NDljY2FkMzM4NQ) if you need this and we are happy to prioritize it.
+Currently there is no way for the agent to ask the user to connect an unconnected integration. Let us know if you need this and we are happy to prioritize it.
 </Note>
 
 ## Toolsets & tools

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2257,12 +2257,6 @@ In both cases, your app only needs to open the Connect UI and pass the session t
 Source: https://nango.dev/docs/guides/agent-sessions.md
 Description: Optimized interface for AI agents to use integrations
 
-<Note>
-    Agent sessions are in public beta.
-    
-    Join our [beta Slack Channel](https://join.slack.com/share/enQtMTE5NDc2MjE1MjI1OTktNWM2OGUwMzI2NWQ2OWJhMzQ5YTA5YzEyNmQzZDVkMzlhOWRlMTBlYTFhYTZlMmU3MGQyOTc1NDljY2FkMzM4NQ) for feedback and notifications of breaking changes.
-</Note>
-
 Agent sessions are an optimized interface for AI agents to use integrations.
 
 Each session has three parts:
@@ -2277,6 +2271,10 @@ Example sessions:
 - A sales agent with a user's personal Gmail & Google Calendar, and a read-only org-wide Salesforce connection
 - A finance agent with a few read-only tools on an org's accounting system, and read & write access to a team's Slack
 - A developer agent with a team's Linear access and a user's personal GitHub access
+
+<Note>
+    Agent sessions are in public beta. We are quickly expanding agent sessions, follow our [changelog](/updates/changelog) for announcements and improvements!
+</Note>
 
 ## Quickstart
 
@@ -2615,7 +2613,7 @@ You can also use `pinned` without any `any` selectors, if you already know the e
 An integration that matches no connection does not fail creation. It appears in the toolset as `connected: false`, and its tool calls fail with a missing authorization error.
 
 <Note>
-Currently there is no way for the agent to ask the user to connect an unconnected integration. Let us know on the [Beta Slack channel](https://join.slack.com/share/enQtMTE5NDc2MjE1MjI1OTktNWM2OGUwMzI2NWQ2OWJhMzQ5YTA5YzEyNmQzZDVkMzlhOWRlMTBlYTFhYTZlMmU3MGQyOTc1NDljY2FkMzM4NQ) if you need this and we are happy to prioritize it.
+Currently there is no way for the agent to ask the user to connect an unconnected integration. Let us know if you need this and we are happy to prioritize it.
 </Note>
 
 ## Toolsets & tools

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2272,9 +2272,9 @@ Example sessions:
 - A finance agent with a few read-only tools on an org's accounting system, and read & write access to a team's Slack
 - A developer agent with a team's Linear access and a user's personal GitHub access
 
-<Note>
+<Info>
     Agent sessions are in public beta. We are quickly expanding agent sessions, follow our [changelog](/updates/changelog) for announcements and improvements!
-</Note>
+</Info>
 
 ## Quickstart
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2273,7 +2273,7 @@ Example sessions:
 - A developer agent with a team's Linear access and a user's personal GitHub access
 
 <Info>
-    Agent sessions are in public beta. We are quickly expanding agent sessions, follow our [changelog](/updates/changelog) for announcements and improvements!
+    We are quickly expanding agent sessions, follow our [changelog](/updates/changelog) for announcements and improvements!
 </Info>
 
 ## Quickstart


### PR DESCRIPTION
Move the public beta note from the top of the page into a callout at the
end of the intro section, drop the beta Slack channel invites, and point
readers to the changelog for announcements and improvements.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cv7nMYx7yegyKKLRwqJqBD