### PR TITLE
fix(webapp): stop the usage table cutting off figures and wrapping headers

### DIFF
--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -14,7 +14,7 @@ export type UsageRowVariant = 'caps' | 'usage' | 'charges' | 'comparison';
 
 // Tailwind only generates classes it sees in source. This helper must return whole strings.
 export function usageTableGrid(variant: UsageRowVariant, planNamedCharges = false): string {
-    // The last column is 44px rather than the chevron's 20px because a row's `px-6` shrinks its first and last subgrid tracks.
+    // A row's `px-6` shrinks its first and last subgrid tracks. The last column is 44px so the 20px chevron survives that.
     if (variant === 'caps') {
         return 'grid grid-cols-[minmax(0,2fr)_minmax(112px,max-content)_minmax(0,2fr)_124px_44px] gap-x-4';
     }
@@ -27,7 +27,7 @@ export function usageTableGrid(variant: UsageRowVariant, planNamedCharges = fals
     return 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_124px_44px] gap-x-4';
 }
 
-/** Maps a row onto the table's columns. Every level between the two needs it, or the tracks stop here. */
+/** Maps a row onto the table's columns. Drop it from any wrapper in between and that row's cells stop lining up. */
 export const usageRowCells = 'col-span-full grid grid-cols-subgrid';
 
 interface UsageRowProps {

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -13,15 +13,22 @@ import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 export type UsageRowVariant = 'caps' | 'usage' | 'charges' | 'comparison';
 
 // Tailwind only generates classes it sees in source. This helper must return whole strings.
-export function usageRowGrid(variant: UsageRowVariant): string {
+export function usageTableGrid(variant: UsageRowVariant, planNamedCharges = false): string {
+    // The last column is 44px rather than the chevron's 20px because a row's `px-6` shrinks its first and last subgrid tracks.
     if (variant === 'caps') {
-        return 'grid grid-cols-[minmax(0,2fr)_minmax(0,2.2fr)_124px_20px] items-center gap-4 px-6';
+        return 'grid grid-cols-[minmax(0,2fr)_minmax(112px,max-content)_minmax(0,2fr)_124px_44px] gap-x-4';
     }
     if (variant === 'comparison') {
-        return 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_124px_180px_20px] items-center gap-4 px-6';
+        return 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_180px_180px_44px] gap-x-4';
     }
-    return 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_124px_20px] items-center gap-4 px-6';
+    if (planNamedCharges) {
+        return 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_180px_44px] gap-x-4';
+    }
+    return 'grid grid-cols-[minmax(0,3fr)_minmax(0,1fr)_124px_44px] gap-x-4';
 }
