### PR TITLE
fix(server): remove open redirect in GitHub App install/OAuth callback

### DIFF
--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -10,7 +10,7 @@ import {
     githubAppClient,
     syncEndUserToConnection
 } from '@nangohq/shared';
-import { report, stringifyError } from '@nangohq/utils';
+import { basePublicUrl, report, stringifyError } from '@nangohq/utils';
 
 import publisher from '../clients/publisher.client.js';
 import { noteConnectionUpsert, oauthAuthType } from '../hooks/auditConnection.js';
@@ -34,7 +34,7 @@ class AppAuthController {
         // this is an instance where an organization approved an install
         // reconcile the installation id using the webhook
         if ((action === 'install' && !state) || (action === 'update' && !state)) {
-            res.redirect(req.get('referer') || req.get('Referer') || req.headers.referer || 'https://github.com');
+            res.redirect(basePublicUrl);
             return;
         }
 

--- a/packages/server/lib/controllers/appAuth.controller.unit.test.ts
+++ b/packages/server/lib/controllers/appAuth.controller.unit.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ConnectionCreationCappedError } from '@nangohq/shared';
-import { Ok } from '@nangohq/utils';
+import { basePublicUrl, Ok } from '@nangohq/utils';
 
 import appAuthController from './appAuth.controller.js';
 
@@ -219,4 +219,31 @@ describe('AppAuthController.connect', () => {
             expect.anything()
         );
     });
+
+    it.each(['install', 'update'])(
+        'redirects to a fixed internal URL, ignoring an attacker-controlled Referer, when %s completes without state',
+        async (setupAction) => {
+            const redirect = vi.fn();
+            const req = {
+                query: { installation_id: 'install-1', setup_action: setupAction },
+                ip: '203.0.113.7',
+                get: vi.fn((header: string) => (header.toLowerCase() === 'referer' ? 'https://evil.example.com/phish' : undefined)),
+                headers: { referer: 'https://evil.example.com/phish' }
+            } as unknown as Request;
+            const res = {
+                locals: {},
+                redirect,
+                sendStatus: vi.fn(),
+                status: vi.fn().mockReturnThis(),
+                send: vi.fn().mockReturnThis()
+            } as unknown as Response;
+            const next = vi.fn();
+
+            await appAuthController.connect(req, res, next);
+
+            expect(redirect).toHaveBeenCalledWith(basePublicUrl);
+            expect(redirect).not.toHaveBeenCalledWith(expect.stringContaining('evil.example.com'));
+            expect(mockFindById).not.toHaveBeenCalled();
+        }
+    );
 });

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -38,7 +38,7 @@ import {
     providerClientManager,
     syncEndUserToConnection
 } from '@nangohq/shared';
-import { errorToObject, metrics, stringifyError } from '@nangohq/utils';
+import { basePublicUrl, errorToObject, metrics, stringifyError } from '@nangohq/utils';
 
 import { OAuth1Client } from '../clients/oauth1.client.js';
 import publisher from '../clients/publisher.client.js';
@@ -1244,7 +1244,7 @@ class OAuthController {
         const action = req.query['setup_action'] as string;
 
         if (!state && installation_id && action) {
-            res.redirect(req.get('referer') || req.get('Referer') || req.headers.referer || 'https://github.com');
+            res.redirect(basePublicUrl);
             return;
         }
         if (state == null) {
@@ -1646,7 +1646,7 @@ class OAuthController {
         if (session.authMode === 'CUSTOM' && req.query['setup_action'] === 'update' && installationId) {
             // this means the update request was performed from the provider itself
             if (!req.query['state']) {
-                res.redirect(req.get('referer') || req.get('Referer') || req.headers.referer || 'https://github.com');
+                res.redirect(basePublicUrl);
 
                 return;
             }

--- a/packages/server/lib/controllers/oauth.controller.unit.test.ts
+++ b/packages/server/lib/controllers/oauth.controller.unit.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { basePublicUrl } from '@nangohq/utils';
+
+import oauthController from './oauth.controller.js';
+
+import type { Request, Response } from 'express';
+
+describe('OAuthController.oauthCallback', () => {
+    it('redirects to a fixed internal URL, ignoring an attacker-controlled Referer, when installation completes without state', async () => {
+        const redirect = vi.fn();
+        const req = {
+            query: { installation_id: 'install-1', setup_action: 'install' },
+            get: vi.fn((header: string) => (header.toLowerCase() === 'referer' ? 'https://evil.example.com/phish' : undefined)),
+            headers: { referer: 'https://evil.example.com/phish' }
+        } as unknown as Request;
+        const res = { redirect } as unknown as Response;
+
+        await oauthController.oauthCallback(req, res, vi.fn());
+
+        expect(redirect).toHaveBeenCalledWith(basePublicUrl);
+        expect(redirect).not.toHaveBeenCalledWith(expect.stringContaining('evil.example.com'));
+    });
+});


### PR DESCRIPTION
## Describe the problem and your solution

- GitHub App `install/update` callbacks with no `state` param redirected to the request's `Referer `header, which is attacker-controlled, enabling open redirect to phishing URLs. This pr redirect to `basePublicUrl` (fixed server config) instead.
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

