### PR TITLE
feat: add OAuth authorization server with Nango login and consent

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "js/ts.tsdk.path": "node_modules/typescript/lib"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15755,7 +15755,6 @@
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
             "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -15824,7 +15823,6 @@
         },
         "node_modules/@types/body-parser": {
             "version": "1.19.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/connect": "*",
@@ -15870,7 +15868,6 @@
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
             "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-            "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -15889,7 +15886,6 @@
             "version": "0.5.9",
             "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.9.tgz",
             "integrity": "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/cookie-parser": {
@@ -15906,7 +15902,6 @@
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.2.tgz",
             "integrity": "sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/connect": "*",
@@ -16054,7 +16049,6 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.2.tgz",
             "integrity": "sha512-BtjL3ZwbCQriyb0DGw+Rt12qAXPiBTPs815lsUvtt1Grk0vLRMZNMUZ741d5rjk+UQOxfDiBZ3dxpX00vSkK3g==",
-            "dev": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^5.0.0",
@@ -16065,7 +16059,6 @@
             "version": "5.0.6",
             "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
             "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
-            "dev": true,
             "dependencies": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -16114,14 +16107,12 @@
             "version": "1.5.6",
             "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.6.tgz",
             "integrity": "sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/http-errors": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
             "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/inquirer": {
@@ -16181,14 +16172,12 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
             "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/koa": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/koa/-/koa-3.0.3.tgz",
             "integrity": "sha512-TdtNEJ7sYSrFQcVuS2ySsVqnq5EyE3oJbnfFJvkC9UtGP4Kpem5KE7r+ivHIbIAQAofSqnlB5D3vkfYO69TQpg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/accepts": "*",
@@ -16205,7 +16194,6 @@
             "version": "3.2.9",
             "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.9.tgz",
             "integrity": "sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/koa": "*"
@@ -16248,7 +16236,6 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/ms": {
@@ -16309,7 +16296,6 @@
             "version": "9.12.0",
             "resolved": "https://registry.npmjs.org/@types/oidc-provider/-/oidc-provider-9.12.0.tgz",
             "integrity": "sha512-qhPxnaiwUFePlUA6TP3+4RcAeNxxXOKIxws/MJ1WRaav419kOvPmV60/t0ybJnlxoMHWntWJMLVEiK4PIOR20A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/keygrip": "*",
@@ -16398,14 +16384,12 @@
         "node_modules/@types/qs": {
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-            "dev": true
+            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="
         },
         "node_modules/@types/range-parser": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-            "dev": true
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
         },
         "node_modules/@types/react": {
             "version": "18.3.4",
@@ -16459,7 +16443,6 @@
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
             "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-            "dev": true,
             "dependencies": {
                 "@types/mime": "^1",
                 "@types/node": "*"
@@ -16467,7 +16450,6 @@
         },
         "node_modules/@types/serve-static": {
             "version": "1.15.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mime": "*",
@@ -36122,13 +36104,13 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@nangohq/egress": "file:../egress",
+                "@types/oidc-provider": "9.12.0",
                 "knex": "3.1.0",
                 "oidc-provider": "9.12.2",
                 "zod": "4.0.5"
             },
             "devDependencies": {
                 "@nangohq/database": "file:../database",
-                "@types/oidc-provider": "9.12.0",
                 "vitest": "4.1.9"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5500,6 +5500,10 @@
             "resolved": "packages/node-client",
             "link": true
         },
+        "node_modules/@nangohq/oauth-server": {
+            "resolved": "packages/oauth-server",
+            "link": true
+        },
         "node_modules/@nangohq/providers": {
             "resolved": "packages/providers",
             "link": true
@@ -15747,6 +15751,16 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/accepts": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/archiver": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.3.tgz",
@@ -15871,6 +15885,13 @@
                 "@types/express": "*"
             }
         },
+        "node_modules/@types/content-disposition": {
+            "version": "0.5.9",
+            "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.9.tgz",
+            "integrity": "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/cookie-parser": {
             "version": "1.4.8",
             "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.8.tgz",
@@ -15879,6 +15900,19 @@
             "license": "MIT",
             "peerDependencies": {
                 "@types/express": "*"
+            }
+        },
+        "node_modules/@types/cookies": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.2.tgz",
+            "integrity": "sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/connect": "*",
+                "@types/express": "*",
+                "@types/keygrip": "*",
+                "@types/node": "*"
             }
         },
         "node_modules/@types/cors": {
@@ -16076,6 +16110,20 @@
             "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
             "dev": true
         },
+        "node_modules/@types/http-assert": {
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.6.tgz",
+            "integrity": "sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/http-errors": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/inquirer": {
             "version": "9.0.7",
             "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.7.tgz",
@@ -16127,6 +16175,40 @@
             "dependencies": {
                 "@types/ms": "*",
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/keygrip": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
+            "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/koa": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/koa/-/koa-3.0.3.tgz",
+            "integrity": "sha512-TdtNEJ7sYSrFQcVuS2ySsVqnq5EyE3oJbnfFJvkC9UtGP4Kpem5KE7r+ivHIbIAQAofSqnlB5D3vkfYO69TQpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/accepts": "*",
+                "@types/content-disposition": "*",
+                "@types/cookies": "*",
+                "@types/http-assert": "*",
+                "@types/http-errors": "^2",
+                "@types/keygrip": "*",
+                "@types/koa-compose": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/koa-compose": {
+            "version": "3.2.9",
+            "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.9.tgz",
+            "integrity": "sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/koa": "*"
             }
         },
         "node_modules/@types/lodash": {
@@ -16220,6 +16302,18 @@
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/oidc-provider": {
+            "version": "9.12.0",
+            "resolved": "https://registry.npmjs.org/@types/oidc-provider/-/oidc-provider-9.12.0.tgz",
+            "integrity": "sha512-qhPxnaiwUFePlUA6TP3+4RcAeNxxXOKIxws/MJ1WRaav419kOvPmV60/t0ybJnlxoMHWntWJMLVEiK4PIOR20A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/keygrip": "*",
+                "@types/koa": "*",
                 "@types/node": "*"
             }
         },
@@ -19301,6 +19395,19 @@
             "version": "1.0.6",
             "license": "MIT"
         },
+        "node_modules/cookies": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+            "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "keygrip": "~1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/copy-anything": {
             "version": "3.0.5",
             "license": "MIT",
@@ -20233,6 +20340,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/deep-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+            "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+            "license": "MIT"
+        },
         "node_modules/deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -20339,6 +20452,12 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+            "license": "MIT"
+        },
         "node_modules/depd": {
             "version": "2.0.0",
             "license": "MIT",
@@ -20372,6 +20491,16 @@
             "dependencies": {
                 "inherits": "^2.0.1",
                 "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "node_modules/destroy": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
             }
         },
         "node_modules/detect-europe-js": {
@@ -23323,6 +23452,53 @@
                 "entities": "^4.5.0"
             }
         },
+        "node_modules/http-assert": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+            "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+            "license": "MIT",
+            "dependencies": {
+                "deep-equal": "~1.0.1",
+                "http-errors": "~1.8.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/http-assert/node_modules/depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/http-assert/node_modules/http-errors": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+            "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/http-assert/node_modules/statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/http-cache-semantics": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -24137,9 +24313,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/jose": {
-            "version": "6.2.8",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
-            "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+            "version": "6.2.12",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+            "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -24387,6 +24563,18 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "node_modules/keygrip": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+            "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+            "license": "MIT",
+            "dependencies": {
+                "tsscmp": "1.0.6"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -24449,6 +24637,166 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/koa": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+            "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^1.3.8",
+                "content-disposition": "~1.0.1",
+                "content-type": "^1.0.5",
+                "cookies": "~0.9.1",
+                "delegates": "^1.0.0",
+                "destroy": "^1.2.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "fresh": "~0.5.2",
+                "http-assert": "^1.5.0",
+                "http-errors": "^2.0.0",
+                "koa-compose": "^4.1.0",
+                "mime-types": "^3.0.1",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/koa-compose": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+            "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+            "license": "MIT"
+        },
+        "node_modules/koa/node_modules/accepts": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/koa/node_modules/content-disposition": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+            "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/koa/node_modules/fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/koa/node_modules/media-typer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/koa/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/koa/node_modules/mime-types/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/koa/node_modules/negotiator": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/koa/node_modules/type-is": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.0.0",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/koa/node_modules/type-is/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/kuler": {
@@ -26172,6 +26520,43 @@
                 "https://github.com/sponsors/sxzz",
                 "https://opencollective.com/debug"
             ],
+            "license": "MIT"
+        },
+        "node_modules/oidc-provider": {
+            "version": "9.12.2",
+            "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-9.12.2.tgz",
+            "integrity": "sha512-UaqeVpeijTocxVbDowPqPKloGjb49bxRSzHfChyI86teR+6xxoiI1V5jv8CHL2AIUmA2rg0xTZcYaC9GguympA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "jose": "^6.2.10",
+                "koa": "^3.2.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/oidc-provider/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/oidc-provider/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
         "node_modules/on-finished": {
@@ -31173,6 +31558,15 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
+        "node_modules/tsscmp": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+            "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.x"
+            }
+        },
         "node_modules/tsup": {
             "version": "8.5.1",
             "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
@@ -35722,6 +36116,31 @@
                 "node": ">= 6"
             }
         },
+        "packages/oauth-server": {
+            "name": "@nangohq/oauth-server",
+            "version": "1.0.0",
+            "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
+            "dependencies": {
+                "@nangohq/egress": "file:../egress",
+                "knex": "3.1.0",
+                "oidc-provider": "9.12.2",
+                "zod": "4.0.5"
+            },
+            "devDependencies": {
+                "@nangohq/database": "file:../database",
+                "@types/oidc-provider": "9.12.0",
+                "vitest": "4.1.9"
+            }
+        },
+        "packages/oauth-server/node_modules/zod": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
+            "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
         "packages/orchestrator": {
             "name": "@nangohq/nango-orchestrator",
             "version": "1.0.0",
@@ -36230,6 +36649,7 @@
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/nango-orchestrator": "file:../orchestrator",
                 "@nangohq/nango-yaml": "file:../nango-yaml",
+                "@nangohq/oauth-server": "file:../oauth-server",
                 "@nangohq/providers": "file:../providers",
                 "@nangohq/records": "file:../records",
                 "@nangohq/sandbox": "file:../sandbox",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16571,6 +16571,108 @@
                 "react-dom": ">=18.0.0"
             }
         },
+        "node_modules/@vitest/browser": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.9.tgz",
+            "integrity": "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@blazediff/core": "1.9.1",
+                "@vitest/mocker": "4.1.9",
+                "@vitest/utils": "4.1.9",
+                "magic-string": "^0.30.21",
+                "pngjs": "^7.0.0",
+                "sirv": "^3.0.2",
+                "tinyrainbow": "^3.1.0",
+                "ws": "^8.19.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "vitest": "4.1.9"
+            }
+        },
+        "node_modules/@vitest/browser-playwright": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.9.tgz",
+            "integrity": "sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/browser": "4.1.9",
+                "@vitest/mocker": "4.1.9",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "playwright": "*",
+                "vitest": "4.1.9"
+            },
+            "peerDependenciesMeta": {
+                "playwright": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/@vitest/browser-playwright/node_modules/tinyrainbow": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+            "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@vitest/browser/node_modules/@vitest/pretty-format": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/browser/node_modules/@vitest/utils": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.9",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/browser/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vitest/browser/node_modules/tinyrainbow": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+            "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@vitest/expect": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -16584,6 +16686,43 @@
                 "chai": "^5.2.0",
                 "tinyrainbow": "^2.0.0"
             },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.9",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+            "dev": true,
+            "license": "MIT",
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
@@ -32395,33 +32534,6 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/vitest/node_modules/@vitest/mocker": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vitest/spy": "4.1.9",
-                "estree-walker": "^3.0.3",
-                "magic-string": "^0.30.21"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "msw": "^2.4.9",
-                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "msw": {
-                    "optional": true
-                },
-                "vite": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/vitest/node_modules/@vitest/pretty-format": {
             "version": "4.1.9",
             "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
@@ -37466,6 +37578,8 @@
                 "@types/stringify-object": "4.0.5",
                 "@uidotdev/usehooks": "2.4.1",
                 "@vitejs/plugin-react-swc": "4.3.1",
+                "@vitest/browser-playwright": "4.1.9",
+                "axe-core": "4.12.0",
                 "class-variance-authority": "0.7.1",
                 "classnames": "2.5.1",
                 "clsx": "2.1.1",
@@ -37478,6 +37592,7 @@
                 "lodash": "4.18.1",
                 "lucide-react": "0.542.0",
                 "nuqs": "2.4.1",
+                "playwright": "1.61.0",
                 "postcss": "8.5.26",
                 "posthog-js": "1.212.1",
                 "qrcode.react": "4.2.0",
@@ -37502,6 +37617,7 @@
                 "vite-plugin-checker": "0.14.1",
                 "vite-plugin-svgr": "5.2.0",
                 "vitest": "4.1.9",
+                "vitest-browser-react": "2.2.0",
                 "web-vitals": "2.1.4",
                 "zod": "3.25.76",
                 "zustand": "5.0.3"

--- a/packages/database/lib/migrations/20260907162000_create_oauth_server_artifacts.cjs
+++ b/packages/database/lib/migrations/20260907162000_create_oauth_server_artifacts.cjs
@@ -6,6 +6,10 @@ const tableName = 'oauth_server_artifacts';
  * @param {import('knex').Knex} knex
  */
 exports.up = async function (knex) {
+    if (await knex.schema.hasTable(tableName)) {
+        return;
+    }
+
     await knex.schema.createTable(tableName, (table) => {
         table.bigIncrements('id').primary();
         table.text('model').notNullable();

--- a/packages/database/lib/migrations/20260907162000_create_oauth_server_artifacts.cjs
+++ b/packages/database/lib/migrations/20260907162000_create_oauth_server_artifacts.cjs
@@ -1,0 +1,33 @@
+exports.config = { transaction: true };
+
+const tableName = 'oauth_server_artifacts';
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.createTable(tableName, (table) => {
+        table.bigIncrements('id').primary();
+        table.text('model').notNullable();
+        table.binary('artifact_id_hash').notNullable();
+        table.binary('payload_encrypted').notNullable();
+        table.binary('grant_id_hash').nullable();
+        table.binary('session_uid_hash').nullable();
+        table.timestamp('expires_at', { useTz: true }).notNullable();
+        table.timestamp('consumed_at', { useTz: true }).nullable();
+        table.timestamp('revoked_at', { useTz: true }).nullable();
+        table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+        table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+
+        table.unique(['model', 'artifact_id_hash'], {
+            indexName: 'oauth_artifacts_model_id_unique'
+        });
+        table.index(['expires_at'], 'oauth_artifacts_expires_at_idx');
+        table.index(['grant_id_hash'], 'oauth_artifacts_grant_idx');
+        table.index(['model', 'session_uid_hash'], 'oauth_artifacts_model_session_idx');
+    });
+};
+
+exports.down = async function () {
+    // Deliberately preserve OAuth grants and tokens during a code rollback.
+};

--- a/packages/database/lib/migrations/20260909160000_create_oauth_consent.cjs
+++ b/packages/database/lib/migrations/20260909160000_create_oauth_consent.cjs
@@ -1,0 +1,63 @@
+exports.config = { transaction: true };
+
+/** @param {import('knex').Knex} knex */
+exports.up = async function (knex) {
+    await knex.raw(`
+        CREATE TABLE oauth_product_grants (
+            id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            provider_grant_hash BYTEA NOT NULL UNIQUE,
+            user_id INTEGER NOT NULL REFERENCES _nango_users(id) ON DELETE CASCADE,
+            account_id INTEGER NOT NULL REFERENCES _nango_accounts(id) ON DELETE CASCADE,
+            client_id TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (status IN ('pending', 'active', 'revoked')),
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            revoked_at TIMESTAMPTZ
+        );
+        CREATE INDEX oauth_product_grants_user_idx ON oauth_product_grants(user_id, status);
+        CREATE INDEX oauth_product_grants_account_idx ON oauth_product_grants(account_id);
+        CREATE INDEX oauth_product_grants_pending_idx ON oauth_product_grants(created_at) WHERE status = 'pending';
+        CREATE TABLE oauth_product_grant_resources (
+            grant_id UUID NOT NULL REFERENCES oauth_product_grants(id) ON DELETE CASCADE,
+            resource TEXT NOT NULL,
+            scopes TEXT[] NOT NULL,
+            PRIMARY KEY(grant_id, resource)
+        );
+        CREATE TABLE oauth_login_handoffs (
+            state_hash BYTEA PRIMARY KEY,
+            browser_hash BYTEA NOT NULL,
+            interaction_uid TEXT NOT NULL,
+            issuer TEXT NOT NULL,
+            return_to TEXT NOT NULL,
+            user_id INTEGER REFERENCES _nango_users(id) ON DELETE CASCADE,
+            account_id INTEGER REFERENCES _nango_accounts(id) ON DELETE CASCADE,
+            code_hash BYTEA UNIQUE,
+            code_expires_at TIMESTAMPTZ,
+            consumed_at TIMESTAMPTZ,
+            expires_at TIMESTAMPTZ NOT NULL
+        );
+        CREATE INDEX oauth_login_handoffs_expiry_idx ON oauth_login_handoffs(expires_at);
+        CREATE INDEX oauth_login_handoffs_user_idx ON oauth_login_handoffs(user_id);
+        CREATE INDEX oauth_login_handoffs_account_idx ON oauth_login_handoffs(account_id);
+        CREATE TABLE oauth_login_sessions (
+            token_hash BYTEA PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES _nango_users(id) ON DELETE CASCADE,
+            account_id INTEGER NOT NULL REFERENCES _nango_accounts(id) ON DELETE CASCADE,
+            expires_at TIMESTAMPTZ NOT NULL
+        );
+        CREATE INDEX oauth_login_sessions_expiry_idx ON oauth_login_sessions(expires_at);
+        CREATE INDEX oauth_login_sessions_user_idx ON oauth_login_sessions(user_id);
+        CREATE INDEX oauth_login_sessions_account_idx ON oauth_login_sessions(account_id);
+        CREATE TABLE oauth_consent_decisions (
+            interaction_hash BYTEA PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES _nango_users(id) ON DELETE CASCADE,
+            expires_at TIMESTAMPTZ NOT NULL
+        );
+        CREATE INDEX oauth_consent_decisions_expiry_idx ON oauth_consent_decisions(expires_at);
+        CREATE INDEX oauth_consent_decisions_user_idx ON oauth_consent_decisions(user_id);
+    `);
+};
+
+exports.down = async function () {
+    // Preserve grants and revocation state during a code rollback, as with provider artifacts.
+};

--- a/packages/database/lib/migrations/20260909160000_create_oauth_consent.cjs
+++ b/packages/database/lib/migrations/20260909160000_create_oauth_consent.cjs
@@ -23,31 +23,6 @@ exports.up = async function (knex) {
             scopes TEXT[] NOT NULL,
             PRIMARY KEY(grant_id, resource)
         );
-        CREATE TABLE oauth_login_handoffs (
-            state_hash BYTEA PRIMARY KEY,
-            browser_hash BYTEA NOT NULL,
-            interaction_uid TEXT NOT NULL,
-            issuer TEXT NOT NULL,
-            return_to TEXT NOT NULL,
-            user_id INTEGER REFERENCES _nango_users(id) ON DELETE CASCADE,
-            account_id INTEGER REFERENCES _nango_accounts(id) ON DELETE CASCADE,
-            code_hash BYTEA UNIQUE,
-            code_expires_at TIMESTAMPTZ,
-            consumed_at TIMESTAMPTZ,
-            expires_at TIMESTAMPTZ NOT NULL
-        );
-        CREATE INDEX oauth_login_handoffs_expiry_idx ON oauth_login_handoffs(expires_at);
-        CREATE INDEX oauth_login_handoffs_user_idx ON oauth_login_handoffs(user_id);
-        CREATE INDEX oauth_login_handoffs_account_idx ON oauth_login_handoffs(account_id);
-        CREATE TABLE oauth_login_sessions (
-            token_hash BYTEA PRIMARY KEY,
-            user_id INTEGER NOT NULL REFERENCES _nango_users(id) ON DELETE CASCADE,
-            account_id INTEGER NOT NULL REFERENCES _nango_accounts(id) ON DELETE CASCADE,
-            expires_at TIMESTAMPTZ NOT NULL
-        );
-        CREATE INDEX oauth_login_sessions_expiry_idx ON oauth_login_sessions(expires_at);
-        CREATE INDEX oauth_login_sessions_user_idx ON oauth_login_sessions(user_id);
-        CREATE INDEX oauth_login_sessions_account_idx ON oauth_login_sessions(account_id);
         CREATE TABLE oauth_consent_decisions (
             interaction_hash BYTEA PRIMARY KEY,
             user_id INTEGER NOT NULL REFERENCES _nango_users(id) ON DELETE CASCADE,

--- a/packages/egress/lib/agent.ts
+++ b/packages/egress/lib/agent.ts
@@ -37,7 +37,14 @@ async function resolvePinnedAddresses(hostname: string, policy: OutboundUrlPolic
         return cached.addresses;
     }
 
-    const url = `http://${formatHostForUrlAuthority(hostname)}/`;
+    const scheme = policy.allowedSchemes.values().next().value;
+    if (!scheme) {
+        throw new Error('Outbound URL policy must allow at least one scheme');
+    }
+    // A DNS lookup receives only a hostname, not the original request URL. Use one of the
+    // policy's allowed schemes for hostname validation rather than inventing an HTTP URL,
+    // which would incorrectly reject callers whose policy deliberately allows HTTPS only.
+    const url = `${scheme}//${formatHostForUrlAuthority(hostname)}/`;
     const syncResult = validateOutboundUrlSync(url, policy);
     if (!syncResult.ok) {
         throw syncResult.error;

--- a/packages/egress/lib/egress.unit.test.ts
+++ b/packages/egress/lib/egress.unit.test.ts
@@ -364,6 +364,14 @@ describe('egress safe lookup pinning', () => {
         await expect(lookupVia(lookupFn, 'rebind.example')).rejects.toThrow(OutboundUrlError);
     });
 
+    it('supports DNS pinning for an HTTPS-only policy', async () => {
+        vi.spyOn(dns, 'lookup').mockResolvedValue([{ address: '8.8.8.8', family: 4 }] as never);
+        const httpsOnly = { ...policy, allowedSchemes: new Set(['https:']) };
+        const lookupFn = createSafeHttpAgents(httpsOnly).httpsAgent.options.lookup!;
+
+        await expect(lookupVia(lookupFn, 'client.example.com')).resolves.toBe('8.8.8.8');
+    });
+
     it('uses a single DNS lookup for pinning and reuses it within TTL', async () => {
         vi.useFakeTimers();
         const lookupSpy = vi.spyOn(dns, 'lookup').mockResolvedValue([{ address: '8.8.8.8', family: 4 }] as never);

--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -13,6 +13,9 @@ import type { FeatureFlagsClient } from './client.js';
  */
 export function buildFlags(client: FeatureFlagsClient) {
     return {
+        isOAuthConsentEnabled(accountUuid?: string) {
+            return client.isEnabled('oauth-server-consent', { targetingKey: accountUuid ?? 'anonymous', accountUuid }, false);
+        },
         /**
          * Whether OAuth callbacks missing the state cookie should be rejected for this account.
          * Default `false`

--- a/packages/oauth-server/lib/adapter.integration.test.ts
+++ b/packages/oauth-server/lib/adapter.integration.test.ts
@@ -1,0 +1,138 @@
+import { generateKeyPairSync } from 'node:crypto';
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import db, { multipleMigrations } from '@nangohq/database';
+
+import { createOAuthAdapter, deleteExpiredOAuthArtifacts, OAUTH_SERVER_ARTIFACTS_TABLE } from './adapter.js';
+import { createOAuthProvider } from './provider.js';
+
+import type { AdapterPayload } from 'oidc-provider';
+
+const encryptionKey = Buffer.alloc(32, 's').toString('base64');
+describe('PostgreSQL OAuth provider adapter', () => {
+    beforeAll(async () => {
+        await multipleMigrations();
+    });
+
+    beforeEach(async () => {
+        await db.knex(OAUTH_SERVER_ARTIFACTS_TABLE).delete();
+    });
+
+    it('persists encrypted artifacts across adapter instances without storing raw identifiers', async () => {
+        const id = 'raw-authorization-code';
+        const grantId = 'raw-grant-id';
+        const payload = artifactPayload('AuthorizationCode', grantId);
+        await adapter('AuthorizationCode').upsert(id, payload, 60);
+
+        const restartedAdapter = adapter('AuthorizationCode');
+        await expect(restartedAdapter.find(id)).resolves.toStrictEqual(payload);
+        const row = await db
+            .knex(OAUTH_SERVER_ARTIFACTS_TABLE)
+            .first<{ artifact_id_hash: Buffer; grant_id_hash: Buffer; payload_encrypted: Buffer }>('artifact_id_hash', 'grant_id_hash', 'payload_encrypted');
+        if (!row) throw new Error('OAuth artifact was not persisted');
+        expect(row.artifact_id_hash).toHaveLength(32);
+        expect(row.grant_id_hash).toHaveLength(32);
+        expect(row.artifact_id_hash.toString()).not.toContain(id);
+        expect(row.grant_id_hash.toString()).not.toContain(grantId);
+        expect(row.payload_encrypted.toString()).not.toContain(id);
+        expect(row.payload_encrypted.toString()).not.toContain(grantId);
+    });
+
+    it('restores sessions and grants across provider instances', async () => {
+        const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+        const options = {
+            knex: db.knex,
+            config: {
+                baseUrl: 'http://localhost',
+                cookieKeys: ['a'.repeat(32), 'b'.repeat(32)],
+                encryptionKey,
+                jwks: { keys: [{ ...privateKey.export({ format: 'jwk' }), kid: 'integration-key', use: 'sig', alg: 'RS256' }] }
+            },
+            resources: [{ resource: 'https://mcp.example.com/mcp', scopes: ['environment:*'] }]
+        };
+        const first = createOAuthProvider(options);
+        const session = new first.Session();
+        session.loginAccount({ accountId: 'account-uuid', amr: ['test'] });
+        const sessionId = await session.save(60);
+        const grant = new first.Grant({ accountId: 'account-uuid', clientId: 'https://client.example.com/metadata.json' });
+        grant.addOIDCScope('environment:*');
+        grant.addResourceScope('https://mcp.example.com/mcp', 'environment:*');
+        const grantId = await grant.save();
+
+        const second = createOAuthProvider(options);
+        const restoredSession = await second.Session.find(sessionId);
+        const restoredByUid = await second.Session.findByUid(session.uid);
+        const restoredGrant = await second.Grant.find(grantId);
+
+        expect(restoredSession?.accountId).toBe('account-uuid');
+        expect(restoredByUid?.jti).toBe(sessionId);
+        expect(restoredGrant?.getResourceScope('https://mcp.example.com/mcp')).toBe('environment:*');
+    });
+
+    it('revokes the grant when concurrent requests replay a single-use artifact', async () => {
+        const refreshToken = adapter('RefreshToken');
+        const accessToken = adapter('AccessToken');
+        const grantId = 'grant-1';
+        await refreshToken.upsert('single-use-refresh', artifactPayload('RefreshToken', grantId), 60);
+        await accessToken.upsert('existing-access-token', artifactPayload('AccessToken', grantId), 60);
+
+        const results = await Promise.allSettled([refreshToken.consume('single-use-refresh'), adapter('RefreshToken').consume('single-use-refresh')]);
+
+        expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+        expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+        await expect(refreshToken.find('single-use-refresh')).resolves.toBeUndefined();
+        await expect(accessToken.find('existing-access-token')).resolves.toBeUndefined();
+        await expect(refreshToken.upsert('late-refresh', artifactPayload('RefreshToken', grantId), 60)).rejects.toThrow(/revoked OAuth grant/);
+    });
+
+    it('serializes grant revocation with artifact creation and rejects late writes', async () => {
+        const grantId = 'racing-grant';
+        const accessToken = adapter('AccessToken');
+        const payload = artifactPayload('AccessToken', grantId);
+
+        await Promise.allSettled([accessToken.upsert('racing-token', payload, 600), adapter('Grant').revokeByGrantId(grantId)]);
+
+        await expect(accessToken.find('racing-token')).resolves.toBeUndefined();
+        await expect(accessToken.upsert('late-token', payload, 600)).rejects.toThrow(/revoked OAuth grant/);
+        const tombstone = await db.knex(OAUTH_SERVER_ARTIFACTS_TABLE).where({ model: 'GrantRevocation' }).first<{ id: string }>('id');
+        expect(tombstone).toBeDefined();
+    });
+
+    it('rejects expired artifacts independently and deletes them in bounded batches', async () => {
+        await adapter('AuthorizationCode').upsert('expired-code', artifactPayload('AuthorizationCode', 'grant-expired'), -10);
+        await adapter('RefreshToken').upsert('expired-refresh', artifactPayload('RefreshToken', 'grant-expired'), -10);
+        await adapter('AccessToken').upsert('active-token', artifactPayload('AccessToken', 'grant-active'), 600);
+
+        await expect(adapter('AuthorizationCode').find('expired-code')).resolves.toBeUndefined();
+        await expect(deleteExpiredOAuthArtifacts(db.knex, 1)).resolves.toBe(1);
+        await expect(deleteExpiredOAuthArtifacts(db.knex, 1)).resolves.toBe(1);
+        await expect(deleteExpiredOAuthArtifacts(db.knex, 1)).resolves.toBe(0);
+        await expect(adapter('AccessToken').find('active-token')).resolves.toBeDefined();
+    });
+
+    it('fails loudly for disabled models and never persists clients', async () => {
+        expect(() => adapter('DeviceCode')).toThrow('Unsupported OAuth provider model: DeviceCode');
+        await expect(adapter('AuthorizationCode').findByUserCode('unused-device-code')).resolves.toBeUndefined();
+        await expect(adapter('Client').upsert('https://client.example.com/metadata.json', {}, 60)).rejects.toThrow('Persisted OAuth clients are disabled');
+    });
+});
+
+function adapter(model: string) {
+    return createOAuthAdapter({
+        knex: db.knex,
+        encryptionKey
+    })(model);
+}
+
+function artifactPayload(kind: string, grantId: string): AdapterPayload {
+    const now = Math.floor(Date.now() / 1000);
+    return {
+        kind,
+        grantId,
+        accountId: 'account-uuid',
+        clientId: 'https://client.example.com/metadata.json',
+        iat: now,
+        exp: now + 600
+    };
+}

--- a/packages/oauth-server/lib/adapter.integration.test.ts
+++ b/packages/oauth-server/lib/adapter.integration.test.ts
@@ -7,6 +7,7 @@ import db, { multipleMigrations } from '@nangohq/database';
 import { createOAuthAdapter, deleteExpiredOAuthArtifacts, OAUTH_SERVER_ARTIFACTS_TABLE } from './adapter.js';
 import { createOAuthProvider } from './provider.js';
 
+import type { Knex } from 'knex';
 import type { AdapterPayload } from 'oidc-provider';
 
 const encryptionKey = Buffer.alloc(32, 's').toString('base64');
@@ -86,6 +87,39 @@ describe('PostgreSQL OAuth provider adapter', () => {
         await expect(refreshToken.upsert('late-refresh', artifactPayload('RefreshToken', grantId), 60)).rejects.toThrow(/revoked OAuth grant/);
     });
 
+    it('does not consume an artifact that expires while waiting for its row lock', async () => {
+        const authorizationCode = adapter('AuthorizationCode');
+        await authorizationCode.upsert('expiring-code', artifactPayload('AuthorizationCode', 'grant-expiring'), 60);
+        const row = await db.knex(OAUTH_SERVER_ARTIFACTS_TABLE).where({ model: 'AuthorizationCode' }).first<{ id: string }>('id');
+        if (!row) throw new Error('OAuth authorization code was not persisted');
+
+        const blocker = await db.knex.transaction();
+        const consumer = await db.knex.transaction();
+        try {
+            await blocker(OAUTH_SERVER_ARTIFACTS_TABLE).where({ id: row.id }).forUpdate().first('id');
+            const { rows } = await consumer.raw<{ rows: { pid: number }[] }>('SELECT pg_backend_pid() AS pid');
+            const backend = rows[0];
+            if (!backend) throw new Error('Consumer transaction has no PostgreSQL backend');
+
+            const consumed = adapter('AuthorizationCode', consumer).consume('expiring-code');
+            await waitForDatabaseLock(backend.pid);
+            await blocker(OAUTH_SERVER_ARTIFACTS_TABLE)
+                .where({ id: row.id })
+                .update({ expires_at: new Date(Date.now() + 100), updated_at: new Date() });
+            await new Promise((resolve) => setTimeout(resolve, 150));
+            await blocker.commit();
+
+            await expect(consumed).rejects.toThrow('invalid_grant');
+            await consumer.commit();
+        } finally {
+            if (!blocker.isCompleted()) await blocker.rollback();
+            if (!consumer.isCompleted()) await consumer.rollback();
+        }
+
+        const persisted = await db.knex(OAUTH_SERVER_ARTIFACTS_TABLE).where({ id: row.id }).first<{ consumed_at: Date | null }>('consumed_at');
+        expect(persisted?.consumed_at).toBeNull();
+    });
+
     it('serializes grant revocation with artifact creation and rejects late writes', async () => {
         const grantId = 'racing-grant';
         const accessToken = adapter('AccessToken');
@@ -111,6 +145,36 @@ describe('PostgreSQL OAuth provider adapter', () => {
         await expect(adapter('AccessToken').find('active-token')).resolves.toBeDefined();
     });
 
+    it('does not delete an artifact renewed while cleanup waits for its row', async () => {
+        const session = adapter('Session');
+        await session.upsert('renewed-session', artifactPayload('Session', 'grant-renewed'), -10);
+        const row = await db.knex(OAUTH_SERVER_ARTIFACTS_TABLE).where({ model: 'Session' }).first<{ id: string }>('id');
+        if (!row) throw new Error('OAuth session was not persisted');
+
+        const renewal = await db.knex.transaction();
+        const cleanup = await db.knex.transaction();
+        try {
+            await renewal(OAUTH_SERVER_ARTIFACTS_TABLE)
+                .where({ id: row.id })
+                .update({ expires_at: new Date(Date.now() + 60_000), updated_at: new Date() });
+            const { rows } = await cleanup.raw<{ rows: { pid: number }[] }>('SELECT pg_backend_pid() AS pid');
+            const backend = rows[0];
+            if (!backend) throw new Error('Cleanup transaction has no PostgreSQL backend');
+
+            const deleted = deleteExpiredOAuthArtifacts(cleanup, 1);
+            await waitForDatabaseLock(backend.pid);
+            await renewal.commit();
+
+            await expect(deleted).resolves.toBe(0);
+            await cleanup.commit();
+        } finally {
+            if (!renewal.isCompleted()) await renewal.rollback();
+            if (!cleanup.isCompleted()) await cleanup.rollback();
+        }
+
+        await expect(session.find('renewed-session')).resolves.toBeDefined();
+    });
+
     it('fails loudly for disabled models and never persists clients', async () => {
         expect(() => adapter('DeviceCode')).toThrow('Unsupported OAuth provider model: DeviceCode');
         await expect(adapter('AuthorizationCode').findByUserCode('unused-device-code')).resolves.toBeUndefined();
@@ -118,9 +182,9 @@ describe('PostgreSQL OAuth provider adapter', () => {
     });
 });
 
-function adapter(model: string) {
+function adapter(model: string, knex: Knex = db.knex) {
     return createOAuthAdapter({
-        knex: db.knex,
+        knex,
         encryptionKey
     })(model);
 }
@@ -135,4 +199,14 @@ function artifactPayload(kind: string, grantId: string): AdapterPayload {
         iat: now,
         exp: now + 600
     };
+}
+
+async function waitForDatabaseLock(pid: number): Promise<void> {
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+        const activity = await db.knex('pg_stat_activity').where({ pid }).first<{ wait_event_type: string | null }>('wait_event_type');
+        if (activity?.wait_event_type === 'Lock') return;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error('Cleanup query did not wait for the concurrent session renewal');
 }

--- a/packages/oauth-server/lib/adapter.ts
+++ b/packages/oauth-server/lib/adapter.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import { errors } from 'oidc-provider';
 
 import { createArtifactCrypto } from './crypto.js';
@@ -11,6 +13,17 @@ export const OAUTH_GRANT_TTL_SECONDS = 30 * 24 * 60 * 60;
 const CLIENT_MODEL = 'Client';
 const REVOCATION_MODEL = 'GrantRevocation';
 const SUPPORTED_MODELS = new Set(['AccessToken', 'AuthorizationCode', 'Client', 'Grant', 'Interaction', 'RefreshToken', 'Session']);
+const transactions = new AsyncLocalStorage<Knex.Transaction>();
+
+/** Share the embedding application's transaction with provider persistence for this async call only. */
+export function withOAuthTransaction<T>(trx: Knex.Transaction, fn: () => Promise<T>): Promise<T> {
+    return transactions.run(trx, fn);
+}
+
+/** Wait for the application transaction, not an adapter savepoint, to commit. */
+export function oauthTransactionCommitted(trx: Knex.Transaction): Promise<unknown> {
+    return (transactions.getStore() ?? trx).executionPromise;
+}
 
 interface ArtifactRow {
     artifact_id_hash: Buffer;
@@ -21,9 +34,10 @@ interface ArtifactRow {
     revoked_at: Date | null;
 }
 
-interface OAuthAdapterOptions {
+export interface OAuthAdapterOptions {
     knex: Knex;
     encryptionKey: string;
+    beforeGrantRevoked?: ((trx: Knex.Transaction, grantIdHash: Buffer) => Promise<void>) | undefined;
 }
 
 export function createOAuthAdapter(options: OAuthAdapterOptions): (model: string) => Adapter {
@@ -32,6 +46,10 @@ export function createOAuthAdapter(options: OAuthAdapterOptions): (model: string
 
 class PostgresOAuthAdapter implements Adapter {
     private readonly crypto;
+
+    private get knex(): Knex {
+        return transactions.getStore() ?? this.options.knex;
+    }
 
     constructor(
         private readonly model: string,
@@ -62,7 +80,7 @@ class PostgresOAuthAdapter implements Adapter {
             updated_at: now
         };
 
-        await this.options.knex.transaction(async (trx) => {
+        await this.knex.transaction(async (trx) => {
             if (grantIdHash) {
                 await lockGrant(trx, grantIdHash);
                 const revoked = await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
@@ -104,7 +122,7 @@ class PostgresOAuthAdapter implements Adapter {
 
     async consume(id: string): Promise<void> {
         const artifactIdHash = this.crypto.hash(id);
-        const outcome = await this.options.knex.transaction(async (trx) => {
+        const outcome = await this.knex.transaction(async (trx) => {
             // Read the immutable grant hash first so every grant-related operation acquires
             // the advisory lock before taking row locks. This avoids a lock-order deadlock
             // with concurrent grant revocation.
@@ -125,7 +143,13 @@ class PostgresOAuthAdapter implements Adapter {
             }
             if (row.consumed_at) {
                 if (row.grant_id_hash) {
-                    await this.revokeGrant(trx, row.grant_id_hash, consumedAt, { reason: 'artifact_replay' });
+                    await revokeOAuthGrantArtifactsInTransaction({
+                        trx,
+                        encryptionKey: this.options.encryptionKey,
+                        grantIdHash: row.grant_id_hash,
+                        beforeGrantRevoked: this.options.beforeGrantRevoked,
+                        payload: { reason: 'artifact_replay' }
+                    });
                 }
                 return 'replayed';
             }
@@ -152,50 +176,22 @@ class PostgresOAuthAdapter implements Adapter {
         if (this.model === CLIENT_MODEL) {
             return;
         }
-        await this.options
-            .knex(OAUTH_SERVER_ARTIFACTS_TABLE)
+        await this.knex(OAUTH_SERVER_ARTIFACTS_TABLE)
             .where({ model: this.model, artifact_id_hash: this.crypto.hash(id) })
             .delete();
     }
 
     async revokeByGrantId(grantId: string): Promise<void> {
         const grantIdHash = this.crypto.hash(grantId);
-        const now = new Date();
-        const expiresAt = new Date(now.getTime() + OAUTH_GRANT_TTL_SECONDS * 1000);
-
-        await this.options.knex.transaction(async (trx) => {
-            await lockGrant(trx, grantIdHash);
-            await this.revokeGrant(trx, grantIdHash, now, { grantId }, expiresAt);
+        await this.knex.transaction(async (trx) => {
+            await revokeOAuthGrantArtifactsInTransaction({
+                trx,
+                encryptionKey: this.options.encryptionKey,
+                grantIdHash,
+                beforeGrantRevoked: this.options.beforeGrantRevoked,
+                payload: { grantId }
+            });
         });
-    }
-
-    private async revokeGrant(
-        trx: Knex.Transaction,
-        grantIdHash: Buffer,
-        revokedAt: Date,
-        payload: Record<string, string>,
-        expiresAt = new Date(revokedAt.getTime() + OAUTH_GRANT_TTL_SECONDS * 1000)
-    ): Promise<void> {
-        await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
-            .insert({
-                model: REVOCATION_MODEL,
-                artifact_id_hash: grantIdHash,
-                payload_encrypted: this.crypto.encrypt(REVOCATION_MODEL, grantIdHash, payload),
-                grant_id_hash: grantIdHash,
-                session_uid_hash: null,
-                expires_at: expiresAt,
-                consumed_at: null,
-                revoked_at: revokedAt,
-                created_at: revokedAt,
-                updated_at: revokedAt
-            })
-            .onConflict(['model', 'artifact_id_hash'])
-            .merge({ expires_at: expiresAt, revoked_at: revokedAt, updated_at: revokedAt });
-
-        await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
-            .where({ grant_id_hash: grantIdHash })
-            .whereNot({ model: REVOCATION_MODEL })
-            .update({ revoked_at: revokedAt, updated_at: revokedAt });
     }
 
     private async findByHash(column: 'artifact_id_hash' | 'session_uid_hash', hash: Buffer): Promise<AdapterPayload | undefined> {
@@ -203,8 +199,7 @@ class PostgresOAuthAdapter implements Adapter {
             return undefined;
         }
 
-        const row = await this.options
-            .knex(OAUTH_SERVER_ARTIFACTS_TABLE)
+        const row = await this.knex(OAUTH_SERVER_ARTIFACTS_TABLE)
             .where({ model: this.model, revoked_at: null })
             .where(column, hash)
             .where('expires_at', '>', new Date())
@@ -219,6 +214,54 @@ class PostgresOAuthAdapter implements Adapter {
         }
         return payload;
     }
+}
+
+export function hashOAuthGrantId(encryptionKey: string, grantId: string): Buffer {
+    return createArtifactCrypto(encryptionKey).hash(grantId);
+}
+
+export async function revokeOAuthGrantArtifactsInTransaction({
+    trx,
+    encryptionKey,
+    grantIdHash,
+    beforeGrantRevoked,
+    payload = { reason: 'product_grant_revoked' }
+}: {
+    trx: Knex.Transaction;
+    encryptionKey: string;
+    grantIdHash: Buffer;
+    beforeGrantRevoked?: ((trx: Knex.Transaction, grantIdHash: Buffer) => Promise<void>) | undefined;
+    payload?: Record<string, string> | undefined;
+}): Promise<void> {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + OAUTH_GRANT_TTL_SECONDS * 1000);
+    const crypto = createArtifactCrypto(encryptionKey);
+
+    await lockGrant(trx, grantIdHash);
+    // Nango's product binding is the resource server's fail-closed source of truth. Let the
+    // embedding application invalidate it before any provider artifacts are touched.
+    await beforeGrantRevoked?.(trx, grantIdHash);
+
+    await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
+        .insert({
+            model: REVOCATION_MODEL,
+            artifact_id_hash: grantIdHash,
+            payload_encrypted: crypto.encrypt(REVOCATION_MODEL, grantIdHash, payload),
+            grant_id_hash: grantIdHash,
+            session_uid_hash: null,
+            expires_at: expiresAt,
+            consumed_at: null,
+            revoked_at: now,
+            created_at: now,
+            updated_at: now
+        })
+        .onConflict(['model', 'artifact_id_hash'])
+        .merge({ expires_at: expiresAt, revoked_at: now, updated_at: now });
+
+    await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
+        .where({ grant_id_hash: grantIdHash })
+        .whereNot({ model: REVOCATION_MODEL })
+        .update({ revoked_at: now, updated_at: now });
 }
 
 function expiration(payload: AdapterPayload, expiresIn: number | undefined): Date {

--- a/packages/oauth-server/lib/adapter.ts
+++ b/packages/oauth-server/lib/adapter.ts
@@ -104,7 +104,6 @@ class PostgresOAuthAdapter implements Adapter {
 
     async consume(id: string): Promise<void> {
         const artifactIdHash = this.crypto.hash(id);
-        const consumedAt = new Date();
         const outcome = await this.options.knex.transaction(async (trx) => {
             // Read the immutable grant hash first so every grant-related operation acquires
             // the advisory lock before taking row locks. This avoids a lock-order deadlock
@@ -120,6 +119,7 @@ class PostgresOAuthAdapter implements Adapter {
                 .where({ model: this.model, artifact_id_hash: artifactIdHash })
                 .forUpdate()
                 .first<ArtifactRow>('artifact_id_hash', 'payload_encrypted', 'grant_id_hash', 'expires_at', 'consumed_at', 'revoked_at');
+            const consumedAt = new Date();
             if (!row || row.revoked_at || row.expires_at <= consumedAt) {
                 return 'invalid';
             }
@@ -236,7 +236,9 @@ async function lockGrant(trx: Knex.Transaction, grantIdHash: Buffer): Promise<vo
 }
 
 export async function deleteExpiredOAuthArtifacts(knex: Knex, limit: number): Promise<number> {
+    const expiresAt = new Date();
     return await knex(OAUTH_SERVER_ARTIFACTS_TABLE)
-        .whereIn('id', knex(OAUTH_SERVER_ARTIFACTS_TABLE).select('id').where('expires_at', '<=', new Date()).orderBy('expires_at', 'asc').limit(limit))
+        .where('expires_at', '<=', expiresAt)
+        .whereIn('id', knex(OAUTH_SERVER_ARTIFACTS_TABLE).select('id').where('expires_at', '<=', expiresAt).orderBy('expires_at', 'asc').limit(limit))
         .delete();
 }

--- a/packages/oauth-server/lib/adapter.ts
+++ b/packages/oauth-server/lib/adapter.ts
@@ -1,0 +1,242 @@
+import { errors } from 'oidc-provider';
+
+import { createArtifactCrypto } from './crypto.js';
+
+import type { Knex } from 'knex';
+import type { Adapter, AdapterPayload } from 'oidc-provider';
+
+export const OAUTH_SERVER_ARTIFACTS_TABLE = 'oauth_server_artifacts';
+export const OAUTH_GRANT_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+const CLIENT_MODEL = 'Client';
+const REVOCATION_MODEL = 'GrantRevocation';
+const SUPPORTED_MODELS = new Set(['AccessToken', 'AuthorizationCode', 'Client', 'Grant', 'Interaction', 'RefreshToken', 'Session']);
+
+interface ArtifactRow {
+    artifact_id_hash: Buffer;
+    payload_encrypted: Buffer;
+    grant_id_hash: Buffer | null;
+    expires_at: Date;
+    consumed_at: Date | null;
+    revoked_at: Date | null;
+}
+
+interface OAuthAdapterOptions {
+    knex: Knex;
+    encryptionKey: string;
+}
+
+export function createOAuthAdapter(options: OAuthAdapterOptions): (model: string) => Adapter {
+    return (model) => new PostgresOAuthAdapter(model, options);
+}
+
+class PostgresOAuthAdapter implements Adapter {
+    private readonly crypto;
+
+    constructor(
+        private readonly model: string,
+        private readonly options: OAuthAdapterOptions
+    ) {
+        if (!SUPPORTED_MODELS.has(model)) {
+            throw new Error(`Unsupported OAuth provider model: ${model}`);
+        }
+        this.crypto = createArtifactCrypto(options.encryptionKey);
+    }
+
+    async upsert(id: string, payload: AdapterPayload, expiresIn?: number): Promise<void> {
+        if (this.model === CLIENT_MODEL) {
+            throw new Error('Persisted OAuth clients are disabled; only CIMD clients are supported');
+        }
+
+        const artifactIdHash = this.crypto.hash(id);
+        const grantId = this.model === 'Grant' ? id : payload.grantId;
+        const grantIdHash = grantId ? this.crypto.hash(grantId) : null;
+        const now = new Date();
+        const mutableFields = {
+            payload_encrypted: this.crypto.encrypt(this.model, artifactIdHash, payload),
+            grant_id_hash: grantIdHash,
+            session_uid_hash: payload.uid ? this.crypto.hash(payload.uid) : null,
+            expires_at: expiration(payload, expiresIn),
+            consumed_at: payload.consumed ? new Date(Number(payload.consumed) * 1000) : null,
+            revoked_at: null,
+            updated_at: now
+        };
+
+        await this.options.knex.transaction(async (trx) => {
+            if (grantIdHash) {
+                await lockGrant(trx, grantIdHash);
+                const revoked = await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
+                    .where({ model: REVOCATION_MODEL, artifact_id_hash: grantIdHash })
+                    .where('expires_at', '>', now)
+                    .first<Pick<ArtifactRow, 'artifact_id_hash'>>('artifact_id_hash');
+                if (revoked) {
+                    throw new Error('Cannot persist an artifact for a revoked OAuth grant');
+                }
+            }
+
+            await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
+                .insert({
+                    model: this.model,
+                    artifact_id_hash: artifactIdHash,
+                    ...mutableFields,
+                    created_at: now
+                })
+                .onConflict(['model', 'artifact_id_hash'])
+                .merge(mutableFields);
+        });
+    }
+
+    async find(id: string): Promise<AdapterPayload | undefined> {
+        if (this.model === CLIENT_MODEL) {
+            return undefined;
+        }
+        return await this.findByHash('artifact_id_hash', this.crypto.hash(id));
+    }
+
+    async findByUid(uid: string): Promise<AdapterPayload | undefined> {
+        return await this.findByHash('session_uid_hash', this.crypto.hash(uid));
+    }
+
+    findByUserCode(userCode: string): Promise<AdapterPayload | undefined> {
+        void userCode;
+        return Promise.resolve(undefined);
+    }
+
+    async consume(id: string): Promise<void> {
+        const artifactIdHash = this.crypto.hash(id);
+        const consumedAt = new Date();
+        const outcome = await this.options.knex.transaction(async (trx) => {
+            // Read the immutable grant hash first so every grant-related operation acquires
+            // the advisory lock before taking row locks. This avoids a lock-order deadlock
+            // with concurrent grant revocation.
+            const grant = await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
+                .where({ model: this.model, artifact_id_hash: artifactIdHash })
+                .first<Pick<ArtifactRow, 'grant_id_hash'>>('grant_id_hash');
+            if (grant?.grant_id_hash) {
+                await lockGrant(trx, grant.grant_id_hash);
+            }
+
+            const row = await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
+                .where({ model: this.model, artifact_id_hash: artifactIdHash })
+                .forUpdate()
+                .first<ArtifactRow>('artifact_id_hash', 'payload_encrypted', 'grant_id_hash', 'expires_at', 'consumed_at', 'revoked_at');
+            if (!row || row.revoked_at || row.expires_at <= consumedAt) {
+                return 'invalid';
+            }
+            if (row.consumed_at) {
+                if (row.grant_id_hash) {
+                    await this.revokeGrant(trx, row.grant_id_hash, consumedAt, { reason: 'artifact_replay' });
+                }
+                return 'replayed';
+            }
+
+            const updated = await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
+                .where({ model: this.model, artifact_id_hash: artifactIdHash, consumed_at: null, revoked_at: null })
+                .where('expires_at', '>', consumedAt)
+                .update({ consumed_at: consumedAt, updated_at: consumedAt });
+            if (updated !== 1) {
+                throw new Error('OAuth artifact changed while locked for consumption');
+            }
+            return 'consumed';
+        });
+
+        if (outcome === 'replayed') {
+            throw new errors.InvalidGrant('OAuth artifact was already consumed; its grant has been revoked');
+        }
+        if (outcome === 'invalid') {
+            throw new errors.InvalidGrant('OAuth artifact is expired, revoked, or missing');
+        }
+    }
+
+    async destroy(id: string): Promise<void> {
+        if (this.model === CLIENT_MODEL) {
+            return;
+        }
+        await this.options
+            .knex(OAUTH_SERVER_ARTIFACTS_TABLE)
+            .where({ model: this.model, artifact_id_hash: this.crypto.hash(id) })
+            .delete();
+    }
+
+    async revokeByGrantId(grantId: string): Promise<void> {
+        const grantIdHash = this.crypto.hash(grantId);
+        const now = new Date();
+        const expiresAt = new Date(now.getTime() + OAUTH_GRANT_TTL_SECONDS * 1000);
+
+        await this.options.knex.transaction(async (trx) => {
+            await lockGrant(trx, grantIdHash);
+            await this.revokeGrant(trx, grantIdHash, now, { grantId }, expiresAt);
+        });
+    }
+
+    private async revokeGrant(
+        trx: Knex.Transaction,
+        grantIdHash: Buffer,
+        revokedAt: Date,
+        payload: Record<string, string>,
+        expiresAt = new Date(revokedAt.getTime() + OAUTH_GRANT_TTL_SECONDS * 1000)
+    ): Promise<void> {
+        await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
+            .insert({
+                model: REVOCATION_MODEL,
+                artifact_id_hash: grantIdHash,
+                payload_encrypted: this.crypto.encrypt(REVOCATION_MODEL, grantIdHash, payload),
+                grant_id_hash: grantIdHash,
+                session_uid_hash: null,
+                expires_at: expiresAt,
+                consumed_at: null,
+                revoked_at: revokedAt,
+                created_at: revokedAt,
+                updated_at: revokedAt
+            })
+            .onConflict(['model', 'artifact_id_hash'])
+            .merge({ expires_at: expiresAt, revoked_at: revokedAt, updated_at: revokedAt });
+
+        await trx(OAUTH_SERVER_ARTIFACTS_TABLE)
+            .where({ grant_id_hash: grantIdHash })
+            .whereNot({ model: REVOCATION_MODEL })
+            .update({ revoked_at: revokedAt, updated_at: revokedAt });
+    }
+
+    private async findByHash(column: 'artifact_id_hash' | 'session_uid_hash', hash: Buffer): Promise<AdapterPayload | undefined> {
+        if (this.model === CLIENT_MODEL) {
+            return undefined;
+        }
+
+        const row = await this.options
+            .knex(OAUTH_SERVER_ARTIFACTS_TABLE)
+            .where({ model: this.model, revoked_at: null })
+            .where(column, hash)
+            .where('expires_at', '>', new Date())
+            .first<ArtifactRow>('artifact_id_hash', 'payload_encrypted', 'consumed_at');
+        if (!row) {
+            return undefined;
+        }
+
+        const payload = this.crypto.decrypt<AdapterPayload>(this.model, row.artifact_id_hash, row.payload_encrypted);
+        if (row.consumed_at) {
+            payload.consumed = Math.floor(row.consumed_at.getTime() / 1000);
+        }
+        return payload;
+    }
+}
+
+function expiration(payload: AdapterPayload, expiresIn: number | undefined): Date {
+    if (typeof expiresIn === 'number') {
+        return new Date(Date.now() + expiresIn * 1000);
+    }
+    if (typeof payload.exp === 'number') {
+        return new Date(payload.exp * 1000);
+    }
+    return new Date(Date.now() + OAUTH_GRANT_TTL_SECONDS * 1000);
+}
+
+async function lockGrant(trx: Knex.Transaction, grantIdHash: Buffer): Promise<void> {
+    await trx.raw('SELECT pg_advisory_xact_lock(hashtextextended(?, 0))', [grantIdHash.toString('base64url')]);
+}
+
+export async function deleteExpiredOAuthArtifacts(knex: Knex, limit: number): Promise<number> {
+    return await knex(OAUTH_SERVER_ARTIFACTS_TABLE)
+        .whereIn('id', knex(OAUTH_SERVER_ARTIFACTS_TABLE).select('id').where('expires_at', '<=', new Date()).orderBy('expires_at', 'asc').limit(limit))
+        .delete();
+}

--- a/packages/oauth-server/lib/cimd.ts
+++ b/packages/oauth-server/lib/cimd.ts
@@ -1,0 +1,126 @@
+import { assertSafeOutboundUrl, getSafeUndiciDispatcher, isBlockedIpLiteral } from '@nangohq/egress';
+
+import type { OutboundUrlPolicy } from '@nangohq/egress';
+import type { Client } from 'oidc-provider';
+
+export const CIMD_MAX_CLIENT_ID_BYTES = 512;
+export const CIMD_MAX_DOCUMENT_BYTES = 5 * 1024;
+export const CIMD_CACHE_MIN_SECONDS = 60;
+export const CIMD_CACHE_MAX_SECONDS = 60 * 60;
+
+const CIMD_OUTBOUND_POLICY: OutboundUrlPolicy = {
+    mode: 'denylist',
+    denylist: new Set(),
+    allowlist: [],
+    blockPrivateIps: true,
+    blockLinkLocal: true,
+    allowedSchemes: new Set(['https:']),
+    maxRedirects: 0
+};
+
+const ALLOWED_GRANT_TYPES = new Set(['authorization_code', 'refresh_token']);
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+export async function allowCimdFetch(clientId: string): Promise<boolean> {
+    if (!isValidCimdClientId(clientId)) {
+        return false;
+    }
+    try {
+        await assertSafeOutboundUrl(clientId, CIMD_OUTBOUND_POLICY, { context: 'oauth_cimd' });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export function allowPublicCimdClient(client: Client, allowedScopes: ReadonlySet<string>): boolean {
+    if (client.tokenEndpointAuthMethod !== 'none') {
+        return false;
+    }
+    const grantTypes = client.grantTypes ?? [];
+    const responseTypes = client.responseTypes ?? [];
+    const responseModes = client.responseModes ?? [];
+    const redirectUris = client.redirectUris ?? [];
+    if (!grantTypes.includes('authorization_code') || grantTypes.some((grantType) => !ALLOWED_GRANT_TYPES.has(grantType))) {
+        return false;
+    }
+    if (responseTypes.length !== 1 || responseTypes[0] !== 'code') {
+        return false;
+    }
+    if (responseModes.some((responseMode) => responseMode !== 'query')) {
+        return false;
+    }
+    if (!redirectUris.length || !redirectUris.every(isAllowedRedirectUri)) {
+        return false;
+    }
+    if (client.scope && client.scope.split(' ').some((scope) => !allowedScopes.has(scope))) {
+        return false;
+    }
+    return !client.jwksUri && !client.sectorIdentifierUri;
+}
+
+export function isValidCimdClientId(clientId: string): boolean {
+    if (Buffer.byteLength(clientId, 'utf8') > CIMD_MAX_CLIENT_ID_BYTES || !clientId.startsWith('https://') || hasForbiddenRawUrlCodePoint(clientId)) {
+        return false;
+    }
+    let url: URL;
+    try {
+        url = new URL(clientId);
+    } catch {
+        return false;
+    }
+    if (url.protocol !== 'https:' || url.username || url.password || url.hash || url.search) {
+        return false;
+    }
+
+    const afterScheme = clientId.slice('https://'.length);
+    const pathStart = afterScheme.indexOf('/');
+    if (pathStart < 0) {
+        return false;
+    }
+    const rawPath = afterScheme.slice(pathStart);
+    return !rawPath.split('/').some((segment) => segment.replaceAll(/%2e/giu, '.') === '.' || segment.replaceAll(/%2e/giu, '.') === '..');
+}
+
+function hasForbiddenRawUrlCodePoint(value: string): boolean {
+    for (let index = 0; index < value.length; index++) {
+        const codePoint = value.charCodeAt(index);
+        // Reject ASCII control characters and space (0x00-0x20), backslash (0x5c), and DEL (0x7f)
+        // in the original string. URL parsers can trim controls or treat backslashes as slashes,
+        // which could make validation, client ID comparison, and the eventual fetch disagree.
+        if (codePoint <= 0x20 || codePoint === 0x5c || codePoint === 0x7f) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function isAllowedRedirectUri(value: string): boolean {
+    let url: URL;
+    try {
+        url = new URL(value);
+    } catch {
+        return false;
+    }
+    // Userinfo can disguise the real callback host, while OAuth redirect URIs must not contain
+    // fragments because fragments are not sent to the callback server. Paths, ports, and query
+    // parameters remain valid and are checked through the protocol and hostname rules below.
+    if (url.username || url.password || url.hash) {
+        return false;
+    }
+    if (url.protocol === 'https:') {
+        return (
+            url.hostname !== 'localhost' &&
+            !isBlockedIpLiteral(url.hostname, {
+                blockPrivateIps: true,
+                blockLinkLocal: true
+            })
+        );
+    }
+    return url.protocol === 'http:' && LOOPBACK_HOSTS.has(url.hostname);
+}
+
+export function secureCimdFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+    const dispatcher = getSafeUndiciDispatcher(CIMD_OUTBOUND_POLICY);
+    return fetch(input, { ...init, redirect: 'manual', dispatcher } as RequestInit) as Promise<Response>;
+}

--- a/packages/oauth-server/lib/cimd.ts
+++ b/packages/oauth-server/lib/cimd.ts
@@ -121,6 +121,9 @@ export function isAllowedRedirectUri(value: string): boolean {
 }
 
 export function secureCimdFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+    // Node's fetch types and the installed undici package use separate, structurally incompatible
+    // Dispatcher declarations. Bridge that type boundary explicitly; the runtime API is compatible.
     const dispatcher = getSafeUndiciDispatcher(CIMD_OUTBOUND_POLICY);
-    return fetch(input, { ...init, redirect: 'manual', dispatcher } as RequestInit) as Promise<Response>;
+    const requestInit = { ...init, redirect: 'manual' as const, dispatcher } as unknown as RequestInit;
+    return fetch(input, requestInit);
 }

--- a/packages/oauth-server/lib/cimd.unit.test.ts
+++ b/packages/oauth-server/lib/cimd.unit.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { allowPublicCimdClient, isAllowedRedirectUri, isValidCimdClientId } from './cimd.js';
+
+import type { Client } from 'oidc-provider';
+
+describe('CIMD validation', () => {
+    it.each(['https://client.example.com/oauth/metadata.json', 'https://client.example.com:8443/', 'https://client.example.com/%E2%9C%93'])(
+        'accepts a valid client identifier URL: %s',
+        (value) => {
+            expect(isValidCimdClientId(value)).toBe(true);
+        }
+    );
+
+    it.each([
+        'http://client.example.com/oauth/metadata.json',
+        'https://client.example.com',
+        'https://user:password@client.example.com/metadata.json',
+        'https://client.example.com/metadata.json?version=1',
+        'https://client.example.com/metadata.json#fragment',
+        'https://client.example.com/a/../metadata.json',
+        'https://client.example.com\\@127.0.0.1/metadata.json',
+        'https://client.example.com/metadata.json\n',
+        `https://client.example.com/${'a'.repeat(500)}`
+    ])('rejects an unsafe client identifier URL: %s', (value) => {
+        expect(isValidCimdClientId(value)).toBe(false);
+    });
+
+    it.each(['https://client.example.com/callback', 'http://localhost:1234/callback', 'http://127.0.0.1:1234/callback', 'http://[::1]:1234/callback'])(
+        'accepts an allowed redirect URI: %s',
+        (value) => {
+            expect(isAllowedRedirectUri(value)).toBe(true);
+        }
+    );
+
+    it.each([
+        'http://client.example.com/callback',
+        'custom-app://callback',
+        'https://user@example.com/callback',
+        'https://example.com/callback#fragment',
+        'https://localhost/callback',
+        'https://127.0.0.1/callback',
+        'https://10.0.0.1/callback',
+        'https://[::1]/callback'
+    ])('rejects a disallowed redirect URI: %s', (value) => {
+        expect(isAllowedRedirectUri(value)).toBe(false);
+    });
+
+    it('accepts only the supported public-client metadata shape', () => {
+        const metadata = {
+            tokenEndpointAuthMethod: 'none',
+            grantTypes: ['authorization_code', 'refresh_token'],
+            responseTypes: ['code'],
+            responseModes: ['query'],
+            redirectUris: ['https://client.example.com/callback'],
+            scope: 'environment:*'
+        };
+        const client = (overrides: Record<string, unknown> = {}) => ({ ...metadata, ...overrides }) as unknown as Client;
+
+        expect(allowPublicCimdClient(client(), new Set(['environment:*']))).toBe(true);
+        expect(allowPublicCimdClient(client({ responseModes: ['fragment'] }), new Set(['environment:*']))).toBe(false);
+        expect(allowPublicCimdClient(client({ tokenEndpointAuthMethod: 'client_secret_basic' }), new Set(['environment:*']))).toBe(false);
+        expect(allowPublicCimdClient(client({ scope: 'openid' }), new Set(['environment:*']))).toBe(false);
+    });
+});

--- a/packages/oauth-server/lib/config.ts
+++ b/packages/oauth-server/lib/config.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+import type { JWKS } from 'oidc-provider';
+
+const jwkSchema = z.looseObject({
+    kid: z.string().min(1),
+    use: z.literal('sig'),
+    alg: z.literal('RS256'),
+    kty: z.literal('RSA'),
+    d: z.string().min(1)
+});
+
+const jwksSchema = z.object({ keys: z.array(jwkSchema).min(1) });
+
+export interface OAuthServerParsedConfig {
+    baseUrl: string;
+    cookieKeys: string[];
+    encryptionKey: string;
+    jwks: JWKS;
+}
+
+export interface OAuthServerRawConfig {
+    baseUrl: string | undefined;
+    cookieKeys: string | undefined;
+    encryptionKey: string | undefined;
+    jwks: string | undefined;
+}
+
+export function parseOAuthServerConfig(raw: OAuthServerRawConfig): OAuthServerParsedConfig {
+    if (!raw.baseUrl || !raw.cookieKeys || !raw.encryptionKey || !raw.jwks) {
+        throw new Error('OAuth server baseUrl, cookieKeys, encryptionKey, and jwks are required when OAuth is enabled');
+    }
+
+    const baseUrl = parseBaseUrl(raw.baseUrl);
+    const cookieKeys = parseJson(raw.cookieKeys, z.array(z.string().min(32)).min(2), 'cookieKeys');
+    if (new Set(cookieKeys).size !== cookieKeys.length) {
+        throw new Error('OAuth server cookieKeys must contain distinct keys');
+    }
+    if (Buffer.from(raw.encryptionKey, 'base64').length !== 32) {
+        throw new Error('OAuth server encryptionKey must decode to exactly 32 bytes');
+    }
+    const jwks = parseJson(raw.jwks, jwksSchema, 'jwks') as JWKS;
+
+    return { baseUrl, cookieKeys, encryptionKey: raw.encryptionKey, jwks };
+}
+
+function parseBaseUrl(value: string): string {
+    const url = new URL(value);
+    const loopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+    if (url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) {
+        throw new Error('OAuth server baseUrl must use HTTPS, except on loopback');
+    }
+    if (url.username || url.password || url.search || url.hash || (url.pathname !== '/' && url.pathname !== '')) {
+        throw new Error('OAuth server baseUrl must be an origin without credentials, path, query, or fragment');
+    }
+    return url.origin;
+}
+
+function parseJson<T>(value: string, schema: z.ZodType<T>, name: string): T {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(value) as unknown;
+    } catch {
+        throw new Error(`${name} must be valid JSON`);
+    }
+    const result = schema.safeParse(parsed);
+    if (!result.success) {
+        throw new Error(`${name} is invalid: ${result.error.issues.map((issue) => issue.message).join(', ')}`);
+    }
+    return result.data;
+}

--- a/packages/oauth-server/lib/config.ts
+++ b/packages/oauth-server/lib/config.ts
@@ -7,7 +7,14 @@ const jwkSchema = z.looseObject({
     use: z.literal('sig'),
     alg: z.literal('RS256'),
     kty: z.literal('RSA'),
-    d: z.string().min(1)
+    n: z.string().min(1),
+    e: z.string().min(1),
+    d: z.string().min(1),
+    p: z.string().min(1),
+    q: z.string().min(1),
+    dp: z.string().min(1),
+    dq: z.string().min(1),
+    qi: z.string().min(1)
 });
 
 const jwksSchema = z.object({ keys: z.array(jwkSchema).min(1) });

--- a/packages/oauth-server/lib/config.unit.test.ts
+++ b/packages/oauth-server/lib/config.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseOAuthServerConfig } from './config.js';
+
+const valid = {
+    baseUrl: 'https://api.example.com',
+    cookieKeys: JSON.stringify(['a'.repeat(32), 'b'.repeat(32)]),
+    encryptionKey: Buffer.alloc(32, 's').toString('base64'),
+    jwks: JSON.stringify({ keys: [{ kid: 'key-1', use: 'sig', alg: 'RS256', kty: 'RSA', d: 'private' }] })
+};
+
+describe('OAuth server configuration', () => {
+    it('parses explicit shared configuration', () => {
+        expect(parseOAuthServerConfig(valid)).toMatchObject({
+            baseUrl: 'https://api.example.com',
+            cookieKeys: ['a'.repeat(32), 'b'.repeat(32)],
+            encryptionKey: Buffer.alloc(32, 's').toString('base64')
+        });
+    });
+
+    it('allows HTTP only for loopback development origins', () => {
+        expect(parseOAuthServerConfig({ ...valid, baseUrl: 'http://localhost:3003' }).baseUrl).toBe('http://localhost:3003');
+        expect(() => parseOAuthServerConfig({ ...valid, baseUrl: 'http://api.example.com' })).toThrow(/HTTPS/);
+    });
+
+    it('requires strong distinct secrets and private signing keys', () => {
+        expect(() => parseOAuthServerConfig({ ...valid, cookieKeys: JSON.stringify(['short', 'also-short']) })).toThrow(/cookieKeys/);
+        expect(() => parseOAuthServerConfig({ ...valid, cookieKeys: JSON.stringify(['a'.repeat(32), 'a'.repeat(32)]) })).toThrow(/distinct/);
+        expect(() => parseOAuthServerConfig({ ...valid, encryptionKey: 'short' })).toThrow(/encryptionKey/);
+        expect(() => parseOAuthServerConfig({ ...valid, jwks: JSON.stringify({ keys: [{ kid: 'key-1', use: 'sig', alg: 'RS256', kty: 'RSA' }] }) })).toThrow(
+            /jwks/
+        );
+    });
+});

--- a/packages/oauth-server/lib/config.unit.test.ts
+++ b/packages/oauth-server/lib/config.unit.test.ts
@@ -1,12 +1,16 @@
+import { generateKeyPairSync } from 'node:crypto';
+
 import { describe, expect, it } from 'vitest';
 
 import { parseOAuthServerConfig } from './config.js';
 
+const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const signingKey = { ...privateKey.export({ format: 'jwk' }), kid: 'key-1', use: 'sig', alg: 'RS256' };
 const valid = {
     baseUrl: 'https://api.example.com',
     cookieKeys: JSON.stringify(['a'.repeat(32), 'b'.repeat(32)]),
     encryptionKey: Buffer.alloc(32, 's').toString('base64'),
-    jwks: JSON.stringify({ keys: [{ kid: 'key-1', use: 'sig', alg: 'RS256', kty: 'RSA', d: 'private' }] })
+    jwks: JSON.stringify({ keys: [signingKey] })
 };
 
 describe('OAuth server configuration', () => {
@@ -27,8 +31,11 @@ describe('OAuth server configuration', () => {
         expect(() => parseOAuthServerConfig({ ...valid, cookieKeys: JSON.stringify(['short', 'also-short']) })).toThrow(/cookieKeys/);
         expect(() => parseOAuthServerConfig({ ...valid, cookieKeys: JSON.stringify(['a'.repeat(32), 'a'.repeat(32)]) })).toThrow(/distinct/);
         expect(() => parseOAuthServerConfig({ ...valid, encryptionKey: 'short' })).toThrow(/encryptionKey/);
-        expect(() => parseOAuthServerConfig({ ...valid, jwks: JSON.stringify({ keys: [{ kid: 'key-1', use: 'sig', alg: 'RS256', kty: 'RSA' }] }) })).toThrow(
-            /jwks/
-        );
+        expect(() =>
+            parseOAuthServerConfig({
+                ...valid,
+                jwks: JSON.stringify({ keys: [{ kid: 'key-1', use: 'sig', alg: 'RS256', kty: 'RSA', d: signingKey.d }] })
+            })
+        ).toThrow(/jwks/);
     });
 });

--- a/packages/oauth-server/lib/crypto.ts
+++ b/packages/oauth-server/lib/crypto.ts
@@ -1,0 +1,52 @@
+import { createCipheriv, createDecipheriv, createHmac, hkdfSync, randomBytes } from 'node:crypto';
+
+const ENCRYPTION_VERSION = 1;
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+export interface ArtifactCrypto {
+    hash(value: string): Buffer;
+    encrypt(model: string, artifactIdHash: Buffer, value: unknown): Buffer;
+    decrypt<T>(model: string, artifactIdHash: Buffer, value: Buffer): T;
+}
+
+export function createArtifactCrypto(encryptionKey: string): ArtifactCrypto {
+    const inputKey = Buffer.from(encryptionKey, 'base64');
+    if (inputKey.length !== 32) {
+        throw new Error('OAuth artifact encryption key must decode to exactly 32 bytes');
+    }
+    const salt = Buffer.from('nango-oauth-server', 'utf8');
+    const payloadEncryptionKey = Buffer.from(hkdfSync('sha256', inputKey, salt, Buffer.from('artifacts:encryption', 'utf8'), 32));
+    const lookupKey = Buffer.from(hkdfSync('sha256', inputKey, salt, Buffer.from('artifacts:lookup', 'utf8'), 32));
+
+    return {
+        hash(value) {
+            return createHmac('sha256', lookupKey).update(value, 'utf8').digest();
+        },
+        encrypt(model: string, artifactIdHash: Buffer, value: unknown) {
+            const iv = randomBytes(IV_LENGTH);
+            const cipher = createCipheriv('aes-256-gcm', payloadEncryptionKey, iv);
+            cipher.setAAD(aad(model, artifactIdHash));
+            const ciphertext = Buffer.concat([cipher.update(JSON.stringify(value), 'utf8'), cipher.final()]);
+            return Buffer.concat([Buffer.from([ENCRYPTION_VERSION]), iv, cipher.getAuthTag(), ciphertext]);
+        },
+        decrypt<T>(model: string, artifactIdHash: Buffer, value: Buffer) {
+            if (value.length < 1 + IV_LENGTH + AUTH_TAG_LENGTH || value[0] !== ENCRYPTION_VERSION) {
+                throw new Error('Unsupported OAuth artifact encryption format');
+            }
+
+            const ivStart = 1;
+            const tagStart = ivStart + IV_LENGTH;
+            const ciphertextStart = tagStart + AUTH_TAG_LENGTH;
+            const decipher = createDecipheriv('aes-256-gcm', payloadEncryptionKey, value.subarray(ivStart, tagStart));
+            decipher.setAAD(aad(model, artifactIdHash));
+            decipher.setAuthTag(value.subarray(tagStart, ciphertextStart));
+            const plaintext = Buffer.concat([decipher.update(value.subarray(ciphertextStart)), decipher.final()]);
+            return JSON.parse(plaintext.toString('utf8')) as T;
+        }
+    };
+}
+
+function aad(model: string, artifactIdHash: Buffer): Buffer {
+    return Buffer.from(`${model}\0${artifactIdHash.toString('base64url')}`, 'utf8');
+}

--- a/packages/oauth-server/lib/crypto.unit.test.ts
+++ b/packages/oauth-server/lib/crypto.unit.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { createArtifactCrypto } from './crypto.js';
+
+describe('OAuth artifact crypto', () => {
+    it('encrypts and decrypts payloads without exposing plaintext', () => {
+        const crypto = createArtifactCrypto(Buffer.alloc(32, 's').toString('base64'));
+        const idHash = crypto.hash('opaque-token');
+        const encrypted = crypto.encrypt('AccessToken', idHash, { jti: 'opaque-token', scope: 'environment:*' });
+
+        expect(encrypted.toString()).not.toContain('opaque-token');
+        expect(crypto.decrypt('AccessToken', idHash, encrypted)).toStrictEqual({ jti: 'opaque-token', scope: 'environment:*' });
+    });
+
+    it('fails to decrypt with a different model or identifier hash', () => {
+        const crypto = createArtifactCrypto(Buffer.alloc(32, 's').toString('base64'));
+        const idHash = crypto.hash('opaque-token');
+        const encrypted = crypto.encrypt('AccessToken', idHash, { value: true });
+
+        expect(() => crypto.decrypt('RefreshToken', idHash, encrypted)).toThrow();
+        expect(() => crypto.decrypt('AccessToken', crypto.hash('other-token'), encrypted)).toThrow();
+    });
+});

--- a/packages/oauth-server/lib/index.ts
+++ b/packages/oauth-server/lib/index.ts
@@ -1,6 +1,15 @@
-export { deleteExpiredOAuthArtifacts } from './adapter.js';
+export {
+    deleteExpiredOAuthArtifacts,
+    hashOAuthGrantId,
+    revokeOAuthGrantArtifactsInTransaction,
+    withOAuthTransaction,
+    oauthTransactionCommitted
+} from './adapter.js';
+export { allowPublicCimdClient, isValidCimdClientId } from './cimd.js';
+export type { OAuthAdapterOptions } from './adapter.js';
 export { parseOAuthServerConfig } from './config.js';
 export { createOAuthProvider, OAUTH_AUTHORIZATION_PATH, OAUTH_DISCOVERY_PATH, OAUTH_JWKS_PATH, OAUTH_REVOCATION_PATH, OAUTH_TOKEN_PATH } from './provider.js';
 export type { OAuthServerParsedConfig, OAuthServerRawConfig } from './config.js';
 export type { CreateOAuthProviderOptions, OAuthResourceConfig } from './provider.js';
 export type { default as OAuthProvider } from 'oidc-provider';
+export { errors as OAuthProviderErrors } from 'oidc-provider';

--- a/packages/oauth-server/lib/index.ts
+++ b/packages/oauth-server/lib/index.ts
@@ -1,0 +1,6 @@
+export { deleteExpiredOAuthArtifacts } from './adapter.js';
+export { parseOAuthServerConfig } from './config.js';
+export { createOAuthProvider, OAUTH_AUTHORIZATION_PATH, OAUTH_DISCOVERY_PATH, OAUTH_JWKS_PATH, OAUTH_REVOCATION_PATH, OAUTH_TOKEN_PATH } from './provider.js';
+export type { OAuthServerParsedConfig, OAuthServerRawConfig } from './config.js';
+export type { CreateOAuthProviderOptions, OAuthResourceConfig } from './provider.js';
+export type { default as OAuthProvider } from 'oidc-provider';

--- a/packages/oauth-server/lib/provider.ts
+++ b/packages/oauth-server/lib/provider.ts
@@ -27,6 +27,7 @@ export interface CreateOAuthProviderOptions {
     knex: Knex;
     config: OAuthServerParsedConfig;
     resources: readonly OAuthResourceConfig[];
+    beforeGrantRevoked?: ((trx: Knex.Transaction, grantIdHash: Buffer) => Promise<void>) | undefined;
 }
 
 interface OAuthResourceRegistry {
@@ -34,12 +35,12 @@ interface OAuthResourceRegistry {
     get(resource: string): OAuthResourceConfig | undefined;
 }
 
-export function createOAuthProvider({ knex, config, resources }: CreateOAuthProviderOptions): Provider {
+export function createOAuthProvider({ knex, config, resources, beforeGrantRevoked }: CreateOAuthProviderOptions): Provider {
     const registry = createResourceRegistry(resources);
     const allowedScopes = new Set(registry.supportedScopes);
 
     const configuration: Configuration = {
-        adapter: createOAuthAdapter({ knex, encryptionKey: config.encryptionKey }),
+        adapter: createOAuthAdapter({ knex, encryptionKey: config.encryptionKey, beforeGrantRevoked }),
         claims: {},
         clientAuthMethods: ['none'],
         clients: [],
@@ -85,13 +86,15 @@ export function createOAuthProvider({ knex, config, resources }: CreateOAuthProv
         findAccount: (_ctx, accountId) => ({ accountId, claims: () => ({ sub: accountId }) }),
         formats: { bitsOfOpaqueRandomness: 256 },
         interactions: {
-            // TODO(NAN-6924): Replace the test-only interaction handler with the authenticated API used by the React consent page.
             url: (_ctx, interaction) => `${OAUTH_ENDPOINT_PATH}/interaction/${encodeURIComponent(interaction.uid)}`
         },
         issueRefreshToken: (_ctx, client) => client.grantTypeAllowed('refresh_token'),
         jwks: config.jwks,
         pkce: { required: () => true },
         responseTypes: ['code'],
+        // A Nango product grant spans every resource approved in the authorization. Revoking any
+        // refresh or access token therefore revokes the complete provider grant as well.
+        revokeGrantPolicy: () => true,
         rotateRefreshToken: (ctx) => validateRefreshResource(ctx, registry),
         routes: {
             authorization: OAUTH_AUTHORIZATION_PATH,

--- a/packages/oauth-server/lib/provider.ts
+++ b/packages/oauth-server/lib/provider.ts
@@ -89,6 +89,12 @@ export function createOAuthProvider({ knex, config, resources, beforeGrantRevoke
             url: (_ctx, interaction) => `${OAUTH_ENDPOINT_PATH}/interaction/${encodeURIComponent(interaction.uid)}`
         },
         issueRefreshToken: (_ctx, client) => client.grantTypeAllowed('refresh_token'),
+        loadExistingGrant: async (ctx) => {
+            // Only resume this interaction's explicit consent. A remembered provider grant
+            // must not bypass the application's current login or consent checks on a new request.
+            const grantId = ctx.oidc.result?.consent?.grantId;
+            return grantId ? await ctx.oidc.provider.Grant.find(grantId) : undefined;
+        },
         jwks: config.jwks,
         pkce: { required: () => true },
         responseTypes: ['code'],

--- a/packages/oauth-server/lib/provider.ts
+++ b/packages/oauth-server/lib/provider.ts
@@ -1,0 +1,237 @@
+import Provider, { errors } from 'oidc-provider';
+
+import { createOAuthAdapter, OAUTH_GRANT_TTL_SECONDS } from './adapter.js';
+import { allowCimdFetch, allowPublicCimdClient, CIMD_CACHE_MAX_SECONDS, CIMD_CACHE_MIN_SECONDS, CIMD_MAX_DOCUMENT_BYTES, secureCimdFetch } from './cimd.js';
+
+import type { OAuthServerParsedConfig } from './config.js';
+import type { Knex } from 'knex';
+import type { Configuration, KoaContextWithOIDC, ResourceServer } from 'oidc-provider';
+
+const ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
+const AUTHORIZATION_CODE_TTL_SECONDS = 60;
+const INTERACTION_TTL_SECONDS = 10 * 60;
+
+export const OAUTH_ENDPOINT_PATH = '/oauth';
+export const OAUTH_AUTHORIZATION_PATH = `${OAUTH_ENDPOINT_PATH}/authorize`;
+export const OAUTH_TOKEN_PATH = `${OAUTH_ENDPOINT_PATH}/token`;
+export const OAUTH_REVOCATION_PATH = `${OAUTH_ENDPOINT_PATH}/revoke`;
+export const OAUTH_JWKS_PATH = `${OAUTH_ENDPOINT_PATH}/jwks`;
+export const OAUTH_DISCOVERY_PATH = '/.well-known/oauth-authorization-server';
+
+export interface OAuthResourceConfig {
+    resource: string;
+    scopes: readonly string[];
+}
+
+export interface CreateOAuthProviderOptions {
+    knex: Knex;
+    config: OAuthServerParsedConfig;
+    resources: readonly OAuthResourceConfig[];
+}
+
+interface OAuthResourceRegistry {
+    supportedScopes: readonly string[];
+    get(resource: string): OAuthResourceConfig | undefined;
+}
+
+export function createOAuthProvider({ knex, config, resources }: CreateOAuthProviderOptions): Provider {
+    const registry = createResourceRegistry(resources);
+    const allowedScopes = new Set(registry.supportedScopes);
+
+    const configuration: Configuration = {
+        adapter: createOAuthAdapter({ knex, encryptionKey: config.encryptionKey }),
+        claims: {},
+        clientAuthMethods: ['none'],
+        clients: [],
+        cookies: {
+            keys: config.cookieKeys,
+            names: {
+                session: 'nango_oauth_session',
+                interaction: 'nango_oauth_interaction',
+                resume: 'nango_oauth_resume'
+            },
+            long: { httpOnly: true, sameSite: 'lax', secure: config.baseUrl.startsWith('https:'), path: OAUTH_ENDPOINT_PATH },
+            short: { httpOnly: true, sameSite: 'lax', secure: config.baseUrl.startsWith('https:'), path: OAUTH_ENDPOINT_PATH }
+        },
+        features: {
+            backchannelLogout: { enabled: false },
+            clientIdMetadataDocument: {
+                enabled: true,
+                ack: 'draft-02',
+                // oidc-provider 9.12 keeps a bounded, per-provider LRU with a logical capacity of 100 and coalesces concurrent fetches.
+                allowFetch: async (_ctx, clientId) => await allowCimdFetch(clientId),
+                allowClient: (_ctx, client) => allowPublicCimdClient(client, allowedScopes),
+                cacheDuration: { min: CIMD_CACHE_MIN_SECONDS, max: CIMD_CACHE_MAX_SECONDS }
+            },
+            devInteractions: { enabled: false },
+            dPoP: { enabled: false },
+            pushedAuthorizationRequests: { enabled: false },
+            registration: { enabled: false },
+            registrationManagement: { enabled: false },
+            resourceIndicators: {
+                enabled: true,
+                defaultResource: () => {
+                    throw new errors.InvalidTarget('The resource parameter is required');
+                },
+                getResourceServerInfo: (ctx, resourceIndicator) => resourceServer(ctx, resourceIndicator, registry),
+                useGrantedResource: () => false
+            },
+            revocation: { enabled: true },
+            rpInitiatedLogout: { enabled: false },
+            userinfo: { enabled: false }
+        },
+        fetch: secureCimdFetch,
+        fetchResponseBodyLimits: { 'client_id metadata document': CIMD_MAX_DOCUMENT_BYTES },
+        findAccount: (_ctx, accountId) => ({ accountId, claims: () => ({ sub: accountId }) }),
+        formats: { bitsOfOpaqueRandomness: 256 },
+        interactions: {
+            // TODO(NAN-6924): Replace the test-only interaction handler with the authenticated API used by the React consent page.
+            url: (_ctx, interaction) => `${OAUTH_ENDPOINT_PATH}/interaction/${encodeURIComponent(interaction.uid)}`
+        },
+        issueRefreshToken: (_ctx, client) => client.grantTypeAllowed('refresh_token'),
+        jwks: config.jwks,
+        pkce: { required: () => true },
+        responseTypes: ['code'],
+        rotateRefreshToken: (ctx) => validateRefreshResource(ctx, registry),
+        routes: {
+            authorization: OAUTH_AUTHORIZATION_PATH,
+            jwks: OAUTH_JWKS_PATH,
+            revocation: OAUTH_REVOCATION_PATH,
+            token: OAUTH_TOKEN_PATH
+        },
+        scopes: registry.supportedScopes,
+        sectorIdentifierUriValidate: () => false,
+        ttl: {
+            AccessToken: ACCESS_TOKEN_TTL_SECONDS,
+            AuthorizationCode: AUTHORIZATION_CODE_TTL_SECONDS,
+            Grant: OAUTH_GRANT_TTL_SECONDS,
+            Interaction: INTERACTION_TTL_SECONDS,
+            RefreshToken: OAUTH_GRANT_TTL_SECONDS,
+            Session: OAUTH_GRANT_TTL_SECONDS
+        }
+    };
+
+    const provider = new Provider(config.baseUrl, configuration);
+    provider.proxy = true;
+    installOAuthOnlyMiddleware(provider);
+    return provider;
+}
+
+function createResourceRegistry(resources: readonly OAuthResourceConfig[]): OAuthResourceRegistry {
+    if (resources.length === 0) {
+        throw new Error('At least one OAuth resource must be configured');
+    }
+
+    const byResource = new Map<string, OAuthResourceConfig>();
+    const supportedScopes = new Set<string>();
+    for (const resource of resources) {
+        validateResourceConfig(resource);
+        if (byResource.has(resource.resource)) {
+            throw new Error(`OAuth resource is configured more than once: ${resource.resource}`);
+        }
+        byResource.set(resource.resource, resource);
+        for (const scope of resource.scopes) supportedScopes.add(scope);
+    }
+
+    return {
+        supportedScopes: [...supportedScopes],
+        get: (resource) => byResource.get(resource)
+    };
+}
+
+function installOAuthOnlyMiddleware(provider: Provider): void {
+    provider.use(async (ctx, next) => {
+        const requestedScope = ctx.query['scope'];
+        if (typeof requestedScope === 'string' && requestedScope.split(' ').some((scope) => scope === 'openid' || scope === 'offline_access')) {
+            ctx.status = 400;
+            ctx.body = {
+                error: 'invalid_scope',
+                error_description: 'OpenID Connect scopes are not supported'
+            };
+            return;
+        }
+
+        await next();
+
+        if (ctx.status !== 200 || !ctx.body || typeof ctx.body !== 'object' || Array.isArray(ctx.body)) {
+            return;
+        }
+
+        const body = ctx.body as Record<string, unknown>;
+        if (body['issuer'] !== provider.issuer || !Array.isArray(body['scopes_supported'])) {
+            return;
+        }
+
+        body['authorization_endpoint'] = provider.urlFor('authorization');
+        body['token_endpoint'] = provider.urlFor('token');
+        body['revocation_endpoint'] = provider.urlFor('revocation');
+        body['jwks_uri'] = provider.urlFor('jwks');
+        body['scopes_supported'] = body['scopes_supported'].filter((scope) => scope !== 'openid' && scope !== 'offline_access');
+        delete body['claims_parameter_supported'];
+        delete body['claims_supported'];
+        delete body['claim_types_supported'];
+        delete body['id_token_signing_alg_values_supported'];
+        delete body['subject_types_supported'];
+    });
+}
+
+function validateRefreshResource(ctx: KoaContextWithOIDC, registry: OAuthResourceRegistry): true {
+    const requestedResource = ctx.oidc.params?.['resource'];
+    if (typeof requestedResource !== 'string') {
+        throw new errors.InvalidTarget('Exactly one resource parameter is required');
+    }
+    if (!registry.get(requestedResource)) {
+        throw new errors.InvalidTarget('The requested resource is not supported');
+    }
+
+    const refreshToken = ctx.oidc.entities.RefreshToken;
+    const grant = ctx.oidc.entities.Grant;
+    if (!refreshToken || !grant) {
+        throw new Error('Refresh token resource validation ran before the token and grant were loaded');
+    }
+    if (!refreshToken.resourceIndicators.has(requestedResource) || !grant.getResourceScope(requestedResource)) {
+        throw new errors.InvalidTarget('The requested resource was not granted');
+    }
+    return true;
+}
+
+function resourceServer(ctx: KoaContextWithOIDC, resourceIndicator: string, registry: OAuthResourceRegistry): ResourceServer {
+    const requestedResource = ctx.oidc.params?.['resource'];
+    const requested = Array.isArray(requestedResource) ? requestedResource : requestedResource ? [requestedResource] : [];
+    if (!requested.includes(resourceIndicator)) {
+        throw new errors.InvalidTarget('The resource parameter is required');
+    }
+
+    const resource = registry.get(resourceIndicator);
+    if (!resource) {
+        throw new errors.InvalidTarget('The requested resource is not supported');
+    }
+    return {
+        scope: resource.scopes.join(' '),
+        audience: resource.resource,
+        accessTokenFormat: 'opaque',
+        accessTokenTTL: ACCESS_TOKEN_TTL_SECONDS
+    };
+}
+
+function validateResourceConfig(resource: OAuthResourceConfig): void {
+    let parsed: URL;
+    try {
+        parsed = new URL(resource.resource);
+    } catch {
+        throw new Error(`OAuth resource must be an absolute URL: ${resource.resource}`);
+    }
+    if (parsed.hash || parsed.href !== resource.resource) {
+        throw new Error(`OAuth resource must be a canonical absolute URL without a fragment: ${resource.resource}`);
+    }
+    validateScopes(resource.scopes, `OAuth resource ${resource.resource}`);
+}
+
+function validateScopes(scopes: readonly string[], owner: string): void {
+    if (scopes.length === 0 || scopes.some((scope) => scope.length === 0 || /\s/.test(scope))) {
+        throw new Error(`${owner} must define non-empty OAuth scopes without whitespace`);
+    }
+    if (new Set(scopes).size !== scopes.length) {
+        throw new Error(`${owner} must not define duplicate OAuth scopes`);
+    }
+}

--- a/packages/oauth-server/lib/provider.unit.test.ts
+++ b/packages/oauth-server/lib/provider.unit.test.ts
@@ -1,0 +1,521 @@
+import { createHash, generateKeyPairSync, randomBytes } from 'node:crypto';
+import { createServer } from 'node:http';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { createOAuthAdapter } from './adapter.js';
+import { allowCimdFetch, secureCimdFetch } from './cimd.js';
+import { createOAuthProvider } from './provider.js';
+
+import type { Knex } from 'knex';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type Provider from 'oidc-provider';
+import type { Adapter, AdapterPayload, Interaction } from 'oidc-provider';
+
+vi.mock('./adapter.js', () => ({ createOAuthAdapter: vi.fn(), OAUTH_GRANT_TTL_SECONDS: 30 * 24 * 60 * 60 }));
+vi.mock('./cimd.js', async (importOriginal) => {
+    const actual = await importOriginal();
+    if (!actual || typeof actual !== 'object') {
+        throw new Error('Invalid CIMD module mock');
+    }
+    return { ...actual, allowCimdFetch: vi.fn(), secureCimdFetch: vi.fn() };
+});
+
+const artifacts = new Map<string, AdapterPayload>();
+const adapter = (model: string): Adapter => ({
+    upsert: (id, payload) => {
+        artifacts.set(`${model}:${id}`, payload);
+        return Promise.resolve();
+    },
+    find: (id) => Promise.resolve(artifacts.get(`${model}:${id}`)),
+    findByUid: (uid) => Promise.resolve([...artifacts].find(([key, payload]) => key.startsWith(`${model}:`) && payload.uid === uid)?.[1]),
+    findByUserCode: (userCode) => Promise.resolve([...artifacts].find(([key, payload]) => key.startsWith(`${model}:`) && payload.userCode === userCode)?.[1]),
+    consume: (id) => {
+        const value = artifacts.get(`${model}:${id}`);
+        if (value) value.consumed = Math.floor(Date.now() / 1000);
+        return Promise.resolve();
+    },
+    destroy: (id) => {
+        artifacts.delete(`${model}:${id}`);
+        return Promise.resolve();
+    },
+    revokeByGrantId: (grantId) => {
+        for (const [key, payload] of artifacts) {
+            if (payload.grantId === grantId) artifacts.delete(key);
+        }
+        return Promise.resolve();
+    }
+});
+
+describe('OAuth provider', () => {
+    let origin: string;
+    let server: ReturnType<typeof createServer>;
+    let provider: Provider;
+    let clientId: string;
+    let cimdFetches = 0;
+
+    beforeAll(async () => {
+        vi.mocked(createOAuthAdapter).mockReturnValue(adapter);
+        vi.mocked(allowCimdFetch).mockImplementation((candidate) => Promise.resolve(candidate.startsWith('https://client.example.com/oauth/')));
+        vi.mocked(secureCimdFetch).mockImplementation((input, init) => {
+            cimdFetches++;
+            const fetchedClientId = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+            expect(init?.redirect).toBe('manual');
+            if (fetchedClientId.endsWith('/redirect.json')) {
+                return Promise.resolve(new Response(null, { status: 302, headers: { location: 'http://127.0.0.1/private' } }));
+            }
+            if (fetchedClientId.endsWith('/mismatch.json')) {
+                return Promise.resolve(
+                    new Response(JSON.stringify({ client_id: 'https://attacker.example.com/metadata.json' }), {
+                        status: 200,
+                        headers: { 'content-type': 'application/json' }
+                    })
+                );
+            }
+            if (fetchedClientId.endsWith('/oversized.json')) {
+                return Promise.resolve(new Response('x'.repeat(5 * 1024 + 1), { status: 200, headers: { 'content-type': 'application/json' } }));
+            }
+            return Promise.resolve(
+                new Response(
+                    JSON.stringify({
+                        client_id: fetchedClientId,
+                        client_name: 'Test MCP Client',
+                        redirect_uris: ['https://client.example.com/callback'],
+                        grant_types: ['authorization_code', 'refresh_token'],
+                        response_types: ['code'],
+                        token_endpoint_auth_method: 'none',
+                        scope: 'environment:* agent-session:*'
+                    }),
+                    { status: 200, headers: { 'content-type': 'application/json', 'cache-control': 'max-age=3600' } }
+                )
+            );
+        });
+
+        const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+        clientId = 'https://client.example.com/oauth/metadata.json';
+        provider = createOAuthProvider({
+            knex: vi.fn() as unknown as Knex,
+            config: {
+                baseUrl: 'http://localhost',
+                cookieKeys: ['a'.repeat(32), 'b'.repeat(32)],
+                encryptionKey: Buffer.alloc(32, 's').toString('base64'),
+                jwks: { keys: [{ ...privateKey.export({ format: 'jwk' }), kid: 'test-key', use: 'sig', alg: 'RS256' }] }
+            },
+            resources: [
+                {
+                    resource: 'https://mcp.example.com/mcp',
+                    scopes: ['environment:*']
+                },
+                {
+                    resource: 'https://api.example.com/agent-sessions/session-1/mcp',
+                    scopes: ['agent-session:*']
+                }
+            ]
+        });
+        const providerCallback = provider.callback();
+        server = createServer((req, res) => {
+            void handleProviderRequest(provider, providerCallback, req, res);
+        });
+        await new Promise<void>((resolve) => server.listen(0, resolve));
+        const address = server.address() as AddressInfo;
+        origin = `http://127.0.0.1:${address.port}`;
+    });
+
+    afterAll(async () => {
+        await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    });
+
+    it('advertises the CIMD-only authorization code server', async () => {
+        const response = await fetch(`${origin}/.well-known/oauth-authorization-server`);
+        const discovery = (await response.json()) as Record<string, unknown>;
+
+        expect(response.status).toBe(200);
+        expect(discovery).toMatchObject({
+            issuer: 'http://localhost',
+            authorization_endpoint: 'http://localhost/oauth/authorize',
+            token_endpoint: 'http://localhost/oauth/token',
+            revocation_endpoint: 'http://localhost/oauth/revoke',
+            jwks_uri: 'http://localhost/oauth/jwks',
+            client_id_metadata_document_supported: true,
+            grant_types_supported: ['authorization_code', 'refresh_token'],
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256']
+        });
+        expect(discovery).not.toHaveProperty('registration_endpoint');
+        expect(discovery).not.toHaveProperty('userinfo_endpoint');
+        expect(discovery['scopes_supported']).toContain('environment:*');
+        expect(discovery['scopes_supported']).toContain('agent-session:*');
+        expect(discovery['scopes_supported']).not.toContain('openid');
+    });
+
+    it('uses OAuth-specific cookie names that cannot shadow the Nango dashboard session', () => {
+        expect(provider.cookieName('session')).toBe('nango_oauth_session');
+        expect(provider.cookieName('interaction')).toBe('nango_oauth_interaction');
+        expect(provider.cookieName('resume')).toBe('nango_oauth_resume');
+    });
+
+    it('does not expose dynamic client registration', async () => {
+        const response = await fetch(`${origin}/oauth/register`, { method: 'POST' });
+        expect(response.status).toBe(404);
+    });
+
+    it('rejects OpenID Connect scopes', async () => {
+        const response = await fetch(`${origin}/oauth/authorize?scope=openid%20environment%3A*`);
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toStrictEqual({
+            error: 'invalid_scope',
+            error_description: 'OpenID Connect scopes are not supported'
+        });
+    });
+
+    it('completes authorization code and rotating refresh token grants with a cached CIMD client', async () => {
+        const first = await authorize(provider, origin, clientId);
+        const tokens = await exchangeCode(origin, clientId, first.code, first.verifier);
+
+        expect(tokens).toMatchObject({
+            token_type: 'Bearer',
+            expires_in: 3600,
+            scope: 'environment:*'
+        });
+        expect(typeof tokens['access_token']).toBe('string');
+        expect(typeof tokens['refresh_token']).toBe('string');
+
+        const refreshed = await postToken(origin, {
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            refresh_token: stringValue(tokens['refresh_token']),
+            resource: 'https://mcp.example.com/mcp'
+        });
+        expect(refreshed.response.status).toBe(200);
+        expect(typeof refreshed.body['access_token']).toBe('string');
+        expect(typeof refreshed.body['refresh_token']).toBe('string');
+        expect(refreshed.body['refresh_token']).not.toBe(tokens['refresh_token']);
+
+        const replay = await postToken(origin, {
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            refresh_token: stringValue(tokens['refresh_token']),
+            resource: 'https://mcp.example.com/mcp'
+        });
+        expect(replay.response.status).toBe(400);
+        expect(replay.body['error']).toBe('invalid_grant');
+        expect(cimdFetches).toBe(1);
+    });
+
+    it('grants several resources in one authorization flow and issues a resource-specific token for each', async () => {
+        const managementResource = 'https://mcp.example.com/mcp';
+        const agentSessionResource = 'https://api.example.com/agent-sessions/session-1/mcp';
+        const authorization = await authorize(provider, origin, clientId, [managementResource, agentSessionResource], 'environment:* agent-session:*');
+        const managementTokens = await exchangeCode(origin, clientId, authorization.code, authorization.verifier, managementResource);
+
+        expect(managementTokens).toMatchObject({
+            token_type: 'Bearer',
+            expires_in: 3600,
+            scope: 'environment:*'
+        });
+        expect(artifacts.get(`AccessToken:${stringValue(managementTokens['access_token'])}`)).toMatchObject({
+            aud: managementResource,
+            scope: 'environment:*'
+        });
+
+        const agentSessionTokens = await postToken(origin, {
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            refresh_token: stringValue(managementTokens['refresh_token']),
+            resource: agentSessionResource
+        });
+        expect(agentSessionTokens.response.status).toBe(200);
+        expect(agentSessionTokens.body).toMatchObject({ token_type: 'Bearer', expires_in: 3600, scope: 'agent-session:*' });
+        expect(artifacts.get(`AccessToken:${stringValue(agentSessionTokens.body['access_token'])}`)).toMatchObject({
+            aud: agentSessionResource,
+            scope: 'agent-session:*'
+        });
+        expect(provider.issuer).toBe('http://localhost');
+    });
+
+    it('requires the exact resource at authorization and token boundaries', async () => {
+        const authorization = await authorize(provider, origin, clientId);
+        const missingAtToken = await postToken(origin, {
+            grant_type: 'authorization_code',
+            client_id: clientId,
+            code: authorization.code,
+            redirect_uri: 'https://client.example.com/callback',
+            code_verifier: authorization.verifier
+        });
+
+        expect(missingAtToken.response.status).toBe(400);
+        expect(missingAtToken.body['error']).toBe('invalid_target');
+
+        const verifier = randomBytes(32).toString('base64url');
+        const invalidAuthorization = new URL(`${origin}/oauth/authorize`);
+        invalidAuthorization.search = authorizationParams(clientId, verifier, 'https://mcp.example.com/not-mcp').toString();
+        const response = await fetch(invalidAuthorization, { redirect: 'manual' });
+
+        expect(response.status).toBe(303);
+        const location = response.headers.get('location');
+        if (!location) throw new Error('Missing authorization error redirect');
+        expect(new URL(location).searchParams.get('error')).toBe('invalid_target');
+
+        const refreshAuthorization = await authorize(provider, origin, clientId);
+        const tokens = await exchangeCode(origin, clientId, refreshAuthorization.code, refreshAuthorization.verifier);
+        const missingAtRefresh = await postToken(origin, {
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            refresh_token: stringValue(tokens['refresh_token'])
+        });
+        expect(missingAtRefresh.response.status).toBe(400);
+        expect(missingAtRefresh.body['error']).toBe('invalid_target');
+
+        const retryAfterMissing = await postToken(origin, {
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            refresh_token: stringValue(tokens['refresh_token']),
+            resource: 'https://mcp.example.com/mcp'
+        });
+        expect(retryAfterMissing.response.status).toBe(200);
+
+        const wrongResourceAuthorization = await authorize(provider, origin, clientId);
+        const wrongResourceTokens = await exchangeCode(origin, clientId, wrongResourceAuthorization.code, wrongResourceAuthorization.verifier);
+        const notGrantedAtRefresh = await postToken(origin, {
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            refresh_token: stringValue(wrongResourceTokens['refresh_token']),
+            resource: 'https://api.example.com/agent-sessions/session-1/mcp'
+        });
+        expect(notGrantedAtRefresh.response.status).toBe(400);
+        expect(notGrantedAtRefresh.body['error']).toBe('invalid_target');
+
+        const retryAfterNotGranted = await postToken(origin, {
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            refresh_token: stringValue(wrongResourceTokens['refresh_token']),
+            resource: 'https://mcp.example.com/mcp'
+        });
+        expect(retryAfterNotGranted.response.status).toBe(200);
+    });
+
+    it('revokes a refresh-token grant', async () => {
+        const authorization = await authorize(provider, origin, clientId);
+        const tokens = await exchangeCode(origin, clientId, authorization.code, authorization.verifier);
+        const refreshToken = stringValue(tokens['refresh_token']);
+        const revocation = await fetch(`${origin}/oauth/revoke`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ client_id: clientId, token: refreshToken, token_type_hint: 'refresh_token' })
+        });
+
+        expect(revocation.status).toBe(200);
+        const refreshed = await postToken(origin, {
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            refresh_token: refreshToken,
+            resource: 'https://mcp.example.com/mcp'
+        });
+        expect(refreshed.response.status).toBe(400);
+        expect(refreshed.body['error']).toBe('invalid_grant');
+    });
+
+    it('does not follow redirects or cache invalid and oversized CIMD responses', async () => {
+        const before = cimdFetches;
+
+        await expect(provider.Client.find('https://client.example.com/oauth/redirect.json')).rejects.toThrow();
+        await expect(provider.Client.find('https://client.example.com/oauth/mismatch.json')).rejects.toThrow();
+        await expect(provider.Client.find('https://client.example.com/oauth/mismatch.json')).rejects.toThrow();
+        await expect(provider.Client.find('https://client.example.com/oauth/oversized.json')).rejects.toThrow();
+
+        expect(cimdFetches).toBe(before + 4);
+    });
+
+    it('coalesces concurrent CIMD fetches for one client ID', async () => {
+        const before = cimdFetches;
+        const candidate = 'https://client.example.com/oauth/concurrent.json';
+
+        await Promise.all(Array.from({ length: 10 }, async () => await provider.Client.find(candidate)));
+
+        expect(cimdFetches).toBe(before + 1);
+    });
+
+    it('bounds the valid CIMD document cache', async () => {
+        const before = cimdFetches;
+        // oidc-provider's max-size 100 LRU uses recent and stale generations. Two full
+        // generations must pass before a frequently used entry is guaranteed evicted.
+        for (let index = 0; index < 200; index++) {
+            const candidate = `https://client.example.com/oauth/client-${index}.json`;
+            const verifier = randomBytes(32).toString('base64url');
+            const authorization = new URL(`${origin}/oauth/authorize`);
+            authorization.search = authorizationParams(candidate, verifier, 'https://mcp.example.com/mcp').toString();
+            const response = await fetch(authorization, { redirect: 'manual' });
+            expect(response.status).toBe(303);
+        }
+        expect(cimdFetches).toBe(before + 200);
+
+        const verifier = randomBytes(32).toString('base64url');
+        const authorization = new URL(`${origin}/oauth/authorize`);
+        authorization.search = authorizationParams(clientId, verifier, 'https://mcp.example.com/mcp').toString();
+        await fetch(authorization, { redirect: 'manual' });
+        expect(cimdFetches).toBe(before + 201);
+    });
+});
+
+async function handleProviderRequest(
+    provider: Provider,
+    providerCallback: ReturnType<Provider['callback']>,
+    req: IncomingMessage,
+    res: ServerResponse
+): Promise<void> {
+    try {
+        if (req.url?.startsWith('/oauth/interaction/')) {
+            await finishTestInteraction(provider, req, res);
+            return;
+        }
+        await providerCallback(req, res);
+    } catch (err) {
+        res.statusCode = 500;
+        res.end(err instanceof Error ? err.message : 'Unknown test error');
+    }
+}
+
+async function finishTestInteraction(provider: Provider, req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const interaction = await provider.interactionDetails(req, res);
+    res.setHeader('x-test-prompt', `${interaction.prompt.name}:${interaction.prompt.reasons.join(',')}:${JSON.stringify(interaction.prompt.details)}`);
+    if (interaction.prompt.name === 'login') {
+        await provider.interactionFinished(req, res, { login: { accountId: 'test-account', amr: ['test'], remember: false } });
+        return;
+    }
+    if (interaction.prompt.name !== 'consent') {
+        throw new Error(`Unexpected test interaction prompt: ${interaction.prompt.name}`);
+    }
+
+    const clientId = interactionParam(interaction, 'client_id');
+    const grant = interaction.grantId ? await provider.Grant.find(interaction.grantId) : new provider.Grant({ accountId: 'test-account', clientId });
+    if (!grant) throw new Error('Test grant disappeared');
+    let addedScopes = false;
+    const missingOidcScopes: unknown = interaction.prompt.details['missingOIDCScope'];
+    if (isStringArray(missingOidcScopes)) {
+        grant.addOIDCScope(missingOidcScopes.join(' '));
+        addedScopes = true;
+    }
+    const missingResourceScopes: unknown = interaction.prompt.details['missingResourceScopes'];
+    if (missingResourceScopes && typeof missingResourceScopes === 'object' && !Array.isArray(missingResourceScopes)) {
+        for (const [resource, scopes] of Object.entries(missingResourceScopes)) {
+            if (!isStringArray(scopes)) throw new Error(`Invalid test resource scopes for ${resource}`);
+            grant.addResourceScope(resource, scopes.join(' '));
+            addedScopes = true;
+        }
+    }
+    if (!addedScopes) {
+        throw new Error(`Test interaction did not request scopes: ${JSON.stringify(interaction.prompt.details)}`);
+    }
+    const grantId = await grant.save();
+    await provider.interactionFinished(req, res, { consent: { grantId } });
+}
+
+function isStringArray(value: unknown): value is string[] {
+    return Array.isArray(value) && value.every((entry): entry is string => typeof entry === 'string');
+}
+
+async function authorize(
+    provider: Provider,
+    origin: string,
+    clientId: string,
+    resource: string | readonly string[] = 'https://mcp.example.com/mcp',
+    scope = 'environment:*'
+): Promise<{ code: string; verifier: string }> {
+    const verifier = randomBytes(32).toString('base64url');
+    const authorization = new URL(`${origin}/oauth/authorize`);
+    authorization.search = authorizationParams(clientId, verifier, resource, scope).toString();
+    let nextUrl = authorization.href;
+    const cookies = new Map<string, string>();
+    const visited: string[] = [];
+
+    for (let redirects = 0; redirects < 10; redirects++) {
+        const headers = new Headers();
+        if (cookies.size) {
+            headers.set('cookie', [...cookies].map(([name, value]) => `${name}=${value}`).join('; '));
+        }
+        const response = await fetch(nextUrl, {
+            headers,
+            redirect: 'manual'
+        });
+        rememberCookies(response, cookies);
+        const location = response.headers.get('location');
+        visited.push(`${response.status} ${nextUrl} -> ${location ?? '(none)'} [${response.headers.get('x-test-prompt') ?? ''}]`);
+        if (!location) throw new Error(`OAuth test flow stopped with ${response.status}: ${await response.text()}`);
+        const resolved = new URL(location, nextUrl);
+        if (resolved.origin === 'https://client.example.com') {
+            expect(resolved.searchParams.get('state')).toBe('test-state');
+            const code = resolved.searchParams.get('code');
+            if (!code) throw new Error(`OAuth test flow failed: ${resolved.searchParams.get('error') ?? 'missing code'}`);
+            return { code, verifier };
+        }
+        nextUrl = resolved.href.replace(provider.issuer, origin);
+    }
+    throw new Error(`OAuth test flow exceeded the redirect limit:\n${visited.join('\n')}`);
+}
+
+function authorizationParams(clientId: string, verifier: string, resource: string | readonly string[], scope = 'environment:*'): URLSearchParams {
+    const params = new URLSearchParams({
+        client_id: clientId,
+        redirect_uri: 'https://client.example.com/callback',
+        response_type: 'code',
+        scope,
+        state: 'test-state',
+        code_challenge: createHash('sha256').update(verifier).digest('base64url'),
+        code_challenge_method: 'S256'
+    });
+    for (const value of typeof resource === 'string' ? [resource] : resource) {
+        params.append('resource', value);
+    }
+    return params;
+}
+
+async function exchangeCode(
+    origin: string,
+    clientId: string,
+    code: string,
+    verifier: string,
+    resource = 'https://mcp.example.com/mcp'
+): Promise<Record<string, unknown>> {
+    const result = await postToken(origin, {
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        code,
+        redirect_uri: 'https://client.example.com/callback',
+        code_verifier: verifier,
+        resource
+    });
+    expect(result.response.status).toBe(200);
+    return result.body;
+}
+
+async function postToken(origin: string, input: Record<string, string>): Promise<{ response: Response; body: Record<string, unknown> }> {
+    const response = await fetch(`${origin}/oauth/token`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(input)
+    });
+    return { response, body: (await response.json()) as Record<string, unknown> };
+}
+
+function rememberCookies(response: Response, cookies: Map<string, string>): void {
+    for (const cookie of response.headers.getSetCookie()) {
+        const [pair] = cookie.split(';');
+        if (!pair) continue;
+        const separator = pair.indexOf('=');
+        if (separator < 1) continue;
+        cookies.set(pair.slice(0, separator), pair.slice(separator + 1));
+    }
+}
+
+function interactionParam(interaction: Interaction, name: string): string {
+    const value = interaction.params[name];
+    if (typeof value !== 'string') throw new Error(`Missing ${name} in test interaction`);
+    return value;
+}
+
+function stringValue(value: unknown): string {
+    if (typeof value !== 'string') throw new Error('Expected a string token');
+    return value;
+}

--- a/packages/oauth-server/package.json
+++ b/packages/oauth-server/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "@nangohq/oauth-server",
+    "version": "1.0.0",
+    "description": "Reusable OAuth authorization server infrastructure for Nango",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "private": true,
+    "scripts": {},
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/NangoHQ/nango.git",
+        "directory": "packages/oauth-server"
+    },
+    "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
+    "dependencies": {
+        "@nangohq/egress": "file:../egress",
+        "knex": "3.1.0",
+        "oidc-provider": "9.12.2",
+        "zod": "4.0.5"
+    },
+    "devDependencies": {
+        "@nangohq/database": "file:../database",
+        "@types/oidc-provider": "9.12.0",
+        "vitest": "4.1.9"
+    },
+    "files": [
+        "dist/**/*"
+    ]
+}

--- a/packages/oauth-server/package.json
+++ b/packages/oauth-server/package.json
@@ -15,13 +15,13 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@nangohq/egress": "file:../egress",
+        "@types/oidc-provider": "9.12.0",
         "knex": "3.1.0",
         "oidc-provider": "9.12.2",
         "zod": "4.0.5"
     },
     "devDependencies": {
         "@nangohq/database": "file:../database",
-        "@types/oidc-provider": "9.12.0",
         "vitest": "4.1.9"
     },
     "files": [

--- a/packages/oauth-server/tsconfig.json
+++ b/packages/oauth-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "lib",
+        "outDir": "dist"
+    },
+    "references": [
+        {
+            "path": "../database"
+        },
+        {
+            "path": "../egress"
+        }
+    ],
+    "include": ["lib/**/*"]
+}

--- a/packages/server/lib/controllers/v1/account/managed/auth.ts
+++ b/packages/server/lib/controllers/v1/account/managed/auth.ts
@@ -5,6 +5,7 @@ import { basePublicUrl, flagHasUsage, nanoid, report } from '@nangohq/utils';
 import { envs } from '../../../../env.js';
 import { linkBillingCustomer, linkBillingFreeSubscription } from '../../../../utils/billing.js';
 import { loginOrStartPendingMfa } from '../mfa/login.js';
+import { safeOAuthContinuation } from '../returnTo.js';
 
 import type { InviteAccountState } from './postSignup.js';
 import type { DBInvitation, DBTeam } from '@nangohq/types';
@@ -221,6 +222,7 @@ export async function finalizeManagedAuthentication({
         return;
     }
 
+    if (!invitation || isNewUser) destination = safeOAuthContinuation(req.session.oauthContinuation) ?? destination;
     try {
         const pendingMfa = await loginOrStartPendingMfa(req, user, destination);
         if (pendingMfa) {

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -1,7 +1,7 @@
 import db from '@nangohq/database';
 import { accountService, mfaService, recordMFALoginRefused, recordMFAVerifyFailure, userService } from '@nangohq/shared';
 
-import { safeOAuthContinuation, safeReturnTo } from '../returnTo.js';
+import { safeReturnTo } from '../returnTo.js';
 import { markMfaVerified } from './elevation.js';
 
 import type { DBUser, PostMFALoginVerification } from '@nangohq/types';
@@ -78,7 +78,6 @@ export async function isMFAEnabled(user: DBUser, trx: Knex = db.knex): Promise<b
 }
 
 async function loginUser(req: Request, user: DBUser): Promise<void> {
-    const continuation = safeOAuthContinuation(req.session.oauthContinuation);
     await new Promise<void>((resolve, reject) => {
         req.login(user, (err) => {
             if (err) {
@@ -89,18 +88,12 @@ async function loginUser(req: Request, user: DBUser): Promise<void> {
             resolve();
         });
     });
-    if (continuation) {
-        req.session.oauthContinuation = continuation;
-        await saveSession(req);
-    }
 }
 
 async function regenerateSession(req: Request): Promise<void> {
-    const continuation = safeOAuthContinuation(req.session.oauthContinuation);
     await new Promise<void>((resolve, reject) => {
         req.session.regenerate((err) => (err ? reject(err instanceof Error ? err : new Error(String(err))) : resolve()));
     });
-    if (continuation) req.session.oauthContinuation = continuation;
 }
 
 async function saveSession(req: Request): Promise<void> {

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -1,7 +1,7 @@
 import db from '@nangohq/database';
 import { accountService, mfaService, recordMFALoginRefused, recordMFAVerifyFailure, userService } from '@nangohq/shared';
 
-import { safeReturnTo } from '../returnTo.js';
+import { safeOAuthContinuation, safeReturnTo } from '../returnTo.js';
 import { markMfaVerified } from './elevation.js';
 
 import type { DBUser, PostMFALoginVerification } from '@nangohq/types';
@@ -78,6 +78,7 @@ export async function isMFAEnabled(user: DBUser, trx: Knex = db.knex): Promise<b
 }
 
 async function loginUser(req: Request, user: DBUser): Promise<void> {
+    const continuation = safeOAuthContinuation(req.session.oauthContinuation);
     await new Promise<void>((resolve, reject) => {
         req.login(user, (err) => {
             if (err) {
@@ -88,12 +89,18 @@ async function loginUser(req: Request, user: DBUser): Promise<void> {
             resolve();
         });
     });
+    if (continuation) {
+        req.session.oauthContinuation = continuation;
+        await saveSession(req);
+    }
 }
 
 async function regenerateSession(req: Request): Promise<void> {
+    const continuation = safeOAuthContinuation(req.session.oauthContinuation);
     await new Promise<void>((resolve, reject) => {
         req.session.regenerate((err) => (err ? reject(err instanceof Error ? err : new Error(String(err))) : resolve()));
     });
+    if (continuation) req.session.oauthContinuation = continuation;
 }
 
 async function saveSession(req: Request): Promise<void> {

--- a/packages/server/lib/controllers/v1/account/putResetPassword.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.ts
@@ -6,6 +6,7 @@ import { pbkdf2, userService } from '@nangohq/shared';
 import { PBKDF2_ITERATIONS, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { deleteUserSessions } from '../../../clients/auth.client.js';
+import { revokeUserOAuthGrants } from '../../../oauth/grants.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { resetPasswordSecret } from '../../../utils/utils.js';
 import { isStepUpRefused, isStepUpRequired, mfaCredentialSchema, verifyStepUpMfa } from './mfa/stepUp.js';
@@ -72,6 +73,7 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
         user.reset_password_token = null;
         await userService.editUserPassword(user, trx);
         await deleteUserSessions(user.id, { trx });
+        await revokeUserOAuthGrants(user.id, trx);
         return 'reset' as const;
     });
 

--- a/packages/server/lib/controllers/v1/account/returnTo.ts
+++ b/packages/server/lib/controllers/v1/account/returnTo.ts
@@ -3,7 +3,7 @@ const RETURN_TO_BASE_ORIGIN = 'https://internal.invalid';
 
 /** Only the server-created, opaque OAuth continuation survives login session rotation. */
 export function safeOAuthContinuation(value: string | undefined): string | undefined {
-    return value && /^\/oauth\/continue\?state=[A-Za-z0-9_-]{20,128}$/.test(value) ? value : undefined;
+    return value && /^\/oauth\/continue\/[A-Za-z0-9_-]{20,128}$/.test(value) ? value : undefined;
 }
 
 export function safeReturnTo(returnTo: string): string {

--- a/packages/server/lib/controllers/v1/account/returnTo.ts
+++ b/packages/server/lib/controllers/v1/account/returnTo.ts
@@ -1,6 +1,11 @@
 // Reserved TLD (RFC 2606) used only to resolve relative paths; a returnTo that escapes this origin is rejected.
 const RETURN_TO_BASE_ORIGIN = 'https://internal.invalid';
 
+/** Only the server-created, opaque OAuth continuation survives login session rotation. */
+export function safeOAuthContinuation(value: string | undefined): string | undefined {
+    return value && /^\/oauth\/continue\?state=[A-Za-z0-9_-]{20,128}$/.test(value) ? value : undefined;
+}
+
 export function safeReturnTo(returnTo: string): string {
     try {
         const url = new URL(returnTo, RETURN_TO_BASE_ORIGIN);

--- a/packages/server/lib/controllers/v1/account/signin.ts
+++ b/packages/server/lib/controllers/v1/account/signin.ts
@@ -6,7 +6,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { userToAPI } from '../../../formatters/user.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { loginOrStartPendingMfa } from './mfa/login.js';
-import { safeReturnTo } from './returnTo.js';
+import { safeOAuthContinuation, safeReturnTo } from './returnTo.js';
 
 import type { RequestLocals } from '../../../utils/express.js';
 import type { DBUser, PostSignin } from '@nangohq/types';
@@ -67,7 +67,7 @@ export const signin = asyncWrapper<PostSignin>(async (req, res: Response<any, Re
         return;
     }
 
-    const destination = resolvePostLoginDestination(user, req.body.returnTo);
+    const destination = resolvePostLoginDestination(user, safeOAuthContinuation(req.session.oauthContinuation) ?? req.body.returnTo);
     const pendingMfa = await loginOrStartPendingMfa(req, user, destination);
     if (pendingMfa) {
         res.status(200).send({ data: { mfaRequired: true } });

--- a/packages/server/lib/controllers/v1/getEnvJs.ts
+++ b/packages/server/lib/controllers/v1/getEnvJs.ts
@@ -15,13 +15,17 @@ import {
     isHosted
 } from '@nangohq/utils';
 
+import { getOAuthServerConfig } from '../../oauth/config.js';
+
 import type { WindowEnv } from '@nangohq/types';
 import type { RequestHandler } from 'express';
 
 export const getEnvJs: RequestHandler = (_, res) => {
+    const oauthServerUrl = getOAuthServerConfig()?.config.baseUrl;
     const configObject: WindowEnv = {
         apiUrl: baseUrl,
         dashboardApiUrl,
+        ...(oauthServerUrl ? { oauthServerUrl } : {}),
         publicUrl: basePublicUrl,
         connectUrl: connectUrl,
         gitHash: envs.GIT_HASH,

--- a/packages/server/lib/controllers/v1/user/password/putPassword.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.ts
@@ -7,6 +7,7 @@ import { pbkdf2, userService } from '@nangohq/shared';
 import { PBKDF2_ITERATIONS, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { deleteUserSessions } from '../../../../clients/auth.client.js';
+import { revokeUserOAuthGrants } from '../../../../oauth/grants.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { hasRecentMfa } from '../../account/mfa/elevation.js';
 import { isStepUpRefused, isStepUpRequired, mfaCredentialSchema, verifyStepUpMfa } from '../../account/mfa/stepUp.js';
@@ -66,6 +67,7 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
 
         await userService.update({ id: user.id, hashed_password: hashedPassword, salt }, trx);
         await deleteUserSessions(user.id, { trx });
+        await revokeUserOAuthGrants(user.id, trx);
         return 'changed' as const;
     });
 

--- a/packages/server/lib/crons/deleteOldData.ts
+++ b/packages/server/lib/crons/deleteOldData.ts
@@ -24,6 +24,7 @@ import { deleteProviderConfigData } from '../deletion/deleteProviderConfigData.j
 import { deleteSyncConfigData } from '../deletion/deleteSyncConfigData.js';
 import { deleteSyncs } from '../deletion/deleteSyncs.js';
 import { envs } from '../env.js';
+import { cleanOAuthConsent } from '../oauth/grants.js';
 import { deleteExpiredConnectSession } from '../services/connectSession.service.js';
 import oauthSessionService from '../services/oauth-session.service.js';
 
@@ -129,6 +130,9 @@ export async function exec(): Promise<void> {
             name: 'oauth server artifacts',
             deleteFn: async () => await deleteExpiredOAuthArtifacts(db.knex, limit)
         });
+
+        // One bounded batch per run, including compensation for stale pending grants.
+        await cleanOAuthConsent(limit);
 
         // Delete invitations
         await batchDelete({

--- a/packages/server/lib/crons/deleteOldData.ts
+++ b/packages/server/lib/crons/deleteOldData.ts
@@ -4,6 +4,7 @@ import * as cron from 'node-cron';
 import db from '@nangohq/database';
 import { deleteExpiredPrivateKeys } from '@nangohq/keystore';
 import { getLocking } from '@nangohq/kvstore';
+import { deleteExpiredOAuthArtifacts } from '@nangohq/oauth-server';
 import { deleteFunctionAsyncJobsOlderThan } from '@nangohq/sandbox';
 import {
     configService,
@@ -121,6 +122,12 @@ export async function exec(): Promise<void> {
             ...opts,
             name: 'oauth sessions',
             deleteFn: async () => await oauthSessionService.deleteExpiredSessions({ limit, olderThan: deleteOauthSessionOlderThan })
+        });
+
+        await batchDelete({
+            ...opts,
+            name: 'oauth server artifacts',
+            deleteFn: async () => await deleteExpiredOAuthArtifacts(db.knex, limit)
         });
 
         // Delete invitations

--- a/packages/server/lib/env.ts
+++ b/packages/server/lib/env.ts
@@ -1,3 +1,5 @@
+import { DekRegistry } from '@nangohq/kms';
 import { ENVS, parseEnvs } from '@nangohq/utils';
 
 export const envs = parseEnvs(ENVS);
+export const dek = await DekRegistry.create(envs);

--- a/packages/server/lib/express.d.ts
+++ b/packages/server/lib/express.d.ts
@@ -43,6 +43,7 @@ declare global {
 
 declare module 'express-session' {
     interface SessionData {
+        oauthContinuation?: string;
         debugMode?: boolean;
         // The account that impersonated, not the person: gated on NANGO_ADMIN_UUID today, but the trail
         // records whoever it was rather than a hardcoded identity.

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -22,6 +22,7 @@ import { envs } from '../env.js';
 import { agentSessionTokenSchema, connectSessionTokenPrefix, connectSessionTokenSchema } from '../helpers/validation.js';
 import * as agentSessionService from '../services/agentSession.service.js';
 import * as connectSessionService from '../services/connectSession.service.js';
+import { loadSessionIdentity } from '../utils/sessionIdentity.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { AgentSession, ApiKeyContext, ApiKeyPrincipal, ConnectSession, DBAPISecret, DBEnvironment, DBPlan, DBTeam, InternalEndUser } from '@nangohq/types';
@@ -707,17 +708,13 @@ export class AccessMiddleware {
  */
 async function fillLocalsFromSession(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
     try {
-        const user = await userService.getUserById(req.user!.id);
-        if (!user) {
+        const identity = await loadSessionIdentity(req.user!.id);
+        if (!identity) {
             res.status(401).send({ error: { code: 'unknown_user' } });
             return;
         }
 
-        const account = await accountService.getAccountById(db.knex, user.account_id);
-        if (!account) {
-            res.status(401).send({ error: { code: 'unknown_account' } });
-            return;
-        }
+        const { user, account } = identity;
 
         let plan: DBPlan | null = null;
         if (flagHasPlan) {

--- a/packages/server/lib/middleware/audit/index.ts
+++ b/packages/server/lib/middleware/audit/index.ts
@@ -88,4 +88,4 @@ export {
 } from './sync.middleware.js';
 export { auditTeamUpdated } from './team.middleware.js';
 export { auditUserUpdated } from './user.middleware.js';
-export { auditOAuthApproved, auditOAuthDenied, auditOAuthSession } from './oauth.middleware.js';
+export { auditOAuthApproved, auditOAuthDenied } from './oauth.middleware.js';

--- a/packages/server/lib/middleware/audit/index.ts
+++ b/packages/server/lib/middleware/audit/index.ts
@@ -88,3 +88,4 @@ export {
 } from './sync.middleware.js';
 export { auditTeamUpdated } from './team.middleware.js';
 export { auditUserUpdated } from './user.middleware.js';
+export { auditOAuthApproved, auditOAuthDenied, auditOAuthSession } from './oauth.middleware.js';

--- a/packages/server/lib/middleware/audit/oauth.middleware.ts
+++ b/packages/server/lib/middleware/audit/oauth.middleware.ts
@@ -1,10 +1,7 @@
-import { makeAuditTarget, recordAuditEvent } from '../../audit.js';
-import { canRecordAuditTrail } from '../../utils/auditTrail.js';
-import { Audit, auditable, auditRequestFields, resolveActor } from './auditable.js';
+import { makeAuditTarget } from '../../audit.js';
+import { Audit, auditable } from './auditable.js';
 
-import type { RequestLocals } from '../../utils/express.js';
-import type { GetOAuthHandoffCallback, PostOAuthApprove, PostOAuthDeny } from '@nangohq/types';
-import type { RequestHandler } from 'express';
+import type { PostOAuthApprove, PostOAuthDeny } from '@nangohq/types';
 
 export const auditOAuthApproved = auditable<PostOAuthApprove>({
     policy: Audit.auditable({ resource: 'oauth_grant', action: 'approved', scope: 'account' }),
@@ -13,27 +10,3 @@ export const auditOAuthApproved = auditable<PostOAuthApprove>({
 export const auditOAuthDenied = auditable<PostOAuthDeny>({
     policy: Audit.auditable({ resource: 'oauth_grant', action: 'denied', scope: 'account' })
 });
-
-const handoffPolicy: GetOAuthHandoffCallback['Audit'] = Audit.auditable({ resource: 'oauth_session', action: 'established', scope: 'account' });
-export const auditOAuthSession: RequestHandler<any, any, any, any, RequestLocals> = (req, res, next) => {
-    res.on('finish', () => {
-        // This callback establishes its principal inside the transaction and responds with a 303.
-        if (res.statusCode !== 303 || !res.locals.account) return;
-        void (async () => {
-            if (!(await canRecordAuditTrail(res.locals.plan))) return;
-            await recordAuditEvent({
-                ...handoffPolicy,
-                occurredAt: new Date().toISOString(),
-                accountId: res.locals.account.id,
-                environment: null,
-                actor: resolveActor(res.locals),
-                targets: [],
-                outcome: 'success',
-                ...auditRequestFields(req, res.locals.account.id)
-            });
-        })().catch(() => {
-            /* Audit sink failure must not alter authentication. */
-        });
-    });
-    next();
-};

--- a/packages/server/lib/middleware/audit/oauth.middleware.ts
+++ b/packages/server/lib/middleware/audit/oauth.middleware.ts
@@ -1,0 +1,39 @@
+import { makeAuditTarget, recordAuditEvent } from '../../audit.js';
+import { canRecordAuditTrail } from '../../utils/auditTrail.js';
+import { Audit, auditable, auditRequestFields, resolveActor } from './auditable.js';
+
+import type { RequestLocals } from '../../utils/express.js';
+import type { GetOAuthHandoffCallback, PostOAuthApprove, PostOAuthDeny } from '@nangohq/types';
+import type { RequestHandler } from 'express';
+
+export const auditOAuthApproved = auditable<PostOAuthApprove>({
+    policy: Audit.auditable({ resource: 'oauth_grant', action: 'approved', scope: 'account' }),
+    targetFromResponse: (response) => makeAuditTarget('oauth_grant', response.data.grantId)
+});
+export const auditOAuthDenied = auditable<PostOAuthDeny>({
+    policy: Audit.auditable({ resource: 'oauth_grant', action: 'denied', scope: 'account' })
+});
+
+const handoffPolicy: GetOAuthHandoffCallback['Audit'] = Audit.auditable({ resource: 'oauth_session', action: 'established', scope: 'account' });
+export const auditOAuthSession: RequestHandler<any, any, any, any, RequestLocals> = (req, res, next) => {
+    res.on('finish', () => {
+        // This callback establishes its principal inside the transaction and responds with a 303.
+        if (res.statusCode !== 303 || !res.locals.account) return;
+        void (async () => {
+            if (!(await canRecordAuditTrail(res.locals.plan))) return;
+            await recordAuditEvent({
+                ...handoffPolicy,
+                occurredAt: new Date().toISOString(),
+                accountId: res.locals.account.id,
+                environment: null,
+                actor: resolveActor(res.locals),
+                targets: [],
+                outcome: 'success',
+                ...auditRequestFields(req, res.locals.account.id)
+            });
+        })().catch(() => {
+            /* Audit sink failure must not alter authentication. */
+        });
+    });
+    next();
+};

--- a/packages/server/lib/middleware/audit/oauth.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/oauth.middleware.unit.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { auditOAuthApproved, auditOAuthDenied, auditOAuthSession } from './oauth.middleware.js';
+import { auditOAuthApproved, auditOAuthDenied } from './oauth.middleware.js';
 import { fakeReq, fakeRes, installAuditMockDefaults, locals, recordMock, resetAuditMocks, runAudit } from './testing.js';
 
 vi.mock('../../audit.js', async (importOriginal) => (await import('./testing.js')).auditModuleMock(importOriginal as never));
@@ -42,21 +42,5 @@ describe('OAuth audit policy', () => {
             outcome: status === 200 ? 'success' : status === 403 ? 'denied' : 'failure',
             actor: { type: 'user', id: '7' }
         });
-    });
-
-    it('records session establishment after the callback resolves its identity', async () => {
-        const res = fakeRes({}, 303);
-        await new Promise<void>((resolve) => auditOAuthSession(fakeReq({ query: { code: 'secret' } }), res, () => resolve()));
-        res.locals = locals;
-        res.emit('finish');
-        await vi.waitFor(() => expect(recordMock).toHaveBeenCalled());
-        expect(recordMock.mock.calls[0]![0]).toMatchObject({
-            accountId: 42,
-            environment: null,
-            action: 'established',
-            outcome: 'success',
-            actor: { type: 'user', id: '7' }
-        });
-        expect(JSON.stringify(recordMock.mock.calls)).not.toContain('secret');
     });
 });

--- a/packages/server/lib/middleware/audit/oauth.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/oauth.middleware.unit.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { auditOAuthApproved, auditOAuthDenied, auditOAuthSession } from './oauth.middleware.js';
+import { fakeReq, fakeRes, installAuditMockDefaults, locals, recordMock, resetAuditMocks, runAudit } from './testing.js';
+
+vi.mock('../../audit.js', async (importOriginal) => (await import('./testing.js')).auditModuleMock(importOriginal as never));
+vi.mock('@nangohq/shared', async (importOriginal) => (await import('./testing.js')).sharedModuleMock(importOriginal as never));
+
+describe('OAuth audit policy', () => {
+    beforeEach(installAuditMockDefaults);
+    afterEach(resetAuditMocks);
+
+    it('records approved product grant without credential-bearing request or response data', async () => {
+        const req = fakeReq({ params: { uid: 'sensitive-interaction' }, body: { csrfToken: 'sensitive-csrf' } });
+        const res = fakeRes(locals);
+        await new Promise<void>((resolve) => auditOAuthApproved(req, res, () => resolve()));
+        res.json({ data: { grantId: 'product-grant-id', redirectUrl: 'https://id.nango.dev/oauth/authorize/secret' } });
+        res.emit('finish');
+        await vi.waitFor(() => expect(recordMock).toHaveBeenCalled());
+        const event = recordMock.mock.calls[0]![0];
+        expect(event).toMatchObject({
+            accountId: 42,
+            environment: null,
+            scope: 'account',
+            resource: 'oauth_grant',
+            action: 'approved',
+            outcome: 'success',
+            actor: { type: 'user', id: '7' },
+            targets: [{ type: 'oauth_grant', id: 'product-grant-id' }]
+        });
+        expect(JSON.stringify(event)).not.toMatch(/sensitive|secret|id\.nango/);
+    });
+
+    it.each([200, 403, 500])('records consent denial and failure outcomes (%i)', async (status) => {
+        const event = await runAudit(auditOAuthDenied, fakeReq(), fakeRes(locals, status));
+        expect(event).toMatchObject({
+            accountId: 42,
+            environment: null,
+            scope: 'account',
+            resource: 'oauth_grant',
+            action: 'denied',
+            outcome: status === 200 ? 'success' : status === 403 ? 'denied' : 'failure',
+            actor: { type: 'user', id: '7' }
+        });
+    });
+
+    it('records session establishment after the callback resolves its identity', async () => {
+        const res = fakeRes({}, 303);
+        await new Promise<void>((resolve) => auditOAuthSession(fakeReq({ query: { code: 'secret' } }), res, () => resolve()));
+        res.locals = locals;
+        res.emit('finish');
+        await vi.waitFor(() => expect(recordMock).toHaveBeenCalled());
+        expect(recordMock.mock.calls[0]![0]).toMatchObject({
+            accountId: 42,
+            environment: null,
+            action: 'established',
+            outcome: 'success',
+            actor: { type: 'user', id: '7' }
+        });
+        expect(JSON.stringify(recordMock.mock.calls)).not.toContain('secret');
+    });
+});

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -6,6 +6,7 @@ import { getRedisUrl } from '@nangohq/kvstore';
 import { flagHasAPIRateLimit, flagHasPlan, getLogger } from '@nangohq/utils';
 
 import { envs } from '../env.js';
+import { oauthTelemetryPath } from '../oauth/telemetry.js';
 import { createRateLimiterRedisClient } from '../utils/rateLimiterRedisClient.js';
 
 import type { RequestLocals } from '../utils/express.js';
@@ -96,11 +97,12 @@ export const rateLimiterMiddleware = async (req: Request, res: Response<any, Par
         next();
     } catch (err) {
         if (err instanceof RateLimiterRes) {
-            logger.info(`Rate limit exceeded for ${key}. Request: ${req.method} ${req.path})`);
+            const path = oauthTelemetryPath(req.originalUrl) ?? req.path;
+            logger.info(`Rate limit exceeded for ${key}. Request: ${req.method} ${path})`);
 
             setXRateLimitHeaders(maxPoints, err);
             res.setHeader('Retry-After', Math.floor(err.msBeforeNext / 1000));
-            res.status(429).send({ error: { code: 'too_many_request', method: req.method, path: req.path } });
+            res.status(429).send({ error: { code: 'too_many_request', method: req.method, path } });
             return;
         }
 

--- a/packages/server/lib/middleware/security.ts
+++ b/packages/server/lib/middleware/security.ts
@@ -2,6 +2,8 @@ import helmet from 'helmet';
 
 import { basePublicUrl, baseUrl, connectUrl, connectUrlAsDocumentBase, dashboardApiUrl } from '@nangohq/utils';
 
+import { getOAuthServerConfig } from '../oauth/config.js';
+
 import type { RequestHandler } from 'express';
 
 // CSP path matching: no trailing slash = exact match (URL older SDKs load), with = prefix match (assets/routes).
@@ -22,6 +24,7 @@ export function securityMiddlewares(): RequestHandler[] {
     const apiCspSources = dashboardApiUrl === '/' ? [hostApi] : [...new Set([hostApi, dashboardApiUrl])];
     const apiWsCspSources = dashboardApiUrl === '/' ? [hostWs] : [...new Set([hostWs, websocketOrigin(dashboardApiUrl)])];
     const reportOnly = process.env['CSP_REPORT_ONLY'];
+    const oauthServerUrl = getOAuthServerConfig()?.config.baseUrl;
 
     return [
         helmet.xssFilter(),
@@ -48,6 +51,7 @@ export function securityMiddlewares(): RequestHandler[] {
                     'https://*.sentry.io',
                     hostPublic,
                     ...apiCspSources,
+                    ...(oauthServerUrl ? [oauthServerUrl] : []),
                     ...apiWsCspSources,
                     ...connectUrlCspSources,
                     'https://*.posthog.com',

--- a/packages/server/lib/oauth/README.md
+++ b/packages/server/lib/oauth/README.md
@@ -1,0 +1,38 @@
+# Nango OAuth login and consent
+
+The reusable protocol provider is `@nangohq/oauth-server`. This directory supplies the Nango session bridge, React interaction API and product-grant lifecycle. It does **not** enable bearer authentication on `/mcp`.
+
+## Configuration
+
+- Enable `NANGO_MANAGEMENT_MCP_OAUTH_ENABLED` and configure `NANGO_MANAGEMENT_MCP_SERVER_URL`.
+- `NANGO_OAUTH_SERVER_BASE_URL` is the issuer origin. Cloud defaults to `https://id.nango.dev`; local/self-hosted installations must configure it explicitly.
+- Supply `NANGO_OAUTH_SERVER_COOKIE_KEYS` (JSON array of at least two independent signing keys), `NANGO_OAUTH_SERVER_JWKS` (private signing keys), and the existing encryption-key configuration.
+- Enable normal dashboard authentication and the account-targeted Unleash flag `oauth-server-consent` (defaults off). The flag gates the bridge and consent, not provider discovery or token endpoints.
+- `NANGO_PUBLIC_SERVER_URL` identifies the exact dashboard origin for credentialed CORS and CSRF Origin checks. The React runtime receives `oauthServerUrl` via `/env.js`, and CSP permits that origin.
+- Route the issuer host to the server and preserve `Host` and the trusted HTTPS forwarding information. Protocol endpoints reject other hosts. Do not widen `nango_session` to a parent domain.
+
+The dashboard and issuer must be same-site for the issuer's `SameSite=Lax` cookies to accompany the React API requests (Cloud's `app.nango.dev` and `id.nango.dev` satisfy this). For local cross-origin browser tests, use same-site HTTPS subdomains, not `localhost` versus `127.0.0.1`.
+
+## Security and persistence
+
+An issuer interaction redirects to `/oauth/continue` with opaque state. The dashboard/API session either issues a 45-second handoff code or completes normal login, MFA and onboarding first. The code is hashed server-side, bound to a browser nonce, identity, interaction and exact issuer return destination, and consumed once under a transaction. The resulting issuer cookie is host-only and independent of dashboard logout.
+
+Approval validates the provider interaction, client callback and all configured resources/scopes again, claims the interaction once, and creates a fresh grant. Provider artifacts and the `pending → active` product binding share the same database transaction; failures roll both back. Resource/scopes live in child rows, without an environment allowlist.
+
+Provider revocation/replay and password changes/resets revoke the entire product grant and its provider artifacts. Password changes also delete issuer sessions and outstanding identity-bound handoffs. The user-row lock serializes these operations against approval and bridge issuance/consumption. The existing old-data cron runs a bounded cleanup of expired bridge/session/decision rows and compensates stale pending grants. The migration's empty `down` preserves security state during code rollbacks.
+
+Reads are explicitly non-audited. Approvals, denials, issuer-session establishment and grant revocation have explicit audit policies; credential-bearing URLs and identifiers are not included in audit metadata or errors.
+
+## Verification
+
+```sh
+npm run test:integration -- --run packages/server/lib/oauth/consent.integration.test.ts packages/oauth-server/lib/adapter.integration.test.ts
+npm run test:unit -- --run packages/server/lib/oauth/ packages/server/lib/middleware/audit/oauth.middleware.unit.test.ts packages/oauth-server/lib/
+npm run test:browser -w packages/webapp
+npm run ts-build
+npm run webapp-build
+npm run lint
+npm run format:check
+```
+
+Integration tests exercise the real HTTP routes, provider and PostgreSQL, with external CIMD/WorkOS fixtures. Browser component tests cover loading, failures, expiry, mobile layout, keyboard actions, duplicate submission, StrictMode and accessibility in both themes. Full-app HTTPS browser verification can use the production webapp build and separate dashboard/API/issuer hostnames; never use a shared database for disposable fixtures.

--- a/packages/server/lib/oauth/README.md
+++ b/packages/server/lib/oauth/README.md
@@ -1,27 +1,30 @@
 # Nango OAuth login and consent
 
-The reusable protocol provider is `@nangohq/oauth-server`. This directory supplies the Nango session bridge, React interaction API and product-grant lifecycle. It does **not** enable bearer authentication on `/mcp`.
+The reusable protocol provider is `@nangohq/oauth-server`. This directory supplies dashboard-session authentication, the React interaction API and the product-grant lifecycle. It does **not** enable bearer authentication on `/mcp`.
 
 ## Configuration
 
 - Enable `NANGO_MANAGEMENT_MCP_OAUTH_ENABLED` and configure `NANGO_MANAGEMENT_MCP_SERVER_URL`.
-- `NANGO_OAUTH_SERVER_BASE_URL` is the issuer origin. Cloud defaults to `https://id.nango.dev`; local/self-hosted installations must configure it explicitly.
+- `NANGO_OAUTH_SERVER_BASE_URL` is an optional issuer-origin override. It defaults to the browser-facing dashboard API origin (`NANGO_DASHBOARD_API_URL`, falling back to `NANGO_SERVER_URL`). Set it to `https://api.nango.dev` for Cloud. If the dashboard API uses `/`, the origin is `NANGO_PUBLIC_SERVER_URL` and its proxy must also forward the OAuth paths.
+- The override must match that API origin; a mismatch fails at startup. Another hostname does not merely require another login: the dashboard's host-only cookie would never reach it. A separate issuer host requires a separate authentication design.
 - Supply `NANGO_OAUTH_SERVER_COOKIE_KEYS` (JSON array of at least two independent signing keys), `NANGO_OAUTH_SERVER_JWKS` (private signing keys), and the existing encryption-key configuration.
-- Enable normal dashboard authentication and the account-targeted Unleash flag `oauth-server-consent` (defaults off). The flag gates the bridge and consent, not provider discovery or token endpoints.
+- Enable normal dashboard authentication and the account-targeted Unleash flag `oauth-server-consent` (defaults off). The flag gates authenticated interactions and consent, not provider discovery or token endpoints.
 - `NANGO_PUBLIC_SERVER_URL` identifies the exact dashboard origin for credentialed CORS and CSRF Origin checks. The React runtime receives `oauthServerUrl` via `/env.js`, and CSP permits that origin.
 - Route the issuer host to the server and preserve `Host` and the trusted HTTPS forwarding information. Protocol endpoints reject other hosts. Do not widen `nango_session` to a parent domain.
 
-The dashboard and issuer must be same-site for the issuer's `SameSite=Lax` cookies to accompany the React API requests (Cloud's `app.nango.dev` and `id.nango.dev` satisfy this). For local cross-origin browser tests, use same-site HTTPS subdomains, not `localhost` versus `127.0.0.1`.
+The dashboard and issuer must be same-site for the provider's `SameSite=Lax` cookies to accompany the React API requests (Cloud's `app.nango.dev` and `api.nango.dev` satisfy this). For local cross-origin browser tests, use same-site HTTPS subdomains, not `localhost` versus `127.0.0.1`.
 
 ## Security and persistence
 
-An issuer interaction redirects to `/oauth/continue` with opaque state. The dashboard/API session either issues a 45-second handoff code or completes normal login, MFA and onboarding first. The code is hashed server-side, bound to a browser nonce, identity, interaction and exact issuer return destination, and consumed once under a transaction. The resulting issuer cookie is host-only and independent of dashboard logout.
+OAuth interaction routes load the existing `nango_session` with the same Passport middleware as the dashboard API; protocol/token routes do not load dashboard sessions or parse their bodies through that middleware. Already-signed-in users go directly to React consent. Signed-out users complete normal login, MFA and onboarding first, then a redirect-only React route (`/oauth/continue/:uid`) returns to the exact provider interaction. Only this validated local continuation is stored before login; normal session rotation discards it after authentication. There are no handoff codes, extra login cookies or separate login-session tables.
 
 Approval validates the provider interaction, client callback and all configured resources/scopes again, claims the interaction once, and creates a fresh grant. Provider artifacts and the `pending → active` product binding share the same database transaction; failures roll both back. Resource/scopes live in child rows, without an environment allowlist.
 
-Provider revocation/replay and password changes/resets revoke the entire product grant and its provider artifacts. Password changes also delete issuer sessions and outstanding identity-bound handoffs. The user-row lock serializes these operations against approval and bridge issuance/consumption. The existing old-data cron runs a bounded cleanup of expired bridge/session/decision rows and compensates stale pending grants. The migration's empty `down` preserves security state during code rollbacks.
+Every new authorization requires explicit consent, even if provider cookies remember an earlier grant. Only the current interaction's approved grant can resume, so remembered provider state cannot bypass dashboard login or the consent flag.
 
-Reads are explicitly non-audited. Approvals, denials, issuer-session establishment and grant revocation have explicit audit policies; credential-bearing URLs and identifiers are not included in audit metadata or errors.
+Provider revocation/replay and password changes/resets revoke the entire product grant and its provider artifacts. Approval rechecks the dashboard session under the same user-row lock as password revocation. Dashboard logout requires login for new consent, but does not revoke existing grants or refresh tokens. The existing old-data cron runs bounded cleanup of expired decision rows and compensates stale pending grants. The migration's empty `down` preserves security state during code rollbacks.
+
+Reads are explicitly non-audited. Approvals, denials and grant revocation have explicit audit policies; normal login keeps its existing authentication audit events. Credential-bearing URLs and identifiers are not included in audit metadata or errors.
 
 ## Verification
 
@@ -35,4 +38,4 @@ npm run lint
 npm run format:check
 ```
 
-Integration tests exercise the real HTTP routes, provider and PostgreSQL, with external CIMD/WorkOS fixtures. Browser component tests cover loading, failures, expiry, mobile layout, keyboard actions, duplicate submission, StrictMode and accessibility in both themes. Full-app HTTPS browser verification can use the production webapp build and separate dashboard/API/issuer hostnames; never use a shared database for disposable fixtures.
+Integration tests exercise the real HTTP routes, provider and PostgreSQL, with external CIMD/WorkOS fixtures. Browser component tests cover loading, failures, expiry, mobile layout, keyboard actions, duplicate submission, StrictMode and accessibility in both themes. Full-app HTTPS browser verification uses the production webapp build with separate dashboard and API hostnames, with OAuth on the API host; never use a shared database for disposable fixtures.

--- a/packages/server/lib/oauth/config.ts
+++ b/packages/server/lib/oauth/config.ts
@@ -1,0 +1,35 @@
+import { parseOAuthServerConfig } from '@nangohq/oauth-server';
+
+import { dek, envs } from '../env.js';
+
+import type { OAuthResourceConfig, OAuthServerParsedConfig } from '@nangohq/oauth-server';
+
+export interface NangoOAuthServerConfig {
+    config: OAuthServerParsedConfig;
+    resources: readonly OAuthResourceConfig[];
+}
+
+export function getOAuthServerConfig(): NangoOAuthServerConfig | null {
+    const resources: OAuthResourceConfig[] = [];
+    if (envs.NANGO_MANAGEMENT_MCP_OAUTH_ENABLED) {
+        if (!envs.NANGO_MANAGEMENT_MCP_SERVER_URL) {
+            throw new Error('NANGO_MANAGEMENT_MCP_SERVER_URL is required when Management MCP OAuth is enabled');
+        }
+        const managementMcpUrl = new URL(envs.NANGO_MANAGEMENT_MCP_SERVER_URL);
+        resources.push({
+            resource: new URL('/mcp', managementMcpUrl.origin).href,
+            scopes: ['environment:*']
+        });
+    }
+    if (resources.length === 0) return null;
+
+    return {
+        config: parseOAuthServerConfig({
+            baseUrl: envs.NANGO_OAUTH_SERVER_BASE_URL,
+            cookieKeys: envs.NANGO_OAUTH_SERVER_COOKIE_KEYS,
+            encryptionKey: dek.get(),
+            jwks: envs.NANGO_OAUTH_SERVER_JWKS
+        }),
+        resources
+    };
+}

--- a/packages/server/lib/oauth/config.ts
+++ b/packages/server/lib/oauth/config.ts
@@ -1,4 +1,5 @@
 import { parseOAuthServerConfig } from '@nangohq/oauth-server';
+import { basePublicUrl, dashboardApiUrl } from '@nangohq/utils';
 
 import { dek, envs } from '../env.js';
 
@@ -23,13 +24,20 @@ export function getOAuthServerConfig(): NangoOAuthServerConfig | null {
     }
     if (resources.length === 0) return null;
 
+    const sessionOrigin = new URL(dashboardApiUrl, basePublicUrl).origin;
+    const config = parseOAuthServerConfig({
+        baseUrl: envs.NANGO_OAUTH_SERVER_BASE_URL ?? sessionOrigin,
+        cookieKeys: envs.NANGO_OAUTH_SERVER_COOKIE_KEYS,
+        encryptionKey: dek.get(),
+        jwks: envs.NANGO_OAUTH_SERVER_JWKS
+    });
+    // Dashboard login and OAuth interactions must receive the same host-only cookie.
+    // Keep the override, but fail at startup instead of sending users around a login loop.
+    if (config.baseUrl !== sessionOrigin) {
+        throw new Error('NANGO_OAUTH_SERVER_BASE_URL must match the browser-facing dashboard API origin to reuse its session');
+    }
     return {
-        config: parseOAuthServerConfig({
-            baseUrl: envs.NANGO_OAUTH_SERVER_BASE_URL ?? (envs.NANGO_CLOUD ? 'https://id.nango.dev' : undefined),
-            cookieKeys: envs.NANGO_OAUTH_SERVER_COOKIE_KEYS,
-            encryptionKey: dek.get(),
-            jwks: envs.NANGO_OAUTH_SERVER_JWKS
-        }),
+        config,
         resources
     };
 }

--- a/packages/server/lib/oauth/config.ts
+++ b/packages/server/lib/oauth/config.ts
@@ -25,7 +25,7 @@ export function getOAuthServerConfig(): NangoOAuthServerConfig | null {
 
     return {
         config: parseOAuthServerConfig({
-            baseUrl: envs.NANGO_OAUTH_SERVER_BASE_URL,
+            baseUrl: envs.NANGO_OAUTH_SERVER_BASE_URL ?? (envs.NANGO_CLOUD ? 'https://id.nango.dev' : undefined),
             cookieKeys: envs.NANGO_OAUTH_SERVER_COOKIE_KEYS,
             encryptionKey: dek.get(),
             jwks: envs.NANGO_OAUTH_SERVER_JWKS

--- a/packages/server/lib/oauth/config.unit.test.ts
+++ b/packages/server/lib/oauth/config.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getOAuthServerConfig } from './config.js';
+
+const settings = await vi.hoisted(async () => {
+    const { generateKeyPairSync } = await import('node:crypto');
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    return {
+        NANGO_CLOUD: true,
+        NANGO_MANAGEMENT_MCP_OAUTH_ENABLED: true,
+        NANGO_MANAGEMENT_MCP_SERVER_URL: 'https://mcp.nango.dev',
+        NANGO_OAUTH_SERVER_BASE_URL: undefined as string | undefined,
+        NANGO_OAUTH_SERVER_COOKIE_KEYS: JSON.stringify(['a'.repeat(32), 'b'.repeat(32)]),
+        NANGO_OAUTH_SERVER_JWKS: JSON.stringify({ keys: [{ ...privateKey.export({ format: 'jwk' }), kid: 'test', alg: 'RS256', use: 'sig' }] })
+    };
+});
+vi.mock('../env.js', () => ({ envs: settings, dek: { get: () => Buffer.alloc(32, 's').toString('base64') } }));
+
+describe('Nango OAuth issuer configuration', () => {
+    it('defaults cloud to the single id.nango.dev issuer without a Management MCP suffix', () => {
+        expect(getOAuthServerConfig()?.config.baseUrl).toBe('https://id.nango.dev');
+        expect(getOAuthServerConfig()?.resources).toEqual([{ resource: 'https://mcp.nango.dev/mcp', scopes: ['environment:*'] }]);
+    });
+    it('supports explicit local/self-hosted issuers', () => {
+        settings.NANGO_CLOUD = false;
+        settings.NANGO_OAUTH_SERVER_BASE_URL = 'http://localhost:3003';
+        try {
+            expect(getOAuthServerConfig()?.config.baseUrl).toBe('http://localhost:3003');
+        } finally {
+            settings.NANGO_CLOUD = true;
+            settings.NANGO_OAUTH_SERVER_BASE_URL = undefined;
+        }
+    });
+});

--- a/packages/server/lib/oauth/config.unit.test.ts
+++ b/packages/server/lib/oauth/config.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getOAuthServerConfig } from './config.js';
 
@@ -6,6 +6,8 @@ const settings = await vi.hoisted(async () => {
     const { generateKeyPairSync } = await import('node:crypto');
     const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
     return {
+        dashboardApiUrl: 'https://api.nango.dev',
+        basePublicUrl: 'https://app.nango.dev',
         NANGO_CLOUD: true,
         NANGO_MANAGEMENT_MCP_OAUTH_ENABLED: true,
         NANGO_MANAGEMENT_MCP_SERVER_URL: 'https://mcp.nango.dev',
@@ -15,20 +17,41 @@ const settings = await vi.hoisted(async () => {
     };
 });
 vi.mock('../env.js', () => ({ envs: settings, dek: { get: () => Buffer.alloc(32, 's').toString('base64') } }));
+vi.mock('@nangohq/utils', () => ({
+    get dashboardApiUrl() {
+        return settings.dashboardApiUrl;
+    },
+    get basePublicUrl() {
+        return settings.basePublicUrl;
+    }
+}));
 
 describe('Nango OAuth issuer configuration', () => {
-    it('defaults cloud to the single id.nango.dev issuer without a Management MCP suffix', () => {
-        expect(getOAuthServerConfig()?.config.baseUrl).toBe('https://id.nango.dev');
+    beforeEach(() => {
+        settings.dashboardApiUrl = 'https://api.nango.dev';
+        settings.NANGO_OAUTH_SERVER_BASE_URL = undefined;
+        settings.NANGO_MANAGEMENT_MCP_OAUTH_ENABLED = true;
+    });
+    it('defaults to the browser-facing dashboard API without a Management MCP suffix', () => {
+        expect(getOAuthServerConfig()?.config.baseUrl).toBe('https://api.nango.dev');
         expect(getOAuthServerConfig()?.resources).toEqual([{ resource: 'https://mcp.nango.dev/mcp', scopes: ['environment:*'] }]);
     });
     it('supports explicit local/self-hosted issuers', () => {
-        settings.NANGO_CLOUD = false;
+        settings.dashboardApiUrl = 'http://localhost:3003';
         settings.NANGO_OAUTH_SERVER_BASE_URL = 'http://localhost:3003';
-        try {
-            expect(getOAuthServerConfig()?.config.baseUrl).toBe('http://localhost:3003');
-        } finally {
-            settings.NANGO_CLOUD = true;
-            settings.NANGO_OAUTH_SERVER_BASE_URL = undefined;
-        }
+        expect(getOAuthServerConfig()?.config.baseUrl).toBe('http://localhost:3003');
+    });
+    it('supports a same-origin dashboard API proxy', () => {
+        settings.dashboardApiUrl = '/';
+        expect(getOAuthServerConfig()?.config.baseUrl).toBe('https://app.nango.dev');
+    });
+    it.each(['https://id.nango.dev', 'https://api.nango.dev:8443'])('rejects an issuer that cannot share the dashboard session: %s', (issuer) => {
+        settings.NANGO_OAUTH_SERVER_BASE_URL = issuer;
+        expect(() => getOAuthServerConfig()).toThrow('must match the browser-facing dashboard API origin');
+    });
+    it('does not validate unused issuer configuration when OAuth is disabled', () => {
+        settings.NANGO_MANAGEMENT_MCP_OAUTH_ENABLED = false;
+        settings.NANGO_OAUTH_SERVER_BASE_URL = 'https://id.nango.dev';
+        expect(getOAuthServerConfig()).toBeNull();
     });
 });

--- a/packages/server/lib/oauth/consent.integration.test.ts
+++ b/packages/server/lib/oauth/consent.integration.test.ts
@@ -1,0 +1,636 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { request as httpRequest } from 'node:http';
+
+import jwt from 'jsonwebtoken';
+import * as OTPAuth from 'otpauth';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import db from '@nangohq/database';
+import { getFlags } from '@nangohq/feature-flags';
+import { OAuthProviderErrors } from '@nangohq/oauth-server';
+import { seeders } from '@nangohq/shared';
+
+import { deleteUserSessions } from '../clients/auth.client.js';
+import { runServer } from '../utils/tests.js';
+import { resetPasswordSecret } from '../utils/utils.js';
+import { cleanOAuthConsent, GRANT_RESOURCES, PRODUCT_GRANTS, revokeUserOAuthGrants } from './grants.js';
+import { oauthConsent, oauthServer } from './server.js';
+import { hashSecret } from './service.js';
+
+import type * as ConfigModule from './config.js';
+import type { GetOAuthInteraction } from '@nangohq/types';
+
+const fixtures = await vi.hoisted(async () => {
+    const { generateKeyPairSync } = await import('node:crypto');
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    process.env['FLAG_AUTH_ENABLED'] = 'true';
+    process.env['FLAG_MANAGED_AUTH_ENABLED'] = 'true';
+    process.env['WORKOS_API_KEY'] = 'sk_test_fixture';
+    process.env['WORKOS_CLIENT_ID'] = 'client_fixture';
+    process.env['NANGO_SERVER_URL'] = 'https://api.nango.test';
+    process.env['NANGO_PUBLIC_SERVER_URL'] = 'https://app.nango.test';
+    process.env['NANGO_MANAGEMENT_MCP_OAUTH_ENABLED'] = 'true';
+    process.env['NANGO_OAUTH_SERVER_BASE_URL'] = 'https://id.nango.test';
+    process.env['NANGO_OAUTH_SERVER_COOKIE_KEYS'] = JSON.stringify(['a'.repeat(32), 'b'.repeat(32)]);
+    process.env['NANGO_OAUTH_SERVER_JWKS'] = JSON.stringify({ keys: [{ ...privateKey.export({ format: 'jwk' }), kid: 'test', use: 'sig', alg: 'RS256' }] });
+    return {
+        clientId: 'https://example.com/nango-client.json',
+        callback: 'https://example.com/callback',
+        secondResource: 'https://agent.nango.test/mcp',
+        authenticateWithCode: vi.fn(),
+        authenticateWithEmailVerification: vi.fn()
+    };
+});
+
+vi.mock('../clients/workos.client.js', () => ({
+    getWorkOSClient: () => ({
+        userManagement: { authenticateWithCode: fixtures.authenticateWithCode, authenticateWithEmailVerification: fixtures.authenticateWithEmailVerification }
+    })
+}));
+
+// Only external CIMD transport is replaced. Provider protocol, cookies, sessions, migrations,
+// authentication and grant persistence all run through their production implementations.
+vi.mock('@nangohq/egress', async (importOriginal) => ({ ...(await importOriginal<object>()), assertSafeOutboundUrl: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./config.js', async (importOriginal) => {
+    const original = await importOriginal<typeof ConfigModule>();
+    return {
+        ...original,
+        getOAuthServerConfig: () => {
+            const config = original.getOAuthServerConfig();
+            return config && { ...config, resources: [...config.resources, { resource: fixtures.secondResource, scopes: ['agent-session:*'] }] };
+        }
+    };
+});
+
+let api: Awaited<ReturnType<typeof runServer>>;
+let seeded: Awaited<ReturnType<typeof seeders.seedAccountEnvAndUser>>;
+let enabled = true;
+const dashboardOrigin = 'https://app.nango.test';
+const issuer = 'https://id.nango.test';
+const management = 'https://mcp-test.nango.dev/mcp';
+
+class Browser {
+    private cookies = new Map<string, string>();
+    async request(url: string, init: RequestInit = {}) {
+        const target = new URL(url);
+        const key = target.host === 'id.nango.test' ? 'issuer:' : 'dashboard:';
+        const cookie = [...this.cookies]
+            .filter(([name]) => name.startsWith(key))
+            .map(([, value]) => value)
+            .join('; ');
+        const headers: Record<string, string> = { host: target.host, 'X-Forwarded-Proto': target.protocol.slice(0, -1), Cookie: cookie };
+        new Headers(init.headers).forEach((value, key) => {
+            headers[key] = value;
+        });
+        // Node fetch drops custom Host headers. Send through HTTP just like a TLS-terminating
+        // ingress so the production issuer-host check is exercised, not bypassed.
+        const response = await new Promise<Response>((resolve, reject) => {
+            const request = httpRequest(
+                `${api.url}${target.pathname}${target.search}`,
+                {
+                    method: init.method ?? 'GET',
+                    headers
+                },
+                (incoming) => {
+                    const chunks: Buffer[] = [];
+                    incoming.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+                    incoming.on('end', () => {
+                        const headers = new Headers();
+                        for (let index = 0; index < incoming.rawHeaders.length; index += 2)
+                            headers.append(incoming.rawHeaders[index]!, incoming.rawHeaders[index + 1]!);
+                        resolve(new Response(incoming.statusCode === 204 ? null : Buffer.concat(chunks), { status: incoming.statusCode!, headers }));
+                    });
+                }
+            );
+            request.on('error', reject);
+            request.end(typeof init.body === 'string' ? init.body : undefined);
+        });
+        for (const value of response.headers.getSetCookie()) {
+            const pair = value.split(';')[0]!;
+            this.cookies.set(`${key}${pair.split('=')[0]}`, pair);
+            expect(value.toLowerCase()).not.toContain('domain=');
+        }
+        return response;
+    }
+    async json(url: string, body?: unknown, origin = dashboardOrigin) {
+        return await this.request(url, {
+            method: body ? 'POST' : 'GET',
+            headers: { Origin: origin, 'Content-Type': 'application/json' },
+            ...(body ? { body: JSON.stringify(body) } : {})
+        });
+    }
+}
+
+async function signIn(browser: Browser) {
+    const response = await browser.json('https://api.nango.test/api/v1/account/signin', { email: seeded.user.email, password: 'Password123!' });
+    expect(response.status).toBe(200);
+    return await response.json();
+}
+
+async function begin(browser: Browser, multi = false) {
+    const verifier = randomBytes(32).toString('base64url');
+    const url = new URL('/oauth/authorize', issuer);
+    url.search = new URLSearchParams({
+        client_id: fixtures.clientId,
+        redirect_uri: fixtures.callback,
+        response_type: 'code',
+        scope: multi ? 'environment:* agent-session:*' : 'environment:*',
+        resource: management,
+        code_challenge: createHash('sha256').update(verifier).digest('base64url'),
+        code_challenge_method: 'S256',
+        state: 'client-state'
+    }).toString();
+    if (multi) url.searchParams.append('resource', fixtures.secondResource);
+    const auth = await browser.request(url.href);
+    expect(auth.status).toBe(303);
+    const entry = await browser.request(new URL(auth.headers.get('location')!, issuer).href);
+    expect(entry.status).toBe(303);
+    const continuation = new URL(entry.headers.get('location')!);
+    expect(continuation.pathname).toBe('/oauth/continue');
+    return { state: continuation.searchParams.get('state')!, verifier };
+}
+
+async function handoff(browser: Browser, state: string) {
+    const response = await browser.json('https://api.nango.test/api/v1/oauth/handoff', { state });
+    expect(response.status).toBe(200);
+    return (await response.json()).data.redirectUrl as string;
+}
+
+async function finishBridge(browser: Browser, callback: string) {
+    let response = await browser.request(callback);
+    expect(response.status).toBe(303);
+    for (let count = 0; count < 6; count++) {
+        const location = new URL(response.headers.get('location')!, issuer);
+        if (location.origin === dashboardOrigin) {
+            expect(location.pathname).toMatch(/^\/oauth\/consent\//);
+            return location.pathname.split('/').at(-1)!;
+        }
+        response = await browser.request(location.href);
+        expect(response.status).toBe(303);
+    }
+    throw new Error('Consent was not reached');
+}
+
+async function consent(multi = false) {
+    const browser = new Browser();
+    await signIn(browser);
+    const { state, verifier } = await begin(browser, multi);
+    const callback = await handoff(browser, state);
+    const uid = await finishBridge(browser, callback);
+    const response = await browser.json(`${issuer}/oauth/interaction/${uid}/details`);
+    expect(response.status).toBe(200);
+    const { data } = (await response.json()) as GetOAuthInteraction['Success'];
+    return { browser, uid, data, verifier, callback };
+}
+
+async function approve(flow: Awaited<ReturnType<typeof consent>>) {
+    const response = await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/approve`, { csrfToken: flow.data.csrfToken });
+    expect(response.status).toBe(200);
+    const { data } = await response.json();
+    const resume = await flow.browser.request(data.redirectUrl);
+    expect(resume.status).toBe(303);
+    const callback = new URL(resume.headers.get('location')!);
+    expect(callback.origin).toBe(new URL(fixtures.callback).origin);
+    expect(callback.searchParams.get('code')).toBeTruthy();
+    const tokens = await flow.browser.request(`${issuer}/oauth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+            grant_type: 'authorization_code',
+            client_id: fixtures.clientId,
+            redirect_uri: fixtures.callback,
+            code: callback.searchParams.get('code')!,
+            code_verifier: flow.verifier,
+            resource: management
+        }).toString()
+    });
+    expect(tokens.status).toBe(200);
+    return { grantId: data.grantId as string, tokens: await tokens.json() };
+}
+
+describe('Nango OAuth login and consent', () => {
+    beforeAll(async () => {
+        const nativeFetch = globalThis.fetch;
+        vi.spyOn(globalThis, 'fetch').mockImplementation((url, init) => {
+            if ((typeof url === 'string' ? url : url instanceof URL ? url.href : url.url) === fixtures.clientId)
+                return Promise.resolve(
+                    new Response(
+                        JSON.stringify({
+                            client_id: fixtures.clientId,
+                            client_name: 'Example client',
+                            redirect_uris: [fixtures.callback],
+                            grant_types: ['authorization_code', 'refresh_token'],
+                            response_types: ['code'],
+                            token_endpoint_auth_method: 'none',
+                            scope: 'environment:* agent-session:*'
+                        }),
+                        { headers: { 'Content-Type': 'application/json' } }
+                    )
+                );
+            return nativeFetch(url, init);
+        });
+        vi.spyOn(getFlags(), 'isOAuthConsentEnabled').mockImplementation(() => Promise.resolve(enabled));
+        api = await runServer();
+    });
+    beforeEach(async () => {
+        enabled = true;
+        seeded = await seeders.seedAccountEnvAndUser();
+        await db.knex('_nango_accounts').where({ id: seeded.account.id }).update({ found_us: 'tests' });
+    });
+    afterAll(() => {
+        api?.server.close();
+        vi.restoreAllMocks();
+    });
+
+    it('bridges an existing dashboard session and issues tokens for a multi-resource product grant', async () => {
+        const flow = await consent(true);
+        expect(flow.data).toMatchObject({
+            clientName: 'Example client',
+            clientHostname: 'example.com',
+            callbackHostname: 'example.com',
+            resources: [
+                { resource: management, scopes: ['environment:*'] },
+                { resource: fixtures.secondResource, scopes: ['agent-session:*'] }
+            ]
+        });
+        expect(JSON.stringify(flow.data)).not.toContain(fixtures.clientId);
+        const { grantId, tokens } = await approve(flow);
+        expect(tokens).toMatchObject({ token_type: 'Bearer', scope: 'environment:*' });
+        expect(tokens.refresh_token).toBeTruthy();
+        const grant = await db.knex(PRODUCT_GRANTS).where({ id: grantId }).first();
+        expect(grant).toMatchObject({ status: 'active', user_id: seeded.user.id, account_id: seeded.account.id, client_id: fixtures.clientId });
+        expect(await db.knex(GRANT_RESOURCES).where({ grant_id: grantId })).toHaveLength(2);
+        const refresh = await flow.browser.request(`${issuer}/oauth/token`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+                grant_type: 'refresh_token',
+                client_id: fixtures.clientId,
+                refresh_token: tokens.refresh_token,
+                resource: fixtures.secondResource
+            }).toString()
+        });
+        expect(refresh.status).toBe(200);
+        expect(await refresh.json()).toMatchObject({ scope: 'agent-session:*', token_type: 'Bearer' });
+    });
+
+    it('resumes the exact interaction after signed-out password login', async () => {
+        const browser = new Browser();
+        const { state } = await begin(browser);
+        expect((await browser.json('https://api.nango.test/api/v1/oauth/handoff', { state })).status).toBe(401);
+        expect(await signIn(browser)).toMatchObject({ url: `/oauth/continue?state=${state}` });
+        expect(await finishBridge(browser, await handoff(browser, state))).toBeTruthy();
+    });
+
+    it('preserves continuation through password login and MFA session regeneration', async () => {
+        const enrolled = new Browser();
+        await signIn(enrolled);
+        const enrollment = await enrolled.json('https://api.nango.test/api/v1/account/mfa/enroll', {});
+        expect(enrollment.status).toBe(200);
+        const totp = OTPAuth.URI.parse((await enrollment.json()).data.otpauthUri) as OTPAuth.TOTP;
+        const activation = await enrolled.json('https://api.nango.test/api/v1/account/mfa/activate', { code: totp.generate() });
+        expect(activation.status).toBe(200);
+        const recoveryCode = (await activation.json()).data.recoveryCodes[0];
+        const browser = new Browser();
+        const { state } = await begin(browser);
+        expect((await browser.json('https://api.nango.test/api/v1/oauth/handoff', { state })).status).toBe(401);
+        expect(await signIn(browser)).toMatchObject({ data: { mfaRequired: true } });
+        expect((await browser.json('https://api.nango.test/api/v1/oauth/handoff', { state })).status).toBe(401);
+        const verified = await browser.json('https://api.nango.test/api/v1/account/mfa/login/verify', { type: 'recoveryCode', recoveryCode });
+        expect(verified.status).toBe(200);
+        expect(await verified.json()).toMatchObject({ data: { url: `/oauth/continue?state=${state}` } });
+        expect(await finishBridge(browser, await handoff(browser, state))).toBeTruthy();
+    });
+
+    it.each([false, true])('resumes managed login (email verification: %s)', async (verifyEmail) => {
+        const browser = new Browser();
+        const { state } = await begin(browser);
+        expect((await browser.json('https://api.nango.test/api/v1/oauth/handoff', { state })).status).toBe(401);
+        const identity = { user: { email: seeded.user.email, firstName: 'Test', lastName: 'User' } };
+        if (verifyEmail)
+            fixtures.authenticateWithCode.mockRejectedValueOnce({
+                rawData: {
+                    code: 'email_verification_required',
+                    pending_authentication_token: 'fixture-pending',
+                    email: seeded.user.email,
+                    email_verification_id: 'fixture-id'
+                }
+            });
+        else fixtures.authenticateWithCode.mockResolvedValueOnce(identity);
+        const callback = await browser.request('https://api.nango.test/api/v1/login/callback?code=fixture-code');
+        expect(callback.status).toBe(302);
+        if (verifyEmail) {
+            expect(callback.headers.get('location')).toBe(`${dashboardOrigin}/signin/verify`);
+            fixtures.authenticateWithEmailVerification.mockResolvedValueOnce(identity);
+            const result = await browser.json('https://api.nango.test/api/v1/account/managed/verification', { code: '123456' });
+            expect(result.status).toBe(200);
+            expect(await result.json()).toMatchObject({ data: { url: `${dashboardOrigin}/oauth/continue?state=${state}` } });
+        } else expect(callback.headers.get('location')).toBe(`${dashboardOrigin}/oauth/continue?state=${state}`);
+        expect(await finishBridge(browser, await handoff(browser, state))).toBeTruthy();
+    });
+
+    it('carries onboarding destinations with only the opaque continuation', async () => {
+        const browser = new Browser();
+        await signIn(browser);
+        const { state } = await begin(browser);
+        await db.knex('_nango_users').where({ id: seeded.user.id }).update({ account_discovery_pending: true });
+        expect(await handoff(browser, state)).toBe(
+            `${dashboardOrigin}/onboarding/account-discovery?next=${encodeURIComponent(`/oauth/continue?state=${state}`)}`
+        );
+        const discovery = await browser.json('https://api.nango.test/api/v1/account/onboarding/account-discovery');
+        expect(discovery.status).toBe(200);
+        await db.knex('_nango_accounts').where({ id: seeded.account.id }).update({ found_us: null });
+        expect(await handoff(browser, state)).toBe(`${dashboardOrigin}/onboarding/hear-about-us?next=${encodeURIComponent(`/oauth/continue?state=${state}`)}`);
+        const submitted = await browser.json('https://api.nango.test/api/v1/account/onboarding/hear-about-us', { source: 'skipped' });
+        expect(submitted.status).toBe(200);
+        expect(await finishBridge(browser, await handoff(browser, state))).toBeTruthy();
+    });
+
+    it('denies through the provider and does not create a product grant', async () => {
+        const flow = await consent();
+        const response = await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/deny`, { csrfToken: flow.data.csrfToken });
+        expect(response.status).toBe(200);
+        const resume = await flow.browser.request((await response.json()).data.redirectUrl);
+        const callback = new URL(resume.headers.get('location')!);
+        expect(callback.searchParams.get('error')).toBe('access_denied');
+        expect(callback.searchParams.get('state')).toBe('client-state');
+        expect(await db.knex(PRODUCT_GRANTS).where({ user_id: seeded.user.id })).toHaveLength(0);
+    });
+
+    it('fails closed on cookie, CSRF, Origin, feature-flag and replay errors', async () => {
+        const flow = await consent();
+        const endpoint = `${issuer}/oauth/interaction/${flow.uid}`;
+        expect((await new Browser().json(`${endpoint}/details`)).status).toBe(401);
+        expect((await flow.browser.json(`${endpoint}/approve`, { csrfToken: 'x'.repeat(43) })).status).toBe(403);
+        expect((await flow.browser.json(`${endpoint}/approve`, { csrfToken: flow.data.csrfToken }, 'https://evil.example')).status).toBe(403);
+        enabled = false;
+        expect((await flow.browser.json(`${endpoint}/details`)).status).toBe(403);
+        expect((await flow.browser.json(`${endpoint}/approve`, { csrfToken: flow.data.csrfToken })).status).toBe(403);
+        expect((await flow.browser.json(`${endpoint}/deny`, { csrfToken: flow.data.csrfToken })).status).toBe(403);
+        expect((await flow.browser.request(`${issuer}/.well-known/oauth-authorization-server`)).status).toBe(200);
+        enabled = true;
+        const responses = await Promise.all([
+            flow.browser.json(`${endpoint}/approve`, { csrfToken: flow.data.csrfToken }),
+            flow.browser.json(`${endpoint}/approve`, { csrfToken: flow.data.csrfToken })
+        ]);
+        expect(responses.map((response) => response.status).sort()).toEqual([200, 409]);
+        expect(await db.knex(PRODUCT_GRANTS).where({ user_id: seeded.user.id, status: 'active' })).toHaveLength(1);
+    });
+
+    it('only exposes the provider on the configured issuer host and exact credentialed CORS origin', async () => {
+        const browser = new Browser();
+        expect((await browser.request('https://api.nango.test/.well-known/oauth-authorization-server')).status).toBe(404);
+        expect((await browser.request(`${issuer}/oauth/authorize`, { headers: { 'X-Forwarded-Host': 'evil.example' } })).status).toBe(404);
+        const response = await browser.request(`${issuer}/oauth/interaction/${'a'.repeat(32)}/details`, {
+            method: 'OPTIONS',
+            headers: { Origin: dashboardOrigin, 'Access-Control-Request-Method': 'GET' }
+        });
+        expect(response.headers.get('access-control-allow-origin')).toBe(dashboardOrigin);
+        expect(response.headers.get('access-control-allow-credentials')).toBe('true');
+        expect(
+            (await browser.json(`${issuer}/oauth/interaction/${'a'.repeat(32)}/details`, undefined, 'https://evil.example')).headers.get(
+                'access-control-allow-origin'
+            )
+        ).not.toBe('https://evil.example');
+    });
+
+    it('rejects handoff replay, browser mismatch, expiry and unsafe destinations', async () => {
+        const flow = await consent();
+        expect((await flow.browser.request(flow.callback)).status).toBe(400);
+        for (const mutation of ['browser', 'expiry', 'destination', 'issuer', 'interaction'] as const) {
+            const browser = new Browser();
+            await signIn(browser);
+            const { state } = await begin(browser);
+            const callback = await handoff(browser, state);
+            if (mutation === 'expiry')
+                await db
+                    .knex('oauth_login_handoffs')
+                    .where({ state_hash: hashSecret(state) })
+                    .update({ code_expires_at: new Date(0) });
+            if (mutation === 'destination')
+                await db
+                    .knex('oauth_login_handoffs')
+                    .where({ state_hash: hashSecret(state) })
+                    .update({ return_to: 'https://evil.example' });
+            if (mutation === 'issuer')
+                await db
+                    .knex('oauth_login_handoffs')
+                    .where({ state_hash: hashSecret(state) })
+                    .update({ issuer: 'https://evil.example' });
+            if (mutation === 'interaction')
+                await db
+                    .knex('oauth_login_handoffs')
+                    .where({ state_hash: hashSecret(state) })
+                    .update({ interaction_uid: 'x'.repeat(32), return_to: `${issuer}/oauth/interaction/${'x'.repeat(32)}` });
+            const result = await (mutation === 'browser' ? new Browser() : browser).request(callback);
+            expect(result.status, mutation).toBe(400);
+        }
+    });
+
+    it('atomically consumes a 45-second, identity-bound handoff only once', async () => {
+        const browser = new Browser();
+        await signIn(browser);
+        const { state } = await begin(browser);
+        const callback = await handoff(browser, state);
+        const row = await db
+            .knex('oauth_login_handoffs')
+            .where({ state_hash: hashSecret(state) })
+            .first();
+        expect(row).toMatchObject({ user_id: seeded.user.id, account_id: seeded.account.id, issuer });
+        expect(row.code_hash).toHaveLength(32);
+        expect(row.code_hash).toEqual(hashSecret(new URL(callback).searchParams.get('code')!));
+        expect(row.code_expires_at.getTime() - Date.now()).toBeGreaterThan(30_000);
+        expect(row.code_expires_at.getTime() - Date.now()).toBeLessThanOrEqual(45_000);
+        const results = await Promise.all([browser.request(callback), browser.request(callback)]);
+        expect(results.map((result) => result.status).sort()).toEqual([303, 400]);
+        expect(await db.knex('oauth_login_sessions').where({ user_id: seeded.user.id })).toHaveLength(1);
+    });
+
+    it('cannot resurrect a dashboard session while a password reset revokes it', async () => {
+        const browser = new Browser();
+        await signIn(browser);
+        const { state } = await begin(browser);
+        const blocker = await db.knex.transaction();
+        try {
+            await blocker('_nango_users').where({ id: seeded.user.id }).forUpdate().first();
+            const result = browser.json('https://api.nango.test/api/v1/oauth/handoff', { state });
+            // Observe the actual row-lock wait rather than sleeping and guessing where issuance is.
+            await vi.waitFor(async () => {
+                const waiting = await db.knex('pg_stat_activity').where({ wait_event_type: 'Lock' }).where('query', 'like', '%_nango_users%').first();
+                expect(waiting).toBeDefined();
+            });
+            await deleteUserSessions(seeded.user.id, { trx: blocker });
+            await revokeUserOAuthGrants(seeded.user.id, blocker);
+            await blocker.commit();
+            expect((await result).status).toBe(401);
+            const resurrected = await db.knex('_nango_sessions').whereRaw(`sess->'passport'->'user'->>'id' = ?`, [String(seeded.user.id)]);
+            expect(resurrected).toHaveLength(0);
+        } finally {
+            if (!blocker.isCompleted()) await blocker.rollback();
+        }
+    });
+
+    it('rejects browser-supplied identity fields and malformed JSON without echoing credentials', async () => {
+        const flow = await consent();
+        const endpoint = `${issuer}/oauth/interaction/${flow.uid}/approve`;
+        expect((await flow.browser.json(endpoint, { csrfToken: flow.data.csrfToken, accountId: seeded.account.id })).status).toBe(400);
+        const response = await flow.browser.request(endpoint, {
+            method: 'POST',
+            headers: { Origin: dashboardOrigin, 'Content-Type': 'application/json' },
+            body: '{"secret":"test-secret"'
+        });
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: { code: 'invalid_body' } });
+    });
+
+    it('revalidates configured resources and scope ceilings immediately before approval', async () => {
+        const flow = await consent(true);
+        const original = oauthConsent!.options.resources;
+        try {
+            oauthConsent!.options.resources = original.filter((resource) => resource.resource !== fixtures.secondResource);
+            expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/approve`, { csrfToken: flow.data.csrfToken })).status).toBe(400);
+            oauthConsent!.options.resources = original.map((resource) => ({ ...resource, scopes: [] }));
+            expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/approve`, { csrfToken: flow.data.csrfToken })).status).toBe(400);
+        } finally {
+            oauthConsent!.options.resources = original;
+        }
+        expect(await db.knex(PRODUCT_GRANTS).where({ user_id: seeded.user.id })).toHaveLength(0);
+    });
+
+    it('revalidates suspension and account membership at approval', async () => {
+        const flow = await consent();
+        await db.knex('_nango_users').where({ id: seeded.user.id }).update({ suspended: true });
+        expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/approve`, { csrfToken: flow.data.csrfToken })).status).toBe(401);
+        const other = await seeders.seedAccountEnvAndUser();
+        await db.knex('_nango_users').where({ id: seeded.user.id }).update({ suspended: false, account_id: other.account.id });
+        expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/approve`, { csrfToken: flow.data.csrfToken })).status).toBe(401);
+    });
+
+    it('rolls back product and provider persistence when interaction completion fails', async () => {
+        const flow = await consent();
+        const before = await db.knex('oauth_server_artifacts').where({ model: 'Grant' }).count();
+        const failure = vi.spyOn(oauthServer!, 'interactionResult').mockRejectedValueOnce(new Error('fixture secret must not leak'));
+        const response = await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/approve`, { csrfToken: flow.data.csrfToken });
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: { code: 'server_error' } });
+        expect(await db.knex(PRODUCT_GRANTS).where({ user_id: seeded.user.id })).toHaveLength(0);
+        expect(await db.knex('oauth_server_artifacts').where({ model: 'Grant' }).count()).toEqual(before);
+        failure.mockRestore();
+        await approve(flow);
+    });
+
+    it('rolls back the provider grant if product activation fails', async () => {
+        const flow = await consent();
+        const before = await db.knex('oauth_server_artifacts').where({ model: 'Grant' }).count();
+        await db.knex.raw(
+            `CREATE FUNCTION oauth_test_activation_failure() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'fixture activation failure'; END $$`
+        );
+        await db.knex.raw(
+            `CREATE TRIGGER oauth_test_activation_failure BEFORE UPDATE ON oauth_product_grants FOR EACH ROW WHEN (NEW.status = 'active') EXECUTE FUNCTION oauth_test_activation_failure()`
+        );
+        try {
+            expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/approve`, { csrfToken: flow.data.csrfToken })).status).toBe(500);
+            expect(await db.knex(PRODUCT_GRANTS).where({ user_id: seeded.user.id })).toHaveLength(0);
+            expect(await db.knex('oauth_server_artifacts').where({ model: 'Grant' }).count()).toEqual(before);
+        } finally {
+            await db.knex.raw('DROP TRIGGER oauth_test_activation_failure ON oauth_product_grants');
+            await db.knex.raw('DROP FUNCTION oauth_test_activation_failure()');
+        }
+        await approve(flow);
+    });
+
+    it('never activates a product binding if the provider grant cannot be saved', async () => {
+        const flow = await consent();
+        const failure = vi.spyOn(oauthServer!.Grant.prototype, 'save').mockRejectedValueOnce(new Error('fixture persistence failure'));
+        try {
+            expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/approve`, { csrfToken: flow.data.csrfToken })).status).toBe(500);
+            expect(await db.knex(PRODUCT_GRANTS).where({ user_id: seeded.user.id })).toHaveLength(0);
+        } finally {
+            failure.mockRestore();
+        }
+        await approve(flow);
+    });
+
+    it('rejects an expired provider interaction with a typed 410', async () => {
+        const flow = await consent();
+        const interaction = await oauthServer!.Interaction.find(flow.uid);
+        await interaction!.save(-1);
+        const response = await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/details`);
+        expect(response.status).toBe(410);
+        expect(await response.json()).toEqual({ error: { code: 'interaction_expired' } });
+    });
+
+    it('also returns a typed 410 if the interaction expires during approval persistence', async () => {
+        const flow = await consent();
+        const expired = vi.spyOn(oauthServer!, 'interactionResult').mockRejectedValueOnce(new OAuthProviderErrors.SessionNotFound('fixture'));
+        try {
+            const response = await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/approve`, { csrfToken: flow.data.csrfToken });
+            expect(response.status).toBe(410);
+            expect(await response.json()).toEqual({ error: { code: 'interaction_expired' } });
+            expect(await db.knex(PRODUCT_GRANTS).where({ user_id: seeded.user.id })).toHaveLength(0);
+        } finally {
+            expired.mockRestore();
+        }
+    });
+
+    it('revokes all resources and artifacts on password change, but not logout', async () => {
+        const flow = await consent(true);
+        const { grantId, tokens } = await approve(flow);
+        await flow.browser.json('https://api.nango.test/api/v1/account/logout', {});
+        expect(await db.knex(PRODUCT_GRANTS).where({ id: grantId }).first()).toMatchObject({ status: 'active' });
+        await signIn(flow.browser);
+        const changed = await flow.browser.request('https://api.nango.test/api/v1/user/password', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ oldPassword: 'Password123!', newPassword: 'NewPassword123!' })
+        });
+        expect(changed.status).toBe(200);
+        expect(await db.knex(PRODUCT_GRANTS).where({ id: grantId }).first()).toMatchObject({ status: 'revoked' });
+        expect(await oauthServer!.AccessToken.find(tokens.access_token)).toBeUndefined();
+        expect(await oauthServer!.RefreshToken.find(tokens.refresh_token)).toBeUndefined();
+        expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/details`)).status).toBe(401);
+    });
+
+    it('revokes the product binding when the client revokes any token', async () => {
+        const flow = await consent(true);
+        const { grantId, tokens } = await approve(flow);
+        const response = await flow.browser.request(`${issuer}/oauth/revoke`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ client_id: fixtures.clientId, token: tokens.access_token }).toString()
+        });
+        expect(response.status).toBe(200);
+        expect(await db.knex(PRODUCT_GRANTS).where({ id: grantId }).first()).toMatchObject({ status: 'revoked' });
+        expect(await oauthServer!.RefreshToken.find(tokens.refresh_token)).toBeUndefined();
+    });
+
+    it('revokes product grants, provider tokens and issuer sessions on password reset', async () => {
+        const flow = await consent(true);
+        const { grantId, tokens } = await approve(flow);
+        const token = jwt.sign({ userId: seeded.user.id }, resetPasswordSecret(), { expiresIn: '5m' });
+        await db.knex('_nango_users').where({ id: seeded.user.id }).update({ reset_password_token: token });
+        const response = await flow.browser.request('https://api.nango.test/api/v1/account/reset-password', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token, password: 'ResetPassword123!' })
+        });
+        expect(response.status).toBe(200);
+        expect(await db.knex(PRODUCT_GRANTS).where({ id: grantId }).first()).toMatchObject({ status: 'revoked' });
+        expect(await oauthServer!.RefreshToken.find(tokens.refresh_token)).toBeUndefined();
+        expect(await db.knex('oauth_login_sessions').where({ user_id: seeded.user.id })).toHaveLength(0);
+    });
+
+    it('compensates stale pending rows in a bounded cleanup batch', async () => {
+        const flow = await consent();
+        const { grantId } = await approve(flow);
+        await db
+            .knex(PRODUCT_GRANTS)
+            .where({ id: grantId })
+            .update({ status: 'pending', created_at: new Date(0) });
+        await cleanOAuthConsent(1);
+        expect(await db.knex(PRODUCT_GRANTS).where({ id: grantId }).first()).toMatchObject({ status: 'revoked' });
+        await db.knex.transaction((trx) => revokeUserOAuthGrants(seeded.user.id, trx));
+        expect(await db.knex('oauth_login_sessions').where({ user_id: seeded.user.id })).toHaveLength(0);
+        expect(oauthConsent).toBeTruthy();
+    });
+});

--- a/packages/server/lib/oauth/consent.integration.test.ts
+++ b/packages/server/lib/oauth/consent.integration.test.ts
@@ -15,7 +15,6 @@ import { runServer } from '../utils/tests.js';
 import { resetPasswordSecret } from '../utils/utils.js';
 import { cleanOAuthConsent, GRANT_RESOURCES, PRODUCT_GRANTS, revokeUserOAuthGrants } from './grants.js';
 import { oauthConsent, oauthServer } from './server.js';
-import { hashSecret } from './service.js';
 
 import type * as ConfigModule from './config.js';
 import type { GetOAuthInteraction } from '@nangohq/types';
@@ -28,9 +27,10 @@ const fixtures = await vi.hoisted(async () => {
     process.env['WORKOS_API_KEY'] = 'sk_test_fixture';
     process.env['WORKOS_CLIENT_ID'] = 'client_fixture';
     process.env['NANGO_SERVER_URL'] = 'https://api.nango.test';
+    process.env['NANGO_DASHBOARD_API_URL'] = 'https://api.nango.test';
     process.env['NANGO_PUBLIC_SERVER_URL'] = 'https://app.nango.test';
     process.env['NANGO_MANAGEMENT_MCP_OAUTH_ENABLED'] = 'true';
-    process.env['NANGO_OAUTH_SERVER_BASE_URL'] = 'https://id.nango.test';
+    process.env['NANGO_OAUTH_SERVER_BASE_URL'] = 'https://api.nango.test';
     process.env['NANGO_OAUTH_SERVER_COOKIE_KEYS'] = JSON.stringify(['a'.repeat(32), 'b'.repeat(32)]);
     process.env['NANGO_OAUTH_SERVER_JWKS'] = JSON.stringify({ keys: [{ ...privateKey.export({ format: 'jwk' }), kid: 'test', use: 'sig', alg: 'RS256' }] });
     return {
@@ -66,14 +66,14 @@ let api: Awaited<ReturnType<typeof runServer>>;
 let seeded: Awaited<ReturnType<typeof seeders.seedAccountEnvAndUser>>;
 let enabled = true;
 const dashboardOrigin = 'https://app.nango.test';
-const issuer = 'https://id.nango.test';
+const issuer = 'https://api.nango.test';
 const management = 'https://mcp-test.nango.dev/mcp';
 
 class Browser {
     private cookies = new Map<string, string>();
     async request(url: string, init: RequestInit = {}) {
         const target = new URL(url);
-        const key = target.host === 'id.nango.test' ? 'issuer:' : 'dashboard:';
+        const key = `${target.host}:`;
         const cookie = [...this.cookies]
             .filter(([name]) => name.startsWith(key))
             .map(([, value]) => value)
@@ -109,8 +109,12 @@ class Browser {
             const pair = value.split(';')[0]!;
             this.cookies.set(`${key}${pair.split('=')[0]}`, pair);
             expect(value.toLowerCase()).not.toContain('domain=');
+            expect(pair).not.toMatch(/^nango_oauth_(login|bridge)=/);
         }
         return response;
+    }
+    clearCookie(name: string) {
+        this.cookies.delete(`api.nango.test:${name}`);
     }
     async json(url: string, body?: unknown, origin = dashboardOrigin) {
         return await this.request(url, {
@@ -143,21 +147,21 @@ async function begin(browser: Browser, multi = false) {
     if (multi) url.searchParams.append('resource', fixtures.secondResource);
     const auth = await browser.request(url.href);
     expect(auth.status).toBe(303);
-    const entry = await browser.request(new URL(auth.headers.get('location')!, issuer).href);
+    const entryUrl = new URL(auth.headers.get('location')!, issuer).href;
+    const uid = new URL(entryUrl).pathname.split('/').at(-1)!;
+    return { entryUrl, continuation: `/oauth/continue/${uid}`, uid, verifier };
+}
+
+async function beginSignedOut(browser: Browser) {
+    const flow = await begin(browser);
+    const entry = await browser.request(flow.entryUrl);
     expect(entry.status).toBe(303);
-    const continuation = new URL(entry.headers.get('location')!);
-    expect(continuation.pathname).toBe('/oauth/continue');
-    return { state: continuation.searchParams.get('state')!, verifier };
+    expect(entry.headers.get('location')).toBe(`${dashboardOrigin}/signin?next=${encodeURIComponent(flow.continuation)}`);
+    return flow;
 }
 
-async function handoff(browser: Browser, state: string) {
-    const response = await browser.json('https://api.nango.test/api/v1/oauth/handoff', { state });
-    expect(response.status).toBe(200);
-    return (await response.json()).data.redirectUrl as string;
-}
-
-async function finishBridge(browser: Browser, callback: string) {
-    let response = await browser.request(callback);
+async function reachConsent(browser: Browser, entryUrl: string) {
+    let response = await browser.request(entryUrl);
     expect(response.status).toBe(303);
     for (let count = 0; count < 6; count++) {
         const location = new URL(response.headers.get('location')!, issuer);
@@ -174,13 +178,12 @@ async function finishBridge(browser: Browser, callback: string) {
 async function consent(multi = false) {
     const browser = new Browser();
     await signIn(browser);
-    const { state, verifier } = await begin(browser, multi);
-    const callback = await handoff(browser, state);
-    const uid = await finishBridge(browser, callback);
+    const { entryUrl, verifier } = await begin(browser, multi);
+    const uid = await reachConsent(browser, entryUrl);
     const response = await browser.json(`${issuer}/oauth/interaction/${uid}/details`);
     expect(response.status).toBe(200);
     const { data } = (await response.json()) as GetOAuthInteraction['Success'];
-    return { browser, uid, data, verifier, callback };
+    return { browser, uid, data, verifier };
 }
 
 async function approve(flow: Awaited<ReturnType<typeof consent>>) {
@@ -242,7 +245,7 @@ describe('Nango OAuth login and consent', () => {
         vi.restoreAllMocks();
     });
 
-    it('bridges an existing dashboard session and issues tokens for a multi-resource product grant', async () => {
+    it('reuses the dashboard session and issues tokens for a multi-resource product grant without a bridge', async () => {
         const flow = await consent(true);
         expect(flow.data).toMatchObject({
             clientName: 'Example client',
@@ -276,10 +279,11 @@ describe('Nango OAuth login and consent', () => {
 
     it('resumes the exact interaction after signed-out password login', async () => {
         const browser = new Browser();
-        const { state } = await begin(browser);
-        expect((await browser.json('https://api.nango.test/api/v1/oauth/handoff', { state })).status).toBe(401);
-        expect(await signIn(browser)).toMatchObject({ url: `/oauth/continue?state=${state}` });
-        expect(await finishBridge(browser, await handoff(browser, state))).toBeTruthy();
+        const { entryUrl, continuation } = await beginSignedOut(browser);
+        expect(await signIn(browser)).toMatchObject({ url: continuation });
+        expect(await reachConsent(browser, entryUrl)).toBeTruthy();
+        // The one-time login destination is not carried into the authenticated session.
+        expect(await signIn(browser)).toMatchObject({ url: '/' });
     });
 
     it('preserves continuation through password login and MFA session regeneration', async () => {
@@ -292,20 +296,18 @@ describe('Nango OAuth login and consent', () => {
         expect(activation.status).toBe(200);
         const recoveryCode = (await activation.json()).data.recoveryCodes[0];
         const browser = new Browser();
-        const { state } = await begin(browser);
-        expect((await browser.json('https://api.nango.test/api/v1/oauth/handoff', { state })).status).toBe(401);
+        const { entryUrl, continuation, uid } = await beginSignedOut(browser);
         expect(await signIn(browser)).toMatchObject({ data: { mfaRequired: true } });
-        expect((await browser.json('https://api.nango.test/api/v1/oauth/handoff', { state })).status).toBe(401);
+        expect((await browser.json(`${issuer}/oauth/interaction/${uid}/details`)).status).toBe(401);
         const verified = await browser.json('https://api.nango.test/api/v1/account/mfa/login/verify', { type: 'recoveryCode', recoveryCode });
         expect(verified.status).toBe(200);
-        expect(await verified.json()).toMatchObject({ data: { url: `/oauth/continue?state=${state}` } });
-        expect(await finishBridge(browser, await handoff(browser, state))).toBeTruthy();
+        expect(await verified.json()).toMatchObject({ data: { url: continuation } });
+        expect(await reachConsent(browser, entryUrl)).toBeTruthy();
     });
 
     it.each([false, true])('resumes managed login (email verification: %s)', async (verifyEmail) => {
         const browser = new Browser();
-        const { state } = await begin(browser);
-        expect((await browser.json('https://api.nango.test/api/v1/oauth/handoff', { state })).status).toBe(401);
+        const { entryUrl, continuation } = await beginSignedOut(browser);
         const identity = { user: { email: seeded.user.email, firstName: 'Test', lastName: 'User' } };
         if (verifyEmail)
             fixtures.authenticateWithCode.mockRejectedValueOnce({
@@ -324,26 +326,28 @@ describe('Nango OAuth login and consent', () => {
             fixtures.authenticateWithEmailVerification.mockResolvedValueOnce(identity);
             const result = await browser.json('https://api.nango.test/api/v1/account/managed/verification', { code: '123456' });
             expect(result.status).toBe(200);
-            expect(await result.json()).toMatchObject({ data: { url: `${dashboardOrigin}/oauth/continue?state=${state}` } });
-        } else expect(callback.headers.get('location')).toBe(`${dashboardOrigin}/oauth/continue?state=${state}`);
-        expect(await finishBridge(browser, await handoff(browser, state))).toBeTruthy();
+            expect(await result.json()).toMatchObject({ data: { url: `${dashboardOrigin}${continuation}` } });
+        } else expect(callback.headers.get('location')).toBe(`${dashboardOrigin}${continuation}`);
+        expect(await reachConsent(browser, entryUrl)).toBeTruthy();
     });
 
     it('carries onboarding destinations with only the opaque continuation', async () => {
         const browser = new Browser();
         await signIn(browser);
-        const { state } = await begin(browser);
+        const { entryUrl, continuation } = await begin(browser);
         await db.knex('_nango_users').where({ id: seeded.user.id }).update({ account_discovery_pending: true });
-        expect(await handoff(browser, state)).toBe(
-            `${dashboardOrigin}/onboarding/account-discovery?next=${encodeURIComponent(`/oauth/continue?state=${state}`)}`
+        expect((await browser.request(entryUrl)).headers.get('location')).toBe(
+            `${dashboardOrigin}/onboarding/account-discovery?next=${encodeURIComponent(continuation)}`
         );
         const discovery = await browser.json('https://api.nango.test/api/v1/account/onboarding/account-discovery');
         expect(discovery.status).toBe(200);
         await db.knex('_nango_accounts').where({ id: seeded.account.id }).update({ found_us: null });
-        expect(await handoff(browser, state)).toBe(`${dashboardOrigin}/onboarding/hear-about-us?next=${encodeURIComponent(`/oauth/continue?state=${state}`)}`);
+        expect((await browser.request(entryUrl)).headers.get('location')).toBe(
+            `${dashboardOrigin}/onboarding/hear-about-us?next=${encodeURIComponent(continuation)}`
+        );
         const submitted = await browser.json('https://api.nango.test/api/v1/account/onboarding/hear-about-us', { source: 'skipped' });
         expect(submitted.status).toBe(200);
-        expect(await finishBridge(browser, await handoff(browser, state))).toBeTruthy();
+        expect(await reachConsent(browser, entryUrl)).toBeTruthy();
     });
 
     it('denies through the provider and does not create a product grant', async () => {
@@ -379,7 +383,7 @@ describe('Nango OAuth login and consent', () => {
 
     it('only exposes the provider on the configured issuer host and exact credentialed CORS origin', async () => {
         const browser = new Browser();
-        expect((await browser.request('https://api.nango.test/.well-known/oauth-authorization-server')).status).toBe(404);
+        expect((await browser.request('https://id.nango.test/.well-known/oauth-authorization-server')).status).toBe(404);
         expect((await browser.request(`${issuer}/oauth/authorize`, { headers: { 'X-Forwarded-Host': 'evil.example' } })).status).toBe(404);
         const response = await browser.request(`${issuer}/oauth/interaction/${'a'.repeat(32)}/details`, {
             method: 'OPTIONS',
@@ -394,67 +398,70 @@ describe('Nango OAuth login and consent', () => {
         ).not.toBe('https://evil.example');
     });
 
-    it('rejects handoff replay, browser mismatch, expiry and unsafe destinations', async () => {
+    it('requires both the dashboard session and the bound provider interaction cookie', async () => {
         const flow = await consent();
-        expect((await flow.browser.request(flow.callback)).status).toBe(400);
-        for (const mutation of ['browser', 'expiry', 'destination', 'issuer', 'interaction'] as const) {
-            const browser = new Browser();
-            await signIn(browser);
-            const { state } = await begin(browser);
-            const callback = await handoff(browser, state);
-            if (mutation === 'expiry')
-                await db
-                    .knex('oauth_login_handoffs')
-                    .where({ state_hash: hashSecret(state) })
-                    .update({ code_expires_at: new Date(0) });
-            if (mutation === 'destination')
-                await db
-                    .knex('oauth_login_handoffs')
-                    .where({ state_hash: hashSecret(state) })
-                    .update({ return_to: 'https://evil.example' });
-            if (mutation === 'issuer')
-                await db
-                    .knex('oauth_login_handoffs')
-                    .where({ state_hash: hashSecret(state) })
-                    .update({ issuer: 'https://evil.example' });
-            if (mutation === 'interaction')
-                await db
-                    .knex('oauth_login_handoffs')
-                    .where({ state_hash: hashSecret(state) })
-                    .update({ interaction_uid: 'x'.repeat(32), return_to: `${issuer}/oauth/interaction/${'x'.repeat(32)}` });
-            const result = await (mutation === 'browser' ? new Browser() : browser).request(callback);
-            expect(result.status, mutation).toBe(400);
-        }
+        const endpoint = `${issuer}/oauth/interaction/${flow.uid}`;
+        flow.browser.clearCookie('nango_oauth_interaction');
+        expect((await flow.browser.json(`${endpoint}/details`)).status).toBe(410);
+        expect((await flow.browser.json(`${endpoint}/approve`, { csrfToken: flow.data.csrfToken })).status).toBe(410);
+        expect(await db.knex(PRODUCT_GRANTS).where({ user_id: seeded.user.id })).toHaveLength(0);
     });
 
-    it('atomically consumes a 45-second, identity-bound handoff only once', async () => {
-        const browser = new Browser();
-        await signIn(browser);
-        const { state } = await begin(browser);
-        const callback = await handoff(browser, state);
-        const row = await db
-            .knex('oauth_login_handoffs')
-            .where({ state_hash: hashSecret(state) })
-            .first();
-        expect(row).toMatchObject({ user_id: seeded.user.id, account_id: seeded.account.id, issuer });
-        expect(row.code_hash).toHaveLength(32);
-        expect(row.code_hash).toEqual(hashSecret(new URL(callback).searchParams.get('code')!));
-        expect(row.code_expires_at.getTime() - Date.now()).toBeGreaterThan(30_000);
-        expect(row.code_expires_at.getTime() - Date.now()).toBeLessThanOrEqual(45_000);
-        const results = await Promise.all([browser.request(callback), browser.request(callback)]);
-        expect(results.map((result) => result.status).sort()).toEqual([303, 400]);
-        expect(await db.knex('oauth_login_sessions').where({ user_id: seeded.user.id })).toHaveLength(1);
+    it('requires a fresh login after logout even with provider cookies, but preserves existing grants', async () => {
+        const flow = await consent();
+        const { grantId, tokens } = await approve(flow);
+        await flow.browser.json(`${issuer}/api/v1/account/logout`, {});
+        await beginSignedOut(flow.browser);
+        expect(await db.knex(PRODUCT_GRANTS).where({ id: grantId }).first()).toMatchObject({ status: 'active' });
+        const refreshed = await flow.browser.request(`${issuer}/oauth/token`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+                grant_type: 'refresh_token',
+                client_id: fixtures.clientId,
+                refresh_token: tokens.refresh_token,
+                resource: management
+            }).toString()
+        });
+        expect(refreshed.status).toBe(200);
+    });
+
+    it('rechecks the flag for a new authorization even when the provider remembers an earlier grant', async () => {
+        const flow = await consent();
+        await approve(flow);
+        enabled = false;
+        const { entryUrl } = await begin(flow.browser);
+        expect((await flow.browser.request(entryUrl)).status).toBe(403);
+        expect(await db.knex(PRODUCT_GRANTS).where({ user_id: seeded.user.id })).toHaveLength(1);
+    });
+
+    it('binds approval CSRF to the dashboard session, including same-user session rotation', async () => {
+        const flow = await consent();
+        await signIn(flow.browser);
+        const endpoint = `${issuer}/oauth/interaction/${flow.uid}`;
+        expect((await flow.browser.json(`${endpoint}/approve`, { csrfToken: flow.data.csrfToken })).status).toBe(403);
+        const details = await flow.browser.json(`${endpoint}/details`);
+        expect(details.status).toBe(200);
+        flow.data = (await details.json()).data;
+        await approve(flow);
+    });
+
+    it('rejects a different signed-in user on an already-bound interaction', async () => {
+        const flow = await consent();
+        const originalUser = seeded.user;
+        seeded = await seeders.seedAccountEnvAndUser();
+        await signIn(flow.browser);
+        expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/details`)).status).toBe(400);
+        expect(await db.knex(PRODUCT_GRANTS).where({ user_id: originalUser.id })).toHaveLength(0);
     });
 
     it('cannot resurrect a dashboard session while a password reset revokes it', async () => {
-        const browser = new Browser();
-        await signIn(browser);
-        const { state } = await begin(browser);
+        const flow = await consent();
         const blocker = await db.knex.transaction();
         try {
             await blocker('_nango_users').where({ id: seeded.user.id }).forUpdate().first();
-            const result = browser.json('https://api.nango.test/api/v1/oauth/handoff', { state });
-            // Observe the actual row-lock wait rather than sleeping and guessing where issuance is.
+            const result = flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/approve`, { csrfToken: flow.data.csrfToken });
+            // Observe approval waiting on the same user lock as password revocation.
             await vi.waitFor(async () => {
                 const waiting = await db.knex('pg_stat_activity').where({ wait_event_type: 'Lock' }).where('query', 'like', '%_nango_users%').first();
                 expect(waiting).toBeDefined();
@@ -588,7 +595,9 @@ describe('Nango OAuth login and consent', () => {
         expect(await db.knex(PRODUCT_GRANTS).where({ id: grantId }).first()).toMatchObject({ status: 'revoked' });
         expect(await oauthServer!.AccessToken.find(tokens.access_token)).toBeUndefined();
         expect(await oauthServer!.RefreshToken.find(tokens.refresh_token)).toBeUndefined();
-        expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/details`)).status).toBe(401);
+        // Password change intentionally reissues the caller's dashboard session. It may
+        // authenticate again, but the old decision stays completed and its grant is revoked.
+        expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/details`)).status).toBe(409);
     });
 
     it('revokes the product binding when the client revokes any token', async () => {
@@ -604,7 +613,7 @@ describe('Nango OAuth login and consent', () => {
         expect(await oauthServer!.RefreshToken.find(tokens.refresh_token)).toBeUndefined();
     });
 
-    it('revokes product grants, provider tokens and issuer sessions on password reset', async () => {
+    it('revokes product grants, provider tokens and the dashboard session on password reset', async () => {
         const flow = await consent(true);
         const { grantId, tokens } = await approve(flow);
         const token = jwt.sign({ userId: seeded.user.id }, resetPasswordSecret(), { expiresIn: '5m' });
@@ -617,7 +626,7 @@ describe('Nango OAuth login and consent', () => {
         expect(response.status).toBe(200);
         expect(await db.knex(PRODUCT_GRANTS).where({ id: grantId }).first()).toMatchObject({ status: 'revoked' });
         expect(await oauthServer!.RefreshToken.find(tokens.refresh_token)).toBeUndefined();
-        expect(await db.knex('oauth_login_sessions').where({ user_id: seeded.user.id })).toHaveLength(0);
+        expect((await flow.browser.json(`${issuer}/oauth/interaction/${flow.uid}/details`)).status).toBe(401);
     });
 
     it('compensates stale pending rows in a bounded cleanup batch', async () => {
@@ -630,7 +639,6 @@ describe('Nango OAuth login and consent', () => {
         await cleanOAuthConsent(1);
         expect(await db.knex(PRODUCT_GRANTS).where({ id: grantId }).first()).toMatchObject({ status: 'revoked' });
         await db.knex.transaction((trx) => revokeUserOAuthGrants(seeded.user.id, trx));
-        expect(await db.knex('oauth_login_sessions').where({ user_id: seeded.user.id })).toHaveLength(0);
         expect(oauthConsent).toBeTruthy();
     });
 });

--- a/packages/server/lib/oauth/grants.ts
+++ b/packages/server/lib/oauth/grants.ts
@@ -65,23 +65,17 @@ export async function revokeUserOAuthGrants(userId: number, trx: Knex.Transactio
             beforeGrantRevoked: revokeProductBinding
         });
     }
-    await trx('oauth_login_sessions').where({ user_id: userId }).delete();
-    await trx('oauth_login_handoffs').where({ user_id: userId }).delete();
 }
 
 export async function cleanOAuthConsent(limit: number): Promise<void> {
     const now = new Date();
-    for (const [table, key] of [
-        ['oauth_login_handoffs', 'state_hash'],
-        ['oauth_login_sessions', 'token_hash'],
-        ['oauth_consent_decisions', 'interaction_hash']
-    ] as const) {
-        await db
-            .knex(table)
-            .where('expires_at', '<=', now)
-            .whereIn(key, db.knex(table).select(key).where('expires_at', '<=', now).orderBy('expires_at').limit(limit))
-            .delete();
-    }
+    await db
+        .knex('oauth_consent_decisions')
+        .whereIn(
+            'interaction_hash',
+            db.knex('oauth_consent_decisions').select('interaction_hash').where('expires_at', '<=', now).orderBy('expires_at').limit(limit)
+        )
+        .delete();
     const stale = await db
         .knex<ProductGrant>(PRODUCT_GRANTS)
         .where({ status: 'pending' })

--- a/packages/server/lib/oauth/grants.ts
+++ b/packages/server/lib/oauth/grants.ts
@@ -1,0 +1,101 @@
+import db from '@nangohq/database';
+import { oauthTransactionCommitted, revokeOAuthGrantArtifactsInTransaction } from '@nangohq/oauth-server';
+
+import { recordAuditEvent } from '../audit.js';
+import { dek } from '../env.js';
+import { canRecordAuditTrailForAccount } from '../utils/auditTrail.js';
+
+import type { Knex } from 'knex';
+
+export const PRODUCT_GRANTS = 'oauth_product_grants';
+export const GRANT_RESOURCES = 'oauth_product_grant_resources';
+
+export interface ProductGrant {
+    id: string;
+    provider_grant_hash: Buffer;
+    user_id: number;
+    account_id: number;
+    client_id: string;
+    status: 'pending' | 'active' | 'revoked';
+    created_at: Date;
+    updated_at: Date;
+    revoked_at: Date | null;
+}
+
+export async function revokeProductBinding(trx: Knex.Transaction, grantIdHash: Buffer): Promise<void> {
+    const rows = await trx<ProductGrant>(PRODUCT_GRANTS)
+        .where({ provider_grant_hash: grantIdHash })
+        .whereNot({ status: 'revoked' })
+        .update({ status: 'revoked', revoked_at: new Date(), updated_at: new Date() })
+        .returning('*');
+    // No event for a rolled-back mutation. No token, client URL or provider grant ID enters the trail.
+    void oauthTransactionCommitted(trx)
+        .then(async () => {
+            for (const row of rows) {
+                if (await canRecordAuditTrailForAccount({ id: row.account_id })) {
+                    await recordAuditEvent({
+                        occurredAt: new Date().toISOString(),
+                        accountId: row.account_id,
+                        scope: 'account',
+                        environment: null,
+                        resource: 'oauth_grant',
+                        action: 'revoked',
+                        outcome: 'success',
+                        actor: { type: 'unknown', id: 'oauth_revocation' },
+                        context: { interface: 'api' },
+                        targets: [{ type: 'oauth_grant', id: row.id }]
+                    });
+                }
+            }
+        })
+        .catch(() => {
+            /* Revocation must not depend on the audit sink. */
+        });
+}
+
+export async function revokeUserOAuthGrants(userId: number, trx: Knex.Transaction): Promise<void> {
+    // Same user row lock as approval: a password change cannot race a new grant into existence.
+    await trx('_nango_users').where({ id: userId }).forUpdate().first('id');
+    const rows = await trx<ProductGrant>(PRODUCT_GRANTS).where({ user_id: userId }).whereNot({ status: 'revoked' }).select('provider_grant_hash');
+    for (const row of rows) {
+        await revokeOAuthGrantArtifactsInTransaction({
+            trx,
+            encryptionKey: dek.get(),
+            grantIdHash: row.provider_grant_hash,
+            beforeGrantRevoked: revokeProductBinding
+        });
+    }
+    await trx('oauth_login_sessions').where({ user_id: userId }).delete();
+    await trx('oauth_login_handoffs').where({ user_id: userId }).delete();
+}
+
+export async function cleanOAuthConsent(limit: number): Promise<void> {
+    const now = new Date();
+    for (const [table, key] of [
+        ['oauth_login_handoffs', 'state_hash'],
+        ['oauth_login_sessions', 'token_hash'],
+        ['oauth_consent_decisions', 'interaction_hash']
+    ] as const) {
+        await db
+            .knex(table)
+            .where('expires_at', '<=', now)
+            .whereIn(key, db.knex(table).select(key).where('expires_at', '<=', now).orderBy('expires_at').limit(limit))
+            .delete();
+    }
+    const stale = await db
+        .knex<ProductGrant>(PRODUCT_GRANTS)
+        .where({ status: 'pending' })
+        .where('created_at', '<', new Date(Date.now() - 10 * 60_000))
+        .orderBy('created_at')
+        .limit(limit);
+    for (const row of stale) {
+        await db.knex.transaction(async (trx) => {
+            await revokeOAuthGrantArtifactsInTransaction({
+                trx,
+                encryptionKey: dek.get(),
+                grantIdHash: row.provider_grant_hash,
+                beforeGrantRevoked: revokeProductBinding
+            });
+        });
+    }
+}

--- a/packages/server/lib/oauth/handlers.ts
+++ b/packages/server/lib/oauth/handlers.ts
@@ -1,0 +1,101 @@
+import { OAuthProviderErrors } from '@nangohq/oauth-server';
+import { report } from '@nangohq/utils';
+
+import { asyncWrapper } from '../utils/asyncWrapper.js';
+import { oauthConsent } from './server.js';
+import { decisionBody, emptyObject, handoffBody, handoffQuery, interactionParams, OAuthConsentError } from './validation.js';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { OAuthConsentService } from './service.js';
+import type { GetOAuthHandoffCallback, GetOAuthInteraction, PostOAuthApprove, PostOAuthDeny, PostOAuthHandoff } from '@nangohq/types';
+import type { ErrorRequestHandler, Request, RequestHandler, Response } from 'express';
+
+export const oauthParsingError: ErrorRequestHandler = (err: unknown, _req, res, _next) => {
+    const type = err && typeof err === 'object' && 'type' in err ? err.type : undefined;
+    const tooLarge = type === 'entity.too.large';
+    const invalidBody = type === 'entity.parse.failed' || type === 'request.aborted' || type === 'encoding.unsupported' || type === 'charset.unsupported';
+    res.set({ 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' });
+    res.status(tooLarge ? 413 : invalidBody ? 400 : 500).json({
+        error: { code: tooLarge ? 'request_too_large' : invalidBody ? 'invalid_body' : 'server_error' }
+    });
+};
+
+export function consent(): OAuthConsentService {
+    if (!oauthConsent) throw new OAuthConsentError(403, 'feature_disabled');
+    return oauthConsent;
+}
+
+async function handleOAuthErrors(res: Response, fn: () => Promise<void>): Promise<void> {
+    res.set({ 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' });
+    try {
+        await fn();
+    } catch (err) {
+        const expected =
+            err instanceof OAuthConsentError
+                ? err
+                : err instanceof OAuthProviderErrors.SessionNotFound
+                  ? new OAuthConsentError(410, 'interaction_expired')
+                  : err instanceof OAuthProviderErrors.InvalidClient ||
+                      err instanceof OAuthProviderErrors.InvalidClientMetadata ||
+                      err instanceof OAuthProviderErrors.InvalidRequest
+                    ? new OAuthConsentError(400, 'invalid_interaction')
+                    : null;
+        // Provider and database errors can contain credentials. Return only a bounded error
+        // vocabulary; never pass the original error to the generic request/error logger.
+        if (!expected) report(new Error('oauth_consent_unexpected_error'));
+        res.status(expected?.status ?? 500).json({ error: { code: expected?.code ?? 'server_error' } });
+    }
+}
+
+function uid(req: Request): string {
+    const result = interactionParams.safeParse(req.params);
+    if (!result.success) throw new OAuthConsentError(400, 'invalid_interaction');
+    if (!emptyObject.safeParse(req.query).success) throw new OAuthConsentError(400, 'invalid_query_params');
+    return result.data.uid;
+}
+
+export const enterOAuthInteraction: RequestHandler<any, any, any, any, RequestLocals> = async (req, res) => {
+    await handleOAuthErrors(res, async () => {
+        await consent().enter(req, res, uid(req));
+    });
+};
+export const readOAuthInteraction = asyncWrapper<GetOAuthInteraction>(async (req, res) => {
+    await handleOAuthErrors(res, async () => {
+        res.json({ data: await consent().read(req, res, uid(req)) });
+    });
+});
+export const authenticateOAuthSession: RequestHandler<any, any, any, any, RequestLocals> = async (req, res, next) => {
+    await handleOAuthErrors(res, async () => {
+        await consent().session(req, res);
+        next();
+    });
+};
+export const approveOAuthInteraction = asyncWrapper<PostOAuthApprove>(async (req, res) => {
+    await handleOAuthErrors(res, async () => {
+        const body = decisionBody.safeParse(req.body);
+        if (!body.success) throw new OAuthConsentError(400, 'invalid_body');
+        res.json({ data: await consent().decide(req, res, uid(req), body.data.csrfToken, true) });
+    });
+});
+export const denyOAuthInteraction = asyncWrapper<PostOAuthDeny>(async (req, res) => {
+    await handleOAuthErrors(res, async () => {
+        const body = decisionBody.safeParse(req.body);
+        if (!body.success) throw new OAuthConsentError(400, 'invalid_body');
+        res.json({ data: await consent().decide(req, res, uid(req), body.data.csrfToken, false) });
+    });
+});
+export const postOAuthHandoff = asyncWrapper<PostOAuthHandoff>(async (req, res) => {
+    await handleOAuthErrors(res, async () => {
+        const body = handoffBody.safeParse(req.body);
+        if (!body.success) throw new OAuthConsentError(400, 'invalid_body');
+        if (!emptyObject.safeParse(req.query).success) throw new OAuthConsentError(400, 'invalid_query_params');
+        res.json({ data: { redirectUrl: await consent().issueHandoff(req, res, body.data.state) } });
+    });
+});
+export const consumeOAuthHandoff = asyncWrapper<GetOAuthHandoffCallback>(async (req, res) => {
+    await handleOAuthErrors(res, async () => {
+        const query = handoffQuery.safeParse(req.query);
+        if (!query.success) throw new OAuthConsentError(400, 'invalid_handoff');
+        await consent().consumeHandoff(req, res, query.data.code);
+    });
+});

--- a/packages/server/lib/oauth/handlers.ts
+++ b/packages/server/lib/oauth/handlers.ts
@@ -3,11 +3,11 @@ import { report } from '@nangohq/utils';
 
 import { asyncWrapper } from '../utils/asyncWrapper.js';
 import { oauthConsent } from './server.js';
-import { decisionBody, emptyObject, handoffBody, handoffQuery, interactionParams, OAuthConsentError } from './validation.js';
+import { decisionBody, emptyObject, interactionParams, OAuthConsentError } from './validation.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { OAuthConsentService } from './service.js';
-import type { GetOAuthHandoffCallback, GetOAuthInteraction, PostOAuthApprove, PostOAuthDeny, PostOAuthHandoff } from '@nangohq/types';
+import type { GetOAuthInteraction, PostOAuthApprove, PostOAuthDeny } from '@nangohq/types';
 import type { ErrorRequestHandler, Request, RequestHandler, Response } from 'express';
 
 export const oauthParsingError: ErrorRequestHandler = (err: unknown, _req, res, _next) => {
@@ -82,20 +82,5 @@ export const denyOAuthInteraction = asyncWrapper<PostOAuthDeny>(async (req, res)
         const body = decisionBody.safeParse(req.body);
         if (!body.success) throw new OAuthConsentError(400, 'invalid_body');
         res.json({ data: await consent().decide(req, res, uid(req), body.data.csrfToken, false) });
-    });
-});
-export const postOAuthHandoff = asyncWrapper<PostOAuthHandoff>(async (req, res) => {
-    await handleOAuthErrors(res, async () => {
-        const body = handoffBody.safeParse(req.body);
-        if (!body.success) throw new OAuthConsentError(400, 'invalid_body');
-        if (!emptyObject.safeParse(req.query).success) throw new OAuthConsentError(400, 'invalid_query_params');
-        res.json({ data: { redirectUrl: await consent().issueHandoff(req, res, body.data.state) } });
-    });
-});
-export const consumeOAuthHandoff = asyncWrapper<GetOAuthHandoffCallback>(async (req, res) => {
-    await handleOAuthErrors(res, async () => {
-        const query = handoffQuery.safeParse(req.query);
-        if (!query.success) throw new OAuthConsentError(400, 'invalid_handoff');
-        await consent().consumeHandoff(req, res, query.data.code);
     });
 });

--- a/packages/server/lib/oauth/server.ts
+++ b/packages/server/lib/oauth/server.ts
@@ -2,14 +2,17 @@ import db from '@nangohq/database';
 import { createOAuthProvider } from '@nangohq/oauth-server';
 
 import { getOAuthServerConfig } from './config.js';
+import { revokeProductBinding } from './grants.js';
+import { OAuthConsentService } from './service.js';
 
 import type { OAuthProvider } from '@nangohq/oauth-server';
 
+const config = getOAuthServerConfig();
 export const oauthServer = createNangoOAuthServer();
+export const oauthConsent = oauthServer && config ? new OAuthConsentService(oauthServer, config) : null;
 
 function createNangoOAuthServer(): OAuthProvider | null {
-    const config = getOAuthServerConfig();
     if (!config) return null;
 
-    return createOAuthProvider({ knex: db.knex, ...config });
+    return createOAuthProvider({ knex: db.knex, ...config, beforeGrantRevoked: revokeProductBinding });
 }

--- a/packages/server/lib/oauth/server.ts
+++ b/packages/server/lib/oauth/server.ts
@@ -1,0 +1,15 @@
+import db from '@nangohq/database';
+import { createOAuthProvider } from '@nangohq/oauth-server';
+
+import { getOAuthServerConfig } from './config.js';
+
+import type { OAuthProvider } from '@nangohq/oauth-server';
+
+export const oauthServer = createNangoOAuthServer();
+
+function createNangoOAuthServer(): OAuthProvider | null {
+    const config = getOAuthServerConfig();
+    if (!config) return null;
+
+    return createOAuthProvider({ knex: db.knex, ...config });
+}

--- a/packages/server/lib/oauth/service.ts
+++ b/packages/server/lib/oauth/service.ts
@@ -1,0 +1,410 @@
+import { createHash, createHmac, randomBytes, randomUUID } from 'node:crypto';
+
+import tracer from 'dd-trace';
+
+import db from '@nangohq/database';
+import { getFlags } from '@nangohq/feature-flags';
+import { allowPublicCimdClient, hashOAuthGrantId, isValidCimdClientId, withOAuthTransaction } from '@nangohq/oauth-server';
+import { accountService, getPlanSafe } from '@nangohq/shared';
+import { basePublicUrl, metrics, stringTimingSafeEqual, tagTraceUser } from '@nangohq/utils';
+
+import { loadSessionIdentity } from '../utils/sessionIdentity.js';
+import { GRANT_RESOURCES, PRODUCT_GRANTS } from './grants.js';
+import { interactionResponse, OAuthConsentError } from './validation.js';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { NangoOAuthServerConfig } from './config.js';
+import type { ProductGrant } from './grants.js';
+import type { OAuthProvider } from '@nangohq/oauth-server';
+import type { DBUser, OAuthConsentResource } from '@nangohq/types';
+import type { Request, Response } from 'express';
+
+const HANDOFFS = 'oauth_login_handoffs';
+const SESSIONS = 'oauth_login_sessions';
+const DECISIONS = 'oauth_consent_decisions';
+export const LOGIN_COOKIE = 'nango_oauth_login';
+const BROWSER_COOKIE = 'nango_oauth_bridge';
+const HANDOFF_TTL_MS = 45_000;
+const LOGIN_TTL_MS = 7 * 24 * 60 * 60_000;
+
+interface LoginSession {
+    token_hash: Buffer;
+    user_id: number;
+    account_id: number;
+    expires_at: Date;
+}
+interface Handoff {
+    user_id: number | null;
+    account_id: number | null;
+    expires_at: Date;
+    state_hash: Buffer;
+    browser_hash: Buffer;
+    interaction_uid: string;
+    issuer: string;
+    return_to: string;
+    code_hash: Buffer | null;
+    code_expires_at: Date | null;
+    consumed_at: Date | null;
+}
+
+export function opaqueSecret(): string {
+    return randomBytes(32).toString('base64url');
+}
+export function hashSecret(value: string): Buffer {
+    return createHash('sha256').update(value).digest();
+}
+export function oauthContinuation(state: string): string {
+    return `/oauth/continue?state=${encodeURIComponent(state)}`;
+}
+
+export class OAuthConsentService {
+    readonly issuer: string;
+    readonly dashboardOrigin: string;
+    constructor(
+        readonly provider: OAuthProvider,
+        readonly options: NangoOAuthServerConfig,
+        dashboardOrigin = basePublicUrl
+    ) {
+        this.issuer = options.config.baseUrl;
+        this.dashboardOrigin = new URL(dashboardOrigin).origin;
+    }
+
+    private cookieOptions(maxAge: number) {
+        return { httpOnly: true, secure: this.issuer.startsWith('https:'), sameSite: 'lax' as const, path: '/oauth', maxAge };
+    }
+
+    async enabled(accountUuid?: string): Promise<void> {
+        if (!(await getFlags().isOAuthConsentEnabled(accountUuid))) throw new OAuthConsentError(403, 'feature_disabled');
+    }
+
+    expectedOrigin(req: Request): void {
+        if (req.get('origin') !== this.dashboardOrigin) throw new OAuthConsentError(403, 'forbidden');
+    }
+
+    async session(req: Request, res: Response<any, RequestLocals>): Promise<LoginSession> {
+        const start = Date.now();
+        try {
+            return await tracer.trace('sessionAuth', async () => {
+                const token: unknown = req.cookies?.[LOGIN_COOKIE];
+                if (typeof token !== 'string') throw new OAuthConsentError(401, 'unauthorized');
+                const session = await db
+                    .knex<LoginSession>(SESSIONS)
+                    .where({ token_hash: hashSecret(token) })
+                    .where('expires_at', '>', new Date())
+                    .first();
+                if (!session) throw new OAuthConsentError(401, 'unauthorized');
+                const identity = await loadSessionIdentity(session.user_id, session.account_id);
+                if (!identity) throw new OAuthConsentError(401, 'unauthorized');
+                Object.assign(res.locals, identity, { authType: 'session', plan: await getPlanSafe(db.knex, { accountId: identity.account.id }) });
+                tagTraceUser(res.locals);
+                return session;
+            });
+        } finally {
+            metrics.duration(metrics.Types.AUTH_SESSION, Date.now() - start);
+        }
+    }
+
+    async interaction(req: Request, res: Response<any, RequestLocals>, uid: string) {
+        if (
+            res.locals.user &&
+            (await db
+                .knex(DECISIONS)
+                .where({ interaction_hash: hashSecret(uid), user_id: res.locals.user.id })
+                .first('user_id'))
+        )
+            throw new OAuthConsentError(409, 'interaction_completed');
+        const interaction = await this.provider.interactionDetails(req, res);
+        if (interaction.uid !== uid) throw new OAuthConsentError(400, 'invalid_interaction');
+        if (interaction.exp * 1000 <= Date.now()) throw new OAuthConsentError(410, 'interaction_expired');
+        if (interaction.result) throw new OAuthConsentError(409, 'interaction_completed');
+        return interaction;
+    }
+
+    async enter(req: Request, res: Response<any, RequestLocals>, uid: string): Promise<void> {
+        const interaction = await this.interaction(req, res, uid);
+        let session: LoginSession | undefined;
+        try {
+            session = await this.session(req, res);
+        } catch (err) {
+            if (!(err instanceof OAuthConsentError)) throw err;
+        }
+        if (!session) {
+            const state = opaqueSecret();
+            const browser = opaqueSecret();
+            await db.knex(HANDOFFS).insert({
+                state_hash: hashSecret(state),
+                browser_hash: hashSecret(browser),
+                interaction_uid: uid,
+                issuer: this.issuer,
+                return_to: `${this.issuer}/oauth/interaction/${uid}`,
+                expires_at: new Date(interaction.exp * 1000)
+            });
+            res.cookie(BROWSER_COOKIE, browser, this.cookieOptions(Math.max(0, interaction.exp * 1000 - Date.now())));
+            res.redirect(303, `${this.dashboardOrigin}${oauthContinuation(state)}`);
+            return;
+        }
+        await this.enabled(res.locals.account.uuid);
+        const subject = this.subject(session);
+        if (interaction.session?.accountId && interaction.session.accountId !== subject) throw new OAuthConsentError(400, 'invalid_interaction');
+        if (interaction.prompt.name === 'login') {
+            await this.provider.interactionFinished(
+                req,
+                res,
+                { login: { accountId: subject, remember: false, amr: ['nango_session'] } },
+                { mergeWithLastSubmission: false }
+            );
+            return;
+        }
+        res.redirect(303, `${this.dashboardOrigin}/oauth/consent/${encodeURIComponent(uid)}`);
+    }
+
+    async issueHandoff(req: Request, res: Response<any, RequestLocals>, state: string): Promise<string> {
+        this.expectedOrigin(req);
+        const handoff = await db
+            .knex<Handoff>(HANDOFFS)
+            .where({ state_hash: hashSecret(state), consumed_at: null, issuer: this.issuer })
+            .where('expires_at', '>', new Date())
+            .first();
+        if (!handoff || handoff.return_to !== `${this.issuer}/oauth/interaction/${handoff.interaction_uid}`)
+            throw new OAuthConsentError(400, 'invalid_handoff');
+        if (req.session.impersonatedBy) throw new OAuthConsentError(403, 'forbidden');
+        if (!req.isAuthenticated() || !req.user || req.session.pendingMfaLogin) {
+            req.session.oauthContinuation = oauthContinuation(state);
+            await saveDashboardSession(req);
+            throw new OAuthConsentError(401, 'unauthorized');
+        }
+        const principal = req.user;
+        return await db.knex.transaction(async (trx) => {
+            // Lock order matches password revocation and consumption: user, then handoff.
+            // Never save an authenticated dashboard session before this check: saving a
+            // stale in-flight request could resurrect a session deleted by a password reset.
+            await trx('_nango_users').where({ id: principal.id }).forUpdate().first('id');
+            const identity = await loadSessionIdentity(principal.id, principal.account_id, trx);
+            if (!identity || !identity.user.email_verified || !(await trx('_nango_sessions').where({ sid: req.sessionID }).first('sid')))
+                throw new OAuthConsentError(401, 'unauthorized');
+            const { user, account } = identity;
+            const current = await trx<Handoff>(HANDOFFS).where({ state_hash: handoff.state_hash }).forUpdate().first();
+            if (
+                !current ||
+                current.consumed_at ||
+                current.expires_at <= new Date() ||
+                (current.user_id && (current.user_id !== user.id || current.account_id !== account.id))
+            )
+                throw new OAuthConsentError(400, 'invalid_handoff');
+            await this.enabled(account.uuid);
+            const next = encodeURIComponent(oauthContinuation(state));
+            const onboarding = user.account_discovery_pending
+                ? 'account-discovery'
+                : (await accountService.shouldShowHearAboutUs(account))
+                  ? 'hear-about-us'
+                  : null;
+            if (onboarding) {
+                req.session.oauthContinuation = oauthContinuation(state);
+                await saveDashboardSession(req);
+                return `${this.dashboardOrigin}/onboarding/${onboarding}?next=${next}`;
+            }
+            const code = opaqueSecret();
+            await trx(HANDOFFS)
+                .where({ state_hash: handoff.state_hash })
+                .update({ user_id: user.id, account_id: account.id, code_hash: hashSecret(code), code_expires_at: new Date(Date.now() + HANDOFF_TTL_MS) });
+            delete req.session.oauthContinuation;
+            await saveDashboardSession(req);
+            Object.assign(res.locals, identity);
+            return `${this.issuer}/oauth/handoff/callback?code=${encodeURIComponent(code)}`;
+        });
+    }
+
+    async consumeHandoff(req: Request, res: Response<any, RequestLocals>, code: string): Promise<void> {
+        const browser: unknown = req.cookies?.[BROWSER_COOKIE];
+        if (typeof browser !== 'string') throw new OAuthConsentError(400, 'invalid_handoff');
+        const token = opaqueSecret();
+        const candidate = await db
+            .knex<Handoff>(HANDOFFS)
+            .where({ code_hash: hashSecret(code) })
+            .first('user_id');
+        if (!candidate?.user_id) throw new OAuthConsentError(400, 'invalid_handoff');
+        const redirectUrl = await db.knex.transaction(async (trx) => {
+            await trx('_nango_users').where({ id: candidate.user_id }).forUpdate().first('id');
+            const row = await trx<Handoff>(HANDOFFS)
+                .where({ code_hash: hashSecret(code) })
+                .forUpdate()
+                .first();
+            const now = new Date();
+            if (
+                !row ||
+                row.consumed_at ||
+                row.expires_at <= now ||
+                !row.code_expires_at ||
+                row.code_expires_at <= now ||
+                !row.browser_hash.equals(hashSecret(browser)) ||
+                row.issuer !== this.issuer ||
+                row.return_to !== `${this.issuer}/oauth/interaction/${row.interaction_uid}` ||
+                row.user_id !== candidate.user_id ||
+                !row.user_id ||
+                !row.account_id
+            )
+                throw new OAuthConsentError(400, 'invalid_handoff');
+            const identity = await loadSessionIdentity(row.user_id, row.account_id, trx);
+            if (!identity) throw new OAuthConsentError(400, 'invalid_handoff');
+            await this.enabled(identity.account.uuid);
+            const interaction = await this.interaction(req, res, row.interaction_uid);
+            if (interaction.session?.accountId && interaction.session.accountId !== this.subject({ user_id: row.user_id, account_id: row.account_id }))
+                throw new OAuthConsentError(400, 'invalid_handoff');
+            const existingToken: unknown = req.cookies?.[LOGIN_COOKIE];
+            if (typeof existingToken === 'string') {
+                const existing = await trx<LoginSession>(SESSIONS)
+                    .where({ token_hash: hashSecret(existingToken) })
+                    .where('expires_at', '>', now)
+                    .first();
+                if (existing && (existing.user_id !== row.user_id || existing.account_id !== row.account_id))
+                    throw new OAuthConsentError(400, 'invalid_handoff');
+            }
+            await trx(HANDOFFS).where({ state_hash: row.state_hash }).update({ consumed_at: now });
+            await trx(SESSIONS).insert({
+                token_hash: hashSecret(token),
+                user_id: row.user_id,
+                account_id: row.account_id,
+                expires_at: new Date(Date.now() + LOGIN_TTL_MS)
+            });
+            Object.assign(res.locals, identity, { authType: 'session', plan: await getPlanSafe(trx, { accountId: row.account_id }) });
+            return row.return_to;
+        });
+        res.cookie(LOGIN_COOKIE, token, this.cookieOptions(LOGIN_TTL_MS));
+        res.clearCookie(BROWSER_COOKIE, this.cookieOptions(0));
+        res.redirect(303, redirectUrl);
+    }
+
+    private subject(session: Pick<LoginSession, 'user_id' | 'account_id'>): string {
+        return `${session.user_id}:${session.account_id}`;
+    }
+    private csrf(req: Request, uid: string, session: LoginSession): string {
+        return createHmac('sha256', this.options.config.cookieKeys[0]!)
+            .update(JSON.stringify([uid, session.user_id, session.account_id, req.cookies[LOGIN_COOKIE]]))
+            .digest('base64url');
+    }
+
+    private async validateRequest(req: Request, res: Response<any, RequestLocals>, uid: string, session: LoginSession) {
+        const interaction = await this.interaction(req, res, uid);
+        if (interaction.prompt.name !== 'consent' || interaction.session?.accountId !== this.subject(session))
+            throw new OAuthConsentError(400, 'invalid_interaction');
+        const clientId = interaction.params['client_id'];
+        const callback = interaction.params['redirect_uri'];
+        if (typeof clientId !== 'string' || !isValidCimdClientId(clientId) || typeof callback !== 'string')
+            throw new OAuthConsentError(400, 'invalid_interaction');
+        const client = await this.provider.Client.find(clientId);
+        const allowedScopes = new Set(this.options.resources.flatMap((r) => [...r.scopes]));
+        if (!client || !allowPublicCimdClient(client, allowedScopes) || !client.redirectUris?.includes(callback))
+            throw new OAuthConsentError(400, 'invalid_interaction');
+        const scope = interaction.params['scope'];
+        if (typeof scope !== 'string') throw new OAuthConsentError(400, 'invalid_interaction');
+        const scopes = [...new Set(scope.split(' ').filter(Boolean))];
+        if (!scopes.length || scopes.some((s) => !allowedScopes.has(s) || (client.scope && !client.scope.split(' ').includes(s))))
+            throw new OAuthConsentError(400, 'invalid_interaction');
+        const raw = interaction.params['resource'];
+        const requested = typeof raw === 'string' ? [raw] : raw;
+        if (!Array.isArray(requested) || !requested.length || requested.length > 20 || requested.some((r) => typeof r !== 'string'))
+            throw new OAuthConsentError(400, 'invalid_interaction');
+        const resources: OAuthConsentResource[] = [...new Set(requested as string[])].map((resource) => {
+            const configured = this.options.resources.find((r) => r.resource === resource);
+            const resourceScopes = configured ? scopes.filter((s) => configured.scopes.includes(s)) : [];
+            if (!configured || !resourceScopes.length) throw new OAuthConsentError(400, 'invalid_interaction');
+            return { resource, scopes: resourceScopes };
+        });
+        if (scopes.some((s) => !resources.some((r) => r.scopes.includes(s)))) throw new OAuthConsentError(400, 'invalid_interaction');
+        return { interaction, client, clientId, callback, resources, scopes };
+    }
+
+    async read(req: Request, res: Response<any, RequestLocals>, uid: string) {
+        const session = await this.session(req, res);
+        await this.enabled(res.locals.account.uuid);
+        const { interaction, client, clientId, callback, resources } = await this.validateRequest(req, res, uid, session);
+        return interactionResponse.parse({
+            clientName: (client.clientName ?? new URL(clientId).hostname).slice(0, 120),
+            clientHostname: new URL(clientId).hostname,
+            callbackHostname: new URL(callback).hostname,
+            accountName: String(res.locals.account.name).slice(0, 120),
+            resources,
+            expiresAt: new Date(interaction.exp * 1000).toISOString(),
+            csrfToken: this.csrf(req, uid, session)
+        });
+    }
+
+    async decide(
+        req: Request,
+        res: Response<any, RequestLocals>,
+        uid: string,
+        csrfToken: string,
+        approve: true
+    ): Promise<{ redirectUrl: string; grantId: string }>;
+    async decide(req: Request, res: Response<any, RequestLocals>, uid: string, csrfToken: string, approve: false): Promise<{ redirectUrl: string }>;
+    async decide(
+        req: Request,
+        res: Response<any, RequestLocals>,
+        uid: string,
+        csrfToken: string,
+        approve: boolean
+    ): Promise<{ redirectUrl: string; grantId?: string }> {
+        this.expectedOrigin(req);
+        const session = await this.session(req, res);
+        if (!stringTimingSafeEqual(csrfToken, this.csrf(req, uid, session))) throw new OAuthConsentError(403, 'forbidden');
+        return await db.knex.transaction((trx) =>
+            withOAuthTransaction(trx, async () => {
+                await trx<DBUser>('_nango_users').where({ id: session.user_id }).forUpdate().first();
+                const identity = await loadSessionIdentity(session.user_id, session.account_id, trx);
+                if (!identity) throw new OAuthConsentError(401, 'unauthorized');
+                const token: string = req.cookies[LOGIN_COOKIE];
+                if (
+                    !(await trx(SESSIONS)
+                        .where({ token_hash: hashSecret(token) })
+                        .where('expires_at', '>', new Date())
+                        .first())
+                )
+                    throw new OAuthConsentError(401, 'unauthorized');
+                const { interaction, clientId, resources, scopes } = await this.validateRequest(req, res, uid, session);
+                const claimed = await trx(DECISIONS)
+                    .insert({ interaction_hash: hashSecret(uid), user_id: session.user_id, expires_at: new Date(interaction.exp * 1000) })
+                    .onConflict('interaction_hash')
+                    .ignore()
+                    .returning('user_id');
+                if (!claimed.length) throw new OAuthConsentError(409, 'interaction_completed');
+                await this.enabled(identity.account.uuid);
+                if (!approve)
+                    return {
+                        redirectUrl: await this.provider.interactionResult(
+                            req,
+                            res,
+                            { error: 'access_denied', error_description: 'The user denied access.' },
+                            { mergeWithLastSubmission: false }
+                        )
+                    };
+                // Always create a fresh provider grant: a new consent never silently expands an older product binding.
+                const grant = new this.provider.Grant({ accountId: this.subject(session), clientId });
+                grant.jti = opaqueSecret();
+                // oidc-provider also tracks authorization-level OAuth scopes in its OIDC scope
+                // slot, even though this server never offers OpenID Connect or ID tokens.
+                grant.addOIDCScope(scopes.join(' '));
+                const productId = randomUUID();
+                await trx<ProductGrant>(PRODUCT_GRANTS).insert({
+                    id: productId,
+                    provider_grant_hash: hashOAuthGrantId(this.options.config.encryptionKey, grant.jti),
+                    user_id: session.user_id,
+                    account_id: session.account_id,
+                    client_id: clientId,
+                    status: 'pending'
+                });
+                for (const resource of resources) {
+                    grant.addResourceScope(resource.resource, resource.scopes.join(' '));
+                    await trx(GRANT_RESOURCES).insert({ grant_id: productId, resource: resource.resource, scopes: resource.scopes });
+                }
+                const grantId = await grant.save();
+                const redirectUrl = await this.provider.interactionResult(req, res, { consent: { grantId } });
+                await trx(PRODUCT_GRANTS).where({ id: productId, status: 'pending' }).update({ status: 'active', updated_at: new Date() });
+                return { redirectUrl, grantId: productId };
+            })
+        );
+    }
+}
+
+async function saveDashboardSession(req: Request): Promise<void> {
+    await new Promise<void>((resolve, reject) => req.session.save((err) => (err ? reject(err) : resolve())));
+}

--- a/packages/server/lib/oauth/service.ts
+++ b/packages/server/lib/oauth/service.ts
@@ -19,32 +19,11 @@ import type { OAuthProvider } from '@nangohq/oauth-server';
 import type { DBUser, OAuthConsentResource } from '@nangohq/types';
 import type { Request, Response } from 'express';
 
-const HANDOFFS = 'oauth_login_handoffs';
-const SESSIONS = 'oauth_login_sessions';
 const DECISIONS = 'oauth_consent_decisions';
-export const LOGIN_COOKIE = 'nango_oauth_login';
-const BROWSER_COOKIE = 'nango_oauth_bridge';
-const HANDOFF_TTL_MS = 45_000;
-const LOGIN_TTL_MS = 7 * 24 * 60 * 60_000;
 
 interface LoginSession {
-    token_hash: Buffer;
     user_id: number;
     account_id: number;
-    expires_at: Date;
-}
-interface Handoff {
-    user_id: number | null;
-    account_id: number | null;
-    expires_at: Date;
-    state_hash: Buffer;
-    browser_hash: Buffer;
-    interaction_uid: string;
-    issuer: string;
-    return_to: string;
-    code_hash: Buffer | null;
-    code_expires_at: Date | null;
-    consumed_at: Date | null;
 }
 
 export function opaqueSecret(): string {
@@ -53,8 +32,8 @@ export function opaqueSecret(): string {
 export function hashSecret(value: string): Buffer {
     return createHash('sha256').update(value).digest();
 }
-export function oauthContinuation(state: string): string {
-    return `/oauth/continue?state=${encodeURIComponent(state)}`;
+export function oauthContinuation(uid: string): string {
+    return `/oauth/continue/${encodeURIComponent(uid)}`;
 }
 
 export class OAuthConsentService {
@@ -69,10 +48,6 @@ export class OAuthConsentService {
         this.dashboardOrigin = new URL(dashboardOrigin).origin;
     }
 
-    private cookieOptions(maxAge: number) {
-        return { httpOnly: true, secure: this.issuer.startsWith('https:'), sameSite: 'lax' as const, path: '/oauth', maxAge };
-    }
-
     async enabled(accountUuid?: string): Promise<void> {
         if (!(await getFlags().isOAuthConsentEnabled(accountUuid))) throw new OAuthConsentError(403, 'feature_disabled');
     }
@@ -85,19 +60,13 @@ export class OAuthConsentService {
         const start = Date.now();
         try {
             return await tracer.trace('sessionAuth', async () => {
-                const token: unknown = req.cookies?.[LOGIN_COOKIE];
-                if (typeof token !== 'string') throw new OAuthConsentError(401, 'unauthorized');
-                const session = await db
-                    .knex<LoginSession>(SESSIONS)
-                    .where({ token_hash: hashSecret(token) })
-                    .where('expires_at', '>', new Date())
-                    .first();
-                if (!session) throw new OAuthConsentError(401, 'unauthorized');
-                const identity = await loadSessionIdentity(session.user_id, session.account_id);
-                if (!identity) throw new OAuthConsentError(401, 'unauthorized');
+                if (req.session.impersonatedBy) throw new OAuthConsentError(403, 'forbidden');
+                if (!req.isAuthenticated() || !req.user || req.session.pendingMfaLogin) throw new OAuthConsentError(401, 'unauthorized');
+                const identity = await loadSessionIdentity(req.user.id, req.user.account_id);
+                if (!identity || !identity.user.email_verified) throw new OAuthConsentError(401, 'unauthorized');
                 Object.assign(res.locals, identity, { authType: 'session', plan: await getPlanSafe(db.knex, { accountId: identity.account.id }) });
                 tagTraceUser(res.locals);
-                return session;
+                return { user_id: identity.user.id, account_id: identity.account.id };
             });
         } finally {
             metrics.duration(metrics.Types.AUTH_SESSION, Date.now() - start);
@@ -122,28 +91,28 @@ export class OAuthConsentService {
 
     async enter(req: Request, res: Response<any, RequestLocals>, uid: string): Promise<void> {
         const interaction = await this.interaction(req, res, uid);
-        let session: LoginSession | undefined;
-        try {
-            session = await this.session(req, res);
-        } catch (err) {
-            if (!(err instanceof OAuthConsentError)) throw err;
-        }
-        if (!session) {
-            const state = opaqueSecret();
-            const browser = opaqueSecret();
-            await db.knex(HANDOFFS).insert({
-                state_hash: hashSecret(state),
-                browser_hash: hashSecret(browser),
-                interaction_uid: uid,
-                issuer: this.issuer,
-                return_to: `${this.issuer}/oauth/interaction/${uid}`,
-                expires_at: new Date(interaction.exp * 1000)
-            });
-            res.cookie(BROWSER_COOKIE, browser, this.cookieOptions(Math.max(0, interaction.exp * 1000 - Date.now())));
-            res.redirect(303, `${this.dashboardOrigin}${oauthContinuation(state)}`);
+        const continuation = oauthContinuation(uid);
+        const next = encodeURIComponent(continuation);
+        if (req.session.impersonatedBy) throw new OAuthConsentError(403, 'forbidden');
+        if (!req.isAuthenticated() || req.session.pendingMfaLogin) {
+            // Persist only on a pre-login session. Never save an authenticated session here:
+            // an in-flight save could resurrect a session revoked by a password reset.
+            req.session.oauthContinuation = continuation;
+            await saveDashboardSession(req);
+            res.redirect(303, `${this.dashboardOrigin}/signin?next=${next}`);
             return;
         }
+        const session = await this.session(req, res);
         await this.enabled(res.locals.account.uuid);
+        const onboarding = res.locals.user.account_discovery_pending
+            ? 'account-discovery'
+            : (await accountService.shouldShowHearAboutUs(res.locals.account))
+              ? 'hear-about-us'
+              : null;
+        if (onboarding) {
+            res.redirect(303, `${this.dashboardOrigin}/onboarding/${onboarding}?next=${next}`);
+            return;
+        }
         const subject = this.subject(session);
         if (interaction.session?.accountId && interaction.session.accountId !== subject) throw new OAuthConsentError(400, 'invalid_interaction');
         if (interaction.prompt.name === 'login') {
@@ -158,128 +127,12 @@ export class OAuthConsentService {
         res.redirect(303, `${this.dashboardOrigin}/oauth/consent/${encodeURIComponent(uid)}`);
     }
 
-    async issueHandoff(req: Request, res: Response<any, RequestLocals>, state: string): Promise<string> {
-        this.expectedOrigin(req);
-        const handoff = await db
-            .knex<Handoff>(HANDOFFS)
-            .where({ state_hash: hashSecret(state), consumed_at: null, issuer: this.issuer })
-            .where('expires_at', '>', new Date())
-            .first();
-        if (!handoff || handoff.return_to !== `${this.issuer}/oauth/interaction/${handoff.interaction_uid}`)
-            throw new OAuthConsentError(400, 'invalid_handoff');
-        if (req.session.impersonatedBy) throw new OAuthConsentError(403, 'forbidden');
-        if (!req.isAuthenticated() || !req.user || req.session.pendingMfaLogin) {
-            req.session.oauthContinuation = oauthContinuation(state);
-            await saveDashboardSession(req);
-            throw new OAuthConsentError(401, 'unauthorized');
-        }
-        const principal = req.user;
-        return await db.knex.transaction(async (trx) => {
-            // Lock order matches password revocation and consumption: user, then handoff.
-            // Never save an authenticated dashboard session before this check: saving a
-            // stale in-flight request could resurrect a session deleted by a password reset.
-            await trx('_nango_users').where({ id: principal.id }).forUpdate().first('id');
-            const identity = await loadSessionIdentity(principal.id, principal.account_id, trx);
-            if (!identity || !identity.user.email_verified || !(await trx('_nango_sessions').where({ sid: req.sessionID }).first('sid')))
-                throw new OAuthConsentError(401, 'unauthorized');
-            const { user, account } = identity;
-            const current = await trx<Handoff>(HANDOFFS).where({ state_hash: handoff.state_hash }).forUpdate().first();
-            if (
-                !current ||
-                current.consumed_at ||
-                current.expires_at <= new Date() ||
-                (current.user_id && (current.user_id !== user.id || current.account_id !== account.id))
-            )
-                throw new OAuthConsentError(400, 'invalid_handoff');
-            await this.enabled(account.uuid);
-            const next = encodeURIComponent(oauthContinuation(state));
-            const onboarding = user.account_discovery_pending
-                ? 'account-discovery'
-                : (await accountService.shouldShowHearAboutUs(account))
-                  ? 'hear-about-us'
-                  : null;
-            if (onboarding) {
-                req.session.oauthContinuation = oauthContinuation(state);
-                await saveDashboardSession(req);
-                return `${this.dashboardOrigin}/onboarding/${onboarding}?next=${next}`;
-            }
-            const code = opaqueSecret();
-            await trx(HANDOFFS)
-                .where({ state_hash: handoff.state_hash })
-                .update({ user_id: user.id, account_id: account.id, code_hash: hashSecret(code), code_expires_at: new Date(Date.now() + HANDOFF_TTL_MS) });
-            delete req.session.oauthContinuation;
-            await saveDashboardSession(req);
-            Object.assign(res.locals, identity);
-            return `${this.issuer}/oauth/handoff/callback?code=${encodeURIComponent(code)}`;
-        });
-    }
-
-    async consumeHandoff(req: Request, res: Response<any, RequestLocals>, code: string): Promise<void> {
-        const browser: unknown = req.cookies?.[BROWSER_COOKIE];
-        if (typeof browser !== 'string') throw new OAuthConsentError(400, 'invalid_handoff');
-        const token = opaqueSecret();
-        const candidate = await db
-            .knex<Handoff>(HANDOFFS)
-            .where({ code_hash: hashSecret(code) })
-            .first('user_id');
-        if (!candidate?.user_id) throw new OAuthConsentError(400, 'invalid_handoff');
-        const redirectUrl = await db.knex.transaction(async (trx) => {
-            await trx('_nango_users').where({ id: candidate.user_id }).forUpdate().first('id');
-            const row = await trx<Handoff>(HANDOFFS)
-                .where({ code_hash: hashSecret(code) })
-                .forUpdate()
-                .first();
-            const now = new Date();
-            if (
-                !row ||
-                row.consumed_at ||
-                row.expires_at <= now ||
-                !row.code_expires_at ||
-                row.code_expires_at <= now ||
-                !row.browser_hash.equals(hashSecret(browser)) ||
-                row.issuer !== this.issuer ||
-                row.return_to !== `${this.issuer}/oauth/interaction/${row.interaction_uid}` ||
-                row.user_id !== candidate.user_id ||
-                !row.user_id ||
-                !row.account_id
-            )
-                throw new OAuthConsentError(400, 'invalid_handoff');
-            const identity = await loadSessionIdentity(row.user_id, row.account_id, trx);
-            if (!identity) throw new OAuthConsentError(400, 'invalid_handoff');
-            await this.enabled(identity.account.uuid);
-            const interaction = await this.interaction(req, res, row.interaction_uid);
-            if (interaction.session?.accountId && interaction.session.accountId !== this.subject({ user_id: row.user_id, account_id: row.account_id }))
-                throw new OAuthConsentError(400, 'invalid_handoff');
-            const existingToken: unknown = req.cookies?.[LOGIN_COOKIE];
-            if (typeof existingToken === 'string') {
-                const existing = await trx<LoginSession>(SESSIONS)
-                    .where({ token_hash: hashSecret(existingToken) })
-                    .where('expires_at', '>', now)
-                    .first();
-                if (existing && (existing.user_id !== row.user_id || existing.account_id !== row.account_id))
-                    throw new OAuthConsentError(400, 'invalid_handoff');
-            }
-            await trx(HANDOFFS).where({ state_hash: row.state_hash }).update({ consumed_at: now });
-            await trx(SESSIONS).insert({
-                token_hash: hashSecret(token),
-                user_id: row.user_id,
-                account_id: row.account_id,
-                expires_at: new Date(Date.now() + LOGIN_TTL_MS)
-            });
-            Object.assign(res.locals, identity, { authType: 'session', plan: await getPlanSafe(trx, { accountId: row.account_id }) });
-            return row.return_to;
-        });
-        res.cookie(LOGIN_COOKIE, token, this.cookieOptions(LOGIN_TTL_MS));
-        res.clearCookie(BROWSER_COOKIE, this.cookieOptions(0));
-        res.redirect(303, redirectUrl);
-    }
-
     private subject(session: Pick<LoginSession, 'user_id' | 'account_id'>): string {
         return `${session.user_id}:${session.account_id}`;
     }
     private csrf(req: Request, uid: string, session: LoginSession): string {
         return createHmac('sha256', this.options.config.cookieKeys[0]!)
-            .update(JSON.stringify([uid, session.user_id, session.account_id, req.cookies[LOGIN_COOKIE]]))
+            .update(JSON.stringify([uid, session.user_id, session.account_id, req.sessionID]))
             .digest('base64url');
     }
 
@@ -351,14 +204,8 @@ export class OAuthConsentService {
             withOAuthTransaction(trx, async () => {
                 await trx<DBUser>('_nango_users').where({ id: session.user_id }).forUpdate().first();
                 const identity = await loadSessionIdentity(session.user_id, session.account_id, trx);
-                if (!identity) throw new OAuthConsentError(401, 'unauthorized');
-                const token: string = req.cookies[LOGIN_COOKIE];
-                if (
-                    !(await trx(SESSIONS)
-                        .where({ token_hash: hashSecret(token) })
-                        .where('expires_at', '>', new Date())
-                        .first())
-                )
+                if (!identity || !identity.user.email_verified) throw new OAuthConsentError(401, 'unauthorized');
+                if (!(await trx('_nango_sessions').where({ sid: req.sessionID }).where('expired', '>', new Date()).first()))
                     throw new OAuthConsentError(401, 'unauthorized');
                 const { interaction, clientId, resources, scopes } = await this.validateRequest(req, res, uid, session);
                 const claimed = await trx(DECISIONS)

--- a/packages/server/lib/oauth/telemetry.ts
+++ b/packages/server/lib/oauth/telemetry.ts
@@ -1,0 +1,6 @@
+/** Never use a full authorization URL or an interaction identifier as a telemetry label. */
+export function oauthTelemetryPath(url: string): string | undefined {
+    const path = url.split('?')[0]!;
+    if (!/^\/(?:oauth\/(?:authorize|interaction|handoff|token|revoke|jwks)(?:\/|$)|api\/v1\/oauth\/handoff$)/.test(path)) return undefined;
+    return path.replace(/^(\/oauth\/(?:authorize|interaction))\/[^/]+/, '$1/:uid');
+}

--- a/packages/server/lib/oauth/telemetry.ts
+++ b/packages/server/lib/oauth/telemetry.ts
@@ -1,6 +1,6 @@
 /** Never use a full authorization URL or an interaction identifier as a telemetry label. */
 export function oauthTelemetryPath(url: string): string | undefined {
     const path = url.split('?')[0]!;
-    if (!/^\/(?:oauth\/(?:authorize|interaction|handoff|token|revoke|jwks)(?:\/|$)|api\/v1\/oauth\/handoff$)/.test(path)) return undefined;
-    return path.replace(/^(\/oauth\/(?:authorize|interaction))\/[^/]+/, '$1/:uid');
+    if (!/^\/oauth\/(?:authorize|interaction|continue|token|revoke|jwks)(?:\/|$)/.test(path)) return undefined;
+    return path.replace(/^(\/oauth\/(?:authorize|interaction|continue))\/[^/]+/, '$1/:uid');
 }

--- a/packages/server/lib/oauth/validation.ts
+++ b/packages/server/lib/oauth/validation.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+import type { GetOAuthHandoffCallback, OAuthConsentInteraction, PostOAuthApprove, PostOAuthHandoff } from '@nangohq/types';
+
+export const opaqueValue = z.string().regex(/^[A-Za-z0-9_-]{20,128}$/);
+export const interactionParams = z.strictObject({ uid: opaqueValue });
+export const emptyObject = z.strictObject({});
+export const decisionBody: z.ZodType<PostOAuthApprove['Body']> = z.strictObject({ csrfToken: opaqueValue });
+export const handoffBody: z.ZodType<PostOAuthHandoff['Body']> = z.strictObject({ state: opaqueValue });
+export const handoffQuery: z.ZodType<GetOAuthHandoffCallback['Querystring']> = z.strictObject({ code: opaqueValue });
+export const interactionResponse: z.ZodType<OAuthConsentInteraction> = z.strictObject({
+    clientName: z.string().max(120),
+    clientHostname: z.string().max(253),
+    callbackHostname: z.string().max(253),
+    accountName: z.string().max(120),
+    resources: z
+        .array(z.strictObject({ resource: z.url().max(2048), scopes: z.array(z.string().min(1).max(128)).min(1).max(100) }))
+        .min(1)
+        .max(20),
+    expiresAt: z.iso.datetime(),
+    csrfToken: opaqueValue
+});
+
+export class OAuthConsentError extends Error {
+    constructor(
+        readonly status: 400 | 401 | 403 | 409 | 410,
+        readonly code:
+            | 'unauthorized'
+            | 'forbidden'
+            | 'feature_disabled'
+            | 'interaction_expired'
+            | 'interaction_completed'
+            | 'invalid_interaction'
+            | 'invalid_handoff'
+            | 'invalid_body'
+            | 'invalid_query_params'
+    ) {
+        super(code);
+    }
+}

--- a/packages/server/lib/oauth/validation.ts
+++ b/packages/server/lib/oauth/validation.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 
-import type { GetOAuthHandoffCallback, OAuthConsentInteraction, PostOAuthApprove, PostOAuthHandoff } from '@nangohq/types';
+import type { OAuthConsentInteraction, PostOAuthApprove } from '@nangohq/types';
 
 export const opaqueValue = z.string().regex(/^[A-Za-z0-9_-]{20,128}$/);
 export const interactionParams = z.strictObject({ uid: opaqueValue });
 export const emptyObject = z.strictObject({});
 export const decisionBody: z.ZodType<PostOAuthApprove['Body']> = z.strictObject({ csrfToken: opaqueValue });
-export const handoffBody: z.ZodType<PostOAuthHandoff['Body']> = z.strictObject({ state: opaqueValue });
-export const handoffQuery: z.ZodType<GetOAuthHandoffCallback['Querystring']> = z.strictObject({ code: opaqueValue });
 export const interactionResponse: z.ZodType<OAuthConsentInteraction> = z.strictObject({
     clientName: z.string().max(120),
     clientHostname: z.string().max(253),
@@ -31,7 +29,6 @@ export class OAuthConsentError extends Error {
             | 'interaction_expired'
             | 'interaction_completed'
             | 'invalid_interaction'
-            | 'invalid_handoff'
             | 'invalid_body'
             | 'invalid_query_params'
     ) {

--- a/packages/server/lib/oauth/validation.unit.test.ts
+++ b/packages/server/lib/oauth/validation.unit.test.ts
@@ -2,33 +2,32 @@ import { describe, expect, it } from 'vitest';
 
 import { safeOAuthContinuation } from '../controllers/v1/account/returnTo.js';
 import { oauthTelemetryPath } from './telemetry.js';
-import { decisionBody, handoffBody, handoffQuery, interactionParams } from './validation.js';
+import { decisionBody, interactionParams } from './validation.js';
 
 const opaque = 'a'.repeat(43);
 
 describe('OAuth boundary schemas and telemetry', () => {
-    it('accepts only opaque state and rejects browser-controlled identities and destinations', () => {
-        expect(handoffBody.safeParse({ state: opaque }).success).toBe(true);
-        expect(handoffQuery.safeParse({ code: opaque }).success).toBe(true);
+    it('accepts only opaque interaction identifiers and rejects browser-controlled identities and destinations', () => {
         expect(interactionParams.safeParse({ uid: opaque }).success).toBe(true);
         for (const extra of [{ userId: 1 }, { accountId: 1 }, { returnTo: 'https://evil.example' }, { issuer: 'https://evil.example' }]) {
-            expect(handoffBody.safeParse({ state: opaque, ...extra }).success).toBe(false);
+            expect(interactionParams.safeParse({ uid: opaque, ...extra }).success).toBe(false);
             expect(decisionBody.safeParse({ csrfToken: opaque, ...extra }).success).toBe(false);
         }
         for (const state of ['', 'short', '../path', 'a'.repeat(129), `${opaque}?code=secret`]) {
-            expect(handoffBody.safeParse({ state }).success).toBe(false);
+            expect(interactionParams.safeParse({ uid: state }).success).toBe(false);
         }
     });
 
     it('retains only the exact server-side OAuth continuation through authentication', () => {
-        expect(safeOAuthContinuation(`/oauth/continue?state=${opaque}`)).toBe(`/oauth/continue?state=${opaque}`);
+        expect(safeOAuthContinuation(`/oauth/continue/${opaque}`)).toBe(`/oauth/continue/${opaque}`);
         for (const value of [
             undefined,
             '/',
             '//evil.example',
-            `https://app.nango.dev/oauth/continue?state=${opaque}`,
-            `/oauth/continue?state=${opaque}&next=https://evil.example`,
-            `/oauth/continue?state=${opaque}#fragment`
+            `https://app.nango.dev/oauth/continue/${opaque}`,
+            `/oauth/continue/${opaque}?next=https://evil.example`,
+            `/oauth/continue/${opaque}#fragment`,
+            `/oauth/continue?state=${opaque}`
         ]) {
             expect(safeOAuthContinuation(value)).toBeUndefined();
         }
@@ -37,8 +36,7 @@ describe('OAuth boundary schemas and telemetry', () => {
     it('never uses authorization URLs, codes, or interaction IDs as telemetry labels', () => {
         expect(oauthTelemetryPath('/oauth/authorize?client_id=secret&code_challenge=secret')).toBe('/oauth/authorize');
         expect(oauthTelemetryPath(`/oauth/interaction/${opaque}/approve?code=secret`)).toBe('/oauth/interaction/:uid/approve');
-        expect(oauthTelemetryPath('/oauth/handoff/callback?code=secret')).toBe('/oauth/handoff/callback');
-        expect(oauthTelemetryPath('/api/v1/oauth/handoff')).toBe('/api/v1/oauth/handoff');
+        expect(oauthTelemetryPath(`/oauth/continue/${opaque}`)).toBe('/oauth/continue/:uid');
         expect(oauthTelemetryPath('/oauth/callback')).toBeUndefined();
     });
 });

--- a/packages/server/lib/oauth/validation.unit.test.ts
+++ b/packages/server/lib/oauth/validation.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { safeOAuthContinuation } from '../controllers/v1/account/returnTo.js';
+import { oauthTelemetryPath } from './telemetry.js';
+import { decisionBody, handoffBody, handoffQuery, interactionParams } from './validation.js';
+
+const opaque = 'a'.repeat(43);
+
+describe('OAuth boundary schemas and telemetry', () => {
+    it('accepts only opaque state and rejects browser-controlled identities and destinations', () => {
+        expect(handoffBody.safeParse({ state: opaque }).success).toBe(true);
+        expect(handoffQuery.safeParse({ code: opaque }).success).toBe(true);
+        expect(interactionParams.safeParse({ uid: opaque }).success).toBe(true);
+        for (const extra of [{ userId: 1 }, { accountId: 1 }, { returnTo: 'https://evil.example' }, { issuer: 'https://evil.example' }]) {
+            expect(handoffBody.safeParse({ state: opaque, ...extra }).success).toBe(false);
+            expect(decisionBody.safeParse({ csrfToken: opaque, ...extra }).success).toBe(false);
+        }
+        for (const state of ['', 'short', '../path', 'a'.repeat(129), `${opaque}?code=secret`]) {
+            expect(handoffBody.safeParse({ state }).success).toBe(false);
+        }
+    });
+
+    it('retains only the exact server-side OAuth continuation through authentication', () => {
+        expect(safeOAuthContinuation(`/oauth/continue?state=${opaque}`)).toBe(`/oauth/continue?state=${opaque}`);
+        for (const value of [
+            undefined,
+            '/',
+            '//evil.example',
+            `https://app.nango.dev/oauth/continue?state=${opaque}`,
+            `/oauth/continue?state=${opaque}&next=https://evil.example`,
+            `/oauth/continue?state=${opaque}#fragment`
+        ]) {
+            expect(safeOAuthContinuation(value)).toBeUndefined();
+        }
+    });
+
+    it('never uses authorization URLs, codes, or interaction IDs as telemetry labels', () => {
+        expect(oauthTelemetryPath('/oauth/authorize?client_id=secret&code_challenge=secret')).toBe('/oauth/authorize');
+        expect(oauthTelemetryPath(`/oauth/interaction/${opaque}/approve?code=secret`)).toBe('/oauth/interaction/:uid/approve');
+        expect(oauthTelemetryPath('/oauth/handoff/callback?code=secret')).toBe('/oauth/handoff/callback');
+        expect(oauthTelemetryPath('/api/v1/oauth/handoff')).toBe('/api/v1/oauth/handoff');
+        expect(oauthTelemetryPath('/oauth/callback')).toBeUndefined();
+    });
+});

--- a/packages/server/lib/routes.integration.test.ts
+++ b/packages/server/lib/routes.integration.test.ts
@@ -62,6 +62,22 @@ describe('route', () => {
         });
     });
 
+    describe('OAuth server', () => {
+        it.each(['/oauth/authorize', '/.well-known/oauth-authorization-server'])('does not expose %s when the issuer is disabled', async (path) => {
+            const res = await fetch(`${api.url}${path}`);
+
+            expect(res.status).toBe(404);
+            expect((await res.json()) as unknown).toStrictEqual({ error: { code: 'not_found', message: 'Not found' } });
+        });
+
+        it("does not intercept Nango's existing OAuth routes", async () => {
+            const res = await fetch(`${api.url}/oauth/client-metadata/not-a-uuid/provider`);
+
+            expect(res.status).toBe(400);
+            expect((await res.json()) as { error: { code: string } }).toMatchObject({ error: { code: 'invalid_uri_params' } });
+        });
+    });
+
     describe('GET /api/v1/environment/callback', () => {
         it('should handle invalid json', async () => {
             const { apiKey } = await seeders.seedAccountEnvAndUser();

--- a/packages/server/lib/routes.oauth.ts
+++ b/packages/server/lib/routes.oauth.ts
@@ -1,16 +1,57 @@
+import cookieParser from 'cookie-parser';
+import cors from 'cors';
 import express from 'express';
 
 import { OAUTH_AUTHORIZATION_PATH, OAUTH_DISCOVERY_PATH, OAUTH_JWKS_PATH, OAUTH_REVOCATION_PATH, OAUTH_TOKEN_PATH } from '@nangohq/oauth-server';
 
+import { auditOAuthApproved, auditOAuthDenied, auditOAuthSession } from './middleware/audit/index.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
-import { oauthServer } from './oauth/server.js';
+import {
+    approveOAuthInteraction,
+    authenticateOAuthSession,
+    consumeOAuthHandoff,
+    denyOAuthInteraction,
+    enterOAuthInteraction,
+    oauthParsingError,
+    readOAuthInteraction
+} from './oauth/handlers.js';
+import { oauthConsent, oauthServer } from './oauth/server.js';
 
 import type { RequestHandler } from 'express';
 
 export const oauthServerAPI = express.Router();
 
+const issuerOnly: RequestHandler = (req, res, next) => {
+    const issuer = oauthServer ? new URL(oauthServer.issuer) : null;
+    const forwardedHost = req.get('x-forwarded-host');
+    // Koa's provider uses forwarded host information when building resume URLs. Validate
+    // that too, so a spoofed forwarding header cannot turn a valid Host into another issuer.
+    if (!issuer || req.get('host') !== issuer.host || (forwardedHost && forwardedHost !== issuer.host) || req.protocol !== issuer.protocol.slice(0, -1)) {
+        res.status(404).json({ error: { code: 'not_found' } });
+        return;
+    }
+    res.set({ 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' });
+    next();
+};
+
+// Only mount on owned paths; legacy integration OAuth routes keep their own router.
+oauthServerAPI.use(
+    ['/oauth/interaction', '/oauth/handoff'],
+    issuerOnly,
+    cookieParser(),
+    cors({ origin: oauthConsent?.dashboardOrigin ?? false, credentials: true, methods: ['GET', 'POST'], allowedHeaders: ['Content-Type'], maxAge: 600 }),
+    rateLimiterMiddleware,
+    express.json({ limit: '8kb' })
+);
+oauthServerAPI.use(['/oauth/interaction', '/oauth/handoff'], oauthParsingError);
+oauthServerAPI.get('/oauth/interaction/:uid', enterOAuthInteraction);
+oauthServerAPI.get('/oauth/interaction/:uid/details', readOAuthInteraction);
+oauthServerAPI.post('/oauth/interaction/:uid/approve', authenticateOAuthSession, auditOAuthApproved, approveOAuthInteraction);
+oauthServerAPI.post('/oauth/interaction/:uid/deny', authenticateOAuthSession, auditOAuthDenied, denyOAuthInteraction);
+oauthServerAPI.get('/oauth/handoff/callback', auditOAuthSession, consumeOAuthHandoff);
+
 const providerHandlers: RequestHandler[] = oauthServer
-    ? [rateLimiterMiddleware, asExpressHandler(oauthServer.callback())]
+    ? [issuerOnly, rateLimiterMiddleware, asExpressHandler(oauthServer.callback())]
     : [(_req, res) => void res.status(404).json({ error: { code: 'not_found', message: 'Not found' } })];
 
 oauthServerAPI.get(OAUTH_DISCOVERY_PATH, ...providerHandlers);
@@ -24,7 +65,6 @@ oauthServerAPI.options(OAUTH_REVOCATION_PATH, ...providerHandlers);
 oauthServerAPI.get(OAUTH_JWKS_PATH, ...providerHandlers);
 oauthServerAPI.options(OAUTH_JWKS_PATH, ...providerHandlers);
 
-// TODO(NAN-6924): Add the authenticated interaction API and React consent flow.
 // Keeping the protocol routes explicit prevents this router from intercepting Nango's existing /oauth/* routes.
 
 function asExpressHandler(providerCallback: ReturnType<NonNullable<typeof oauthServer>['callback']>): RequestHandler {

--- a/packages/server/lib/routes.oauth.ts
+++ b/packages/server/lib/routes.oauth.ts
@@ -1,0 +1,34 @@
+import express from 'express';
+
+import { OAUTH_AUTHORIZATION_PATH, OAUTH_DISCOVERY_PATH, OAUTH_JWKS_PATH, OAUTH_REVOCATION_PATH, OAUTH_TOKEN_PATH } from '@nangohq/oauth-server';
+
+import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
+import { oauthServer } from './oauth/server.js';
+
+import type { RequestHandler } from 'express';
+
+export const oauthServerAPI = express.Router();
+
+const providerHandlers: RequestHandler[] = oauthServer
+    ? [rateLimiterMiddleware, asExpressHandler(oauthServer.callback())]
+    : [(_req, res) => void res.status(404).json({ error: { code: 'not_found', message: 'Not found' } })];
+
+oauthServerAPI.get(OAUTH_DISCOVERY_PATH, ...providerHandlers);
+oauthServerAPI.options(OAUTH_DISCOVERY_PATH, ...providerHandlers);
+oauthServerAPI.get(OAUTH_AUTHORIZATION_PATH, ...providerHandlers);
+oauthServerAPI.get(`${OAUTH_AUTHORIZATION_PATH}/:uid`, ...providerHandlers);
+oauthServerAPI.post(OAUTH_TOKEN_PATH, ...providerHandlers);
+oauthServerAPI.options(OAUTH_TOKEN_PATH, ...providerHandlers);
+oauthServerAPI.post(OAUTH_REVOCATION_PATH, ...providerHandlers);
+oauthServerAPI.options(OAUTH_REVOCATION_PATH, ...providerHandlers);
+oauthServerAPI.get(OAUTH_JWKS_PATH, ...providerHandlers);
+oauthServerAPI.options(OAUTH_JWKS_PATH, ...providerHandlers);
+
+// TODO(NAN-6924): Add the authenticated interaction API and React consent flow.
+// Keeping the protocol routes explicit prevents this router from intercepting Nango's existing /oauth/* routes.
+
+function asExpressHandler(providerCallback: ReturnType<NonNullable<typeof oauthServer>['callback']>): RequestHandler {
+    return (req, res, next) => {
+        void providerCallback(req, res).catch(next);
+    };
+}

--- a/packages/server/lib/routes.oauth.ts
+++ b/packages/server/lib/routes.oauth.ts
@@ -1,15 +1,14 @@
-import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import express from 'express';
 
 import { OAUTH_AUTHORIZATION_PATH, OAUTH_DISCOVERY_PATH, OAUTH_JWKS_PATH, OAUTH_REVOCATION_PATH, OAUTH_TOKEN_PATH } from '@nangohq/oauth-server';
 
-import { auditOAuthApproved, auditOAuthDenied, auditOAuthSession } from './middleware/audit/index.js';
+import { setupAuth } from './clients/auth.client.js';
+import { auditOAuthApproved, auditOAuthDenied } from './middleware/audit/index.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import {
     approveOAuthInteraction,
     authenticateOAuthSession,
-    consumeOAuthHandoff,
     denyOAuthInteraction,
     enterOAuthInteraction,
     oauthParsingError,
@@ -20,6 +19,8 @@ import { oauthConsent, oauthServer } from './oauth/server.js';
 import type { RequestHandler } from 'express';
 
 export const oauthServerAPI = express.Router();
+const browserSession = express.Router();
+setupAuth(browserSession);
 
 const issuerOnly: RequestHandler = (req, res, next) => {
     const issuer = oauthServer ? new URL(oauthServer.issuer) : null;
@@ -36,19 +37,18 @@ const issuerOnly: RequestHandler = (req, res, next) => {
 
 // Only mount on owned paths; legacy integration OAuth routes keep their own router.
 oauthServerAPI.use(
-    ['/oauth/interaction', '/oauth/handoff'],
+    '/oauth/interaction',
     issuerOnly,
-    cookieParser(),
+    browserSession,
     cors({ origin: oauthConsent?.dashboardOrigin ?? false, credentials: true, methods: ['GET', 'POST'], allowedHeaders: ['Content-Type'], maxAge: 600 }),
     rateLimiterMiddleware,
     express.json({ limit: '8kb' })
 );
-oauthServerAPI.use(['/oauth/interaction', '/oauth/handoff'], oauthParsingError);
+oauthServerAPI.use('/oauth/interaction', oauthParsingError);
 oauthServerAPI.get('/oauth/interaction/:uid', enterOAuthInteraction);
 oauthServerAPI.get('/oauth/interaction/:uid/details', readOAuthInteraction);
 oauthServerAPI.post('/oauth/interaction/:uid/approve', authenticateOAuthSession, auditOAuthApproved, approveOAuthInteraction);
 oauthServerAPI.post('/oauth/interaction/:uid/deny', authenticateOAuthSession, auditOAuthDenied, denyOAuthInteraction);
-oauthServerAPI.get('/oauth/handoff/callback', auditOAuthSession, consumeOAuthHandoff);
 
 const providerHandlers: RequestHandler[] = oauthServer
     ? [issuerOnly, rateLimiterMiddleware, asExpressHandler(oauthServer.callback())]

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -192,7 +192,6 @@ import {
 import { authenticateLocalSignin } from './middleware/authenticateLocalSignin.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
-import { oauthParsingError, postOAuthHandoff } from './oauth/handlers.js';
 import { isAllowedWebCorsOrigin } from './utils/cors.js';
 
 import type { Request, RequestHandler, Response } from 'express';
@@ -240,8 +239,6 @@ web.use(bodyParser.raw({ limit: bodyLimit }));
 web.use(express.urlencoded({ extended: true, limit: bodyLimit }));
 
 // --- No auth
-web.use('/oauth/handoff', oauthParsingError);
-web.route('/oauth/handoff').post(rateLimiterMiddleware, postOAuthHandoff);
 if (flagHasAuth) {
     web.route('/account/signup').post(rateLimiterMiddleware, auditAuthSignup, signup);
     web.route('/account/logout').post(rateLimiterMiddleware, auditAuthLogout, postLogout);

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -192,6 +192,7 @@ import {
 import { authenticateLocalSignin } from './middleware/authenticateLocalSignin.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
+import { oauthParsingError, postOAuthHandoff } from './oauth/handlers.js';
 import { isAllowedWebCorsOrigin } from './utils/cors.js';
 
 import type { Request, RequestHandler, Response } from 'express';
@@ -239,6 +240,8 @@ web.use(bodyParser.raw({ limit: bodyLimit }));
 web.use(express.urlencoded({ extended: true, limit: bodyLimit }));
 
 // --- No auth
+web.use('/oauth/handoff', oauthParsingError);
+web.route('/oauth/handoff').post(rateLimiterMiddleware, postOAuthHandoff);
 if (flagHasAuth) {
     web.route('/account/signup').post(rateLimiterMiddleware, auditAuthSignup, signup);
     web.route('/account/logout').post(rateLimiterMiddleware, auditAuthLogout, postLogout);

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -11,6 +11,7 @@ import { securityMiddlewares } from './middleware/security.js';
 import { getReady } from './ready.js';
 import { internalApi } from './routes.internal.js';
 import { managementMcpAPI } from './routes.management-mcp.js';
+import { oauthServerAPI } from './routes.oauth.js';
 import { privateApi } from './routes.private.js';
 import { publicAPI } from './routes.public.js';
 import { dirname } from './utils/utils.js';
@@ -33,6 +34,7 @@ router.get('/providers.json', rateLimiterMiddleware, getProvidersJSON);
 
 // Import main routers
 // Order is important because public API has no prefix
+router.use(oauthServerAPI);
 router.use(managementMcpAPI);
 router.use('/api/v1', privateApi);
 router.use('/internal', internalApi);

--- a/packages/server/lib/tracer.ts
+++ b/packages/server/lib/tracer.ts
@@ -1,5 +1,7 @@
 import tracer from 'dd-trace';
 
+import { oauthTelemetryPath } from './oauth/telemetry.js';
+
 tracer.init({
     service: 'nango',
     clientIpEnabled: true,
@@ -19,6 +21,16 @@ tracer.use('elasticsearch', {
 tracer.use('express');
 tracer.use('http', {
     headers: ['x-forwarded-for'],
+    hooks: {
+        request: (span, req) => {
+            const path = req && 'url' in req && req.url ? oauthTelemetryPath(req.url) : undefined;
+            if (!span || !path) return;
+            span.setTag('http.url', path);
+            span.setTag('http.query.string', '');
+            span.setTag('http.target', path);
+            span.setTag('resource.name', `${req?.method ?? 'HTTP'} ${path}`);
+        }
+    },
     blocklist: ['/health', '/favicon.ico', '/logo-dark.svg', '/logo-text.svg', /^\/static\//, /^\/images\//, '/manifest.json']
 });
 tracer.use('net', {

--- a/packages/server/lib/utils/sessionIdentity.ts
+++ b/packages/server/lib/utils/sessionIdentity.ts
@@ -1,0 +1,13 @@
+import db from '@nangohq/database';
+import { accountService, userService } from '@nangohq/shared';
+
+import type { DBUser } from '@nangohq/types';
+import type { Knex } from 'knex';
+
+/** Refresh the principal from database truth for both dashboard and OAuth authorization sessions. */
+export async function loadSessionIdentity(userId: number, accountId?: number, trx: Knex = db.knex) {
+    const user = trx === db.knex ? await userService.getUserById(userId, true) : await trx<DBUser>('_nango_users').where({ id: userId }).first();
+    if (!user || user.suspended || (accountId !== undefined && user.account_id !== accountId)) return null;
+    const account = await accountService.getAccountById(trx, user.account_id);
+    return account ? { user, account } : null;
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,6 +37,7 @@
         "@nangohq/logs": "file:../logs",
         "@nangohq/nango-orchestrator": "file:../orchestrator",
         "@nangohq/nango-yaml": "file:../nango-yaml",
+        "@nangohq/oauth-server": "file:../oauth-server",
         "@nangohq/providers": "file:../providers",
         "@nangohq/records": "file:../records",
         "@nangohq/sandbox": "file:../sandbox",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -42,6 +42,9 @@
             "path": "../orchestrator"
         },
         {
+            "path": "../oauth-server"
+        },
+        {
             "path": "../records"
         },
         {

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -123,6 +123,7 @@ import type { DeleteInvite, GetInvite, PostInvite } from './invitations/api.js';
 import type { GetOperation, PostInsights, SearchFilters, SearchMessages, SearchOperations } from './logs/api.js';
 import type { GetMeta } from './meta/api.js';
 import type { DeleteMFA, GetMFAStatus, PostMFAActivation, PostMFAEnrollment, PostMFALoginVerification, PostMFARecoveryCodes } from './mfa/api.js';
+import type { GetOAuthHandoffCallback, GetOAuthInteraction, PostOAuthApprove, PostOAuthDeny, PostOAuthHandoff } from './oauth/api.js';
 import type { GetPlainHmac } from './plain/api.js';
 import type {
     DeleteSpendAlert,
@@ -340,7 +341,14 @@ export type PrivateApiEndpoints =
     | DeleteMFA
     | GetPlainHmac;
 
-export type APIEndpoints = PrivateApiEndpoints | PublicApiEndpoints;
+export type APIEndpoints =
+    | PrivateApiEndpoints
+    | PublicApiEndpoints
+    | GetOAuthInteraction
+    | PostOAuthApprove
+    | PostOAuthDeny
+    | PostOAuthHandoff
+    | GetOAuthHandoffCallback;
 
 /**
  * Automatically narrow endpoints type with Method + Path

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -123,7 +123,7 @@ import type { DeleteInvite, GetInvite, PostInvite } from './invitations/api.js';
 import type { GetOperation, PostInsights, SearchFilters, SearchMessages, SearchOperations } from './logs/api.js';
 import type { GetMeta } from './meta/api.js';
 import type { DeleteMFA, GetMFAStatus, PostMFAActivation, PostMFAEnrollment, PostMFALoginVerification, PostMFARecoveryCodes } from './mfa/api.js';
-import type { GetOAuthHandoffCallback, GetOAuthInteraction, PostOAuthApprove, PostOAuthDeny, PostOAuthHandoff } from './oauth/api.js';
+import type { GetOAuthInteraction, PostOAuthApprove, PostOAuthDeny } from './oauth/api.js';
 import type { GetPlainHmac } from './plain/api.js';
 import type {
     DeleteSpendAlert,
@@ -341,14 +341,7 @@ export type PrivateApiEndpoints =
     | DeleteMFA
     | GetPlainHmac;
 
-export type APIEndpoints =
-    | PrivateApiEndpoints
-    | PublicApiEndpoints
-    | GetOAuthInteraction
-    | PostOAuthApprove
-    | PostOAuthDeny
-    | PostOAuthHandoff
-    | GetOAuthHandoffCallback;
+export type APIEndpoints = PrivateApiEndpoints | PublicApiEndpoints | GetOAuthInteraction | PostOAuthApprove | PostOAuthDeny;
 
 /**
  * Automatically narrow endpoints type with Method + Path

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -40,6 +40,14 @@ export type AuditInterface = 'api' | 'mcp';
 // without a declared payload shape, and a shape cannot be declared for an action that does not exist.
 // `never` means the action carries no metadata.
 interface AuditEventTable {
+    oauth_grant: {
+        approved: never;
+        denied: never;
+        revoked: never;
+    };
+    oauth_session: {
+        established: never;
+    };
     connection: {
         created: ConnectionMetadata;
         updated: ConnectionUpdatedMetadata;
@@ -137,7 +145,7 @@ export type AuditMetadataFor<R extends AuditResource, A> = A extends keyof Audit
 
 export type AuditScope = 'account' | 'environment';
 
-export type AuditTargetType = 'connection' | 'sync' | 'function' | 'integration' | 'api_key' | 'member' | 'team' | 'user' | 'environment';
+export type AuditTargetType = 'connection' | 'sync' | 'function' | 'integration' | 'api_key' | 'member' | 'team' | 'user' | 'environment' | 'oauth_grant';
 
 export interface AuditActor {
     type: AuditActorType;

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -45,9 +45,6 @@ interface AuditEventTable {
         denied: never;
         revoked: never;
     };
-    oauth_session: {
-        established: never;
-    };
     connection: {
         created: ConnectionMetadata;
         updated: ConnectionUpdatedMetadata;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -65,6 +65,7 @@ export type * from './integration/db.js';
 export type * from './providers/provider.js';
 export type * from './auth/api.js';
 export type * from './oauthSessions/db.js';
+export type * from './oauth/api.js';
 export type * from './auth/http.api.js';
 export type * from './deploy/api.js';
 export type * from './deploy/index.js';

--- a/packages/types/lib/oauth/api.ts
+++ b/packages/types/lib/oauth/api.ts
@@ -16,7 +16,7 @@ export interface OAuthConsentInteraction {
     csrfToken: string;
 }
 
-export type OAuthInteractionError = ApiError<'unauthorized' | 'interaction_expired' | 'interaction_completed' | 'invalid_interaction' | 'invalid_handoff'>;
+export type OAuthInteractionError = ApiError<'unauthorized' | 'interaction_expired' | 'interaction_completed' | 'invalid_interaction'>;
 
 export type GetOAuthInteraction = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'read-only consent details' };
@@ -44,23 +44,5 @@ export type PostOAuthDeny = ApiEndpoint<{
     Params: { uid: string };
     Body: { csrfToken: string };
     Success: { data: { redirectUrl: string } };
-    Error: OAuthInteractionError;
-}>;
-
-export type PostOAuthHandoff = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'issues a short-lived bridge code; session establishment audited on consumption' };
-    Method: 'POST';
-    Path: '/api/v1/oauth/handoff';
-    Body: { state: string };
-    Success: { data: { redirectUrl: string } };
-    Error: OAuthInteractionError;
-}>;
-
-export type GetOAuthHandoffCallback = ApiEndpoint<{
-    Audit: AuditPolicy<'oauth_session', 'established', 'account'>;
-    Method: 'GET';
-    Path: '/oauth/handoff/callback';
-    Querystring: { code: string };
-    Success: never;
     Error: OAuthInteractionError;
 }>;

--- a/packages/types/lib/oauth/api.ts
+++ b/packages/types/lib/oauth/api.ts
@@ -1,0 +1,66 @@
+import type { ApiEndpoint, ApiError } from '../api.js';
+import type { AuditPolicy } from '../audit-trail/event.js';
+
+export interface OAuthConsentResource {
+    resource: string;
+    scopes: string[];
+}
+
+export interface OAuthConsentInteraction {
+    clientName: string;
+    clientHostname: string;
+    callbackHostname: string;
+    accountName: string;
+    resources: OAuthConsentResource[];
+    expiresAt: string;
+    csrfToken: string;
+}
+
+export type OAuthInteractionError = ApiError<'unauthorized' | 'interaction_expired' | 'interaction_completed' | 'invalid_interaction' | 'invalid_handoff'>;
+
+export type GetOAuthInteraction = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'read-only consent details' };
+    Method: 'GET';
+    Path: '/oauth/interaction/:uid/details';
+    Params: { uid: string };
+    Success: { data: OAuthConsentInteraction };
+    Error: OAuthInteractionError;
+}>;
+
+export type PostOAuthApprove = ApiEndpoint<{
+    Audit: AuditPolicy<'oauth_grant', 'approved', 'account'>;
+    Method: 'POST';
+    Path: '/oauth/interaction/:uid/approve';
+    Params: { uid: string };
+    Body: { csrfToken: string };
+    Success: { data: { redirectUrl: string; grantId: string } };
+    Error: OAuthInteractionError;
+}>;
+
+export type PostOAuthDeny = ApiEndpoint<{
+    Audit: AuditPolicy<'oauth_grant', 'denied', 'account'>;
+    Method: 'POST';
+    Path: '/oauth/interaction/:uid/deny';
+    Params: { uid: string };
+    Body: { csrfToken: string };
+    Success: { data: { redirectUrl: string } };
+    Error: OAuthInteractionError;
+}>;
+
+export type PostOAuthHandoff = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'issues a short-lived bridge code; session establishment audited on consumption' };
+    Method: 'POST';
+    Path: '/api/v1/oauth/handoff';
+    Body: { state: string };
+    Success: { data: { redirectUrl: string } };
+    Error: OAuthInteractionError;
+}>;
+
+export type GetOAuthHandoffCallback = ApiEndpoint<{
+    Audit: AuditPolicy<'oauth_session', 'established', 'account'>;
+    Method: 'GET';
+    Path: '/oauth/handoff/callback';
+    Querystring: { code: string };
+    Success: never;
+    Error: OAuthInteractionError;
+}>;

--- a/packages/types/lib/web/env.ts
+++ b/packages/types/lib/web/env.ts
@@ -3,6 +3,8 @@ export interface WindowEnv {
     apiUrl: string;
     /** Where the dashboard sends its own API requests. Equals `apiUrl` unless NANGO_DASHBOARD_API_URL is set. `/` means same-origin. */
     dashboardApiUrl: string;
+    /** Separate, host-only authorization session origin. Absent when OAuth is disabled. */
+    oauthServerUrl?: string;
     publicUrl: string;
     connectUrl: string;
     gitHash: string | undefined;

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -206,6 +206,10 @@ const ENVS_SHAPE = z.object({
     // `/` keeps requests on whichever host served the dashboard (same-origin).
     NANGO_DASHBOARD_API_URL: z.url().or(z.literal('/')).optional(),
     NANGO_MANAGEMENT_MCP_SERVER_URL: z.url().optional(),
+    NANGO_MANAGEMENT_MCP_OAUTH_ENABLED: z.stringbool().optional().default(false),
+    NANGO_OAUTH_SERVER_BASE_URL: z.url().optional(),
+    NANGO_OAUTH_SERVER_COOKIE_KEYS: z.string().optional(),
+    NANGO_OAUTH_SERVER_JWKS: z.string().optional(),
     NANGO_SERVER_KEEP_ALIVE_TIMEOUT: z.coerce.number().optional().default(61_000),
     DEFAULT_RATE_LIMIT_PER_MIN: z.coerce.number().min(1).optional().default(200),
     NANGO_CACHE_ENV_KEYS: z.stringbool().optional().default(false),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -66,7 +66,7 @@ describe('parse', () => {
         expect(parseEnvs(ENVS, {}).NANGO_MANAGEMENT_MCP_OAUTH_ENABLED).toBe(false);
     });
 
-    it('parses shared OAuth server settings without requiring them while disabled', () => {
+    it('parses shared OAuth server settings when OAuth is enabled', () => {
         const res = parseEnvs(ENVS, {
             NANGO_MANAGEMENT_MCP_OAUTH_ENABLED: 'true',
             NANGO_OAUTH_SERVER_BASE_URL: 'https://api.example.com',

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -62,6 +62,23 @@ describe('parse', () => {
         expect(res.NANGO_MANAGEMENT_MCP_SERVER_URL).toBe('https://mcp-development.nango.dev');
     });
 
+    it('defaults Management MCP OAuth to disabled', () => {
+        expect(parseEnvs(ENVS, {}).NANGO_MANAGEMENT_MCP_OAUTH_ENABLED).toBe(false);
+    });
+
+    it('parses shared OAuth server settings without requiring them while disabled', () => {
+        const res = parseEnvs(ENVS, {
+            NANGO_MANAGEMENT_MCP_OAUTH_ENABLED: 'true',
+            NANGO_OAUTH_SERVER_BASE_URL: 'https://api.example.com',
+            NANGO_OAUTH_SERVER_COOKIE_KEYS: '["first","second"]',
+            NANGO_OAUTH_SERVER_JWKS: '{"keys":[]}'
+        });
+        expect(res).toMatchObject({
+            NANGO_MANAGEMENT_MCP_OAUTH_ENABLED: true,
+            NANGO_OAUTH_SERVER_BASE_URL: 'https://api.example.com'
+        });
+    });
+
     it('should accept `/` as NANGO_DASHBOARD_API_URL', () => {
         const res = parseEnvs(ENVS, { NANGO_DASHBOARD_API_URL: '/' });
         expect(res.NANGO_DASHBOARD_API_URL).toBe('/');

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -8,6 +8,7 @@
         "build": "vite build",
         "preview": "vite preview",
         "test": "vitest",
+        "test:browser": "vitest run --config vitest.browser.config.ts",
         "tokens:usage": "node scripts/generate-token-usage.mjs"
     },
     "browserslist": {
@@ -63,6 +64,8 @@
         "@types/stringify-object": "4.0.5",
         "@uidotdev/usehooks": "2.4.1",
         "@vitejs/plugin-react-swc": "4.3.1",
+        "@vitest/browser-playwright": "4.1.9",
+        "axe-core": "4.12.0",
         "class-variance-authority": "0.7.1",
         "classnames": "2.5.1",
         "clsx": "2.1.1",
@@ -77,6 +80,7 @@
         "nuqs": "2.4.1",
         "postcss": "8.5.26",
         "posthog-js": "1.212.1",
+        "playwright": "1.61.0",
         "qrcode.react": "4.2.0",
         "radix-ui": "1.4.3",
         "react": "18.3.1",
@@ -99,6 +103,7 @@
         "vite-plugin-checker": "0.14.1",
         "vite-plugin-svgr": "5.2.0",
         "vitest": "4.1.9",
+        "vitest-browser-react": "2.2.0",
         "web-vitals": "2.1.4",
         "zod": "3.25.76",
         "zustand": "5.0.3"

--- a/packages/webapp/src/app/router.tsx
+++ b/packages/webapp/src/app/router.tsx
@@ -34,6 +34,8 @@ import { Templates } from '@/pages/Integrations/providerConfigKey/Templates';
 import { IntegrationsList } from '@/pages/Integrations/Show';
 import { LogsShow } from '@/pages/Logs/Show';
 import { NotFound } from '@/pages/NotFound';
+import { OAuthConsent } from '@/pages/OAuth/Consent';
+import { OAuthContinue } from '@/pages/OAuth/Continue';
 import { AccountDiscovery } from '@/pages/Onboarding/AccountDiscovery';
 import { HearAboutUs } from '@/pages/Onboarding/HearAboutUs';
 import { Root } from '@/pages/Root';
@@ -147,6 +149,8 @@ const publicAuthRoutes = (() => {
 })();
 
 export const router = sentryCreateBrowserRouter([
+    { path: '/oauth/continue', element: <OAuthContinue /> },
+    { path: '/oauth/consent/:uid', element: <OAuthConsent /> },
     {
         path: '/',
         element: <Root />

--- a/packages/webapp/src/app/router.tsx
+++ b/packages/webapp/src/app/router.tsx
@@ -149,7 +149,7 @@ const publicAuthRoutes = (() => {
 })();
 
 export const router = sentryCreateBrowserRouter([
-    { path: '/oauth/continue', element: <OAuthContinue /> },
+    { path: '/oauth/continue/:uid', element: <OAuthContinue /> },
     { path: '/oauth/consent/:uid', element: <OAuthConsent /> },
     {
         path: '/',

--- a/packages/webapp/src/main.tsx
+++ b/packages/webapp/src/main.tsx
@@ -15,7 +15,7 @@ if (globalEnv.publicPosthogKey) {
         // mask_personal_data_properties only covers ad/click params, so name the rest explicitly.
         // invite_email carries a requester's address and the first $pageview fires here, before
         // React can strip it from the URL.
-        custom_personal_data_properties: ['session_token', 'token', 'next', INVITE_PREFILL_PARAM],
+        custom_personal_data_properties: ['session_token', 'token', 'next', 'code', 'state', INVITE_PREFILL_PARAM],
         // The dashboard renders customer-supplied data that can contain PHI (NAN-6428):
         // mask all text by default, opt Nango-owned static chrome out with data-ph-unmask.
         mask_all_text: true,

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -10,7 +10,6 @@ import type { ApiAuditTrailEvent, AuditAction, AuditActionOf, AuditEventKey, Aud
  */
 const actionsByResource = {
     oauth_grant: ['approved', 'denied', 'revoked'],
-    oauth_session: ['established'],
     connection: ['created', 'updated', 'metadata_updated', 'refreshed', 'deleted'],
     sync: ['enabled', 'disabled', 'paused', 'started', 'triggered', 'cancelled', 'frequency_changed', 'variant_created', 'variant_deleted'],
     function: ['deployed', 'upgraded', 'deleted'],
@@ -39,7 +38,6 @@ true satisfies [Exclude<AuditEventKey, ListedEvent>] extends [never] ? true : ne
 
 const resourceLabels: Record<AuditResource, string> = {
     oauth_grant: 'OAuth grant',
-    oauth_session: 'OAuth session',
     connection: 'Connection',
     sync: 'Sync',
     function: 'Function',

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -9,6 +9,8 @@ import type { ApiAuditTrailEvent, AuditAction, AuditActionOf, AuditEventKey, Aud
  * step by the checks below, as `PUBLIC_ENVIRONMENT_SCOPES` does in `@nangohq/authz`.
  */
 const actionsByResource = {
+    oauth_grant: ['approved', 'denied', 'revoked'],
+    oauth_session: ['established'],
     connection: ['created', 'updated', 'metadata_updated', 'refreshed', 'deleted'],
     sync: ['enabled', 'disabled', 'paused', 'started', 'triggered', 'cancelled', 'frequency_changed', 'variant_created', 'variant_deleted'],
     function: ['deployed', 'upgraded', 'deleted'],
@@ -36,6 +38,8 @@ type ListedEvent = { [R in AuditResource]: `${R}.${(typeof actionsByResource)[R]
 true satisfies [Exclude<AuditEventKey, ListedEvent>] extends [never] ? true : never;
 
 const resourceLabels: Record<AuditResource, string> = {
+    oauth_grant: 'OAuth grant',
+    oauth_session: 'OAuth session',
     connection: 'Connection',
     sync: 'Sync',
     function: 'Function',

--- a/packages/webapp/src/pages/OAuth/Consent.browser.test.tsx
+++ b/packages/webapp/src/pages/OAuth/Consent.browser.test.tsx
@@ -5,20 +5,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { page, userEvent } from 'vitest/browser';
 
-import { decideInteraction, followOAuthRedirect, issueHandoff, OAuthError, readInteraction } from './api';
+import { decideInteraction, followOAuthRedirect, OAuthError, readInteraction, resumeOAuthInteraction } from './api';
 import { OAuthConsent } from './Consent';
 import { OAuthContinue } from './Continue';
 
 import type { OAuthConsentInteraction } from '@nangohq/types';
 
 vi.mock('@/utils/analytics', () => ({ track: vi.fn() }));
-vi.mock('@/utils/env', () => ({ globalEnv: { oauthServerUrl: 'https://id.nango.dev', dashboardApiUrl: 'https://api.nango.dev' } }));
+vi.mock('@/utils/env', () => ({ globalEnv: { oauthServerUrl: 'https://api.nango.dev', dashboardApiUrl: 'https://api.nango.dev' } }));
 vi.mock('./api', async (importOriginal) => ({
     ...(await importOriginal<object>()),
     readInteraction: vi.fn(),
     decideInteraction: vi.fn(),
     followOAuthRedirect: vi.fn(),
-    issueHandoff: vi.fn()
+    resumeOAuthInteraction: vi.fn()
 }));
 
 const uid = 'a'.repeat(32);
@@ -49,7 +49,7 @@ describe('OAuth consent browser experience', () => {
     beforeEach(async () => {
         vi.resetAllMocks();
         vi.mocked(readInteraction).mockResolvedValue({ data: { ...fixture, expiresAt: new Date(Date.now() + 600_000).toISOString() } });
-        vi.mocked(decideInteraction).mockResolvedValue({ data: { redirectUrl: `https://id.nango.dev/oauth/authorize/${uid}`, grantId: 'product-id' } });
+        vi.mocked(decideInteraction).mockResolvedValue({ data: { redirectUrl: `https://api.nango.dev/oauth/authorize/${uid}`, grantId: 'product-id' } });
         await page.viewport(1440, 1000);
     });
 
@@ -134,16 +134,18 @@ describe('OAuth consent browser experience', () => {
         expect(readInteraction).toHaveBeenCalledTimes(2);
     });
 
-    it('issues only one handoff under React StrictMode', async () => {
-        vi.mocked(issueHandoff).mockResolvedValue({ data: { redirectUrl: 'https://id.nango.dev/oauth/handoff/callback?code=opaque' } });
+    it('resumes the interaction after login under React StrictMode without a handoff API call', async () => {
         await render(
             <StrictMode>
-                <MemoryRouter initialEntries={[`/oauth/continue?state=${uid}`]}>
-                    <OAuthContinue />
+                <MemoryRouter initialEntries={[`/oauth/continue/${uid}`]}>
+                    <Routes>
+                        <Route path="/oauth/continue/:uid" element={<OAuthContinue />} />
+                    </Routes>
                 </MemoryRouter>
             </StrictMode>
         );
-        await vi.waitFor(() => expect(followOAuthRedirect).toHaveBeenCalled());
-        expect(issueHandoff).toHaveBeenCalledTimes(1);
+        await vi.waitFor(() => expect(resumeOAuthInteraction).toHaveBeenCalledWith(uid));
+        expect(readInteraction).not.toHaveBeenCalled();
+        expect(decideInteraction).not.toHaveBeenCalled();
     });
 });

--- a/packages/webapp/src/pages/OAuth/Consent.browser.test.tsx
+++ b/packages/webapp/src/pages/OAuth/Consent.browser.test.tsx
@@ -1,0 +1,149 @@
+import axe from 'axe-core';
+import { StrictMode } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+
+import { decideInteraction, followOAuthRedirect, issueHandoff, OAuthError, readInteraction } from './api';
+import { OAuthConsent } from './Consent';
+import { OAuthContinue } from './Continue';
+
+import type { OAuthConsentInteraction } from '@nangohq/types';
+
+vi.mock('@/utils/analytics', () => ({ track: vi.fn() }));
+vi.mock('@/utils/env', () => ({ globalEnv: { oauthServerUrl: 'https://id.nango.dev', dashboardApiUrl: 'https://api.nango.dev' } }));
+vi.mock('./api', async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    readInteraction: vi.fn(),
+    decideInteraction: vi.fn(),
+    followOAuthRedirect: vi.fn(),
+    issueHandoff: vi.fn()
+}));
+
+const uid = 'a'.repeat(32);
+const fixture: OAuthConsentInteraction = {
+    clientName: 'Example application',
+    clientHostname: 'example.com',
+    callbackHostname: 'callback.example.com',
+    accountName: 'Example account',
+    resources: [
+        { resource: 'https://mcp.nango.dev/mcp', scopes: ['environment:*'] },
+        { resource: 'https://api.nango.dev/agent-sessions/example/mcp', scopes: ['agent-session:*'] }
+    ],
+    csrfToken: 'c'.repeat(43),
+    expiresAt: new Date(Date.now() + 600_000).toISOString()
+};
+
+async function renderConsent() {
+    return await render(
+        <MemoryRouter initialEntries={[`/oauth/consent/${uid}`]}>
+            <Routes>
+                <Route path="/oauth/consent/:uid" element={<OAuthConsent />} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+describe('OAuth consent browser experience', () => {
+    beforeEach(async () => {
+        vi.resetAllMocks();
+        vi.mocked(readInteraction).mockResolvedValue({ data: { ...fixture, expiresAt: new Date(Date.now() + 600_000).toISOString() } });
+        vi.mocked(decideInteraction).mockResolvedValue({ data: { redirectUrl: `https://id.nango.dev/oauth/authorize/${uid}`, grantId: 'product-id' } });
+        await page.viewport(1440, 1000);
+    });
+
+    it('shows all resources and unverified identity, and supports keyboard approval', async () => {
+        const { container } = await renderConsent();
+        await expect.element(page.getByRole('heading', { name: 'Authorize access' })).toBeInTheDocument();
+        for (const resource of fixture.resources) await expect.element(page.getByRole('heading', { name: resource.resource })).toBeInTheDocument();
+        await expect.element(page.getByText(/Nango has not verified its identity/)).toBeInTheDocument();
+        await expect.element(page.getByText(/New environments and role promotions may expand access/)).toBeInTheDocument();
+        expect(container.querySelector('select')).toBeNull();
+        for (const theme of ['light', 'dark']) {
+            document.documentElement.setAttribute('data-theme', theme);
+            const results = await axe.run(container);
+            expect(results.violations).toEqual([]);
+        }
+        document.documentElement.removeAttribute('data-theme');
+        page.getByRole('button', { name: 'Deny' }).element().focus();
+        await userEvent.tab();
+        await expect.element(page.getByRole('button', { name: 'Approve access' })).toHaveFocus();
+        await userEvent.keyboard('{Enter}');
+        await vi.waitFor(() => expect(decideInteraction).toHaveBeenCalledWith(uid, fixture.csrfToken, true));
+        expect(followOAuthRedirect).toHaveBeenCalled();
+    });
+
+    it('fits a narrow mobile viewport with long untrusted metadata', async () => {
+        await page.viewport(375, 812);
+        vi.mocked(readInteraction).mockResolvedValue({
+            data: { ...fixture, clientName: 'VeryLongClientName'.repeat(7), accountName: 'LongAccountName'.repeat(8) }
+        });
+        const { container } = await renderConsent();
+        await expect.element(page.getByRole('button', { name: 'Approve access' })).toBeVisible();
+        expect(container.scrollWidth).toBeLessThanOrEqual(375);
+        await page.getByRole('button', { name: 'Deny' }).click();
+        expect(decideInteraction).toHaveBeenCalledWith(uid, fixture.csrfToken, false);
+    });
+
+    it('exposes loading state and disables both actions during a single submission', async () => {
+        let resolveRead!: (value: { data: OAuthConsentInteraction }) => void;
+        vi.mocked(readInteraction).mockReturnValue(
+            new Promise((resolve) => {
+                resolveRead = resolve;
+            })
+        );
+        await renderConsent();
+        await expect.element(page.getByRole('status')).toHaveTextContent('Loading authorization request');
+        resolveRead({ data: fixture });
+        await expect.element(page.getByRole('button', { name: 'Approve access' })).toBeVisible();
+        vi.mocked(decideInteraction).mockReturnValue(new Promise(() => {}));
+        const button = page.getByRole('button', { name: 'Approve access' });
+        (button.element() as HTMLButtonElement).click();
+        (button.element() as HTMLButtonElement).click();
+        await expect.element(button).toBeDisabled();
+        await expect.element(page.getByRole('button', { name: 'Deny' })).toBeDisabled();
+        expect(decideInteraction).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+        ['interaction_expired', 'Request expired'],
+        ['interaction_completed', 'Request already completed'],
+        ['unauthorized', 'Authorization unavailable'],
+        ['feature_disabled', 'Authorization unavailable']
+    ])('renders %s without exposing API details', async (code, title) => {
+        vi.mocked(readInteraction).mockRejectedValue(new OAuthError(code!));
+        await renderConsent();
+        await expect.element(page.getByRole('heading', { name: title! })).toBeInTheDocument();
+        expect(page.getByRole('button', { name: 'Approve access' }).query()).toBeNull();
+    });
+
+    it('expires an open consent page without allowing stale approval', async () => {
+        vi.mocked(readInteraction).mockResolvedValue({ data: { ...fixture, expiresAt: new Date(Date.now() + 100).toISOString() } });
+        await renderConsent();
+        await expect.element(page.getByRole('heading', { name: 'Request expired' })).toBeInTheDocument();
+    });
+
+    it('recovers from API failure by re-reading the interaction before offering approval', async () => {
+        vi.mocked(readInteraction).mockRejectedValueOnce(new Error('sensitive-url-must-not-be-shown'));
+        const { container } = await renderConsent();
+        await expect.element(page.getByRole('button', { name: 'Try again' })).toBeVisible();
+        expect(container.textContent).not.toContain('sensitive-url');
+        await page.getByRole('button', { name: 'Try again' }).click();
+        await expect.element(page.getByRole('button', { name: 'Approve access' })).toBeVisible();
+        expect(readInteraction).toHaveBeenCalledTimes(2);
+    });
+
+    it('issues only one handoff under React StrictMode', async () => {
+        vi.mocked(issueHandoff).mockResolvedValue({ data: { redirectUrl: 'https://id.nango.dev/oauth/handoff/callback?code=opaque' } });
+        await render(
+            <StrictMode>
+                <MemoryRouter initialEntries={[`/oauth/continue?state=${uid}`]}>
+                    <OAuthContinue />
+                </MemoryRouter>
+            </StrictMode>
+        );
+        await vi.waitFor(() => expect(followOAuthRedirect).toHaveBeenCalled());
+        expect(issueHandoff).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/webapp/src/pages/OAuth/Consent.tsx
+++ b/packages/webapp/src/pages/OAuth/Consent.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { Button } from '@nangohq/design-system';
+
+import { track } from '@/utils/analytics';
+import { decideInteraction, followOAuthRedirect, OAuthError, readInteraction } from './api';
+import { OAuthFailure, OAuthLayout } from './Layout';
+
+import type { OAuthConsentInteraction } from '@nangohq/types';
+
+export function OAuthConsent() {
+    const { uid = '' } = useParams();
+    const [interaction, setInteraction] = useState<OAuthConsentInteraction>();
+    const [error, setError] = useState<unknown>();
+    const [attempt, setAttempt] = useState(0);
+    const [pending, setPending] = useState<'approve' | 'deny'>();
+    const submitting = useRef(false);
+
+    useEffect(() => {
+        let disposed = false;
+        setError(undefined);
+        setInteraction(undefined);
+        void readInteraction(uid).then(
+            ({ data }) => {
+                if (!disposed) setInteraction(data);
+            },
+            (err) => {
+                if (!disposed) setError(err);
+            }
+        );
+        return () => {
+            disposed = true;
+        };
+    }, [uid, attempt]);
+
+    useEffect(() => {
+        if (!interaction) return;
+        const timer = window.setTimeout(
+            () => setError(new OAuthError('interaction_expired')),
+            Math.max(0, new Date(interaction.expiresAt).getTime() - Date.now())
+        );
+        return () => window.clearTimeout(timer);
+    }, [interaction]);
+
+    async function decide(approve: boolean) {
+        if (!interaction || submitting.current) return;
+        submitting.current = true;
+        setPending(approve ? 'approve' : 'deny');
+        track('web:oauth:consent_decided', { decision: approve ? 'approve' : 'deny' });
+        try {
+            const { data } = await decideInteraction(uid, interaction.csrfToken, approve);
+            followOAuthRedirect(data.redirectUrl);
+        } catch (err) {
+            setError(err);
+            setPending(undefined);
+            submitting.current = false;
+        }
+    }
+
+    return (
+        <OAuthLayout>
+            {error ? (
+                <OAuthFailure error={error} retry={() => setAttempt((value) => value + 1)} />
+            ) : !interaction ? (
+                <p role="status" className="text-text-secondary">
+                    Loading authorization request…
+                </p>
+            ) : (
+                <>
+                    <h1 className="text-title-group text-text-strong">Authorize access</h1>
+                    <div className="space-y-2 text-body-base text-text-secondary">
+                        <p>
+                            <strong className="break-words text-text-strong" dir="auto">
+                                {interaction.clientName}
+                            </strong>{' '}
+                            wants to access your Nango account.
+                        </p>
+                        <dl className="space-y-2 rounded border border-border-muted p-4">
+                            <div>
+                                <dt className="text-text-secondary">Application website</dt>
+                                <dd className="break-all text-text-strong">{interaction.clientHostname}</dd>
+                            </div>
+                            <div>
+                                <dt className="text-text-secondary">Callback hostname</dt>
+                                <dd className="break-all text-text-strong">{interaction.callbackHostname}</dd>
+                            </div>
+                            <div>
+                                <dt className="text-text-secondary">Nango account</dt>
+                                <dd className="break-words text-text-strong" dir="auto">
+                                    {interaction.accountName}
+                                </dd>
+                            </div>
+                        </dl>
+                        <p className="text-body-small">
+                            The application supplies its own name and metadata. Nango has not verified its identity. Only approve applications you trust.
+                        </p>
+                    </div>
+                    <section aria-labelledby="oauth-resources" className="space-y-3">
+                        <h2 id="oauth-resources" className="text-body-base font-semibold text-text-strong">
+                            Requested access
+                        </h2>
+                        {interaction.resources.map((resource) => (
+                            <div key={resource.resource} className="space-y-2 rounded border border-border-muted p-4">
+                                <h3 className="break-all text-body-base text-text-strong">{resource.resource}</h3>
+                                <ul className="list-disc space-y-1 pl-5 text-body-base text-text-secondary">
+                                    {resource.scopes.map((scope) => (
+                                        <li key={scope} className="break-words">
+                                            <code>{scope}</code>
+                                            {scope === 'environment:*' && ' — access environments within your current Nango permissions'}
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        ))}
+                    </section>
+                    {interaction.resources.some((resource) => resource.scopes.includes('environment:*')) && (
+                        <section aria-labelledby="oauth-permissions" className="space-y-2 text-body-base text-text-secondary">
+                            <h2 id="oauth-permissions" className="font-semibold text-text-strong">
+                                Your permissions remain in control
+                            </h2>
+                            <p>
+                                Management access covers every environment you can access, not a fixed list. New environments and role promotions may expand
+                                access. Role downgrades, suspension, account removal and environment deletion reduce access on the next request.
+                            </p>
+                            <p>The application can keep access when you sign out. Changing or resetting your password revokes this authorization.</p>
+                        </section>
+                    )}
+                    <div className="flex flex-wrap justify-end gap-3" aria-busy={Boolean(pending)}>
+                        <Button variant="outline" disabled={Boolean(pending)} loading={pending === 'deny'} onClick={() => void decide(false)}>
+                            Deny
+                        </Button>
+                        <Button disabled={Boolean(pending)} loading={pending === 'approve'} onClick={() => void decide(true)}>
+                            Approve access
+                        </Button>
+                    </div>
+                    {pending && (
+                        <p role="status" className="text-body-small text-text-secondary">
+                            Completing authorization…
+                        </p>
+                    )}
+                </>
+            )}
+        </OAuthLayout>
+    );
+}

--- a/packages/webapp/src/pages/OAuth/Continue.tsx
+++ b/packages/webapp/src/pages/OAuth/Continue.tsx
@@ -1,47 +1,23 @@
-import { useEffect, useRef, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
-import { followOAuthRedirect, issueHandoff, OAuthError } from './api';
+import { resumeOAuthInteraction } from './api';
 import { OAuthFailure, OAuthLayout } from './Layout';
 
-import type { PostOAuthHandoff } from '@nangohq/types';
-
 export function OAuthContinue() {
-    const [params] = useSearchParams();
-    const state = params.get('state') ?? '';
-    const navigate = useNavigate();
+    const { uid = '' } = useParams();
     const [error, setError] = useState<unknown>();
-    const [attempt, setAttempt] = useState(0);
-    // StrictMode replays effects. Reuse the in-flight issuance so it cannot invalidate
-    // its own one-time code by issuing a second one before the browser follows it.
-    const request = useRef<{ key: string; promise: Promise<PostOAuthHandoff['Success']> }>();
     useEffect(() => {
-        let disposed = false;
-        setError(undefined);
-        if (!/^[A-Za-z0-9_-]{20,128}$/.test(state)) {
-            setError(new OAuthError('invalid_handoff'));
-            return;
+        try {
+            resumeOAuthInteraction(uid);
+        } catch (err) {
+            setError(err);
         }
-        const key = `${state}:${attempt}`;
-        if (request.current?.key !== key) request.current = { key, promise: issueHandoff(state) };
-        void request.current.promise
-            .then(({ data }) => {
-                if (!disposed) followOAuthRedirect(data.redirectUrl, true);
-            })
-            .catch((err) => {
-                if (disposed) return;
-                if (err instanceof OAuthError && err.code === 'unauthorized') {
-                    navigate(`/signin?next=${encodeURIComponent(`/oauth/continue?state=${state}`)}`, { replace: true });
-                } else setError(err);
-            });
-        return () => {
-            disposed = true;
-        };
-    }, [state, attempt, navigate]);
+    }, [uid]);
     return (
         <OAuthLayout>
             {error ? (
-                <OAuthFailure error={error} retry={() => setAttempt((value) => value + 1)} />
+                <OAuthFailure error={error} retry={() => resumeOAuthInteraction(uid)} />
             ) : (
                 <p role="status" className="text-text-secondary">
                     Continuing securely to Nango…

--- a/packages/webapp/src/pages/OAuth/Continue.tsx
+++ b/packages/webapp/src/pages/OAuth/Continue.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { followOAuthRedirect, issueHandoff, OAuthError } from './api';
+import { OAuthFailure, OAuthLayout } from './Layout';
+
+import type { PostOAuthHandoff } from '@nangohq/types';
+
+export function OAuthContinue() {
+    const [params] = useSearchParams();
+    const state = params.get('state') ?? '';
+    const navigate = useNavigate();
+    const [error, setError] = useState<unknown>();
+    const [attempt, setAttempt] = useState(0);
+    // StrictMode replays effects. Reuse the in-flight issuance so it cannot invalidate
+    // its own one-time code by issuing a second one before the browser follows it.
+    const request = useRef<{ key: string; promise: Promise<PostOAuthHandoff['Success']> }>();
+    useEffect(() => {
+        let disposed = false;
+        setError(undefined);
+        if (!/^[A-Za-z0-9_-]{20,128}$/.test(state)) {
+            setError(new OAuthError('invalid_handoff'));
+            return;
+        }
+        const key = `${state}:${attempt}`;
+        if (request.current?.key !== key) request.current = { key, promise: issueHandoff(state) };
+        void request.current.promise
+            .then(({ data }) => {
+                if (!disposed) followOAuthRedirect(data.redirectUrl, true);
+            })
+            .catch((err) => {
+                if (disposed) return;
+                if (err instanceof OAuthError && err.code === 'unauthorized') {
+                    navigate(`/signin?next=${encodeURIComponent(`/oauth/continue?state=${state}`)}`, { replace: true });
+                } else setError(err);
+            });
+        return () => {
+            disposed = true;
+        };
+    }, [state, attempt, navigate]);
+    return (
+        <OAuthLayout>
+            {error ? (
+                <OAuthFailure error={error} retry={() => setAttempt((value) => value + 1)} />
+            ) : (
+                <p role="status" className="text-text-secondary">
+                    Continuing securely to Nango…
+                </p>
+            )}
+        </OAuthLayout>
+    );
+}

--- a/packages/webapp/src/pages/OAuth/Layout.tsx
+++ b/packages/webapp/src/pages/OAuth/Layout.tsx
@@ -1,0 +1,63 @@
+import { Helmet } from 'react-helmet';
+
+import { Alert, AlertDescription, Button } from '@nangohq/design-system';
+
+import { LogoInverted } from '@/assets/LogoInverted';
+import { OAuthError } from './api';
+
+import type { ReactNode } from 'react';
+
+export function OAuthLayout({ children }: { children: ReactNode }) {
+    return (
+        <main className="min-h-screen w-full bg-surface-canvas px-4 py-8 sm:py-16">
+            <Helmet>
+                <title>Authorize access - Nango</title>
+                <meta name="referrer" content="no-referrer" />
+            </Helmet>
+            <div className="mx-auto flex max-w-xl flex-col gap-6 rounded-lg border border-border-muted bg-surface-page p-6 sm:p-8">
+                <div className="flex items-center gap-3 text-text-strong">
+                    <LogoInverted className="size-8" />
+                    <span className="text-title-group">Nango</span>
+                </div>
+                {children}
+            </div>
+        </main>
+    );
+}
+
+export function OAuthFailure({ error, retry }: { error: unknown; retry: () => void }) {
+    const code = error instanceof OAuthError ? error.code : 'server_error';
+    const completed = code === 'interaction_completed';
+    const expired = ['interaction_expired', 'invalid_handoff'].includes(code);
+    const unavailable = ['unauthorized', 'forbidden', 'feature_disabled', 'invalid_interaction'].includes(code);
+    const recoverable = !completed && !expired && !unavailable;
+    return (
+        <>
+            <h1 className="text-title-group text-text-strong">
+                {completed
+                    ? 'Request already completed'
+                    : expired
+                      ? 'Request expired'
+                      : unavailable
+                        ? 'Authorization unavailable'
+                        : 'Unable to load this request'}
+            </h1>
+            <Alert variant={completed ? 'info' : 'danger'}>
+                <AlertDescription>
+                    {completed
+                        ? 'This authorization request has already been handled. You can close this tab.'
+                        : recoverable
+                          ? 'There was a connection problem. Try again to check the status of your request.'
+                          : 'Return to the application and start a new authorization request.'}
+                </AlertDescription>
+            </Alert>
+            {recoverable && (
+                <div>
+                    <Button variant="outline" onClick={retry}>
+                        Try again
+                    </Button>
+                </div>
+            )}
+        </>
+    );
+}

--- a/packages/webapp/src/pages/OAuth/Layout.tsx
+++ b/packages/webapp/src/pages/OAuth/Layout.tsx
@@ -28,7 +28,7 @@ export function OAuthLayout({ children }: { children: ReactNode }) {
 export function OAuthFailure({ error, retry }: { error: unknown; retry: () => void }) {
     const code = error instanceof OAuthError ? error.code : 'server_error';
     const completed = code === 'interaction_completed';
-    const expired = ['interaction_expired', 'invalid_handoff'].includes(code);
+    const expired = code === 'interaction_expired';
     const unavailable = ['unauthorized', 'forbidden', 'feature_disabled', 'invalid_interaction'].includes(code);
     const recoverable = !completed && !expired && !unavailable;
     return (

--- a/packages/webapp/src/pages/OAuth/api.ts
+++ b/packages/webapp/src/pages/OAuth/api.ts
@@ -1,6 +1,6 @@
 import { globalEnv } from '@/utils/env';
 
-import type { GetOAuthInteraction, PostOAuthApprove, PostOAuthDeny, PostOAuthHandoff } from '@nangohq/types';
+import type { GetOAuthInteraction, PostOAuthApprove, PostOAuthDeny } from '@nangohq/types';
 
 export class OAuthError extends Error {
     constructor(readonly code: string) {
@@ -37,18 +37,16 @@ export async function decideInteraction(uid: string, csrfToken: string, approve:
     return await request(new URL(`/oauth/interaction/${encodeURIComponent(uid)}/${approve ? 'approve' : 'deny'}`, issuer()), body);
 }
 
-export async function issueHandoff(state: string): Promise<PostOAuthHandoff['Success']> {
-    const body: PostOAuthHandoff['Body'] = { state };
-    return await request(new URL('/api/v1/oauth/handoff', globalEnv.dashboardApiUrl), body);
+/** Login/onboarding return to a local React route, then navigate to the provider interaction. */
+export function resumeOAuthInteraction(uid: string): void {
+    if (!/^[A-Za-z0-9_-]{20,128}$/.test(uid)) throw new OAuthError('invalid_interaction');
+    window.location.replace(new URL(`/oauth/interaction/${uid}`, issuer()).href);
 }
 
-export function followOAuthRedirect(url: string, handoff = false): void {
+export function followOAuthRedirect(url: string): void {
     const target = new URL(url);
     const isIssuer = target.origin === new URL(issuer()).origin;
-    const valid = handoff
-        ? (isIssuer && target.pathname === '/oauth/handoff/callback') ||
-          (target.origin === window.location.origin && ['/onboarding/account-discovery', '/onboarding/hear-about-us'].includes(target.pathname))
-        : isIssuer && /^\/oauth\/authorize\/[A-Za-z0-9_-]+$/.test(target.pathname);
+    const valid = isIssuer && /^\/oauth\/authorize\/[A-Za-z0-9_-]+$/.test(target.pathname);
     if (!valid) throw new OAuthError('invalid_interaction');
     window.location.assign(target.href);
 }
@@ -56,5 +54,5 @@ export function followOAuthRedirect(url: string, handoff = false): void {
 /** Only the opaque OAuth continuation may be carried through onboarding. */
 export function oauthContinuation(search: string): string | undefined {
     const next = new URLSearchParams(search).get('next');
-    return next && /^\/oauth\/continue\?state=[A-Za-z0-9_-]{20,128}$/.test(next) ? next : undefined;
+    return next && /^\/oauth\/continue\/[A-Za-z0-9_-]{20,128}$/.test(next) ? next : undefined;
 }

--- a/packages/webapp/src/pages/OAuth/api.ts
+++ b/packages/webapp/src/pages/OAuth/api.ts
@@ -1,0 +1,60 @@
+import { globalEnv } from '@/utils/env';
+
+import type { GetOAuthInteraction, PostOAuthApprove, PostOAuthDeny, PostOAuthHandoff } from '@nangohq/types';
+
+export class OAuthError extends Error {
+    constructor(readonly code: string) {
+        super('oauth_request_failed');
+    }
+}
+
+async function request<T>(url: URL, body?: unknown): Promise<T> {
+    const response = await fetch(url, {
+        method: body ? 'POST' : 'GET',
+        credentials: 'include',
+        cache: 'no-store',
+        referrerPolicy: 'no-referrer',
+        ...(body ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) } : {})
+    });
+    if (!response.ok) {
+        const json = await response.json().catch(() => null);
+        throw new OAuthError(typeof json?.error?.code === 'string' ? json.error.code : 'server_error');
+    }
+    return await response.json();
+}
+
+function issuer(): string {
+    if (!globalEnv.oauthServerUrl) throw new OAuthError('feature_disabled');
+    return globalEnv.oauthServerUrl;
+}
+
+export async function readInteraction(uid: string): Promise<GetOAuthInteraction['Success']> {
+    return await request(new URL(`/oauth/interaction/${encodeURIComponent(uid)}/details`, issuer()));
+}
+
+export async function decideInteraction(uid: string, csrfToken: string, approve: boolean): Promise<PostOAuthApprove['Success'] | PostOAuthDeny['Success']> {
+    const body: PostOAuthApprove['Body'] = { csrfToken };
+    return await request(new URL(`/oauth/interaction/${encodeURIComponent(uid)}/${approve ? 'approve' : 'deny'}`, issuer()), body);
+}
+
+export async function issueHandoff(state: string): Promise<PostOAuthHandoff['Success']> {
+    const body: PostOAuthHandoff['Body'] = { state };
+    return await request(new URL('/api/v1/oauth/handoff', globalEnv.dashboardApiUrl), body);
+}
+
+export function followOAuthRedirect(url: string, handoff = false): void {
+    const target = new URL(url);
+    const isIssuer = target.origin === new URL(issuer()).origin;
+    const valid = handoff
+        ? (isIssuer && target.pathname === '/oauth/handoff/callback') ||
+          (target.origin === window.location.origin && ['/onboarding/account-discovery', '/onboarding/hear-about-us'].includes(target.pathname))
+        : isIssuer && /^\/oauth\/authorize\/[A-Za-z0-9_-]+$/.test(target.pathname);
+    if (!valid) throw new OAuthError('invalid_interaction');
+    window.location.assign(target.href);
+}
+
+/** Only the opaque OAuth continuation may be carried through onboarding. */
+export function oauthContinuation(search: string): string | undefined {
+    const next = new URLSearchParams(search).get('next');
+    return next && /^\/oauth\/continue\?state=[A-Za-z0-9_-]{20,128}$/.test(next) ? next : undefined;
+}

--- a/packages/webapp/src/pages/Onboarding/AccountDiscovery.tsx
+++ b/packages/webapp/src/pages/Onboarding/AccountDiscovery.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Alert, AlertDescription, Button } from '@nangohq/design-system';
 
@@ -9,11 +9,12 @@ import { useOnboardingAccountDiscovery, usePostOnboardingRequestInvite } from '@
 import DefaultLayout from '@/layout/DefaultLayout';
 import { track } from '@/utils/analytics';
 import { APIError } from '@/utils/api';
-
-const hearAboutUsRoute = '/onboarding/hear-about-us';
+import { oauthContinuation } from '../OAuth/api';
 
 export const AccountDiscovery: React.FC = () => {
     const navigate = useNavigate();
+    const next = oauthContinuation(useLocation().search);
+    const hearAboutUsRoute = `/onboarding/hear-about-us${next ? `?next=${encodeURIComponent(next)}` : ''}`;
     const { data, isLoading, error } = useOnboardingAccountDiscovery();
     const { mutateAsync: requestInvite, isPending: isRequestingInvite } = usePostOnboardingRequestInvite();
     const [requestError, setRequestError] = useState<'retry' | 'contact_admin' | null>(null);
@@ -40,7 +41,7 @@ export const AccountDiscovery: React.FC = () => {
             // If there are no recommendations, redirect the user to hear-about-us:
             navigate(hearAboutUsRoute, { replace: true });
         }
-    }, [data, error, navigate]);
+    }, [data, error, navigate, hearAboutUsRoute]);
 
     if (isLoading || !data?.data.suggestedAccountName) {
         return <AccountDiscoveryLoading />;

--- a/packages/webapp/src/pages/Onboarding/HearAboutUs.tsx
+++ b/packages/webapp/src/pages/Onboarding/HearAboutUs.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Button } from '@nangohq/design-system';
 
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/Skeleton';
 import { useOnboardingHearAboutUs, usePostOnboardingHearAboutUs } from '../../hooks/useAuth';
 import DefaultLayout from '../../layout/DefaultLayout';
 import { track } from '../../utils/analytics';
+import { oauthContinuation } from '../OAuth/api';
 
 import type { PostOnboardingHearAboutUs } from '@nangohq/types';
 
@@ -23,19 +24,20 @@ const HEAR_ABOUT_OPTIONS: { label: string; value: PostOnboardingHearAboutUs['Bod
 
 export const HearAboutUs: React.FC = () => {
     const navigate = useNavigate();
+    const destination = oauthContinuation(useLocation().search) ?? '/';
 
     const { data, isLoading, error } = useOnboardingHearAboutUs();
     const { mutateAsync: postHearAboutUs, isPending } = usePostOnboardingHearAboutUs();
 
     useEffect(() => {
         if (error) {
-            navigate('/', { replace: true });
+            navigate(destination, { replace: true });
             return;
         }
         if (data && !data.data.showHearAboutUs) {
-            navigate('/', { replace: true });
+            navigate(destination, { replace: true });
         }
-    }, [data, error, navigate]);
+    }, [data, error, navigate, destination]);
 
     const submit = async (source: PostOnboardingHearAboutUs['Body']['source']) => {
         track('web:signup:hear_about', { source });
@@ -43,7 +45,7 @@ export const HearAboutUs: React.FC = () => {
             await postHearAboutUs({ source });
         } finally {
             // Don't block on errors as this is not critical
-            navigate('/', { replace: true });
+            navigate(destination, { replace: true });
         }
     };
 
@@ -77,7 +79,7 @@ export const HearAboutUs: React.FC = () => {
 
             <div className="flex w-full flex-col gap-4">
                 {HEAR_ABOUT_OPTIONS.map(({ label, value }) => (
-                    <Button variant="outline" key={value} loading={isPending} onClick={() => submit(value)} className="w-full p-3 h-auto justify-start">
+                    <Button variant="outline" key={value} loading={isPending} onClick={() => submit(value)}>
                         {label}
                     </Button>
                 ))}

--- a/packages/webapp/src/test/browserSetup.ts
+++ b/packages/webapp/src/test/browserSetup.ts
@@ -1,0 +1,5 @@
+import '@/index.css';
+
+const noMotion = document.createElement('style');
+noMotion.textContent = '*, *::before, *::after { transition: none !important; animation: none !important; }';
+document.head.appendChild(noMotion);

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -13,6 +13,7 @@ import type { PostOnboardingHearAboutUs, UsageMetric } from '@nangohq/types';
  * Property values must be PostHog-serializable primitives (string | number | boolean).
  */
 export interface AnalyticsEvents {
+    'web:oauth:consent_decided': { decision: 'approve' | 'deny' };
     // Usage page (Billing)
     'web:usage:viewed': Record<string, never>;
     'web:usage:month_changed': { direction: 'previous' | 'next' };

--- a/packages/webapp/src/utils/sensitive-url.ts
+++ b/packages/webapp/src/utils/sensitive-url.ts
@@ -10,6 +10,7 @@ const TOKEN_SEGMENT = String.raw`[^/?#&:\s"';]+`;
 // static `expired` and `verification` segments as tokens. Case-insensitive: react-router
 // matches routes case-insensitively, so /Signup/<token> serves the page too.
 const SENSITIVE_PATH_PATTERNS = [
+    new RegExp(String.raw`(/oauth/(?:consent|interaction|authorize)/)${TOKEN_SEGMENT}`, 'gi'),
     new RegExp(String.raw`(/reset-password/)${TOKEN_SEGMENT}`, 'gi'),
     new RegExp(String.raw`(/signup/verification/)${TOKEN_SEGMENT}`, 'gi'),
     new RegExp(String.raw`(/verify-email/expired/)${TOKEN_SEGMENT}`, 'gi'),
@@ -23,7 +24,8 @@ const SENSITIVE_PATH_PATTERNS = [
 
 // Signin carries tokens in ?next=/<token route>/<token>, raw or percent-encoded. The path
 // patterns above only see literal slashes, and a percent-encoded uuid has no jwt catch-all.
-const NEXT_PARAM_PATTERN = /(next=(?:%2F|\/)(?:signup|reset-password|verify-email)(?:%2F|\/))[^&#\s"';]+/gi;
+const NEXT_PARAM_PATTERN = /(next=(?:%2F|\/)(?:signup|reset-password|verify-email|oauth)(?:%2F|\/))[^&#\s"';]+/gi;
+const OAUTH_QUERY_PATTERN = /([?&](?:code|state|code_challenge|redirect_uri|client_id)=)[^&#\s"';]+/gi;
 
 // No leading \b: a percent-encoded delimiter ends in a word char ('%2F'), which defeats it.
 const JWT_PATTERN = /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/g;
@@ -31,7 +33,7 @@ const JWT_PATTERN = /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/g;
 // Every string the patterns above can match contains one of these, so skipping on a miss can
 // never skip a redaction. Keep that true when adding a pattern: no delimiters, they vary by
 // encoding and case (`/signup/`, `%2Fsignup%2F`, `%2fsignup/`, …).
-const HINTS = ['reset-password', 'email', 'signup', 'invite', 'eyj'];
+const HINTS = ['reset-password', 'email', 'signup', 'invite', 'eyj', 'oauth', 'code=', 'state=', 'code_challenge=', 'redirect_uri=', 'client_id='];
 
 /**
  * Removes auth tokens from URLs and URL-shaped strings before they reach PostHog or Sentry.
@@ -52,6 +54,7 @@ export function redactSensitiveText(value: string): string {
         redacted = redacted.replace(pattern, `$1${REDACTED}`);
     }
     redacted = redacted.replace(NEXT_PARAM_PATTERN, `$1${REDACTED}`);
+    redacted = redacted.replace(OAUTH_QUERY_PATTERN, `$1${REDACTED}`);
 
     return redacted.replace(JWT_PATTERN, REDACTED);
 }

--- a/packages/webapp/src/utils/sensitive-url.ts
+++ b/packages/webapp/src/utils/sensitive-url.ts
@@ -10,7 +10,7 @@ const TOKEN_SEGMENT = String.raw`[^/?#&:\s"';]+`;
 // static `expired` and `verification` segments as tokens. Case-insensitive: react-router
 // matches routes case-insensitively, so /Signup/<token> serves the page too.
 const SENSITIVE_PATH_PATTERNS = [
-    new RegExp(String.raw`(/oauth/(?:consent|interaction|authorize)/)${TOKEN_SEGMENT}`, 'gi'),
+    new RegExp(String.raw`(/oauth/(?:consent|continue|interaction|authorize)/)${TOKEN_SEGMENT}`, 'gi'),
     new RegExp(String.raw`(/reset-password/)${TOKEN_SEGMENT}`, 'gi'),
     new RegExp(String.raw`(/signup/verification/)${TOKEN_SEGMENT}`, 'gi'),
     new RegExp(String.raw`(/verify-email/expired/)${TOKEN_SEGMENT}`, 'gi'),

--- a/packages/webapp/src/utils/sensitive-url.unit.test.ts
+++ b/packages/webapp/src/utils/sensitive-url.unit.test.ts
@@ -10,6 +10,7 @@ const UUID = '8f14e45f-ceea-467a-9b0d-1e0a1b2c3d4e';
 describe('redactSensitiveText', () => {
     it('redacts issuer interactions, handoffs and OAuth callbacks', () => {
         expect(redactSensitiveText('/oauth/consent/secret-uid')).toBe('/oauth/consent/[redacted]');
+        expect(redactSensitiveText('/oauth/continue/secret-uid')).toBe('/oauth/continue/[redacted]');
         expect(redactSensitiveText('/oauth/interaction/secret-uid/approve')).toBe('/oauth/interaction/[redacted]/approve');
         expect(redactSensitiveText('https://id.nango.dev/oauth/handoff/callback?code=secret')).toBe(
             'https://id.nango.dev/oauth/handoff/callback?code=[redacted]'

--- a/packages/webapp/src/utils/sensitive-url.unit.test.ts
+++ b/packages/webapp/src/utils/sensitive-url.unit.test.ts
@@ -8,6 +8,17 @@ const JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoibWF0ZWpAbmFuZ28uZG
 const UUID = '8f14e45f-ceea-467a-9b0d-1e0a1b2c3d4e';
 
 describe('redactSensitiveText', () => {
+    it('redacts issuer interactions, handoffs and OAuth callbacks', () => {
+        expect(redactSensitiveText('/oauth/consent/secret-uid')).toBe('/oauth/consent/[redacted]');
+        expect(redactSensitiveText('/oauth/interaction/secret-uid/approve')).toBe('/oauth/interaction/[redacted]/approve');
+        expect(redactSensitiveText('https://id.nango.dev/oauth/handoff/callback?code=secret')).toBe(
+            'https://id.nango.dev/oauth/handoff/callback?code=[redacted]'
+        );
+        expect(redactSensitiveText('/oauth/continue?state=secret')).toBe('/oauth/continue?state=[redacted]');
+        expect(redactSensitiveText('/signin?next=%2Foauth%2Fcontinue%3Fstate%3Dsecret')).not.toContain('secret');
+        expect(redactSensitiveText('https://client.example/callback?code=secret&state=secret')).not.toContain('secret');
+        expect(redactSensitiveText('/oauth/authorize?client_id=secret&redirect_uri=secret&code_challenge=secret')).not.toContain('secret');
+    });
     it('redacts the reset password token from a full url', () => {
         expect(redactSensitiveText(`https://app.nango.dev/reset-password/${JWT}`)).toBe('https://app.nango.dev/reset-password/[redacted]');
     });

--- a/packages/webapp/vitest.browser.config.ts
+++ b/packages/webapp/vitest.browser.config.ts
@@ -1,0 +1,24 @@
+import path from 'node:path';
+
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react-swc';
+import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    plugins: [react(), tailwindcss()],
+    resolve: { alias: { '@': path.resolve(__dirname, './src') } },
+    optimizeDeps: { include: ['react/jsx-runtime'] },
+    test: {
+        attachmentsDir: '../../.context/oauth-browser-attachments',
+        include: ['src/**/*.browser.test.tsx'],
+        setupFiles: ['./src/test/browserSetup.ts'],
+        browser: {
+            enabled: true,
+            headless: true,
+            screenshotDirectory: '../../.context/oauth-browser-tests',
+            provider: playwright(),
+            instances: [{ browser: 'chromium' }]
+        }
+    }
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -71,6 +71,9 @@
             "path": "packages/orchestrator"
         },
         {
+            "path": "packages/oauth-server"
+        },
+        {
             "path": "packages/server"
         },
         {


### PR DESCRIPTION
Adds a standalone OAuth issuer at `https://id.nango.dev` with CIMD public clients, PKCE, multi-resource grants, rotating refresh tokens, and grant revocation.
Reuses Nango sign-in, MFA, and onboarding through a one-time session handoff and presents React approval/denial consent bound to the authenticated user and account.
Persists grants atomically, revokes them on password changes/resets, and gates new consent with Unleash; `/mcp` bearer authorization remains out of scope.

[NAN-6924](https://linear.app/nango/issue/NAN-6924/oauth-nango-login-and-consent-flow)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

