### PR TITLE
feat: add one-off Orb pay-as-you-go migration scheduler

### DIFF
--- a/scripts/one-off/schedule-payg-migrations/README.md
+++ b/scripts/one-off/schedule-payg-migrations/README.md
@@ -6,7 +6,7 @@ The script validates, but deliberately ignores, `with_growth_addon`. Growth add-
 
 ## Prerequisites
 
-- Set `ORB_API_KEY` to a key for the selected mode.
+- Set `ORB_API_KEY` to the Orb API key for the environment you intend to target.
 - Prepare a CSV with this exact structure:
 
 ```csv
@@ -20,13 +20,13 @@ account_id,current_plan,with_growth_addon
 Always run a dry-run first. It reads Orb and prints every candidate, skipped row, and failure, but does not schedule changes:
 
 ```sh
-ORB_API_KEY=... npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts test ./customers.csv
+ORB_API_KEY=... npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts ./customers.csv
 ```
 
 After reviewing the output, execute the schedules:
 
 ```sh
-ORB_API_KEY=... npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts test ./customers.csv --execute
+ORB_API_KEY=... npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts ./customers.csv --execute
 ```
 
 The script skips accounts with no or multiple active subscriptions, a CSV/Orb current-plan mismatch, an existing pay-as-you-go plan, a pending Orb change, or any future plan change already recorded in the Orb subscription schedule. It never cancels or replaces an existing change.
@@ -34,5 +34,5 @@ The script skips accounts with no or multiple active subscriptions, a CSV/Orb cu
 Schedule calls are throttled by 2 seconds by default. Change the delay, or pass `0` to disable it, with `--throttle-ms`:
 
 ```sh
