### PR TITLE
refactor(authz): replace withScope with can

### DIFF
--- a/packages/server/lib/authz/middleware.ts
+++ b/packages/server/lib/authz/middleware.ts
@@ -39,5 +39,15 @@ export function can(scope: Scope, ...or: Scope[]) {
     };
 }
 
-export const withScope = can;
-export const withAnyScope = can;
+/**
+ * Slot in the public pipeline for naming the environment target.
+ * Auth still infers a single-env key in SQL. This does not check key ownership — `can` / `authorize` owns `where`.
+ */
+export function resolveEnvironment(_req: Request, res: Response, next: NextFunction): void {
+    if ((res.locals as Partial<RequestLocals>).environment) {
+        next();
+        return;
+    }
+    // TODO: resolve a client-supplied env (header or otherwise). Do not invent an env here.
+    next();
+}

--- a/packages/server/lib/authz/middleware.ts
+++ b/packages/server/lib/authz/middleware.ts
@@ -39,15 +39,13 @@ export function can(scope: Scope, ...or: Scope[]) {
     };
 }
 
-/**
- * Slot in the public pipeline for naming the environment target.
- * Auth still infers a single-env key in SQL. This does not check key ownership — `can` / `authorize` owns `where`.
- */
 export function resolveEnvironment(_req: Request, res: Response, next: NextFunction): void {
+    // Keys with access to a single-env will already have an environment in the locals.
     if ((res.locals as Partial<RequestLocals>).environment) {
         next();
         return;
     }
-    // TODO: resolve a client-supplied env (header or otherwise). Do not invent an env here.
+
+    // TODO: resolve a client-supplied env (eg. through a `x-nango-environment` header)
     next();
 }

--- a/packages/server/lib/authz/middleware.unit.test.ts
+++ b/packages/server/lib/authz/middleware.unit.test.ts
@@ -2,8 +2,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { flags } from '@nangohq/utils';
 
