### PR TITLE
fix(webapp): hide the current-plan column when it has no charges

### DIFF
--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -196,8 +196,8 @@ export const Usage: React.FC = () => {
                 <Alert variant="info">
                     <Info />
                     <AlertDescription>
-                        Amounts above show what this usage costs today under your included allowance, and what the same usage would cost under Pay-as-you-go (no
-                        allowance).
+                        Your current plan includes an allowance in its base fee, so you&apos;re charged only for usage beyond it. Pay-as-you-go has no allowance
+                        — you only pay for what you use.
                     </AlertDescription>
                 </Alert>
             )}

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -158,7 +158,7 @@ export const Usage: React.FC = () => {
                           rightmostTooltip: transition ? `Plan active until ${transition.at}.` : undefined,
                           extraTooltip: projectedNote
                       }
-                    : isMigrating
+                    : isMigrating && charges
                       ? { rightmostHeader: 'Pay-as-you-go plan', rightmostTooltip: projectedNote }
                       : {})}
             />

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -59,6 +59,11 @@ export const Usage: React.FC = () => {
     const { data: projected, isPending: projectedPending, isError: projectedError } = useApiGetProjectedCosts(env, timeframe, { enabled: isMigrating });
     const projectedCharges = buildProjectedCharges({ enabled: isMigrating, isPending: projectedPending, isError: projectedError, data: projected });
 
+    // Orb reports no per-metric costs for a plan `isSpendPlan` excludes, so there is no column to
+    // compare against and both tables drop it.
+    const comparing = isMigrating && orbChargesEnabled;
+    const projectedNote = 'Estimated amount based on new rates.';
+
     if (usageError) {
         return (
             <div className="w-full flex flex-col gap-6">
@@ -145,11 +150,17 @@ export const Usage: React.FC = () => {
                 env={env}
                 timeframe={timeframe}
                 chartMode="daily"
-                variant={isMigrating ? 'comparison' : charges ? 'charges' : 'usage'}
+                variant={comparing ? 'comparison' : charges ? 'charges' : 'usage'}
                 charges={charges}
                 currentPlanTitle={transition?.fromTitle}
-                currentPlanTooltip={transition ? `Plan active until ${transition.at}.` : undefined}
-                projectedTooltip={isMigrating ? 'Estimated amount based on new rates.' : undefined}
+                {...(comparing
+                    ? {
+                          rightmostTooltip: transition ? `Plan active until ${transition.at}.` : undefined,
+                          extraTooltip: projectedNote
+                      }
+                    : isMigrating
+                      ? { rightmostHeader: 'Pay-as-you-go plan', rightmostTooltip: projectedNote }
+                      : {})}
             />
 
             {isMigrating && (
@@ -175,7 +186,7 @@ export const Usage: React.FC = () => {
                     env={env}
                     timeframe={timeframe}
                     chartMode="daily"
-                    variant="comparison"
+                    variant={comparing ? 'comparison' : 'usage'}
                     currentPlanTitle={transition?.fromTitle}
                     legacy
                 />

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -61,7 +61,7 @@ export const Usage: React.FC = () => {
 
     // Orb reports no per-metric costs for a plan `isSpendPlan` excludes, so there is no column to
     // compare against and both tables drop it.
-    const comparing = isMigrating && orbChargesEnabled;
+    const comparing = isMigrating && orbChargesEnabled && showLegacy;
     const projectedNote = 'Estimated amount based on new rates.';
 
     if (usageError) {
@@ -143,6 +143,16 @@ export const Usage: React.FC = () => {
                 <span className="text-text-strong text-body-medium-medium">Usage</span>
                 <MonthSelector />
             </div>
+
+            {comparing && (
+                <Alert variant="info">
+                    <Info />
+                    <AlertDescription>
+                        Amounts below show what this usage costs today under your included allowance, and what the same usage would cost under Pay-as-you-go (no
+                        allowance).
+                    </AlertDescription>
+                </Alert>
+            )}
 
             <UsageTable
                 rows={rows}

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -196,8 +196,8 @@ export const Usage: React.FC = () => {
                 <Alert variant="info">
                     <Info />
                     <AlertDescription>
-                        Your current plan includes an allowance in its base fee, so you&apos;re charged only for usage beyond it. Pay-as-you-go has no allowance
-                        — you only pay for what you use.
+                        Your current plan includes an allowance in its base fee, so you&apos;re charged only for usage beyond it. Pay-as-you-go has no
+                        allowance.
                     </AlertDescription>
                 </Alert>
             )}

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -144,16 +144,6 @@ export const Usage: React.FC = () => {
                 <MonthSelector />
             </div>
 
-            {comparing && (
-                <Alert variant="info">
-                    <Info />
-                    <AlertDescription>
-                        Amounts below show what this usage costs today under your included allowance, and what the same usage would cost under Pay-as-you-go (no
-                        allowance).
-                    </AlertDescription>
-                </Alert>
-            )}
-
             <UsageTable
                 rows={rows}
                 isLoading={isLoading}
@@ -200,6 +190,16 @@ export const Usage: React.FC = () => {
                     currentPlanTitle={transition?.fromTitle}
                     legacy
                 />
+            )}
+
+            {comparing && (
+                <Alert variant="info">
+                    <Info />
+                    <AlertDescription>
+                        Amounts above show what this usage costs today under your included allowance, and what the same usage would cost under Pay-as-you-go (no
+                        allowance).
+                    </AlertDescription>
+                </Alert>
             )}
         </div>
     );

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -32,17 +32,23 @@ interface UsageTableProps {
     onRowOpenChange?: (metric: UsageMetric, open: boolean) => void;
     currentPlanTitle?: string;
     legacy?: boolean;
-    currentPlanTooltip?: string;
-    projectedTooltip?: string;
+    /** Overrides the rightmost column's header, which otherwise names the current plan. */
+    rightmostHeader?: string;
+    rightmostTooltip?: string;
+    extraTooltip?: string;
 }
 
 /** The two right-hand column headers, which differ by variant. */
-function usageColumnHeaders(variant: UsageTableProps['variant'], currentPlanTitle?: string): { thisPeriod: string; rightmost: string; extra?: string } {
+function usageColumnHeaders(
+    variant: UsageTableProps['variant'],
+    currentPlanTitle?: string,
+    rightmostHeader?: string
+): { thisPeriod: string; rightmost: string; extra?: string } {
     switch (variant) {
         case 'caps':
             return { thisPeriod: 'Used / Limit', rightmost: '% of limit' };
         case 'charges':
-            return { thisPeriod: 'This period', rightmost: 'Charges' };
+            return { thisPeriod: 'This period', rightmost: rightmostHeader ?? 'Charges' };
         case 'comparison':
             return { thisPeriod: 'This period', rightmost: `${currentPlanTitle ?? 'Current'} plan`, extra: 'Pay-as-you-go plan' };
         case 'usage':
@@ -66,10 +72,11 @@ export const UsageTable: React.FC<UsageTableProps> = ({
     onRowOpenChange,
     currentPlanTitle,
     legacy,
-    currentPlanTooltip,
-    projectedTooltip
+    rightmostHeader,
+    rightmostTooltip,
+    extraTooltip
 }) => {
-    const { thisPeriod, rightmost, extra } = usageColumnHeaders(variant, currentPlanTitle);
+    const { thisPeriod, rightmost, extra } = usageColumnHeaders(variant, currentPlanTitle, rightmostHeader);
     return (
         <div className="w-full rounded border border-border-default overflow-hidden">
             <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
@@ -77,18 +84,18 @@ export const UsageTable: React.FC<UsageTableProps> = ({
                 <span>{thisPeriod}</span>
                 <span className="flex items-center gap-1.5">
                     {rightmost}
-                    {currentPlanTooltip && (
+                    {rightmostTooltip && (
                         <InfoTooltip side="top" align="start">
-                            {currentPlanTooltip}
+                            {rightmostTooltip}
                         </InfoTooltip>
                     )}
                 </span>
                 {extra && (
                     <span className="flex items-center gap-1.5">
                         {!legacy && extra}
-                        {!legacy && projectedTooltip && (
+                        {!legacy && extraTooltip && (
                             <InfoTooltip side="top" align="end">
-                                {projectedTooltip}
+                                {extraTooltip}
                             </InfoTooltip>
                         )}
                     </span>


### PR DESCRIPTION
## Context

Two problems with the current-plan column, both found while checking real accounts on production.

On a legacy plan it was empty — Orb reports no per-metric costs for those plans, so the column was a header, a tooltip and a row of blanks.

Everywhere else it was misleading. The old plans bundle an allowance into the base fee, so a metric the plan already covers charges $0.00, while Pay-as-you-go charges from the first unit. Side by side that reads as "connections got more expensive". On August's figures it affects **345 of the 578** migrating accounts that have a connections price, 272 of them showing $0.00 — and for many of them the total bill actually goes down.

## Changes

- The column now appears only when "Show legacy billing metrics" is on, next to a note saying what the two amounts mean.
- A plan with no per-metric costs never shows it. Both tables fall back to layouts they already had: Pay-as-you-go alone, and usage alone.
- The estimate tooltip moves to the Pay-as-you-go header when that is the only charge column.
- Renames the two tooltip props to say which column they head.

Follow-up to [NAN-6744](https://linear.app/nango/issue/NAN-6744).

## Testing

Checked against a real Orb test account, switching it between `starter-v2` and `starter-legacy` with the toggle both ways.

| | Main table | Note | Legacy table |
|---|---|---|---|
| Spend plan, off | Pay-as-you-go | — | — |
| Spend plan, on | Starter + Pay-as-you-go | shown | Starter charges |
| Legacy plan, off | Pay-as-you-go | — | — |
| Legacy plan, on | Pay-as-you-go | — | usage only |
