### PR TITLE
feat(authz): authorize public routes through grants

### DIFF
--- a/packages/server/lib/authz/grants-equivalence.unit.test.ts
+++ b/packages/server/lib/authz/grants-equivalence.unit.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { ISSUABLE_SCOPES } from '@nangohq/authz';
+import { buildSandboxApiKeyScopes } from '@nangohq/shared';
+import { authorizeApiKey } from '@nangohq/utils';
+
+import { principalCan } from './principal.js';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { IssuableScope } from '@nangohq/authz';
+import type { ApiKeyAuthorizationTarget, ApiKeyPrincipal, CustomerKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
+
+const account = { id: 1 } as DBTeam;
+const environment = { id: 5, account_id: 1, is_production: true } as DBEnvironment;
+
+function key(scopes: string[], environmentIds: number[], source: ApiKeyPrincipal['source'] = 'customer_key'): ApiKeyPrincipal {
+    return { type: 'api_key', source, accountId: 1, scopes, environmentIds };
+}
+
+function localsFor(principal: ApiKeyPrincipal): Partial<RequestLocals> {
+    return { account, environment, apiKeyPrincipal: principal };
+}
+
+function publicTarget(scope: IssuableScope, requestLocals: Partial<RequestLocals>): ApiKeyAuthorizationTarget | null {
+    if (!requestLocals.account) {
+        return null;
+    }
+    if (scope.startsWith('account:')) {
+        return { type: 'account', accountId: requestLocals.account.id };
+    }
+    if (!requestLocals.environment) {
+        return null;
+    }
+    return { type: 'environment', accountId: requestLocals.account.id, environmentId: requestLocals.environment.id };
+}
+
+function authorizeApiKeyOnLocals(requestLocals: Partial<RequestLocals>, scope: IssuableScope): boolean {
+    const principal = requestLocals.apiKeyPrincipal;
+    const target = publicTarget(scope, requestLocals);
+    return Boolean(principal && target && authorizeApiKey({ principal, requiredScope: scope as CustomerKeyScope, target }));
+}
+
+const parentDryrunScopes = ['environment:functions:dryrun'];
+
+const fixtures: { name: string; principal: ApiKeyPrincipal }[] = [
+    { name: 'concrete scope', principal: key(['environment:connections:read'], [5]) },
+    { name: 'environment:*', principal: key(['environment:*'], [5]) },
+    { name: 'environment:integrations:*', principal: key(['environment:integrations:*'], [5]) },
+    { name: 'account key', principal: key(['account:environments:list'], []) },
+    { name: 'wrong env id', principal: key(['environment:*'], [9]) },
+    { name: 'empty scopes', principal: key([], [5]) },
+    { name: 'empty environmentIds', principal: key(['environment:*'], []) },
+    { name: 'account:* asked for an environment scope', principal: key(['account:*'], []) },
+    { name: 'env_var', principal: key(['environment:*'], [5], 'env_var') },
+    { name: 'api_secret', principal: key(['environment:*'], [5], 'api_secret') },
+    {
+        name: 'sandbox_token dryrun',
+        principal: key(buildSandboxApiKeyScopes({ purpose: 'dryrun', parentScopes: parentDryrunScopes }), [5], 'sandbox_token')
+    },
+    {
+        name: 'sandbox_token deploy',
+        principal: key(buildSandboxApiKeyScopes({ purpose: 'deploy', parentScopes: ['environment:*'] }), [5], 'sandbox_token')
+    },
+    { name: 'connect_session', principal: key(['environment:integrations:list'], [5], 'connect_session') },
+    { name: 'customer_key', principal: key(['environment:connections:read', 'environment:proxy'], [5], 'customer_key') }
+];
+
+describe('principalCan ≡ authorizeApiKey on issuable scopes', () => {
+    it.each(fixtures)('$name', ({ principal }) => {
+        const requestLocals = localsFor(principal);
+        for (const scope of ISSUABLE_SCOPES) {
+            expect(principalCan(requestLocals, scope), scope).toBe(authorizeApiKeyOnLocals(requestLocals, scope));
+        }
+    });
+});

--- a/packages/server/lib/authz/middleware.ts
+++ b/packages/server/lib/authz/middleware.ts
@@ -1,16 +1,43 @@
-import { principalCan } from './principal.js';
+import { ScopeRequiresEnvironmentError } from '@nangohq/authz';
+
+import { MissingPrincipalError, principalCan } from './principal.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { Scope } from '@nangohq/authz';
-import type { RequestHandler } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 
-export function can(scope: Scope): RequestHandler {
-    return (_req, res, next) => {
-        if (!principalCan(res.locals as Partial<RequestLocals>, scope)) {
-            res.status(403).json({ error: { code: 'forbidden', message: 'You do not have permission to perform this action' } });
-            return;
+function insufficientScopeMessage(scopes: readonly Scope[]): string {
+    if (scopes.length === 1) {
+        return `Insufficient scope. Required: ${scopes[0]}`;
+    }
+    return `Insufficient scope. Required one of: ${scopes.join(' or ')}`;
+}
+
+export function can(scope: Scope, ...or: Scope[]) {
+    const scopes = [scope, ...or];
+    return (_req: Request, res: Response, next: NextFunction): void => {
+        try {
+            for (const required of scopes) {
+                if (principalCan(res.locals as Partial<RequestLocals>, required)) {
+                    next();
+                    return;
+                }
+            }
+        } catch (err) {
+            if (err instanceof ScopeRequiresEnvironmentError) {
+                res.status(400).json({ error: { code: 'missing_environment' } });
+                return;
+            }
+            if (err instanceof MissingPrincipalError) {
+                res.status(500).json({ error: { code: 'missing_principal' } });
+                return;
+            }
+            throw err;
         }
 
-        next();
+        res.status(403).json({ error: { code: 'forbidden', message: insufficientScopeMessage(scopes) } });
     };
 }
+
+export const withScope = can;
+export const withAnyScope = can;

--- a/packages/server/lib/authz/middleware.unit.test.ts
+++ b/packages/server/lib/authz/middleware.unit.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { flags } from '@nangohq/utils';
+
+import { withAnyScope as withAnyScopeAlias, withScope as withScopeAlias } from '../middleware/scope.middleware.js';
+import { can, withAnyScope, withScope } from './middleware.js';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { ApiKeyPrincipal, DBEnvironment, DBTeam, DBUser } from '@nangohq/types';
+import type { NextFunction, Request, Response } from 'express';
+
+const account = { id: 1 } as DBTeam;
+const environment = { id: 5, account_id: 1, is_production: true } as DBEnvironment;
+
+function key(scopes: string[], environmentIds: number[] = [5]): ApiKeyPrincipal {
+    return { type: 'api_key', source: 'customer_key', accountId: 1, scopes, environmentIds };
+}
+
+function locals(over: Partial<RequestLocals> = {}): Partial<RequestLocals> {
+    return { account, environment, apiKeyPrincipal: key(['environment:deploy']), ...over };
+}
+
+function run(middleware: ReturnType<typeof can>, requestLocals: Partial<RequestLocals>) {
+    const res = {
+        locals: requestLocals,
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis()
+    };
+    const next = vi.fn();
+
+    middleware({} as Request, res as unknown as Response<unknown, Partial<RequestLocals>>, next as unknown as NextFunction);
+    return { next, status: res.status, json: res.json };
+}
+
+describe('can', () => {
+    const originalFlag = flags.hasAuthRoles;
+    beforeAll(() => {
+        flags.hasAuthRoles = true;
+    });
+    afterAll(() => {
+        flags.hasAuthRoles = originalFlag;
+    });
+
+    it('is the function exported as withScope and withAnyScope', () => {
+        expect(withScope).toBe(can);
+        expect(withAnyScope).toBe(can);
+        expect(withScopeAlias).toBe(can);
+        expect(withAnyScopeAlias).toBe(can);
+    });
+
+    it('calls next() when the principal holds the scope', () => {
+        const { next, status } = run(can('environment:deploy'), locals());
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(status).not.toHaveBeenCalled();
+    });
+
+    it('responds 403 naming the required scope', () => {
+        const { next, status, json } = run(can('environment:deploy'), locals({ apiKeyPrincipal: key(['environment:proxy']) }));
+
+        expect(next).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(403);
+        expect(json).toHaveBeenCalledWith({ error: { code: 'forbidden', message: 'Insufficient scope. Required: environment:deploy' } });
+    });
+
+    it('responds 403 naming every accepted scope', () => {
+        const { next, status, json } = run(can('environment:deploy', 'environment:proxy'), locals({ apiKeyPrincipal: key(['environment:logs:read']) }));
+
+        expect(next).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(403);
+        expect(json).toHaveBeenCalledWith({
+            error: { code: 'forbidden', message: 'Insufficient scope. Required one of: environment:deploy or environment:proxy' }
+        });
+    });
+
+    it('calls next() exactly once when any listed scope is held', () => {
+        const { next } = run(can('environment:deploy', 'environment:proxy'), locals({ apiKeyPrincipal: key(['environment:deploy', 'environment:proxy']) }));
+
+        expect(next).toHaveBeenCalledOnce();
+    });
+
+    it('names the scope on a denied private-route role', () => {
+        const user = { id: 7, role: 'production_support', email: 'a@b.c' } as DBUser;
+        const { next, status, json } = run(can('account:team:update'), { account, user, plan: { has_rbac: true } as RequestLocals['plan'] });
+
+        expect(next).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(403);
+        expect(json).toHaveBeenCalledWith({ error: { code: 'forbidden', message: 'Insufficient scope. Required: account:team:update' } });
+    });
+
+    it('responds 400 when an environment scope is checked with no environment', () => {
+        const { next, status, json } = run(can('environment:deploy'), { account, apiKeyPrincipal: key(['environment:deploy']) });
+
+        expect(next).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(400);
+        expect(json).toHaveBeenCalledWith({ error: { code: 'missing_environment' } });
+    });
+
+    it('still answers an account scope with no environment', () => {
+        const { next, status } = run(can('account:environments:list'), { account, apiKeyPrincipal: key(['account:*'], []) });
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(status).not.toHaveBeenCalled();
+    });
+
+    it('responds 500 when nothing authenticated onto a principal', () => {
+        const { next, status, json } = run(can('environment:deploy'), { account, environment });
+
+        expect(next).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(500);
+        expect(json).toHaveBeenCalledWith({ error: { code: 'missing_principal' } });
+    });
+});

--- a/packages/server/lib/authz/principal.ts
+++ b/packages/server/lib/authz/principal.ts
@@ -41,7 +41,6 @@ function subjectForKey(key: ApiKeyPrincipal): PrincipalSubject {
 
 /**
  * The grants behind the current request, or null when nothing authenticated well enough to have any.
- * Roles authorize from this; the key path compares against the legacy answer and counts.
  */
 export function buildPrincipal(locals: Partial<RequestLocals>): Principal | null {
     const account = locals.account;

--- a/packages/server/lib/middleware/scope.middleware.ts
+++ b/packages/server/lib/middleware/scope.middleware.ts
@@ -1,5 +1,7 @@
 import { authorizeApiKey, canAccessApiKeyTarget } from '@nangohq/utils';
 
+import { can } from '../authz/middleware.js';
+
 import type { RequestLocals } from '../utils/express.js';
 import type { ApiKeyAuthorizationTarget, CustomerKeyScope } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
@@ -51,28 +53,5 @@ export function withEnvironmentTarget(_req: Request, res: Response<unknown, Part
     next();
 }
 
-export function withScope(requiredScope: CustomerKeyScope) {
-    return function (_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
-        const allowed = hasAuthorizedScope({ locals: res.locals, requiredScope });
-
-        if (allowed) {
-            next();
-            return;
-        }
-
-        res.status(403).json({ error: { code: 'forbidden', message: `Insufficient scope. Required: ${requiredScope}` } });
-    };
-}
-
-export function withAnyScope(...requiredScopes: CustomerKeyScope[]) {
-    return function (_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
-        const allowed = requiredScopes.some((requiredScope) => hasAuthorizedScope({ locals: res.locals, requiredScope }));
-
-        if (allowed) {
-            next();
-            return;
-        }
-
-        res.status(403).json({ error: { code: 'forbidden', message: `Insufficient scope. Required one of: ${requiredScopes.join(' or ')}` } });
-    };
-}
+export const withScope = can;
+export const withAnyScope = can;

--- a/packages/server/lib/middleware/scope.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/scope.middleware.unit.test.ts
@@ -10,7 +10,7 @@ const accountId = 10;
 const environmentId = 100;
 
 const account = { id: accountId } as DBTeam;
-const environment = { id: environmentId } as DBEnvironment;
+const environment = { id: environmentId, account_id: accountId, is_production: false } as DBEnvironment;
 
 function principal(overrides: Partial<ApiKeyPrincipal> = {}): ApiKeyPrincipal {
     return {
@@ -32,7 +32,7 @@ const withoutAccount: Partial<RequestLocals> = { environment, apiKeyPrincipal: p
 const withoutEnvironment: Partial<RequestLocals> = { account, apiKeyPrincipal: principal() };
 const withoutPrincipal: Partial<RequestLocals> = { account, environment };
 
-type ScopeMiddleware = (req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction) => void;
+type ScopeMiddleware = ReturnType<typeof withScope>;
 
 function run(middleware: ScopeMiddleware, requestLocals: Partial<RequestLocals>) {
     const res = {
@@ -145,6 +145,22 @@ describe('withScope', () => {
         expect(next).not.toHaveBeenCalled();
         expect(status).toHaveBeenCalledWith(403);
         expect(json).toHaveBeenCalledWith({ error: { code: 'forbidden', message: 'Insufficient scope. Required: environment:deploy' } });
+    });
+
+    it('responds 400 when an environment scope is checked with no environment', () => {
+        const { next, status, json } = run(withScope('environment:deploy'), withoutEnvironment);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(400);
+        expect(json).toHaveBeenCalledWith({ error: { code: 'missing_environment' } });
+    });
+
+    it('responds 500 when locals carry no principal', () => {
+        const { next, status, json } = run(withScope('environment:deploy'), withoutPrincipal);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(500);
+        expect(json).toHaveBeenCalledWith({ error: { code: 'missing_principal' } });
     });
 });
 


### PR DESCRIPTION
## Summary
- Public `withScope` / `withAnyScope` now alias `can()`, so Bearer keys authorize through `grantsForKey` instead of `authorizeApiKey`. Route registrations are unchanged.
- Shared 403 copy names the required scope(s). A missing environment on an environment-scoped `can()` is 400 `missing_environment` (including `/api/v1`). A missing principal is 500 `missing_principal`, caught in the middleware so it does not become `generic_error_support`.
- Characterization tests pin `principalCan` ≡ `authorizeApiKey` on every issuable scope for the production key shapes and the empty / cross-namespace cases.

## Test plan
- [x] Unit: `packages/server/lib/authz` and `scope.middleware.unit.test.ts`
- [ ] Integration: `scopeEnforcement.integration.test.ts` and `authz.integration.test.ts` (Docker was not running when this was cut)
- [ ] Public 403 body is still `Insufficient scope. Required: …` / `Required one of: …`
- [ ] Private denied role is still 403; body now names the scope
- [ ] Environment-scoped `can()` with no env is 400, not 500


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

