### PR TITLE
fix(runner): allow node:-prefixed core module specifiers in sandboxed scripts

### DIFF
--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -118,8 +118,10 @@ export async function exec({
                 require: (moduleName: string) => {
                     switch (moduleName) {
                         case 'url':
+                        case 'node:url':
                             return url;
                         case 'crypto':
+                        case 'node:crypto':
                             return crypto;
                         case 'zod':
                             return zod;


### PR DESCRIPTION
## Describe the problem and your solution

- allow node prefixed core module specifiers in sandboxed scripts, this is allowed at [cli](https://github.com/NangoHQ/nango/blob/master/packages/cli/lib/zeroYaml/constants.ts#L46) compilation time.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