-ORB_API_KEY=... npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts test ./customers.csv --execute --throttle-ms=5000
+ORB_API_KEY=... npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts ./customers.csv --execute --throttle-ms=5000
 ```

--- a/scripts/one-off/schedule-payg-migrations/README.md
+++ b/scripts/one-off/schedule-payg-migrations/README.md
@@ -1,0 +1,38 @@
+# Schedule pay-as-you-go migrations
+
+Schedules eligible Orb subscriptions to move to the pay-as-you-go plan at the end of their current term. It does not update Nango's database: Orb's `subscription.plan_change_scheduled` webhook records the future plan and date.
+
+The script validates, but deliberately ignores, `with_growth_addon`. Growth add-on migration is a separate follow-up.
+
+## Prerequisites
+
+- Set `ORB_API_KEY` to a key for the selected mode.
+- Prepare a CSV with this exact structure:
+
+```csv
+account_id,current_plan,with_growth_addon
+123,growth-legacy,true
+456,starter-legacy,false
+```
+
+## Run
+
+Always run a dry-run first. It reads Orb and prints every candidate, skipped row, and failure, but does not schedule changes:
+
+```sh
+ORB_API_KEY=... npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts test ./customers.csv
+```
+
+After reviewing the output, execute the schedules:
+
+```sh
+ORB_API_KEY=... npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts test ./customers.csv --execute
+```
+
+The script skips accounts with no or multiple active subscriptions, a CSV/Orb current-plan mismatch, an existing pay-as-you-go plan, a pending Orb change, or any future plan change already recorded in the Orb subscription schedule. It never cancels or replaces an existing change.
+
+Schedule calls are throttled by 2 seconds by default. Change the delay, or pass `0` to disable it, with `--throttle-ms`:
+
+```sh
+ORB_API_KEY=... npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts test ./customers.csv --execute --throttle-ms=5000
+```

--- a/scripts/one-off/schedule-payg-migrations/csv.ts
+++ b/scripts/one-off/schedule-payg-migrations/csv.ts
@@ -1,0 +1,103 @@
+export interface MigrationRow {
+    accountId: string;
+    currentPlan: string;
+}
+
+/** Minimal CSV reader supporting quoted fields and escaped quotes. */
+function readCsvRows(contents: string): string[][] {
+    const rows: string[][] = [];
+    let row: string[] = [];
+    let field = '';
+    let quoted = false;
+
+    for (let index = 0; index < contents.length; index++) {
+        const character = contents[index];
+        if (character === undefined) {
+            continue;
+        }
+        if (quoted) {
+            if (character === '"') {
+                if (contents[index + 1] === '"') {
+                    field += '"';
+                    index++;
+                } else {
+                    quoted = false;
+                }
+            } else {
+                field += character;
+            }
+            continue;
+        }
+
+        if (character === '"') {
+            if (field.length !== 0) {
+                throw new Error('Invalid CSV: a quote must start at the beginning of a field');
+            }
+            quoted = true;
+        } else if (character === ',') {
+            row.push(field);
+            field = '';
+        } else if (character === '\n') {
+            row.push(field);
+            rows.push(row);
+            row = [];
+            field = '';
+        } else if (character !== '\r') {
+            field += character;
+        }
+    }
+
+    if (quoted) {
+        throw new Error('Invalid CSV: unterminated quoted field');
+    }
+    if (field.length > 0 || row.length > 0) {
+        row.push(field);
+        rows.push(row);
+    }
+
+    return rows.filter((cells) => cells.some((cell) => cell.trim().length > 0));
+}
+
+export function parseMigrationCsv(contents: string): MigrationRow[] {
+    const [header, ...data] = readCsvRows(contents);
+    if (!header) {
+        throw new Error('CSV is empty');
+    }
+
+    const normalizedHeader = header.map((column, index) => (index === 0 ? column.replace(/^\uFEFF/, '').trim() : column.trim()));
+    const required = ['account_id', 'current_plan', 'with_growth_addon'];
+    if (normalizedHeader.length !== required.length || required.some((column, index) => normalizedHeader[index] !== column)) {
+        throw new Error(`CSV headers must be exactly: ${required.join(', ')}`);
+    }
+
+    const rows: MigrationRow[] = [];
+    const accountIds = new Set<string>();
+    for (const [index, cells] of data.entries()) {
+        const line = index + 2;
+        if (cells.length !== required.length) {
+            throw new Error(`CSV row ${line} must contain exactly ${required.length} columns`);
+        }
+
+        const [accountIdCell = '', currentPlanCell = '', withGrowthAddonCell = ''] = cells;
+        const accountId = accountIdCell.trim();
+        const currentPlan = currentPlanCell.trim();
+        const withGrowthAddon = withGrowthAddonCell.trim().toLowerCase();
+        if (!/^\d+$/.test(accountId) || !Number.isSafeInteger(Number(accountId)) || Number(accountId) <= 0) {
+            throw new Error(`CSV row ${line} has an invalid account_id: ${accountId || '(empty)'}`);
+        }
+        if (!currentPlan) {
+            throw new Error(`CSV row ${line} has an empty current_plan`);
+        }
+        if (withGrowthAddon !== 'true' && withGrowthAddon !== 'false') {
+            throw new Error(`CSV row ${line} has an invalid with_growth_addon value: ${withGrowthAddon || '(empty)'}`);
+        }
+        if (accountIds.has(accountId)) {
+            throw new Error(`CSV row ${line} duplicates account_id: ${accountId}`);
+        }
+
+        accountIds.add(accountId);
+        rows.push({ accountId, currentPlan });
+    }
+
+    return rows;
+}

--- a/scripts/one-off/schedule-payg-migrations/schedule.ts
+++ b/scripts/one-off/schedule-payg-migrations/schedule.ts
@@ -1,0 +1,269 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import Orb from 'orb-billing';
+
+import { parseMigrationCsv } from './csv.js';
+
+import type { MigrationRow } from './csv.js';
+
+export type Mode = 'test' | 'live';
+
+interface OrbSubscription {
+    id: string;
+    customer: { external_customer_id: string | null };
+    plan: { external_plan_id: string | null } | null;
+    pending_subscription_change?: { id: string } | null;
+}
+
+interface OrbSubscriptionScheduleItem {
+    start_date: string;
+    plan: { external_plan_id: string | null } | null;
+}
+
+export interface OrbSubscriptionsClient {
+    list(params: { external_customer_id: string[]; status: 'active'; limit: 100 }): AsyncIterable<OrbSubscription>;
+    fetchSchedule(subscriptionId: string): AsyncIterable<OrbSubscriptionScheduleItem>;
+    schedulePlanChange(
+        subscriptionId: string,
+        params: { change_option: 'end_of_subscription_term'; auto_collection: true; external_plan_id: string }
+    ): Promise<unknown>;
+}
+
+export interface ScheduleClient {
+    subscriptions: OrbSubscriptionsClient;
+}
+
+export interface Summary {
+    dryRun: number;
+    scheduled: number;
+    skipped: number;
+    failed: number;
+}
+
+export const DEFAULT_THROTTLE_MS = 2_000;
+
+const PAYG_EXTERNAL_PLAN_IDS: Record<Mode, string> = {
+    test: 'pay-as-you-go',
+    live: 'pay-as-you-go'
+};
+
+const SUBSCRIPTION_LOOKUP_BATCH_SIZE = 100;
+
+function usage(): string {
+    return 'Usage: npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts <test|live> <input.csv> [--execute] [--throttle-ms=<milliseconds>]';
+}
+
+export function parseArgs(args: string[]): { mode: Mode; inputPath: string; execute: boolean; throttleMs: number } {
+    const execute = args.includes('--execute');
+    const throttleArgument = args.find((arg) => arg.startsWith('--throttle-ms='));
+    const positional = args.filter((arg) => arg !== '--execute' && arg !== throttleArgument);
+
+    if (
+        positional.length !== 2 ||
+        args.some((arg) => arg.startsWith('--') && arg !== '--execute' && arg !== throttleArgument) ||
+        args.filter((arg) => arg.startsWith('--throttle-ms=')).length > 1
+    ) {
+        throw new Error(usage());
+    }
+
+    const [mode, inputPath] = positional;
+    if ((mode !== 'test' && mode !== 'live') || !inputPath) {
+        throw new Error(usage());
+    }
+
+    const throttleMs = throttleArgument ? Number(throttleArgument.slice('--throttle-ms='.length)) : DEFAULT_THROTTLE_MS;
+    if (!Number.isSafeInteger(throttleMs) || throttleMs < 0) {
+        throw new Error('--throttle-ms must be a non-negative integer');
+    }
+
+    return { mode, inputPath, execute, throttleMs };
+}
+
+function logSkip(accountId: string, reason: string): void {
+    console.log(`SKIP account ${accountId}: ${reason}`);
+}
+
+function sleep(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let index = 0; index < items.length; index += size) {
+        chunks.push(items.slice(index, index + size));
+    }
+    return chunks;
+}
+
+async function getFutureScheduledPlanChange(subscriptionId: string, client: ScheduleClient, now: Date): Promise<OrbSubscriptionScheduleItem | null> {
+    for await (const item of client.subscriptions.fetchSchedule(subscriptionId)) {
+        const startsAt = new Date(item.start_date);
+        if (Number.isNaN(startsAt.getTime())) {
+            throw new Error(`Orb returned an invalid schedule start date for subscription ${subscriptionId}`);
+        }
+        if (startsAt > now) {
+            return item;
+        }
+    }
+    return null;
+}
+
+async function getActiveSubscriptionsByAccountId(
+    client: ScheduleClient,
+    accountIds: string[]
+): Promise<{ subscriptions: Map<string, OrbSubscription[]>; errors: Map<string, Error> }> {
+    const subscriptions = new Map(accountIds.map((accountId) => [accountId, [] as OrbSubscription[]]));
+    const errors = new Map<string, Error>();
+
+    for (const accountIdBatch of chunk(accountIds, SUBSCRIPTION_LOOKUP_BATCH_SIZE)) {
+        try {
+            // The SDK's async iterator follows Orb's cursors, so a malformed account with multiple
+            // active subscriptions cannot hide behind the endpoint's maximum page size of 100.
+            for await (const subscription of client.subscriptions.list({
+                external_customer_id: accountIdBatch,
+                status: 'active',
+                limit: SUBSCRIPTION_LOOKUP_BATCH_SIZE
+            })) {
+                const accountId = subscription.customer.external_customer_id;
+                if (accountId) {
+                    subscriptions.get(accountId)?.push(subscription);
+                }
+            }
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            for (const accountId of accountIdBatch) {
+                errors.set(accountId, new Error(message));
+            }
+        }
+    }
+
+    return { subscriptions, errors };
+}
+
+export async function scheduleMigrations({
+    client,
+    rows,
+    mode,
+    execute,
+    throttleMs = DEFAULT_THROTTLE_MS
+}: {
+    client: ScheduleClient;
+    rows: MigrationRow[];
+    mode: Mode;
+    execute: boolean;
+    throttleMs?: number;
+}): Promise<Summary> {
+    const planExternalId = PAYG_EXTERNAL_PLAN_IDS[mode];
+    const summary: Summary = { dryRun: 0, scheduled: 0, skipped: 0, failed: 0 };
+    let hasAttemptedSchedule = false;
+
+    const { subscriptions: subscriptionsByAccountId, errors: lookupErrors } = await getActiveSubscriptionsByAccountId(
+        client,
+        rows.map((row) => row.accountId)
+    );
+
+    for (const row of rows) {
+        try {
+            const lookupError = lookupErrors.get(row.accountId);
+            if (lookupError) {
+                throw lookupError;
+            }
+
+            const subscriptions = subscriptionsByAccountId.get(row.accountId) ?? [];
+            if (subscriptions.length === 0) {
+                summary.skipped++;
+                logSkip(row.accountId, 'no active Orb subscription');
+                continue;
+            }
+            if (subscriptions.length !== 1) {
+                summary.skipped++;
+                logSkip(row.accountId, `expected one active Orb subscription, found ${subscriptions.length}`);
+                continue;
+            }
+
+            const [subscription] = subscriptions;
+            if (!subscription) {
+                throw new Error(`Active Orb subscription missing for account ${row.accountId}`);
+            }
+            const currentPlan = subscription.plan?.external_plan_id;
+            if (currentPlan !== row.currentPlan) {
+                summary.skipped++;
+                logSkip(row.accountId, `Orb plan ${currentPlan || '(empty)'} does not match CSV current_plan ${row.currentPlan}`);
+                continue;
+            }
+            if (currentPlan === planExternalId) {
+                summary.skipped++;
+                logSkip(row.accountId, `already on ${planExternalId}`);
+                continue;
+            }
+            if (subscription.pending_subscription_change) {
+                summary.skipped++;
+                logSkip(row.accountId, `pending Orb plan change ${subscription.pending_subscription_change.id} already exists`);
+                continue;
+            }
+
+            const futureChange = await getFutureScheduledPlanChange(subscription.id, client, new Date());
+            if (futureChange) {
+                summary.skipped++;
+                logSkip(
+                    row.accountId,
+                    `Orb has a future plan change to ${futureChange.plan?.external_plan_id || '(unknown plan)'} starting ${futureChange.start_date}`
+                );
+                continue;
+            }
+
+            if (!execute) {
+                summary.dryRun++;
+                console.log(`DRY RUN account ${row.accountId}: would schedule ${currentPlan} -> ${planExternalId} at end of term`);
+                continue;
+            }
+
+            if (hasAttemptedSchedule) {
+                await sleep(throttleMs);
+            }
+            hasAttemptedSchedule = true;
+            await client.subscriptions.schedulePlanChange(subscription.id, {
+                change_option: 'end_of_subscription_term',
+                auto_collection: true,
+                external_plan_id: planExternalId
+            });
+            summary.scheduled++;
+            console.log(`SCHEDULED account ${row.accountId}: ${currentPlan} -> ${planExternalId} at end of term`);
+        } catch (err) {
+            summary.failed++;
+            const message = err instanceof Error ? err.message : String(err);
+            console.log(`FAILED account ${row.accountId}: ${message}`);
+        }
+    }
+
+    console.log(`Summary: dry-run=${summary.dryRun}, scheduled=${summary.scheduled}, skipped=${summary.skipped}, failed=${summary.failed}`);
+    return summary;
+}
+
+async function main(): Promise<void> {
+    const { mode, inputPath, execute, throttleMs } = parseArgs(process.argv.slice(2));
+    const apiKey = process.env['ORB_API_KEY'];
+    if (!apiKey) {
+        throw new Error('ORB_API_KEY is not set');
+    }
+
+    const rows = parseMigrationCsv(await readFile(inputPath, 'utf8'));
+    console.log(`Loaded ${rows.length} CSV row(s) for Orb ${mode} mode.`);
+    if (!execute) {
+        console.log('Dry-run only. Review the output, then rerun with --execute to schedule eligible migrations.');
+    }
+
+    const client = new Orb({ apiKey });
+    const summary = await scheduleMigrations({ client, rows, mode, execute, throttleMs });
+    if (summary.failed > 0) {
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    void main().catch((err: unknown) => {
+        console.error(err instanceof Error ? err.message : err);
+        process.exitCode = 1;
+    });
+}

--- a/scripts/one-off/schedule-payg-migrations/schedule.ts
+++ b/scripts/one-off/schedule-payg-migrations/schedule.ts
@@ -7,8 +7,6 @@ import { parseMigrationCsv } from './csv.js';
 
 import type { MigrationRow } from './csv.js';
 
-export type Mode = 'test' | 'live';
-
 interface OrbSubscription {
     id: string;
     customer: { external_customer_id: string | null };
@@ -43,41 +41,43 @@ export interface Summary {
 
 export const DEFAULT_THROTTLE_MS = 2_000;
 
-const PAYG_EXTERNAL_PLAN_IDS: Record<Mode, string> = {
-    test: 'pay-as-you-go',
-    live: 'pay-as-you-go'
-};
+const PAYG_EXTERNAL_PLAN_ID = 'pay-as-you-go';
 
 const SUBSCRIPTION_LOOKUP_BATCH_SIZE = 100;
 
 function usage(): string {
-    return 'Usage: npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts <test|live> <input.csv> [--execute] [--throttle-ms=<milliseconds>]';
+    return 'Usage: npx tsx scripts/one-off/schedule-payg-migrations/schedule.ts <input.csv> [--execute] [--throttle-ms=<milliseconds>]';
 }
 
-export function parseArgs(args: string[]): { mode: Mode; inputPath: string; execute: boolean; throttleMs: number } {
+export function parseArgs(args: string[]): { inputPath: string; execute: boolean; throttleMs: number } {
     const execute = args.includes('--execute');
     const throttleArgument = args.find((arg) => arg.startsWith('--throttle-ms='));
     const positional = args.filter((arg) => arg !== '--execute' && arg !== throttleArgument);
 
     if (
-        positional.length !== 2 ||
+        positional.length !== 1 ||
         args.some((arg) => arg.startsWith('--') && arg !== '--execute' && arg !== throttleArgument) ||
         args.filter((arg) => arg.startsWith('--throttle-ms=')).length > 1
     ) {
         throw new Error(usage());
     }
 
-    const [mode, inputPath] = positional;
-    if ((mode !== 'test' && mode !== 'live') || !inputPath) {
+    const [inputPath] = positional;
+    if (!inputPath) {
         throw new Error(usage());
     }
 
-    const throttleMs = throttleArgument ? Number(throttleArgument.slice('--throttle-ms='.length)) : DEFAULT_THROTTLE_MS;
+    const throttleValue = throttleArgument?.slice('--throttle-ms='.length);
+    if (throttleValue === '') {
+        throw new Error('--throttle-ms must be a non-negative integer');
+    }
+
+    const throttleMs = throttleValue === undefined ? DEFAULT_THROTTLE_MS : Number(throttleValue);
     if (!Number.isSafeInteger(throttleMs) || throttleMs < 0) {
         throw new Error('--throttle-ms must be a non-negative integer');
     }
 
-    return { mode, inputPath, execute, throttleMs };
+    return { inputPath, execute, throttleMs };
 }
 
 function logSkip(accountId: string, reason: string): void {
@@ -144,17 +144,15 @@ async function getActiveSubscriptionsByAccountId(
 export async function scheduleMigrations({
     client,
     rows,
-    mode,
     execute,
     throttleMs = DEFAULT_THROTTLE_MS
 }: {
     client: ScheduleClient;
     rows: MigrationRow[];
-    mode: Mode;
     execute: boolean;
     throttleMs?: number;
 }): Promise<Summary> {
-    const planExternalId = PAYG_EXTERNAL_PLAN_IDS[mode];
+    const planExternalId = PAYG_EXTERNAL_PLAN_ID;
     const summary: Summary = { dryRun: 0, scheduled: 0, skipped: 0, failed: 0 };
     let hasAttemptedSchedule = false;
 
@@ -242,20 +240,20 @@ export async function scheduleMigrations({
 }
 
 async function main(): Promise<void> {
-    const { mode, inputPath, execute, throttleMs } = parseArgs(process.argv.slice(2));
+    const { inputPath, execute, throttleMs } = parseArgs(process.argv.slice(2));
     const apiKey = process.env['ORB_API_KEY'];
     if (!apiKey) {
         throw new Error('ORB_API_KEY is not set');
     }
 
     const rows = parseMigrationCsv(await readFile(inputPath, 'utf8'));
-    console.log(`Loaded ${rows.length} CSV row(s) for Orb ${mode} mode.`);
+    console.log(`Loaded ${rows.length} CSV row(s).`);
     if (!execute) {
         console.log('Dry-run only. Review the output, then rerun with --execute to schedule eligible migrations.');
     }
 
     const client = new Orb({ apiKey });
-    const summary = await scheduleMigrations({ client, rows, mode, execute, throttleMs });
+    const summary = await scheduleMigrations({ client, rows, execute, throttleMs });
     if (summary.failed > 0) {
         process.exitCode = 1;
     }

--- a/scripts/one-off/schedule-payg-migrations/schedule.ts
+++ b/scripts/one-off/schedule-payg-migrations/schedule.ts
@@ -116,7 +116,9 @@ async function getActiveSubscriptionsByAccountId(
     const subscriptions = new Map(accountIds.map((accountId) => [accountId, [] as OrbSubscription[]]));
     const errors = new Map<string, Error>();
 
-    for (const accountIdBatch of chunk(accountIds, SUBSCRIPTION_LOOKUP_BATCH_SIZE)) {
+    const accountIdBatches = chunk(accountIds, SUBSCRIPTION_LOOKUP_BATCH_SIZE);
+    for (const [batchIndex, accountIdBatch] of accountIdBatches.entries()) {
+        console.log(`Looking up active Orb subscriptions: batch ${batchIndex + 1}/${accountIdBatches.length} (${accountIdBatch.length} account(s)).`);
         try {
             // The SDK's async iterator follows Orb's cursors, so a malformed account with multiple
             // active subscriptions cannot hide behind the endpoint's maximum page size of 100.
@@ -130,6 +132,7 @@ async function getActiveSubscriptionsByAccountId(
                     subscriptions.get(accountId)?.push(subscription);
                 }
             }
+            console.log(`Finished active Orb subscription lookup: batch ${batchIndex + 1}/${accountIdBatches.length}.`);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             for (const accountId of accountIdBatch) {
@@ -208,6 +211,8 @@ export async function scheduleMigrations({
                     row.accountId,
                     `Orb has a future plan change to ${futureChange.plan?.external_plan_id || '(unknown plan)'} starting ${futureChange.start_date}`
                 );
+                // sleep half the time we'd sleep when scheduling so we don't get rate limited on fetchSchedule calls.
+                await sleep(throttleMs / 2);
                 continue;
             }
 

--- a/scripts/one-off/schedule-payg-migrations/schedule.unit.test.ts
+++ b/scripts/one-off/schedule-payg-migrations/schedule.unit.test.ts
@@ -15,10 +15,9 @@ afterEach(() => {
 });
 
 describe('pay-as-you-go migration arguments', () => {
-    it('accepts a mode, CSV path, and optional execute guard', () => {
-        expect(parseArgs(['test', './customers.csv'])).toEqual({ mode: 'test', inputPath: './customers.csv', execute: false, throttleMs: DEFAULT_THROTTLE_MS });
-        expect(parseArgs(['live', './customers.csv', '--execute', '--throttle-ms=500'])).toEqual({
-            mode: 'live',
+    it('accepts a CSV path and optional execution settings', () => {
+        expect(parseArgs(['./customers.csv'])).toEqual({ inputPath: './customers.csv', execute: false, throttleMs: DEFAULT_THROTTLE_MS });
+        expect(parseArgs(['./customers.csv', '--execute', '--throttle-ms=500'])).toEqual({
             inputPath: './customers.csv',
             execute: true,
             throttleMs: 500
@@ -26,10 +25,11 @@ describe('pay-as-you-go migration arguments', () => {
     });
 
     it('rejects unexpected or incomplete arguments', () => {
-        expect(() => parseArgs(['test'])).toThrow('Usage:');
-        expect(() => parseArgs(['staging', './customers.csv'])).toThrow('Usage:');
-        expect(() => parseArgs(['test', './customers.csv', '--force'])).toThrow('Usage:');
-        expect(() => parseArgs(['test', './customers.csv', '--throttle-ms=-1'])).toThrow('non-negative integer');
+        expect(() => parseArgs([])).toThrow('Usage:');
+        expect(() => parseArgs(['./customers.csv', './another.csv'])).toThrow('Usage:');
+        expect(() => parseArgs(['./customers.csv', '--force'])).toThrow('Usage:');
+        expect(() => parseArgs(['./customers.csv', '--throttle-ms=-1'])).toThrow('non-negative integer');
+        expect(() => parseArgs(['./customers.csv', '--throttle-ms='])).toThrow('non-negative integer');
     });
 });
 
@@ -65,7 +65,6 @@ describe('pay-as-you-go migration scheduling', () => {
                 }
             },
             rows,
-            mode: 'test',
             execute: false
         });
 
@@ -90,8 +89,8 @@ describe('pay-as-you-go migration scheduling', () => {
         const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
         const client = { subscriptions: { list, fetchSchedule: vi.fn().mockReturnValue(listResult([])), schedulePlanChange: vi.fn() } };
 
-        await scheduleMigrations({ client, rows, mode: 'test', execute: false });
-        const summary = await scheduleMigrations({ client, rows, mode: 'test', execute: false });
+        await scheduleMigrations({ client, rows, execute: false });
+        const summary = await scheduleMigrations({ client, rows, execute: false });
 
         expect(summary).toEqual({ dryRun: 0, scheduled: 0, skipped: 1, failed: 0 });
         expect(client.subscriptions.schedulePlanChange).not.toHaveBeenCalled();
@@ -114,7 +113,6 @@ describe('pay-as-you-go migration scheduling', () => {
                 }
             },
             rows,
-            mode: 'test',
             execute: true,
             throttleMs: 0
         });
@@ -141,7 +139,6 @@ describe('pay-as-you-go migration scheduling', () => {
                 { accountId: '123', currentPlan: 'growth-legacy' },
                 { accountId: '456', currentPlan: 'starter-legacy' }
             ],
-            mode: 'test',
             execute: false
         });
 
@@ -169,7 +166,6 @@ describe('pay-as-you-go migration scheduling', () => {
                 { accountId: '123', currentPlan: 'growth-legacy' },
                 { accountId: '456', currentPlan: 'starter-legacy' }
             ],
-            mode: 'test',
             execute: true,
             throttleMs: 250
         });
@@ -201,7 +197,6 @@ describe('pay-as-you-go migration scheduling', () => {
                 }
             },
             rows: [{ accountId: '68', currentPlan: 'growth-v2' }],
-            mode: 'test',
             execute: true,
             throttleMs: 0
         });

--- a/scripts/one-off/schedule-payg-migrations/schedule.unit.test.ts
+++ b/scripts/one-off/schedule-payg-migrations/schedule.unit.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { parseMigrationCsv } from './csv.js';
+import { DEFAULT_THROTTLE_MS, parseArgs, scheduleMigrations } from './schedule.js';
+
+function listResult<T>(items: T[]) {
+    return (async function* () {
+        yield* await Promise.resolve(items);
+    })();
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+});
+
+describe('pay-as-you-go migration arguments', () => {
+    it('accepts a mode, CSV path, and optional execute guard', () => {
+        expect(parseArgs(['test', './customers.csv'])).toEqual({ mode: 'test', inputPath: './customers.csv', execute: false, throttleMs: DEFAULT_THROTTLE_MS });
+        expect(parseArgs(['live', './customers.csv', '--execute', '--throttle-ms=500'])).toEqual({
+            mode: 'live',
+            inputPath: './customers.csv',
+            execute: true,
+            throttleMs: 500
+        });
+    });
+
+    it('rejects unexpected or incomplete arguments', () => {
+        expect(() => parseArgs(['test'])).toThrow('Usage:');
+        expect(() => parseArgs(['staging', './customers.csv'])).toThrow('Usage:');
+        expect(() => parseArgs(['test', './customers.csv', '--force'])).toThrow('Usage:');
+        expect(() => parseArgs(['test', './customers.csv', '--throttle-ms=-1'])).toThrow('non-negative integer');
+    });
+});
+
+describe('pay-as-you-go migration CSV', () => {
+    it('validates the required shape while ignoring the growth add-on value afterward', () => {
+        expect(parseMigrationCsv('account_id,current_plan,with_growth_addon\n123,"growth, legacy",true\n')).toEqual([
+            { accountId: '123', currentPlan: 'growth, legacy' }
+        ]);
+    });
+
+    it('rejects duplicate IDs and invalid add-on booleans', () => {
+        expect(() => parseMigrationCsv('account_id,current_plan,with_growth_addon\n123,growth,false\n123,starter,true\n')).toThrow('duplicates account_id');
+        expect(() => parseMigrationCsv('account_id,current_plan,with_growth_addon\n123,growth,yes\n')).toThrow('invalid with_growth_addon');
+    });
+});
+
+describe('pay-as-you-go migration scheduling', () => {
+    const rows = [{ accountId: '123', currentPlan: 'growth-legacy' }];
+
+    it('reports eligible accounts in dry-run mode without calling Orb to schedule them', async () => {
+        const schedulePlanChange = vi.fn();
+        vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        const summary = await scheduleMigrations({
+            client: {
+                subscriptions: {
+                    list: vi
+                        .fn()
+                        .mockReturnValue(
+                            listResult([{ id: 'sub_123', customer: { external_customer_id: '123' }, plan: { external_plan_id: 'growth-legacy' } }])
+                        ),
+                    fetchSchedule: vi.fn().mockReturnValue(listResult([])),
+                    schedulePlanChange
+                }
+            },
+            rows,
+            mode: 'test',
+            execute: false
+        });
+
+        expect(summary).toEqual({ dryRun: 1, scheduled: 0, skipped: 0, failed: 0 });
+        expect(schedulePlanChange).not.toHaveBeenCalled();
+    });
+
+    it('skips a mismatched plan and an existing pending change', async () => {
+        const list = vi
+            .fn()
+            .mockReturnValueOnce(listResult([{ id: 'sub_wrong', customer: { external_customer_id: '123' }, plan: { external_plan_id: 'starter-legacy' } }]))
+            .mockReturnValueOnce(
+                listResult([
+                    {
+                        id: 'sub_pending',
+                        customer: { external_customer_id: '123' },
+                        plan: { external_plan_id: 'growth-legacy' },
+                        pending_subscription_change: { id: 'change_123' }
+                    }
+                ])
+            );
+        const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        const client = { subscriptions: { list, fetchSchedule: vi.fn().mockReturnValue(listResult([])), schedulePlanChange: vi.fn() } };
+
+        await scheduleMigrations({ client, rows, mode: 'test', execute: false });
+        const summary = await scheduleMigrations({ client, rows, mode: 'test', execute: false });
+
+        expect(summary).toEqual({ dryRun: 0, scheduled: 0, skipped: 1, failed: 0 });
+        expect(client.subscriptions.schedulePlanChange).not.toHaveBeenCalled();
+        expect(log).toHaveBeenCalledWith(expect.stringContaining('pending Orb plan change'));
+    });
+
+    it('sends the end-of-term change payload when execution is enabled', async () => {
+        const schedulePlanChange = vi.fn().mockResolvedValue({});
+        vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        const summary = await scheduleMigrations({
+            client: {
+                subscriptions: {
+                    list: vi
+                        .fn()
+                        .mockReturnValue(
+                            listResult([{ id: 'sub_123', customer: { external_customer_id: '123' }, plan: { external_plan_id: 'growth-legacy' } }])
+                        ),
+                    fetchSchedule: vi.fn().mockReturnValue(listResult([])),
+                    schedulePlanChange
+                }
+            },
+            rows,
+            mode: 'test',
+            execute: true,
+            throttleMs: 0
+        });
+
+        expect(summary).toEqual({ dryRun: 0, scheduled: 1, skipped: 0, failed: 0 });
+        expect(schedulePlanChange).toHaveBeenCalledWith('sub_123', {
+            change_option: 'end_of_subscription_term',
+            auto_collection: true,
+            external_plan_id: 'pay-as-you-go'
+        });
+    });
+
+    it('looks up multiple accounts in one Orb request', async () => {
+        const list = vi.fn().mockReturnValue(
+            listResult([
+                { id: 'sub_123', customer: { external_customer_id: '123' }, plan: { external_plan_id: 'growth-legacy' } },
+                { id: 'sub_456', customer: { external_customer_id: '456' }, plan: { external_plan_id: 'starter-legacy' } }
+            ])
+        );
+
+        const summary = await scheduleMigrations({
+            client: { subscriptions: { list, fetchSchedule: vi.fn().mockReturnValue(listResult([])), schedulePlanChange: vi.fn() } },
+            rows: [
+                { accountId: '123', currentPlan: 'growth-legacy' },
+                { accountId: '456', currentPlan: 'starter-legacy' }
+            ],
+            mode: 'test',
+            execute: false
+        });
+
+        expect(summary).toEqual({ dryRun: 2, scheduled: 0, skipped: 0, failed: 0 });
+        expect(list).toHaveBeenCalledWith({ external_customer_id: ['123', '456'], status: 'active', limit: 100 });
+    });
+
+    it('waits between each Orb schedule request', async () => {
+        const schedulePlanChange = vi.fn().mockResolvedValue({});
+        vi.useFakeTimers();
+        const scheduling = scheduleMigrations({
+            client: {
+                subscriptions: {
+                    list: vi.fn().mockReturnValue(
+                        listResult([
+                            { id: 'sub_123', customer: { external_customer_id: '123' }, plan: { external_plan_id: 'growth-legacy' } },
+                            { id: 'sub_456', customer: { external_customer_id: '456' }, plan: { external_plan_id: 'starter-legacy' } }
+                        ])
+                    ),
+                    fetchSchedule: vi.fn().mockReturnValue(listResult([])),
+                    schedulePlanChange
+                }
+            },
+            rows: [
+                { accountId: '123', currentPlan: 'growth-legacy' },
+                { accountId: '456', currentPlan: 'starter-legacy' }
+            ],
+            mode: 'test',
+            execute: true,
+            throttleMs: 250
+        });
+
+        await vi.runAllTimersAsync();
+        await scheduling;
+
+        expect(schedulePlanChange).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips an end-of-term plan change already present in Orb’s subscription schedule', async () => {
+        const schedulePlanChange = vi.fn();
+        const fetchSchedule = vi.fn().mockReturnValue(
+            listResult([
+                { start_date: '2000-09-01T00:00:00Z', plan: { external_plan_id: 'growth-v2' } },
+                { start_date: '2999-10-01T00:00:00Z', plan: { external_plan_id: 'free' } }
+            ])
+        );
+        const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+        const summary = await scheduleMigrations({
+            client: {
+                subscriptions: {
+                    list: vi
+                        .fn()
+                        .mockReturnValue(listResult([{ id: 'sub_68', customer: { external_customer_id: '68' }, plan: { external_plan_id: 'growth-v2' } }])),
+                    fetchSchedule,
+                    schedulePlanChange
+                }
+            },
+            rows: [{ accountId: '68', currentPlan: 'growth-v2' }],
+            mode: 'test',
+            execute: true,
+            throttleMs: 0
+        });
+
+        expect(summary).toEqual({ dryRun: 0, scheduled: 0, skipped: 1, failed: 0 });
+        expect(fetchSchedule).toHaveBeenCalledWith('sub_68');
+        expect(schedulePlanChange).not.toHaveBeenCalled();
+        expect(log).toHaveBeenCalledWith(expect.stringContaining('future plan change to free'));
+    });
+});


### PR DESCRIPTION
Adds a guarded one-off script to schedule listed Orb subscriptions onto the pay-as-you-go plan at the end of their current term.

The script:
- reads and validates the migration CSV;
- batch-fetches active subscriptions;
- skips plan mismatches, existing pending/future plan changes, and subscriptions already on pay-as-you-go;
- defaults to dry-run and requires --execute for Orb mutations;
- throttles schedule requests by 2 seconds by default;
- relies on the existing Orb webhook to persist scheduled plan state.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