+
+/** Maps a row onto the table's columns. Every level between the two needs it, or the tracks stop here. */
+export const usageRowCells = 'col-span-full grid grid-cols-subgrid';
 
 interface UsageRowProps {
     metric: UsageMetric;
@@ -79,55 +86,56 @@ export const UsageRow: React.FC<UsageRowProps> = ({
     const isPending = variant === 'charges' || variant === 'comparison' ? charge?.pending : capsLoading;
 
     return (
-        <Collapsible open={open} onOpenChange={onOpenChange} className="border-b border-border-muted last:border-b-0 data-[state=open]:bg-surface-panel">
-            <CollapsibleTrigger className="group w-full text-left py-4 transition-colors data-[state=closed]:hover:bg-surface-panel data-[state=open]:border-b data-[state=open]:border-border-muted">
-                <div className={usageRowGrid(variant)}>
-                    <div className="flex flex-col min-w-0">
-                        <span className="text-text-default type-text-regular-sm truncate">{label}</span>
-                    </div>
-                    {variant !== 'usage' ? (
-                        // Fixed track: every row's bar starts at the same x, whatever the figure's width.
-                        <div className={cn('items-center gap-5', showLimits ? 'grid grid-cols-[80px_minmax(0,1fr)]' : 'flex')}>
-                            {capsLoading ? (
-                                <Skeleton className={cn('h-5', showLimits ? 'w-full' : 'w-32')} />
-                            ) : (
-                                <>
-                                    <span className="text-text-default type-text-regular-sm truncate" title={exactFigure}>
-                                        {figures.usage}
-                                        {figures.limit != null && <span className="text-text-muted"> / {figures.limit}</span>}
-                                    </span>
-                                    {showLimits && limit != null && <UsageBar usage={usage} limit={limit} className="max-w-[200px]" />}
-                                </>
-                            )}
-                        </div>
-                    ) : (
-                        <div />
-                    )}
-                    {/* A dash means unpriced. Blank means this row has no applicable figure. */}
-                    {variant === 'comparison' &&
-                        (currentPlanCharge?.pending ? (
-                            <Skeleton className="h-4 w-12" />
-                        ) : (
-                            <div className="text-text-default type-text-regular-sm">{currentPlanCharge ? (currentPlanCharge.formatted ?? '—') : ''}</div>
-                        ))}
-                    {isPending ? (
-                        <Skeleton className="h-4 w-12" />
-                    ) : showLimits ? (
-                        <div className={cn('type-text-regular-sm', getUsageStateTextColor(state))}>
-                            {limit == null ? '—' : state === 'over' ? 'Limit reached' : `${percent}%`}
-                        </div>
-                    ) : variant === 'usage' ? (
-                        <div className="text-text-default type-text-regular-sm" title={formatMetricUsageExact(metric, usage)}>
-                            {figures.usage}
-                        </div>
-                    ) : (
-                        // On an uncapped plan a charge is what was billed, not a threshold crossed.
-                        <div className="text-text-default type-text-regular-sm">{charge ? (charge.formatted ?? '—') : ''}</div>
-                    )}
-                    <ChevronDown className="size-5 text-text-muted transition-transform group-data-[state=open]:rotate-180" />
+        <Collapsible
+            open={open}
+            onOpenChange={onOpenChange}
+            className={cn(usageRowCells, 'border-b border-border-muted last:border-b-0 data-[state=open]:bg-surface-panel')}
+        >
+            <CollapsibleTrigger
+                className={cn(
+                    usageRowCells,
+                    'group items-center text-left py-4 px-6 transition-colors data-[state=closed]:hover:bg-surface-panel data-[state=open]:border-b data-[state=open]:border-border-muted'
+                )}
+            >
+                <div className="flex flex-col min-w-0">
+                    <span className="text-text-default type-text-regular-sm truncate">{label}</span>
                 </div>
+                {variant === 'usage' ? (
+                    <div />
+                ) : capsLoading ? (
+                    // Matches the caps column's 112px floor, so a month switch doesn't resize the column.
+                    <Skeleton className="h-5 w-28" />
+                ) : (
+                    <span className="text-text-default type-text-regular-sm truncate" title={exactFigure}>
+                        {figures.usage}
+                        {figures.limit != null && <span className="text-text-muted"> / {figures.limit}</span>}
+                    </span>
+                )}
+                {showLimits && <div>{limit != null && !capsLoading && <UsageBar usage={usage} limit={limit} className="max-w-[200px]" />}</div>}
+                {/* A dash means unpriced. Blank means this row has no applicable figure. */}
+                {variant === 'comparison' &&
+                    (currentPlanCharge?.pending ? (
+                        <Skeleton className="h-4 w-12" />
+                    ) : (
+                        <div className="text-text-default type-text-regular-sm">{currentPlanCharge ? (currentPlanCharge.formatted ?? '—') : ''}</div>
+                    ))}
+                {isPending ? (
+                    <Skeleton className="h-4 w-12" />
+                ) : showLimits ? (
+                    <div className={cn('type-text-regular-sm', getUsageStateTextColor(state))}>
+                        {limit == null ? '—' : state === 'over' ? 'Limit reached' : `${percent}%`}
+                    </div>
+                ) : variant === 'usage' ? (
+                    <div className="text-text-default type-text-regular-sm" title={formatMetricUsageExact(metric, usage)}>
+                        {figures.usage}
+                    </div>
+                ) : (
+                    // On an uncapped plan a charge is what was billed, not a threshold crossed.
+                    <div className="text-text-default type-text-regular-sm">{charge ? (charge.formatted ?? '—') : ''}</div>
+                )}
+                <ChevronDown className="size-5 text-text-muted transition-transform group-data-[state=open]:rotate-180" />
             </CollapsibleTrigger>
-            <CollapsibleContent>
+            <CollapsibleContent className="col-span-full">
                 <UsageChartCard
                     metric={metric}
                     data={data}

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -1,6 +1,6 @@
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { cn } from '@/utils/utils';
-import { UsageRow, usageRowGrid } from './UsageRow';
+import { UsageRow, usageRowCells, usageTableGrid } from './UsageRow';
 
 import type { UsageChargeLookup, UsageRowCharge } from '../usageCharges';
 import type { UsageRowVariant } from './UsageRow';
@@ -77,11 +77,18 @@ export const UsageTable: React.FC<UsageTableProps> = ({
     extraTooltip
 }) => {
     const { thisPeriod, rightmost, extra } = usageColumnHeaders(variant, currentPlanTitle, rightmostHeader);
+    const planNamedCharges = rightmostHeader !== undefined;
     return (
-        <div className="w-full rounded border border-border-default overflow-hidden">
-            <div className={cn(usageRowGrid(variant), 'bg-surface-panel py-3 border-b border-border-default text-text-secondary type-label-xxs uppercase')}>
+        <div className={cn('w-full rounded border border-border-default overflow-hidden', usageTableGrid(variant, planNamedCharges))}>
+            <div
+                className={cn(
+                    usageRowCells,
+                    'items-center bg-surface-panel py-3 px-6 border-b border-border-default text-text-secondary type-label-xxs uppercase'
+                )}
+            >
                 <span>{legacy ? 'Legacy metric' : 'Metric'}</span>
-                <span>{thisPeriod}</span>
+                {/* The figure and its bar are separate columns, so the one header covers both. */}
+                <span className={cn(variant === 'caps' && 'col-span-2')}>{thisPeriod}</span>
                 <span className="flex items-center gap-1.5">
                     {rightmost}
                     {rightmostTooltip && (

--- a/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageTable.tsx
@@ -87,7 +87,7 @@ export const UsageTable: React.FC<UsageTableProps> = ({
                 )}
             >
                 <span>{legacy ? 'Legacy metric' : 'Metric'}</span>
-                {/* The figure and its bar are separate columns, so the one header covers both. */}
+                {/* The caps figure and its bar are separate columns, so this header spans both. */}
                 <span className={cn(variant === 'caps' && 'col-span-2')}>{thisPeriod}</span>
                 <span className="flex items-center gap-1.5">
                     {rightmost}


### PR DESCRIPTION
## Context

Two columns in the Billing & usage table are too narrow for what they hold. An account migrating to Pay-as-you-go sees the "Pay-as-you-go plan" header wrap onto a second line, doubling the header row's height, and on the Free plan a pair like `<0.01 GB / 10 GB` is cut to `<0.01 GB / 1…`. Same cause: every row set its own column widths by hand, with the figure pinned to 80px.

## Changes

- The table declares its columns once and every row maps onto them with a CSS subgrid, so header and rows can't disagree.
- The Free plan's figure column sizes to its widest figure instead of a fixed 80px, and the bars still line up.
- A column headed by a plan name gets 180px so the header and its tooltip fit on one line.
- The figure column's 112px floor matches the loading skeleton, so stepping through months doesn't resize it.

## Testing

Open Billing & usage on the preview. Dev Tools (Ctrl+Shift+D) → Billing Overrides switches the variants: `Free` for the caps table, `Growth (legacy)` with a scheduled move to Pay-as-you-go for the plan-named header, and `Growth` plus "Show legacy billing metrics" for the comparison tables.

## Screenshots

### Free plan

**Before**

![Data transfer cut to "<0.01 GB / 1…"](https://github.com/user-attachments/assets/f4398718-2194-43c9-b92c-455497bf2ee2)

**After**

![Data transfer showing "<0.01 GB / 10 GB"](https://github.com/user-attachments/assets/394691c7-9eb3-401a-86bb-8604d604c52c)

### Account migrating to Pay-as-you-go

**Before**

![Header wrapped onto two lines](https://github.com/user-attachments/assets/46c2cf03-f16e-443b-be0a-6b9b54a95533)

**After**

![Header on one line](https://github.com/user-attachments/assets/907cd64b-f02f-44bd-82e2-5952661bf38f)
