### PR TITLE
fix(server): surface a clear 400 for unsupported multipart Content-Type on /proxy

### DIFF
--- a/packages/server/lib/routes.integration.test.ts
+++ b/packages/server/lib/routes.integration.test.ts
@@ -119,6 +119,30 @@ describe('route', () => {
         });
     });
 
+    describe('POST /proxy', () => {
+        it('should return a clear 400 instead of a generic 500 for an unsupported multipart Content-Type', async () => {
+            const { apiKey } = await seeders.seedAccountEnvAndUser();
+            const res = await fetch(`${api.url}/proxy/some/path`, {
+                method: 'POST',
+                body: '--boundary123\r\nContent-Type: application/json\r\n\r\n{}\r\n--boundary123--',
+                headers: {
+                    Authorization: `Bearer ${apiKey.secret}`,
+                    'Provider-Config-Key': 'does-not-matter',
+                    'Connection-Id': 'does-not-matter',
+                    'Content-Type': 'multipart/related; boundary=boundary123'
+                }
+            });
+
+            expect(res.status).toBe(400);
+            expect(await res.json()).toStrictEqual({
+                error: {
+                    code: 'unsupported_content_type',
+                    message: expect.stringContaining('Unsupported content type: multipart/related')
+                }
+            });
+        });
+    });
+
     describe('Authenticated endpoints', () => {
         it('should return 401 if unknown bearer token', async () => {
             const res = await fetch(`${api.url}/providers`, {

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -59,7 +59,7 @@ router.use(staticSite);
 
 // -------
 // Error handling.
-router.use((err: any, req: Request, res: Response<ApiError<'invalid_json'> | ApiError<'request_too_large'>>, _: any) => {
+router.use((err: any, req: Request, res: Response<ApiError<'invalid_json'> | ApiError<'request_too_large'> | ApiError<'unsupported_content_type'>>, _: any) => {
     if (err instanceof SyntaxError && 'body' in err && 'type' in err && err.type === 'entity.parse.failed') {
         res.status(400).send({ error: { code: 'invalid_json', message: err.message } });
         return;
@@ -68,6 +68,16 @@ router.use((err: any, req: Request, res: Response<ApiError<'invalid_json'> | Api
     if (err instanceof Error && 'type' in err && err.type === 'entity.too.large') {
         const limit = 'limit' in err && typeof err.limit === 'number' ? formatByteLimit(err.limit) : undefined;
         res.status(413).send({ error: { code: 'request_too_large', message: `Request entity too large${limit ? ` (limit: ${limit})` : ''}` } });
+        return;
+    }
+
+    if (err instanceof Error && err.message.startsWith('Unsupported content type:') && req.path.startsWith('/proxy')) {
+        res.status(400).send({
+            error: {
+                code: 'unsupported_content_type',
+                message: `${err.message}. The "Content-Type" header on a request to the Nango proxy must be "multipart/form-data" or omitted. To send this Content-Type to the destination API, set it via the "nango-proxy-Content-Type" header instead (see https://docs.nango.dev/guides/platform/proxy-requests).`
+            }
+        });
         return;
     }
 


### PR DESCRIPTION
## Describe the problem and your solution

- surface a clear 400 for unsupported multipart `Content-Type` on `/proxy` endpoint instead of returning a generic 500 error response.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

