### PR TITLE
fix(provider): Allow hyphen in pipelinecrm api key

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -18207,7 +18207,7 @@ pipelinecrm:
             title: API Key
             description: Authenticates API requests as a specific Pipeline CRM user.
             example: Ksh3************ol5g
-            pattern: '^[A-Za-z0-9]{20}$'
+            pattern: '^[A-Za-z0-9-]{20}$'
             doc_section: '#step-2-finding-your-api-key'
 
 pivotaltracker:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

