### PR TITLE
fix(ci): stop Ubuntu mirror outages from failing the connect-ui tests

### DIFF
--- a/.github/actions/playwright-browsers/action.yml
+++ b/.github/actions/playwright-browsers/action.yml
@@ -1,0 +1,20 @@
+name: 'Playwright browsers'
+description: 'Restores the cached Chromium build for the pinned Playwright version, downloading it on a miss.'
+
+runs:
+    using: 'composite'
+    steps:
+        - name: Resolve Playwright version
+          id: playwright
+          shell: bash
+          run: echo "version=$(node -p "require('./packages/connect-ui/package.json').devDependencies.playwright")" >> "$GITHUB_OUTPUT"
+
+        - name: Cache Playwright browsers
+          uses: actions/cache@v4
+          with:
+              path: ~/.cache/ms-playwright
+              key: ms-playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+        # Browser Mode needs the Chromium binary (ignore-scripts blocks the postinstall download).
+        - shell: bash
+          run: npx --yes playwright@${{ steps.playwright.outputs.version }} install chromium

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -22,8 +22,6 @@ jobs:
             - run: npm ci
 
     warm-playwright-cache:
-        # tests-connect-ui saves only under its own PR's ref, and should-run skips it on the master
-        # push after a merge-queue merge, so this job writes the entry every PR restores from.
         runs-on: blacksmith-4vcpu-ubuntu-2404
         permissions:
             contents: read

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -30,14 +30,4 @@ jobs:
 
             - uses: ./.github/actions/setup-node
 
-            - name: Resolve Playwright version
-              id: playwright
-              run: echo "version=$(node -p "require('./packages/connect-ui/package.json').devDependencies.playwright")" >> "$GITHUB_OUTPUT"
-
-            - name: Cache Playwright browsers
-              uses: actions/cache@v4
-              with:
-                  path: ~/.cache/ms-playwright
-                  key: ms-playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
-
-            - run: npx --yes playwright@${{ steps.playwright.outputs.version }} install chromium
+            - uses: ./.github/actions/playwright-browsers

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -20,3 +20,26 @@ jobs:
             - uses: ./.github/actions/setup-node
 
             - run: npm ci
+
+    warm-playwright-cache:
+        # tests-connect-ui saves only under its own PR's ref, and should-run skips it on the master
+        # push after a merge-queue merge, so this job writes the entry every PR restores from.
+        runs-on: blacksmith-4vcpu-ubuntu-2404
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: ./.github/actions/setup-node
+
+            - name: Resolve Playwright version
+              id: playwright
+              run: echo "version=$(node -p "require('./packages/connect-ui/package.json').devDependencies.playwright")" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Playwright browsers
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: ms-playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+            - run: npx --yes playwright@${{ steps.playwright.outputs.version }} install chromium

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -142,17 +142,6 @@ jobs:
             # connect-ui imports @nangohq/types and @nangohq/frontend; build their dist first.
             - run: npm run ts-build -- --noCheck
 
-            - name: Resolve Playwright version
-              id: playwright
-              run: echo "version=$(node -p "require('./packages/connect-ui/package.json').devDependencies.playwright")" >> "$GITHUB_OUTPUT"
-
-            - name: Cache Playwright browsers
-              uses: actions/cache@v4
-              with:
-                  path: ~/.cache/ms-playwright
-                  key: ms-playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
-
-            # Browser Mode needs the Chromium binary (ignore-scripts blocks the postinstall download).
-            - run: npx playwright install chromium
+            - uses: ./.github/actions/playwright-browsers
 
             - run: npm test -w packages/connect-ui

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -142,7 +142,17 @@ jobs:
             # connect-ui imports @nangohq/types and @nangohq/frontend; build their dist first.
             - run: npm run ts-build -- --noCheck
 
+            - name: Resolve Playwright version
+              id: playwright
+              run: echo "version=$(node -p "require('./packages/connect-ui/package.json').devDependencies.playwright")" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Playwright browsers
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: ms-playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
             # Browser Mode needs the Chromium binary (ignore-scripts blocks the postinstall download).
-            - run: npx playwright install --with-deps chromium
+            - run: npx playwright install chromium
 
             - run: npm test -w packages/connect-ui


### PR DESCRIPTION
## Context

`tests-connect-ui` failed five times in the last ~33 runs, always in the same step and never in the suite itself: `playwright install --with-deps` runs `apt-get`, and when an Ubuntu mirror is unreachable from the runner it retries for ~7 minutes and then fails the job. It's a required check, so anyone whose PR caught that window was blocked with nothing wrong in their branch.

The apt install is unnecessary here. Of the 30 packages it wanted, 21 were already installed and only being upgraded — including every library Chromium links against (`libnss3`, `libgbm1`, `libasound2`, `libdrm`, mesa). All 9 genuinely new ones were fonts.

Chromium itself was also re-downloaded on every run, so the job now caches it. That needs a warm-up job to be worth anything: caches are scoped to the ref that writes them, and `tests-connect-ui` only ever runs on a PR branch or on a throwaway `gh-readonly-queue` ref.

## Changes

- Drop `--with-deps`, so the job no longer depends on Ubuntu mirrors being up.
- Cache `~/.cache/ms-playwright`, keyed on the pinned Playwright version.
- Warm that cache on every push to master.

## Testing

On this branch, a cold run installed Chromium in 6s and the suite passed with no apt step at all. Re-running the job restored the cache in 1s and turned the install into a 1s no-op.

The master warm-up job can only be checked after this merges — the first PR opened afterwards should restore instead of downloading.