-import { withAnyScope as withAnyScopeAlias, withScope as withScopeAlias } from '../middleware/scope.middleware.js';
-import { can, withAnyScope, withScope } from './middleware.js';
+import { can } from './middleware.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { ApiKeyPrincipal, DBEnvironment, DBTeam, DBUser } from '@nangohq/types';
@@ -39,13 +38,6 @@ describe('can', () => {
     });
     afterAll(() => {
         flags.hasAuthRoles = originalFlag;
-    });
-
-    it('is the function exported as withScope and withAnyScope', () => {
-        expect(withScope).toBe(can);
-        expect(withAnyScope).toBe(can);
-        expect(withScopeAlias).toBe(can);
-        expect(withAnyScopeAlias).toBe(can);
     });
 
     it('calls next() when the principal holds the scope', () => {

--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -11,7 +11,7 @@ import {
 } from '@nangohq/shared';
 import { report } from '@nangohq/utils';
 
-import { hasAuthorizedScope } from '../middleware/scope.middleware.js';
+import { principalCan } from '../authz/principal.js';
 import { requireEnvironment } from '../utils/asyncWrapper.js';
 
 import type { RequestLocals } from '../utils/express.js';
@@ -112,7 +112,7 @@ class ConfigController {
             }
 
             let configRes: ProviderIntegration | IntegrationWithCreds;
-            if (includeCreds && !hasAuthorizedScope({ locals: res.locals, requiredScope: 'environment:integrations:read_credentials' })) {
+            if (includeCreds && !principalCan(res.locals, 'environment:integrations:read_credentials')) {
                 res.status(403).json({ error: { code: 'forbidden', message: 'Insufficient scope. Required: environment:integrations:read_credentials' } });
                 return;
             }

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.ts
@@ -3,10 +3,10 @@ import * as z from 'zod';
 import { connectionService } from '@nangohq/shared';
 import { metrics, zodErrorToHTTP } from '@nangohq/utils';
 
+import { principalCan } from '../../../authz/principal.js';
 import { retrievedConnectionToPublicApi } from '../../../formatters/connection.js';
 import { connectionIdSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
 import { connectionRefreshFailed, connectionRefreshSuccess } from '../../../hooks/hooks.js';
-import { hasAuthorizedScope } from '../../../middleware/scope.middleware.js';
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { RetrievedConnection } from '@nangohq/shared';
@@ -57,7 +57,7 @@ export const getPublicConnection = asyncWrapperWithEnvironment<GetPublicConnecti
 
     metrics.increment(metrics.Types.GET_CONNECTION, 1, { internal: isSync ? 'true' : 'false' });
 
-    const includeCredentials = hasAuthorizedScope({ locals: res.locals, requiredScope: 'environment:connections:read_credentials' });
+    const includeCredentials = principalCan(res.locals, 'environment:connections:read_credentials');
     const requestsCredentialOperation = returnRefreshToken || instantRefresh || refreshGithubAppJwtToken;
     if (!includeCredentials && requestsCredentialOperation) {
         res.status(403).send({

--- a/packages/server/lib/controllers/environment/postEnvironment.ts
+++ b/packages/server/lib/controllers/environment/postEnvironment.ts
@@ -3,8 +3,8 @@ import * as z from 'zod';
 import { PROD_ENVIRONMENT_NAME } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { principalCan } from '../../authz/principal.js';
 import { envSchema } from '../../helpers/validation.js';
-import { hasAuthorizedScope } from '../../middleware/scope.middleware.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import { handlePostEnvironment } from '../shared/environments/postEnvironment.js';
 
@@ -47,7 +47,7 @@ export const postPublicEnvironment = asyncWrapper<PostPublicEnvironment>(async (
     }
 
     const createsProductionEnvironment = body.is_production === true || (body.name === PROD_ENVIRONMENT_NAME && body.is_production !== false);
-    if (createsProductionEnvironment && !hasAuthorizedScope({ locals: res.locals, requiredScope: 'account:environments:set_production' })) {
+    if (createsProductionEnvironment && !principalCan(res.locals, 'account:environments:set_production')) {
         res.status(403).json({
             error: { code: 'forbidden', message: 'Insufficient scope. Required: account:environments:set_production' }
         });

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -2,9 +2,9 @@ import * as z from 'zod';
 
 import { zodErrorToHTTP } from '@nangohq/utils';
 
+import { principalCan } from '../../../authz/principal.js';
 import { integrationCredentialsToPublicApi, integrationToPublicApi } from '../../../formatters/integration.js';
 import { providerConfigKeySchema } from '../../../helpers/validation.js';
-import { hasAuthorizedScope } from '../../../middleware/scope.middleware.js';
 import integrationService from '../../../services/integration.service.js';
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
@@ -55,8 +55,7 @@ export const getPublicIntegration = asyncWrapperWithEnvironment<GetPublicIntegra
         environmentUuid: environment.uuid,
         integrationId: params.uniqueKey,
         includeWebhook: queryInclude.has('webhook'),
-        includeCredentials:
-            queryInclude.has('credentials') && hasAuthorizedScope({ locals: res.locals, requiredScope: 'environment:integrations:read_credentials' })
+        includeCredentials: queryInclude.has('credentials') && principalCan(res.locals, 'environment:integrations:read_credentials')
     });
     if (result.isErr()) {
         if (result.error.code === 'not_found') {

--- a/packages/server/lib/controllers/v1/getV1.ts
+++ b/packages/server/lib/controllers/v1/getV1.ts
@@ -3,8 +3,8 @@ import * as z from 'zod';
 import { connectionService, getActionOrModelByEndpoint } from '@nangohq/shared';
 import { baseUrl, metrics, zodErrorToHTTP } from '@nangohq/utils';
 
+import { principalCan } from '../../authz/principal.js';
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
-import { hasAuthorizedScope } from '../../middleware/scope.middleware.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { postPublicTriggerAction } from '../action/postTriggerAction.js';
 import { getPublicRecords } from '../records/getRecords.js';
@@ -46,7 +46,7 @@ export const allPublicV1 = asyncWrapperWithEnvironment<GetPublicV1>(async (req, 
 
     const { action, model } = await getActionOrModelByEndpoint(connection, req.method as HTTP_METHOD, path);
     if (action) {
-        if (!hasAuthorizedScope({ locals: res.locals, requiredScope: 'environment:actions:execute' })) {
+        if (!principalCan(res.locals, 'environment:actions:execute')) {
             res.status(403).json({ error: { code: 'forbidden', message: 'Insufficient scope. Required: environment:actions:execute' } });
             return;
         }
@@ -56,7 +56,7 @@ export const allPublicV1 = asyncWrapperWithEnvironment<GetPublicV1>(async (req, 
         req.body['input'] = input;
         await postPublicTriggerAction(req, res, next);
     } else if (model) {
-        if (!hasAuthorizedScope({ locals: res.locals, requiredScope: 'environment:records:read' })) {
+        if (!principalCan(res.locals, 'environment:records:read')) {
             res.status(403).json({ error: { code: 'forbidden', message: 'Insufficient scope. Required: environment:records:read' } });
             return;
         }

--- a/packages/server/lib/middleware/audit.integration.test.ts
+++ b/packages/server/lib/middleware/audit.integration.test.ts
@@ -18,7 +18,7 @@ import type { MockInstance } from 'vitest';
 //
 // What has to stay here:
 //   - wiring ORDER: a denied (403) request must still be recorded, which only holds if the audit
-//     middleware is installed before authorization. Probed once per wiring shape (public withScope,
+//     middleware is installed before authorization. Probed once per wiring shape (public can,
 //     private can).
 //   - resolve-before-next against a REAL controller that mutates the row it audits (a fake can't
 //     honestly reproduce the mutation): pre-change role, removed-member email.
@@ -81,9 +81,9 @@ describe('audit middleware — live-stack contract', () => {
             });
         });
 
-        it('public (apiAuth + withScope): a scope the key does not hold', async () => {
+        it('public (apiAuth + can): a scope the key does not hold', async () => {
             const { account, env, apiKey } = await seeders.seedAccountEnvAndUser({ plan: { has_audit_trail_control_plane: true } });
-            // Restrict the key so withScope('environment:connections:update') rejects with 403 first.
+            // Restrict the key so can('environment:connections:update') rejects with 403 first.
             (await customerKeyService.updateApiKeyScopes(db.knex, apiKey.id, ['environment:integrations:list'], env.id)).unwrap();
 
             const res = await api.fetch('/connections/:connectionId', {

--- a/packages/server/lib/middleware/scope.middleware.ts
+++ b/packages/server/lib/middleware/scope.middleware.ts
@@ -1,38 +1,11 @@
-import { authorizeApiKey, canAccessApiKeyTarget } from '@nangohq/utils';
-
-import { can } from '../authz/middleware.js';
+import { canAccessApiKeyTarget } from '@nangohq/utils';
 
 import type { RequestLocals } from '../utils/express.js';
-import type { ApiKeyAuthorizationTarget, CustomerKeyScope } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
-
-function targetForScope(locals: Partial<RequestLocals>, requiredScope: CustomerKeyScope): ApiKeyAuthorizationTarget | null {
-    const account = locals.account;
-    if (!account) {
-        return null;
-    }
-
-    if (requiredScope.startsWith('account:')) {
-        return { type: 'account', accountId: account.id };
-    }
-
-    const environment = locals.environment;
-    if (!environment) {
-        return null;
-    }
-
-    return { type: 'environment', accountId: account.id, environmentId: environment.id };
-}
-
-export function hasAuthorizedScope({ locals, requiredScope }: { locals: Partial<RequestLocals>; requiredScope: CustomerKeyScope }): boolean {
-    const principal = locals.apiKeyPrincipal;
-    const target = targetForScope(locals, requiredScope);
-    return Boolean(principal && target && authorizeApiKey({ principal, requiredScope, target }));
-}
 
 /**
  * Enforces environment ownership for routes that intentionally have no API scope.
- * Routes with scope requirements must use withScope or withAnyScope instead.
+ * Routes with scope requirements must use `can` instead.
  */
 export function withEnvironmentTarget(_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
     const { account, environment, apiKeyPrincipal } = res.locals;
@@ -52,6 +25,3 @@ export function withEnvironmentTarget(_req: Request, res: Response<unknown, Part
 
     next();
 }
-
-export const withScope = can;
-export const withAnyScope = can;

--- a/packages/server/lib/middleware/scope.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/scope.middleware.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { hasAuthorizedScope, withAnyScope, withEnvironmentTarget, withScope } from './scope.middleware.js';
+import { withEnvironmentTarget } from './scope.middleware.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { ApiKeyPrincipal, DBEnvironment, DBTeam } from '@nangohq/types';
@@ -32,9 +32,7 @@ const withoutAccount: Partial<RequestLocals> = { environment, apiKeyPrincipal: p
 const withoutEnvironment: Partial<RequestLocals> = { account, apiKeyPrincipal: principal() };
 const withoutPrincipal: Partial<RequestLocals> = { account, environment };
 
-type ScopeMiddleware = ReturnType<typeof withScope>;
-
-function run(middleware: ScopeMiddleware, requestLocals: Partial<RequestLocals>) {
+function run(middleware: typeof withEnvironmentTarget, requestLocals: Partial<RequestLocals>) {
     const res = {
         locals: requestLocals,
         status: vi.fn().mockReturnThis(),
@@ -46,59 +44,6 @@ function run(middleware: ScopeMiddleware, requestLocals: Partial<RequestLocals>)
 
     return { next, status: res.status, json: res.json };
 }
-
-describe('hasAuthorizedScope', () => {
-    it('authorizes an environment scope for a key bound to that environment', () => {
-        expect(hasAuthorizedScope({ locals: locals(), requiredScope: 'environment:deploy' })).toBe(true);
-    });
-
-    it('authorizes an account scope against the account plane', () => {
-        expect(hasAuthorizedScope({ locals: locals(), requiredScope: 'account:environments:create' })).toBe(true);
-    });
-
-    // An `account:` scope resolves to an account target, which is why it needs no environment binding.
-    // Resolving it against the environment plane instead would deny this.
-    it('authorizes an account scope for a key with no environment binding at all', () => {
-        const requestLocals = {
-            account,
-            apiKeyPrincipal: principal({ scopes: ['account:environments:create'], environmentIds: [] })
-        };
-
-        expect(hasAuthorizedScope({ locals: requestLocals, requiredScope: 'account:environments:create' })).toBe(true);
-    });
-
-    it('denies an environment scope when locals carry no environment', () => {
-        expect(hasAuthorizedScope({ locals: withoutEnvironment, requiredScope: 'environment:deploy' })).toBe(false);
-    });
-
-    it('denies both planes when locals carry no account', () => {
-        expect(hasAuthorizedScope({ locals: withoutAccount, requiredScope: 'environment:deploy' })).toBe(false);
-        expect(hasAuthorizedScope({ locals: withoutAccount, requiredScope: 'account:environments:create' })).toBe(false);
-    });
-
-    it('denies when locals carry no API key principal', () => {
-        expect(hasAuthorizedScope({ locals: withoutPrincipal, requiredScope: 'environment:deploy' })).toBe(false);
-    });
-
-    it('denies an environment scope when the key is bound to a different environment', () => {
-        const requestLocals = locals({ apiKeyPrincipal: principal({ environmentIds: [environmentId + 1] }) });
-
-        expect(hasAuthorizedScope({ locals: requestLocals, requiredScope: 'environment:deploy' })).toBe(false);
-    });
-
-    it('denies both planes when the key belongs to a different account', () => {
-        const requestLocals = locals({ apiKeyPrincipal: principal({ accountId: accountId + 1 }) });
-
-        expect(hasAuthorizedScope({ locals: requestLocals, requiredScope: 'environment:deploy' })).toBe(false);
-        expect(hasAuthorizedScope({ locals: requestLocals, requiredScope: 'account:environments:create' })).toBe(false);
-    });
-
-    it('denies a scope the key was not granted', () => {
-        const requestLocals = locals({ apiKeyPrincipal: principal({ scopes: ['environment:connections:read'] }) });
-
-        expect(hasAuthorizedScope({ locals: requestLocals, requiredScope: 'environment:deploy' })).toBe(false);
-    });
-});
 
 describe('withEnvironmentTarget', () => {
     it('calls next() for a key bound to the environment', () => {
@@ -128,73 +73,5 @@ describe('withEnvironmentTarget', () => {
         expect(next).not.toHaveBeenCalled();
         expect(status).toHaveBeenCalledWith(403);
         expect(json).toHaveBeenCalledWith({ error: { code: 'forbidden', message: 'API key is not authorized for an environment' } });
-    });
-});
-
-describe('withScope', () => {
-    it('calls next() when the key holds the scope', () => {
-        const { next, status } = run(withScope('environment:deploy'), locals({ apiKeyPrincipal: principal({ scopes: ['environment:deploy'] }) }));
-
-        expect(next).toHaveBeenCalledOnce();
-        expect(status).not.toHaveBeenCalled();
-    });
-
-    it('responds 403 naming the required scope and does not call next()', () => {
-        const { next, status, json } = run(withScope('environment:deploy'), locals({ apiKeyPrincipal: principal({ scopes: ['environment:proxy'] }) }));
-
-        expect(next).not.toHaveBeenCalled();
-        expect(status).toHaveBeenCalledWith(403);
-        expect(json).toHaveBeenCalledWith({ error: { code: 'forbidden', message: 'Insufficient scope. Required: environment:deploy' } });
-    });
-
-    it('responds 400 when an environment scope is checked with no environment', () => {
-        const { next, status, json } = run(withScope('environment:deploy'), withoutEnvironment);
-
-        expect(next).not.toHaveBeenCalled();
-        expect(status).toHaveBeenCalledWith(400);
-        expect(json).toHaveBeenCalledWith({ error: { code: 'missing_environment' } });
-    });
-
-    it('responds 500 when locals carry no principal', () => {
-        const { next, status, json } = run(withScope('environment:deploy'), withoutPrincipal);
-
-        expect(next).not.toHaveBeenCalled();
-        expect(status).toHaveBeenCalledWith(500);
-        expect(json).toHaveBeenCalledWith({ error: { code: 'missing_principal' } });
-    });
-});
-
-describe('withAnyScope', () => {
-    const middleware = withAnyScope('environment:deploy', 'environment:proxy');
-
-    it('calls next() when the key holds the first accepted scope', () => {
-        const { next, status } = run(middleware, locals({ apiKeyPrincipal: principal({ scopes: ['environment:deploy'] }) }));
-
-        expect(next).toHaveBeenCalledOnce();
-        expect(status).not.toHaveBeenCalled();
-    });
-
-    // any-of, not all-of: holding only the last listed scope is enough.
-    it('calls next() when the key holds only the last accepted scope', () => {
-        const { next, status } = run(middleware, locals({ apiKeyPrincipal: principal({ scopes: ['environment:proxy'] }) }));
-
-        expect(next).toHaveBeenCalledOnce();
-        expect(status).not.toHaveBeenCalled();
-    });
-
-    it('calls next() exactly once when the key holds every accepted scope', () => {
-        const { next } = run(middleware, locals({ apiKeyPrincipal: principal({ scopes: ['environment:deploy', 'environment:proxy'] }) }));
-
-        expect(next).toHaveBeenCalledOnce();
-    });
-
-    it('responds 403 naming every accepted scope and does not call next()', () => {
-        const { next, status, json } = run(middleware, locals({ apiKeyPrincipal: principal({ scopes: ['environment:logs:read'] }) }));
-
-        expect(next).not.toHaveBeenCalled();
-        expect(status).toHaveBeenCalledWith(403);
-        expect(json).toHaveBeenCalledWith({
-            error: { code: 'forbidden', message: 'Insufficient scope. Required one of: environment:deploy or environment:proxy' }
-        });
     });
 });

--- a/packages/server/lib/routes.management-mcp.ts
+++ b/packages/server/lib/routes.management-mcp.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 
+import { resolveEnvironment } from './authz/middleware.js';
 import { getManagementMcp, postManagementMcp } from './controllers/mcp/management.js';
 import { envs } from './env.js';
 import authMiddleware from './middleware/access.middleware.js';
@@ -11,6 +12,7 @@ import { withEnvironmentTarget } from './middleware/scope.middleware.js';
 import type { Request, RequestHandler } from 'express';
 
 const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
+const envAuth: RequestHandler[] = [...apiAuth, resolveEnvironment];
 const bodyLimit = envs.NANGO_SERVER_PUBLIC_BODY_LIMIT;
 const managementMcpRouter = express.Router();
 
@@ -24,8 +26,8 @@ managementMcpRouter.use(
     }),
     jsonContentTypeMiddleware
 );
-managementMcpRouter.route('/mcp').post(apiAuth, withEnvironmentTarget, postManagementMcp);
-managementMcpRouter.route('/mcp').get(apiAuth, withEnvironmentTarget, getManagementMcp);
+managementMcpRouter.route('/mcp').post(envAuth, withEnvironmentTarget, postManagementMcp);
+managementMcpRouter.route('/mcp').get(envAuth, withEnvironmentTarget, getManagementMcp);
 managementMcpRouter.use((_, res) => {
     res.status(404).json({ error: { code: 'not_found', message: 'Not found' } });
 });

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -6,6 +6,7 @@ import multer from 'multer';
 
 import { connectUrl, flagEnforceCLIVersion, metrics } from '@nangohq/utils';
 
+import { can, resolveEnvironment } from './authz/middleware.js';
 import { getAsyncActionResult } from './controllers/action/getAsyncActionResult.js';
 import { postPublicTriggerAction } from './controllers/action/postTriggerAction.js';
 import { deleteAgentSession } from './controllers/agent/deleteSession.js';
@@ -118,7 +119,7 @@ import { cliMaxVersion, cliMinVersion } from './middleware/cliVersionCheck.js';
 import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
-import { withAnyScope, withEnvironmentTarget, withScope } from './middleware/scope.middleware.js';
+import { withEnvironmentTarget } from './middleware/scope.middleware.js';
 import { webhookIngressRateLimit } from './middleware/webhook-ingress-ratelimit.middleware.js';
 import { isBinaryContentType } from './utils/utils.js';
 
@@ -126,6 +127,7 @@ import type { RequestLocals } from './utils/express.js';
 import type { Request, RequestHandler } from 'express';
 
 const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
+const envAuth: RequestHandler[] = [...apiAuth, resolveEnvironment];
 const connectSessionAuth: RequestHandler[] = [authMiddleware.connectSessionAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
 const agentSessionAuth: RequestHandler[] = [authMiddleware.agentSessionAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
 const connectSessionAuthBody: RequestHandler[] = [authMiddleware.connectSessionAuthBody.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
@@ -134,14 +136,15 @@ const connectSessionOrApiAuth: RequestHandler[] = [
     rateLimiterMiddleware,
     egressMeterMiddleware
 ];
+const connectSessionOrEnvAuth: RequestHandler[] = [...connectSessionOrApiAuth, resolveEnvironment];
 const connectSessionOrPublicAuth: RequestHandler[] = [
     authMiddleware.connectSessionOrPublicKeyAuth.bind(authMiddleware),
     rateLimiterMiddleware,
     egressMeterMiddleware
 ];
 
-const functionCompileAuth: RequestHandler[] = [...apiAuth, withScope('environment:functions:compile')];
-const functionDryrunAuth: RequestHandler[] = [...apiAuth, withScope('environment:functions:dryrun')];
+const functionCompileAuth: RequestHandler[] = [...envAuth, can('environment:functions:compile')];
+const functionDryrunAuth: RequestHandler[] = [...envAuth, can('environment:functions:dryrun')];
 const sandboxTokenOnly: RequestHandler = (_req, res, next) => {
     if (res.locals['apiKeyAuthSource'] !== 'sandbox_token') {
         res.status(403).send({ error: { code: 'forbidden', message: 'This endpoint only accepts sandbox tokens' } });
@@ -165,9 +168,9 @@ function trackDeprecatedPublicEndpoint(endpoint: string, isInternal?: (req: Requ
         next();
     };
 }
-const functionDryrunResultAuth: RequestHandler[] = [...apiAuth, withEnvironmentTarget, sandboxTokenOnly];
-const functionDeployAuth: RequestHandler[] = [...apiAuth, withScope('environment:deploy')];
-const functionDeploymentResultAuth: RequestHandler[] = [...apiAuth, withEnvironmentTarget, sandboxTokenOnly];
+const functionDryrunResultAuth: RequestHandler[] = [...envAuth, withEnvironmentTarget, sandboxTokenOnly];
+const functionDeployAuth: RequestHandler[] = [...envAuth, can('environment:deploy')];
+const functionDeploymentResultAuth: RequestHandler[] = [...envAuth, withEnvironmentTarget, sandboxTokenOnly];
 
 export const publicAPI = express.Router();
 
@@ -254,31 +257,29 @@ publicAPI.route('/auth/unauthenticated/:providerConfigKey').post(connectSessionO
 publicAPI.route('/webhook/:environmentUuid/:providerConfigKey').post(webhookIngressRateLimit, postWebhook);
 
 publicAPI.use('/providers', jsonContentTypeMiddleware);
-publicAPI.route('/providers').get(connectSessionOrApiAuth, withEnvironmentTarget, acceptLanguageMiddleware, getPublicProviders);
-publicAPI.route('/providers/:provider').get(connectSessionOrApiAuth, withEnvironmentTarget, acceptLanguageMiddleware, getPublicProvider);
-publicAPI.route('/providers/:provider/templates').get(apiAuth, withEnvironmentTarget, getPublicProviderTemplates);
+publicAPI.route('/providers').get(connectSessionOrEnvAuth, withEnvironmentTarget, acceptLanguageMiddleware, getPublicProviders);
+publicAPI.route('/providers/:provider').get(connectSessionOrEnvAuth, withEnvironmentTarget, acceptLanguageMiddleware, getPublicProvider);
+publicAPI.route('/providers/:provider/templates').get(envAuth, withEnvironmentTarget, getPublicProviderTemplates);
 
 publicAPI.use('/environments', jsonContentTypeMiddleware);
-publicAPI.route('/environments').get(apiAuth, withScope('account:environments:list'), getPublicEnvironments);
-publicAPI.route('/environments').post(apiAuth, auditPublicEnvironmentCreated, withScope('account:environments:create'), postPublicEnvironment);
-publicAPI
-    .route('/environments/:environmentUuid')
-    .delete(apiAuth, auditPublicEnvironmentDeleted, withScope('account:environments:delete'), deletePublicEnvironment);
+publicAPI.route('/environments').get(apiAuth, can('account:environments:list'), getPublicEnvironments);
+publicAPI.route('/environments').post(apiAuth, auditPublicEnvironmentCreated, can('account:environments:create'), postPublicEnvironment);
+publicAPI.route('/environments/:environmentUuid').delete(apiAuth, auditPublicEnvironmentDeleted, can('account:environments:delete'), deletePublicEnvironment);
 publicAPI
     .route('/environments/:environmentUuid/api-keys')
-    .get(apiAuth, withScope('account:environments:api_keys:list'), getPublicEnvironmentApiKeys)
-    .post(apiAuth, auditPublicApiKeyCreated, withScope('account:environments:api_keys:create'), postPublicEnvironmentApiKey);
+    .get(apiAuth, can('account:environments:api_keys:list'), getPublicEnvironmentApiKeys)
+    .post(apiAuth, auditPublicApiKeyCreated, can('account:environments:api_keys:create'), postPublicEnvironmentApiKey);
 publicAPI
     .route('/environments/:environmentUuid/api-keys/:keyUuid')
-    .get(apiAuth, withScope('account:environments:api_keys:read'), getPublicEnvironmentApiKey)
-    .delete(apiAuth, auditPublicApiKeyDeleted, withScope('account:environments:api_keys:delete'), deletePublicEnvironmentApiKey);
+    .get(apiAuth, can('account:environments:api_keys:read'), getPublicEnvironmentApiKey)
+    .delete(apiAuth, auditPublicApiKeyDeleted, can('account:environments:api_keys:delete'), deletePublicEnvironmentApiKey);
 
 // @deprecated rollbacked for one customer, to delete asap
 publicAPI
     .route('/config/:providerConfigKey')
     .get(
-        apiAuth,
-        withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'),
+        envAuth,
+        can('environment:integrations:read', 'environment:integrations:read_credentials'),
         trackDeprecatedPublicEndpoint('GET /config/:providerConfigKey'),
         configController.getProviderConfig.bind(configController)
     );
@@ -287,32 +288,30 @@ publicAPI
 publicAPI.use('/integrations', jsonContentTypeMiddleware);
 publicAPI
     .route('/integrations')
-    .get(connectSessionOrApiAuth, withAnyScope('environment:integrations:list', 'environment:integrations:list_credentials'), getPublicListIntegrations);
-publicAPI.route('/integrations').post(apiAuth, auditPublicIntegrationCreated, withScope('environment:integrations:create'), postPublicIntegration);
+    .get(connectSessionOrEnvAuth, can('environment:integrations:list', 'environment:integrations:list_credentials'), getPublicListIntegrations);
+publicAPI.route('/integrations').post(envAuth, auditPublicIntegrationCreated, can('environment:integrations:create'), postPublicIntegration);
 publicAPI
     .route('/integrations/quickstart')
-    .post(apiAuth, auditPublicQuickstartIntegrationCreated, withScope('environment:integrations:create'), postPublicQuickstartIntegration);
-publicAPI.route('/integrations/:uniqueKey').patch(apiAuth, auditPublicIntegrationUpdated, withScope('environment:integrations:update'), patchPublicIntegration);
+    .post(envAuth, auditPublicQuickstartIntegrationCreated, can('environment:integrations:create'), postPublicQuickstartIntegration);
+publicAPI.route('/integrations/:uniqueKey').patch(envAuth, auditPublicIntegrationUpdated, can('environment:integrations:update'), patchPublicIntegration);
 publicAPI
     .route('/integrations/:uniqueKey')
-    .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getPublicIntegration);
+    .get(envAuth, can('environment:integrations:read', 'environment:integrations:read_credentials'), getPublicIntegration);
 
-publicAPI
-    .route('/integrations/:uniqueKey')
-    .delete(apiAuth, auditPublicIntegrationDeleted, withScope('environment:integrations:delete'), deletePublicIntegration);
-publicAPI.route('/integrations/:uniqueKey/functions/:name/code').get(apiAuth, withScope('environment:functions:read'), getFunctionCode);
-publicAPI.route('/integrations/:uniqueKey/functions').get(apiAuth, withScope('environment:functions:list'), getPublicIntegrationFunctions);
+publicAPI.route('/integrations/:uniqueKey').delete(envAuth, auditPublicIntegrationDeleted, can('environment:integrations:delete'), deletePublicIntegration);
+publicAPI.route('/integrations/:uniqueKey/functions/:name/code').get(envAuth, can('environment:functions:read'), getFunctionCode);
+publicAPI.route('/integrations/:uniqueKey/functions').get(envAuth, can('environment:functions:list'), getPublicIntegrationFunctions);
 publicAPI
     .route('/integrations/:uniqueKey/functions/:name')
-    .get(apiAuth, withScope('environment:functions:read'), getPublicIntegrationFunction)
-    .delete(apiAuth, auditPublicFunctionDeleted, withScope('environment:functions:delete'), deletePublicIntegrationFunction);
+    .get(envAuth, can('environment:functions:read'), getPublicIntegrationFunction)
+    .delete(envAuth, auditPublicFunctionDeleted, can('environment:functions:delete'), deletePublicIntegrationFunction);
 
 // @deprecated connections
 publicAPI.use('/connection', jsonContentTypeMiddleware);
 // @deprecated
 publicAPI.route('/connection/:connectionId').get(
-    apiAuth,
-    withAnyScope('environment:connections:read', 'environment:connections:read_credentials'),
+    envAuth,
+    can('environment:connections:read', 'environment:connections:read_credentials'),
     trackDeprecatedPublicEndpoint('GET /connection/:connectionId', (req) => req.get('Nango-Is-Sync') === 'true'),
     getPublicConnection
 );
@@ -320,8 +319,8 @@ publicAPI.route('/connection/:connectionId').get(
 publicAPI
     .route('/connection')
     .get(
-        apiAuth,
-        withAnyScope('environment:connections:list', 'environment:connections:list_credentials'),
+        envAuth,
+        can('environment:connections:list', 'environment:connections:list_credentials'),
         trackDeprecatedPublicEndpoint('GET /connection'),
         getPublicConnections
     );
@@ -329,9 +328,9 @@ publicAPI
 publicAPI
     .route('/connection/:connectionId')
     .delete(
-        apiAuth,
+        envAuth,
         auditPublicConnectionDeleted,
-        withScope('environment:connections:delete'),
+        can('environment:connections:delete'),
         trackDeprecatedPublicEndpoint('DELETE /connection/:connectionId'),
         deletePublicConnection
     );
@@ -339,8 +338,8 @@ publicAPI
 publicAPI
     .route('/connection/:connectionId/metadata')
     .post(
-        apiAuth,
-        withScope('environment:connections:update'),
+        envAuth,
+        can('environment:connections:update'),
         trackDeprecatedPublicEndpoint('POST /connection/:connectionId/metadata'),
         connectionController.setMetadataLegacy.bind(connectionController)
     );
@@ -348,90 +347,86 @@ publicAPI
 publicAPI
     .route('/connection/:connectionId/metadata')
     .patch(
-        apiAuth,
-        withScope('environment:connections:update'),
+        envAuth,
+        can('environment:connections:update'),
         trackDeprecatedPublicEndpoint('PATCH /connection/:connectionId/metadata'),
         connectionController.updateMetadataLegacy.bind(connectionController)
     );
 // @deprecated
 publicAPI
     .route('/connection/metadata')
-    .post(apiAuth, withScope('environment:connections:update'), trackDeprecatedPublicEndpoint('POST /connection/metadata'), postPublicMetadata);
+    .post(envAuth, can('environment:connections:update'), trackDeprecatedPublicEndpoint('POST /connection/metadata'), postPublicMetadata);
 // @deprecated
 publicAPI
     .route('/connection/metadata')
-    .patch(apiAuth, withScope('environment:connections:update'), trackDeprecatedPublicEndpoint('PATCH /connection/metadata'), patchPublicMetadata);
+    .patch(envAuth, can('environment:connections:update'), trackDeprecatedPublicEndpoint('PATCH /connection/metadata'), patchPublicMetadata);
 // @deprecated
 publicAPI
     .route('/connection')
     .post(
-        apiAuth,
+        envAuth,
         auditConnectionCreated,
-        withScope('environment:connections:create'),
+        can('environment:connections:create'),
         trackDeprecatedPublicEndpoint('POST /connection'),
         connectionController.createConnection.bind(connectionController)
     );
 
 // Connections
 publicAPI.use('/connections', jsonContentTypeMiddleware);
-publicAPI.route('/connections').post(apiAuth, auditConnectionCreated, withScope('environment:connections:create'), postPublicConnection);
-publicAPI.route('/connections').get(apiAuth, withAnyScope('environment:connections:list', 'environment:connections:list_credentials'), getPublicConnections);
-publicAPI.route('/connections/metadata').post(apiAuth, withScope('environment:connections:update'), postPublicMetadata);
-publicAPI.route('/connections/metadata').patch(apiAuth, withScope('environment:connections:update'), patchPublicMetadata);
+publicAPI.route('/connections').post(envAuth, auditConnectionCreated, can('environment:connections:create'), postPublicConnection);
+publicAPI.route('/connections').get(envAuth, can('environment:connections:list', 'environment:connections:list_credentials'), getPublicConnections);
+publicAPI.route('/connections/metadata').post(envAuth, can('environment:connections:update'), postPublicMetadata);
+publicAPI.route('/connections/metadata').patch(envAuth, can('environment:connections:update'), patchPublicMetadata);
 publicAPI
     .route('/connections/:connectionId')
-    .get(apiAuth, withAnyScope('environment:connections:read', 'environment:connections:read_credentials'), getPublicConnection);
-publicAPI.route('/connections/:connectionId').patch(apiAuth, auditPublicConnectionUpdated, withScope('environment:connections:update'), patchPublicConnection);
-publicAPI
-    .route('/connections/:connectionId')
-    .delete(apiAuth, auditPublicConnectionDeleted, withScope('environment:connections:delete'), deletePublicConnection);
+    .get(envAuth, can('environment:connections:read', 'environment:connections:read_credentials'), getPublicConnection);
+publicAPI.route('/connections/:connectionId').patch(envAuth, auditPublicConnectionUpdated, can('environment:connections:update'), patchPublicConnection);
+publicAPI.route('/connections/:connectionId').delete(envAuth, auditPublicConnectionDeleted, can('environment:connections:delete'), deletePublicConnection);
 
 // Config
 publicAPI.use('/environment-variables', jsonContentTypeMiddleware);
-publicAPI.route('/environment-variables').get(apiAuth, withScope('environment:variables:read'), getPublicEnvironmentVariables);
+publicAPI.route('/environment-variables').get(envAuth, can('environment:variables:read'), getPublicEnvironmentVariables);
 
 publicAPI.use('/environment', jsonContentTypeMiddleware);
 publicAPI
     .route('/environment/webhook-signing-key/rotate')
-    .post(apiAuth, auditPublicWebhookSigningKeyRotated, withScope('environment:webhook_signing_key:rotate'), postPublicRotateWebhookSigningKey);
+    .post(envAuth, auditPublicWebhookSigningKeyRotated, can('environment:webhook_signing_key:rotate'), postPublicRotateWebhookSigningKey);
 
 // Deploy
 publicAPI.use('/sync', jsonContentTypeMiddleware);
-publicAPI.route('/sync/deploy').post(apiAuth, auditFunctionDeployedCli, withScope('environment:deploy'), cliMinVersion('0.39.25'), postDeploy);
-publicAPI.route('/sync/deploy/confirmation').post(apiAuth, withScope('environment:deploy'), cliMinVersion('0.39.25'), postDeployConfirmation);
-publicAPI.route('/sync/deploy/internal').post(apiAuth, withScope('environment:deploy'), postDeployInternal);
+publicAPI.route('/sync/deploy').post(envAuth, auditFunctionDeployedCli, can('environment:deploy'), cliMinVersion('0.39.25'), postDeploy);
+publicAPI.route('/sync/deploy/confirmation').post(envAuth, can('environment:deploy'), cliMinVersion('0.39.25'), postDeployConfirmation);
+publicAPI.route('/sync/deploy/internal').post(envAuth, can('environment:deploy'), postDeployInternal);
 
 // CLI
 publicAPI.use('/cli', jsonContentTypeMiddleware);
 publicAPI.route('/cli/telemetry').post(rateLimiterMiddleware, postCliTelemetry);
 
 // Syncs
-publicAPI
-    .route('/sync/update-connection-frequency')
-    .put(apiAuth, auditPublicSyncFrequencyChanged, withScope('environment:syncs:update'), putSyncConnectionFrequency);
+publicAPI.route('/sync/update-connection-frequency').put(envAuth, auditPublicSyncFrequencyChanged, can('environment:syncs:update'), putSyncConnectionFrequency);
 
 // Records
 publicAPI.use('/records', jsonContentTypeMiddleware);
-publicAPI.route('/records').get(apiAuth, withScope('environment:records:read'), getPublicRecords);
-publicAPI.route('/records/prune').patch(apiAuth, withScope('environment:records:write'), patchPublicPruneRecords);
+publicAPI.route('/records').get(envAuth, can('environment:records:read'), getPublicRecords);
+publicAPI.route('/records/prune').patch(envAuth, can('environment:records:write'), patchPublicPruneRecords);
 
 // Syncs (continued)
 publicAPI.use('/sync', jsonContentTypeMiddleware);
-publicAPI.route('/sync/trigger').post(apiAuth, withScope('environment:syncs:execute'), postPublicTrigger);
-publicAPI.route('/sync/pause').post(apiAuth, auditSyncPaused, withScope('environment:syncs:execute'), postPublicSyncPause);
-publicAPI.route('/sync/start').post(apiAuth, auditSyncStarted, withScope('environment:syncs:execute'), postPublicSyncStart);
-publicAPI.route('/sync/status').get(apiAuth, withScope('environment:syncs:read'), getPublicSyncStatus);
-publicAPI.route('/sync/:name/variant/:variant').post(apiAuth, auditSyncVariantCreated, withScope('environment:syncs:variant:create'), postSyncVariant);
-publicAPI.route('/sync/:name/variant/:variant').delete(apiAuth, auditSyncVariantDeleted, withScope('environment:syncs:variant:delete'), deleteSyncVariant);
+publicAPI.route('/sync/trigger').post(envAuth, can('environment:syncs:execute'), postPublicTrigger);
+publicAPI.route('/sync/pause').post(envAuth, auditSyncPaused, can('environment:syncs:execute'), postPublicSyncPause);
+publicAPI.route('/sync/start').post(envAuth, auditSyncStarted, can('environment:syncs:execute'), postPublicSyncStart);
+publicAPI.route('/sync/status').get(envAuth, can('environment:syncs:read'), getPublicSyncStatus);
+publicAPI.route('/sync/:name/variant/:variant').post(envAuth, auditSyncVariantCreated, can('environment:syncs:variant:create'), postSyncVariant);
+publicAPI.route('/sync/:name/variant/:variant').delete(envAuth, auditSyncVariantDeleted, can('environment:syncs:variant:delete'), deleteSyncVariant);
 
 // MCP
 publicAPI.use('/mcp', jsonContentTypeMiddleware);
-publicAPI.route('/mcp').post(apiAuth, withScope('environment:mcp'), postConnectionToolsMcp);
-publicAPI.route('/mcp').get(apiAuth, withScope('environment:mcp'), getConnectionToolsMcp);
+publicAPI.route('/mcp').post(envAuth, can('environment:mcp'), postConnectionToolsMcp);
+publicAPI.route('/mcp').get(envAuth, can('environment:mcp'), getConnectionToolsMcp);
 
 // Scripts config
 publicAPI.use('/scripts', jsonContentTypeMiddleware);
-publicAPI.route('/scripts/config').get(apiAuth, withScope('environment:integrations:list_functions'), getPublicScriptsConfig);
+publicAPI.route('/scripts/config').get(envAuth, can('environment:integrations:list_functions'), getPublicScriptsConfig);
 
 // Functions
 publicAPI.use('/functions', jsonContentTypeMiddleware);
@@ -440,40 +435,40 @@ publicAPI.route('/functions/compile').post(functionCompileAuth, postFunctionComp
 publicAPI.route('/functions/dryruns').post(functionDryrunAuth, postFunctionDryrun);
 publicAPI.route('/functions/dryruns/:id').get(functionDryrunAuth, getFunctionDryrun);
 publicAPI.route('/functions/dryruns/:id/result').post(functionDryrunResultAuth, postFunctionDryrunResult);
-publicAPI.route('/functions/deployments').post(apiAuth, auditFunctionDeployedFromTemplate, withScope('environment:deploy'), postFunctionDeployment);
+publicAPI.route('/functions/deployments').post(envAuth, auditFunctionDeployedFromTemplate, can('environment:deploy'), postFunctionDeployment);
 publicAPI.route('/functions/deployments/:id').get(functionDeployAuth, getFunctionDeployment);
 publicAPI.route('/functions/deployments/:id/result').post(functionDeploymentResultAuth, postFunctionDeploymentResult);
 
-publicAPI.route('/functions/deployments/bundle/preview').post(apiAuth, withScope('environment:deploy'), postFunctionDeploymentBundlePreview);
-publicAPI.route('/functions/deployments/bundle').post(apiAuth, auditFunctionDeploymentBundle, withScope('environment:deploy'), postFunctionDeploymentBundle);
+publicAPI.route('/functions/deployments/bundle/preview').post(envAuth, can('environment:deploy'), postFunctionDeploymentBundlePreview);
+publicAPI.route('/functions/deployments/bundle').post(envAuth, auditFunctionDeploymentBundle, can('environment:deploy'), postFunctionDeploymentBundle);
 
-publicAPI.route('/functions/invocations').post(apiAuth, withScope('environment:functions:invocations'), postFunctionInvocation);
-publicAPI.route('/functions/invocations/:id').get(apiAuth, withScope('environment:functions:invocations'), getFunctionInvocation);
+publicAPI.route('/functions/invocations').post(envAuth, can('environment:functions:invocations'), postFunctionInvocation);
+publicAPI.route('/functions/invocations/:id').get(envAuth, can('environment:functions:invocations'), getFunctionInvocation);
 
 // Actions
 publicAPI.use('/action', jsonContentTypeMiddleware);
-publicAPI.route('/action/trigger').post(apiAuth, withScope('environment:actions:execute'), postPublicTriggerAction); //TODO: to deprecate
-publicAPI.route('/action/:id').get(apiAuth, withScope('environment:actions:execute'), getAsyncActionResult);
+publicAPI.route('/action/trigger').post(envAuth, can('environment:actions:execute'), postPublicTriggerAction); //TODO: to deprecate
+publicAPI.route('/action/:id').get(envAuth, can('environment:actions:execute'), getAsyncActionResult);
 
 // Connect sessions
 publicAPI.use('/connect', jsonContentTypeMiddleware);
-publicAPI.route('/connect/sessions').post(apiAuth, withScope('environment:connect_sessions:write'), postConnectSessions);
-publicAPI.route('/connect/sessions/reconnect').post(apiAuth, withScope('environment:connect_sessions:write'), postConnectSessionsReconnect);
+publicAPI.route('/connect/sessions').post(envAuth, can('environment:connect_sessions:write'), postConnectSessions);
+publicAPI.route('/connect/sessions/reconnect').post(envAuth, can('environment:connect_sessions:write'), postConnectSessionsReconnect);
 publicAPI.route('/connect/session').get(connectSessionAuth, getConnectSession);
 publicAPI.route('/connect/session').delete(connectSessionAuth, deleteConnectSession);
 publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTelemetry);
 
 // Agent sessions
 publicAPI.use('/sessions', jsonContentTypeMiddleware);
-publicAPI.route('/sessions').post(apiAuth, withScope('environment:agent_sessions:write'), postAgentSessions);
-publicAPI.route('/sessions/:sessionId').delete(apiAuth, withScope('environment:agent_sessions:write'), deleteAgentSession);
+publicAPI.route('/sessions').post(envAuth, can('environment:agent_sessions:write'), postAgentSessions);
+publicAPI.route('/sessions/:sessionId').delete(envAuth, can('environment:agent_sessions:write'), deleteAgentSession);
 publicAPI.use('/session/:sessionId/mcp', jsonContentTypeMiddleware);
 publicAPI.route('/session/:sessionId/mcp').post(agentSessionAuth, postAgentSessionMcp);
 publicAPI.route('/session/:sessionId/mcp').get(agentSessionAuth, getAgentSessionMcp);
 
 // V1 passthrough (deprecated) — scope checks are inline in allPublicV1 after action/model resolution
 publicAPI.use('/v1', jsonContentTypeMiddleware);
-publicAPI.route('/v1/*splat').all(apiAuth, withEnvironmentTarget, allPublicV1);
+publicAPI.route('/v1/*splat').all(envAuth, withEnvironmentTarget, allPublicV1);
 
 // Proxy
-publicAPI.route('/proxy{/*splat}').all(apiAuth, withScope('environment:proxy'), upload.any(), allPublicProxy);
+publicAPI.route('/proxy{/*splat}').all(envAuth, can('environment:proxy'), upload.any(), allPublicProxy);


### PR DESCRIPTION
## Summary
- Replace public `withScope` / `withAnyScope` call sites with `can()`. Account-scoped routes stay on `apiAuth`; environment-scoped routes and `withEnvironmentTarget` use `envAuth` (`apiAuth` + pass-through `resolveEnvironment`).
- In-handler `hasAuthorizedScope` → `principalCan`. Delete the aliases and `hasAuthorizedScope`. `withEnvironmentTarget` stays (ownership without a grant).
- `resolveEnvironment` is a no-op slot: if auth already set `locals.environment`, keep it; otherwise leave it unset. No header, no ownership check.

Stacked on #7490.

## Test plan
- [x] Unit: `packages/server/lib/authz` and `scope.middleware.unit.test.ts`
- [ ] Integration: `scopeEnforcement.integration.test.ts`, `environmentManagement.integration.test.ts`, `environmentApiKeys.integration.test.ts` (account keys, no extra client hint)
- [ ] Account routes still work with no environment on locals
- [ ] Single-env environment routes still work with no extra client hint