### PR TITLE
fix(server): stop local dev servers surviving a failed start

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -6,7 +6,7 @@ import { generateImage } from '@nangohq/fleet';
 import { destroy as destroyKvstore } from '@nangohq/kvstore';
 import { destroy as destroyLogs, otlp } from '@nangohq/logs';
 import { getOtlpRoutes } from '@nangohq/shared';
-import { getLogger, once, report, stringifyError } from '@nangohq/utils';
+import { exitOnListenFailure, getLogger, once, report, stringifyError } from '@nangohq/utils';
 
 import { orchestratorClient } from './clients.js';
 import { envs } from './env.js';
@@ -40,6 +40,7 @@ try {
     const port = envs.NANGO_JOBS_PORT;
     const orchestratorUrl = envs.ORCHESTRATOR_SERVICE_URL;
     const srv = server.listen(port);
+    exitOnListenFailure(srv, (err) => logger.error(`Failed to listen on port ${port}: ${err.code ?? err.message}`));
     if (envs.NANGO_JOBS_KEEP_ALIVE_TIMEOUT_MS && envs.NANGO_JOBS_KEEP_ALIVE_TIMEOUT_MS > 0) {
         srv.keepAliveTimeout = envs.NANGO_JOBS_KEEP_ALIVE_TIMEOUT_MS;
         srv.headersTimeout = envs.NANGO_JOBS_KEEP_ALIVE_TIMEOUT_MS + 1000;

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -2,7 +2,7 @@ import './tracer.js';
 
 import { destroy as destroyFeatureFlags, initialize as initializeFeatureFlags } from '@nangohq/feature-flags';
 import { DatabaseClient, defaultDatabaseClientOptions, Scheduler } from '@nangohq/scheduler';
-import { once, report, stringifyError } from '@nangohq/utils';
+import { exitOnListenFailure, once, report, stringifyError } from '@nangohq/utils';
 
 import { BackpressureMonitor } from './backpressure-monitor.js';
 import { envs } from './env.js';
@@ -88,6 +88,7 @@ try {
     const api = server.listen(port, () => {
         logger.info(`🚀 Orchestrator API ready at http://localhost:${port}`);
     });
+    exitOnListenFailure(api, (err) => logger.error(`Failed to listen on port ${port}: ${err.code ?? err.message}`));
     if (envs.NANGO_ORCHESTRATOR_KEEP_ALIVE_TIMEOUT_MS && envs.NANGO_ORCHESTRATOR_KEEP_ALIVE_TIMEOUT_MS > 0) {
         api.keepAliveTimeout = envs.NANGO_ORCHESTRATOR_KEEP_ALIVE_TIMEOUT_MS;
         api.headersTimeout = envs.NANGO_ORCHESTRATOR_KEEP_ALIVE_TIMEOUT_MS + 1000;

--- a/packages/persist/lib/app.ts
+++ b/packages/persist/lib/app.ts
@@ -5,7 +5,7 @@ import { destroy as destroyFeatureFlags, initialize as initializeFeatureFlags } 
 import { destroy as destroyKvstore } from '@nangohq/kvstore';
 import { destroy as destroyLogs } from '@nangohq/logs';
 import { records } from '@nangohq/records';
-import { getLogger, once, report } from '@nangohq/utils';
+import { exitOnListenFailure, getLogger, once, report } from '@nangohq/utils';
 
 import { autoDeletingDaemon } from './daemons/autodeleting.daemon.js';
 import { autoPruningDaemon } from './daemons/autopruning.daemon.js';
@@ -46,6 +46,7 @@ try {
     api = server.listen(port, () => {
         logger.info(`🚀 API ready at http://localhost:${port}`);
     });
+    exitOnListenFailure(api, (err) => logger.error(`Failed to listen on port ${port}: ${err.code ?? err.message}`));
     if (envs.NANGO_PERSIST_KEEP_ALIVE_TIMEOUT_MS && envs.NANGO_PERSIST_KEEP_ALIVE_TIMEOUT_MS > 0) {
         api.keepAliveTimeout = envs.NANGO_PERSIST_KEEP_ALIVE_TIMEOUT_MS;
         api.headersTimeout = envs.NANGO_PERSIST_KEEP_ALIVE_TIMEOUT_MS + 1000;

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -129,9 +129,22 @@ const close = once(() => {
 
     cron.getTasks().forEach((task) => task.stop());
 
+    // server.close() waits for every open connection and an upgraded websocket never closes on its
+    // own, so terminating the clients from inside its callback waits on itself forever.
+    wss.close();
+    for (const client of wss.clients) {
+        client.terminate();
+    }
+
+    // Each await below reaches an external service and can hang, leaving the process alive with
+    // its database pool open.
+    setTimeout(() => {
+        logger.error(`Closing did not finish within ${envs.SERVER_SHUTDOWN_TIMEOUT_MS}ms, exiting`);
+        process.exit(1);
+    }, envs.SERVER_SHUTDOWN_TIMEOUT_MS);
+
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     server.close(async () => {
-        wss.close();
         await stopFleets();
         await auditPartitions?.abort();
         await destroyAuditDb();

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -15,7 +15,7 @@ import { destroy as destroyKvstore } from '@nangohq/kvstore';
 import { destroy as destroyLogs, start as migrateLogs, otlp } from '@nangohq/logs';
 import { records } from '@nangohq/records';
 import { getGlobalOAuthCallbackUrl, getOtlpRoutes, getProviders, getServerPort, getWebsocketsPath, pubsub } from '@nangohq/shared';
-import { flags, getLogger, NANGO_VERSION, once, report } from '@nangohq/utils';
+import { exitOnListenFailure, flags, getLogger, NANGO_VERSION, once, report } from '@nangohq/utils';
 
 import { destroyAuditDb, migrateAuditDb, startAuditPartitions } from './auditDb.js';
 import publisher from './clients/publisher.client.js';
@@ -114,6 +114,7 @@ if (pubsubConnect.isErr()) {
 await initializeFeatureFlags();
 
 const port = getServerPort();
+exitOnListenFailure(server, (err) => logger.error(`Failed to listen on port ${port}: ${err.code ?? err.message}`));
 server.listen(port, () => {
     logger.info(`✅ Nango Server with version ${NANGO_VERSION} is listening on port ${port}. OAuth callback URL: ${getGlobalOAuthCallbackUrl()}`);
     logger.info(`Role-based authorization: ${flags.hasAuthRoles ? 'enabled' : 'disabled'}`);

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -129,15 +129,14 @@ const close = once(() => {
 
     cron.getTasks().forEach((task) => task.stop());
 
-    // server.close() waits for every open connection and an upgraded websocket never closes on its
-    // own, so terminating the clients from inside its callback waits on itself forever.
+    // server.close() runs its callback only once every connection is gone, and an upgraded websocket
+    // never closes on its own. Terminate the clients here, not in that callback.
     wss.close();
     for (const client of wss.clients) {
         client.terminate();
     }
 
-    // Each await below reaches an external service and can hang, leaving the process alive with
-    // its database pool open.
+    // Each await below can hang on an external service, leaving the process alive with its pool open.
     setTimeout(() => {
         logger.error(`Closing did not finish within ${envs.SERVER_SHUTDOWN_TIMEOUT_MS}ms, exiting`);
         process.exit(1);

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -219,6 +219,7 @@ const ENVS_SHAPE = z.object({
         .optional()
         .default(16 * 1024),
     SERVER_SHUTDOWN_DELAY_MS: z.coerce.number().optional().default(0),
+    SERVER_SHUTDOWN_TIMEOUT_MS: z.coerce.number().optional().default(15_000),
     SERVER_EGRESS_TELEMETRY_BATCH_SIZE: z.coerce.number().int().positive().default(1_000),
     SERVER_EGRESS_TELEMETRY_FLUSH_INTERVAL_MS: z.coerce.number().int().nonnegative().default(60_000),
     SERVER_EGRESS_TELEMETRY_MAX_QUEUE_SIZE: z.coerce.number().int().positive().default(100_000),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -219,7 +219,7 @@ const ENVS_SHAPE = z.object({
         .optional()
         .default(16 * 1024),
     SERVER_SHUTDOWN_DELAY_MS: z.coerce.number().optional().default(0),
-    SERVER_SHUTDOWN_TIMEOUT_MS: z.coerce.number().optional().default(15_000),
+    SERVER_SHUTDOWN_TIMEOUT_MS: z.coerce.number().int().positive().optional().default(15_000),
     SERVER_EGRESS_TELEMETRY_BATCH_SIZE: z.coerce.number().int().positive().default(1_000),
     SERVER_EGRESS_TELEMETRY_FLUSH_INTERVAL_MS: z.coerce.number().int().nonnegative().default(60_000),
     SERVER_EGRESS_TELEMETRY_MAX_QUEUE_SIZE: z.coerce.number().int().positive().default(100_000),

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -25,6 +25,7 @@ export * from './axios.js';
 export * from './tls/internal.js';
 export * from './auth.js';
 export * from './once.js';
+export * from './listen.js';
 export * from './chunk.js';
 export * from './http.js';
 export * from './version.js';

--- a/packages/utils/lib/listen.ts
+++ b/packages/utils/lib/listen.ts
@@ -3,7 +3,9 @@ import type { Server } from 'node:http';
 // A bind failure otherwise reaches the uncaughtException handler, which never exits. The process
 // then holds its crons and database pool while serving nothing.
 export function exitOnListenFailure(server: Server, onFailure: (err: NodeJS.ErrnoException) => void): void {
-    server.on('error', (err: NodeJS.ErrnoException) => {
+    // WebSocketServer re-emits the server's error on itself, and an unhandled one there throws
+    // before a later listener runs. Prepend so this stays first however the caller orders it.
+    server.prependListener('error', (err: NodeJS.ErrnoException) => {
         if (server.listening) {
             // Not a bind failure; leave it to the uncaughtException handler.
             throw err;

--- a/packages/utils/lib/listen.ts
+++ b/packages/utils/lib/listen.ts
@@ -1,0 +1,14 @@
+import type { Server } from 'node:http';
+
+// A bind failure otherwise lands in the service's uncaughtException handler, which never exits,
+// leaving the crons, consumers and database pool running with nothing served and no port to spot.
+export function exitOnListenFailure(server: Server, onFailure: (err: NodeJS.ErrnoException) => void): void {
+    server.on('error', (err: NodeJS.ErrnoException) => {
+        if (server.listening) {
+            // Not a bind failure; leave it to the uncaughtException handler as before.
+            throw err;
+        }
+        onFailure(err);
+        process.exit(1);
+    });
+}

--- a/packages/utils/lib/listen.ts
+++ b/packages/utils/lib/listen.ts
@@ -1,11 +1,11 @@
 import type { Server } from 'node:http';
 
-// A bind failure otherwise lands in the service's uncaughtException handler, which never exits,
-// leaving the crons, consumers and database pool running with nothing served and no port to spot.
+// A bind failure otherwise reaches the uncaughtException handler, which never exits. The process
+// then holds its crons and database pool while serving nothing.
 export function exitOnListenFailure(server: Server, onFailure: (err: NodeJS.ErrnoException) => void): void {
     server.on('error', (err: NodeJS.ErrnoException) => {
         if (server.listening) {
-            // Not a bind failure; leave it to the uncaughtException handler as before.
+            // Not a bind failure; leave it to the uncaughtException handler.
             throw err;
         }
         onFailure(err);

--- a/packages/utils/lib/listen.unit.test.ts
+++ b/packages/utils/lib/listen.unit.test.ts
@@ -27,6 +27,24 @@ describe('exitOnListenFailure', () => {
         await new Promise<void>((resolve) => holder.close(() => resolve()));
     });
 
+    it('should run before a listener registered earlier', async () => {
+        vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+        const order: string[] = [];
+
+        const holder = http.createServer();
+        await new Promise<void>((resolve) => holder.listen(0, resolve));
+        const port = (holder.address() as { port: number }).port;
+
+        const loser = http.createServer();
+        loser.on('error', () => order.push('earlier'));
+        exitOnListenFailure(loser, () => order.push('ours'));
+        loser.listen(port);
+
+        await vi.waitFor(() => expect(order).toStrictEqual(['ours', 'earlier']));
+
+        await new Promise<void>((resolve) => holder.close(() => resolve()));
+    });
+
     it('should not exit for an error raised after the server is listening', async () => {
         const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
         const onFailure = vi.fn();

--- a/packages/utils/lib/listen.unit.test.ts
+++ b/packages/utils/lib/listen.unit.test.ts
@@ -1,0 +1,44 @@
+import http from 'node:http';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { exitOnListenFailure } from './listen.js';
+
+describe('exitOnListenFailure', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should exit when the port is already taken', async () => {
+        const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+        const onFailure = vi.fn();
+
+        const holder = http.createServer();
+        await new Promise<void>((resolve) => holder.listen(0, resolve));
+        const port = (holder.address() as { port: number }).port;
+
+        const loser = http.createServer();
+        exitOnListenFailure(loser, onFailure);
+        loser.listen(port);
+
+        await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1));
+        expect(onFailure.mock.calls[0]?.[0]).toMatchObject({ code: 'EADDRINUSE' });
+
+        await new Promise<void>((resolve) => holder.close(() => resolve()));
+    });
+
+    it('should not exit for an error raised after the server is listening', async () => {
+        const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+        const onFailure = vi.fn();
+
+        const server = http.createServer();
+        exitOnListenFailure(server, onFailure);
+        await new Promise<void>((resolve) => server.listen(0, resolve));
+
+        expect(() => server.emit('error', new Error('boom'))).toThrow('boom');
+        expect(onFailure).not.toHaveBeenCalled();
+        expect(exit).not.toHaveBeenCalled();
+
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+});


### PR DESCRIPTION
## Context

A local Nango service can end up alive when it should be dead — either it never got its port, or it ignored `SIGTERM`. Both leave a process with no listener still holding Postgres connections, so it looks stopped and a port scan can't find it. They accumulate: enough to use up the shared dev container's 100 connections and lock everyone out of their local stack.

The `SIGTERM` half isn't only local. A pod with an open websocket never finishes draining, so it just waits for the kubelet to kill it.

## Changes

- A failed `listen()` now exits non-zero instead of logging and carrying on — server, jobs, persist, orchestrator.
- The server terminates its websocket clients before `server.close()`, which otherwise waits on them forever.
- `SERVER_SHUTDOWN_TIMEOUT_MS` (15s) force-exits if a cleanup step hangs.

Fixes [NAN-7003](https://linear.app/nango/issue/NAN-7003)

## Testing

- `listen.unit.test.ts` covers `EADDRINUSE`, an error raised after the server is listening, and that the handler runs ahead of `WebSocketServer`'s.
- Shutdown has no test. By hand: start the stack, open the dashboard so a websocket is live, `SIGTERM` the server, check the process is gone.
