### PR TITLE
feat(audit): audit agent session creation and termination (NAN-6751)

### DIFF
--- a/packages/server/lib/middleware/audit/agentSession.middleware.ts
+++ b/packages/server/lib/middleware/audit/agentSession.middleware.ts
@@ -1,0 +1,17 @@
+import { makeAuditTarget as makeTarget } from '../../audit.js';
+import { Audit, auditable } from './auditable.js';
+import { omitUndefined, param, uuid } from './input.js';
+
+import type { DeleteAgentSession, PostAgentSessions } from '@nangohq/types';
+
+export const auditAgentSessionCreated = auditable<PostAgentSessions>({
+    policy: Audit.auditable({ resource: 'agent_session', action: 'created', scope: 'environment' }),
+    // Never read the token from the response — only the session id identifies the session.
+    targetFromResponse: (response) => makeTarget('agent_session', response.data.session_id),
+    metadataFromResponse: (response) => omitUndefined({ expiresAt: response.data.expires_at })
+});
+
+export const auditAgentSessionTerminated = auditable<DeleteAgentSession>({
+    policy: Audit.auditable({ resource: 'agent_session', action: 'terminated', scope: 'environment' }),
+    target: (req) => makeTarget('agent_session', uuid(param(req, 'sessionId')))
+});

--- a/packages/server/lib/middleware/audit/agentSession.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/audit/agentSession.middleware.unit.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { auditAgentSessionCreated, auditAgentSessionTerminated } from './agentSession.middleware.js';
+import { fakeReq, fakeRes, installAuditMockDefaults, recordMock, resetAuditMocks, runAudit, secretKeyLocals } from './testing.js';
+
+vi.mock('../../audit.js', async (importOriginal) => (await import('./testing.js')).auditModuleMock(importOriginal as never));
+vi.mock('@nangohq/shared', async (importOriginal) => (await import('./testing.js')).sharedModuleMock(importOriginal as never));
+
+const SESSION_ID = '3f2a1b00-0000-4000-8000-000000000001';
+
+describe('agent session audit middleware (unit)', () => {
+    beforeEach(() => {
+        installAuditMockDefaults();
+    });
+
+    afterEach(() => {
+        resetAuditMocks();
+    });
+
+    it('session create: names the key that minted the session and never records the token', async () => {
+        const req = fakeReq({ body: { tenant: { connections: { any: [{ tags: { team: 'ops' } }] } } } });
+        const res = fakeRes(secretKeyLocals, 201);
+        await new Promise<void>((resolve) => auditAgentSessionCreated(req, res, () => resolve()));
+        res.json({
+            data: {
+                session_id: SESSION_ID,
+                session_token: 'nango_agent_supersecret',
+                mcp_url: 'https://api.nango.dev/session/x/mcp',
+                expires_at: '2026-09-26T10:00:00.000Z',
+                toolset: {},
+                meta_tools: { nango_tool_search: true, nango_execute: true, nango_proxy: false }
+            }
+        });
+        res.emit('finish');
+        await vi.waitFor(() => expect(recordMock).toHaveBeenCalled());
+        const event = recordMock.mock.calls.at(-1)?.[0];
+        expect(event).toMatchObject({
+            resource: 'agent_session',
+            action: 'created',
+            outcome: 'success',
+            accountId: 42,
+            scope: 'environment',
+            environment: { id: 'e0000000-0000-4000-8000-000000000009', display: 'dev' },
+            actor: { type: 'api_key', id: 'c0000000-0000-4000-8000-000000000005', display: 'ci-key' },
+            targets: [{ type: 'agent_session', id: SESSION_ID }],
+            metadata: { expiresAt: '2026-09-26T10:00:00.000Z' }
+        });
+        expect(JSON.stringify(event)).not.toContain('nango_agent_supersecret');
+    });
+
+    it('session terminate: names the session from the request, so a denial still identifies it', async () => {
+        const event = await runAudit(auditAgentSessionTerminated, fakeReq({ params: { sessionId: SESSION_ID } }), fakeRes(secretKeyLocals, 403));
+        expect(event).toMatchObject({
+            resource: 'agent_session',
+            action: 'terminated',
+            outcome: 'denied',
+            accountId: 42,
+            scope: 'environment',
+            environment: { id: 'e0000000-0000-4000-8000-000000000009', display: 'dev' },
+            actor: { type: 'api_key', id: 'c0000000-0000-4000-8000-000000000005', display: 'ci-key' },
+            targets: [{ type: 'agent_session', id: SESSION_ID }]
+        });
+    });
+
+    it('session terminate: a malformed session id records the attempt with no target', async () => {
+        const event = await runAudit(auditAgentSessionTerminated, fakeReq({ params: { sessionId: 'not-a-uuid' } }), fakeRes(secretKeyLocals, 400));
+        expect(event).toMatchObject({ resource: 'agent_session', action: 'terminated', outcome: 'failure', accountId: 42, targets: [] });
+    });
+});

--- a/packages/server/lib/middleware/audit/index.ts
+++ b/packages/server/lib/middleware/audit/index.ts
@@ -1,3 +1,4 @@
+export { auditAgentSessionCreated, auditAgentSessionTerminated } from './agentSession.middleware.js';
 export {
     auditAccountApiKeyCreated,
     auditAccountApiKeyDeleted,

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -92,6 +92,8 @@ import { envs } from './env.js';
 import { acceptLanguageMiddleware } from './middleware/accept-language.middleware.js';
 import authMiddleware from './middleware/access.middleware.js';
 import {
+    auditAgentSessionCreated,
+    auditAgentSessionTerminated,
     auditConnectionCreated,
     auditFunctionDeployedCli,
     auditFunctionDeployedFromTemplate,
@@ -465,8 +467,8 @@ publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTe
 
 // Agent sessions
 publicAPI.use('/sessions', jsonContentTypeMiddleware);
-publicAPI.route('/sessions').post(apiAuth, withScope('environment:agent_sessions:write'), postAgentSessions);
-publicAPI.route('/sessions/:sessionId').delete(apiAuth, withScope('environment:agent_sessions:write'), deleteAgentSession);
+publicAPI.route('/sessions').post(apiAuth, auditAgentSessionCreated, withScope('environment:agent_sessions:write'), postAgentSessions);
+publicAPI.route('/sessions/:sessionId').delete(apiAuth, auditAgentSessionTerminated, withScope('environment:agent_sessions:write'), deleteAgentSession);
 publicAPI.use('/session/:sessionId/mcp', jsonContentTypeMiddleware);
 publicAPI.route('/session/:sessionId/mcp').post(agentSessionAuth, postAgentSessionMcp);
 publicAPI.route('/session/:sessionId/mcp').get(agentSessionAuth, getAgentSessionMcp);

--- a/packages/types/lib/agent/api.ts
+++ b/packages/types/lib/agent/api.ts
@@ -1,4 +1,5 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
+import type { AuditPolicy } from '../audit-trail/event.js';
 import type { Tags } from '../db.js';
 import type { AgentSessionUnknownPinnedConnectionsPayload } from './connections.js';
 import type { AgentSessionEndedReason } from './session.js';
@@ -103,7 +104,7 @@ export type AgentSessionCreationErrorPayload =
 export type PostAgentSessionsCreationError = ApiError<AgentSessionCreationErrorCode, undefined, AgentSessionCreationErrorPayload>;
 
 export type PostAgentSessions = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: AuditPolicy<'agent_session', 'created', 'environment'>;
     Method: 'POST';
     Path: '/sessions';
     Body: PostAgentSessionsBody;
@@ -127,7 +128,7 @@ export interface ApiTerminatedAgentSession {
 }
 
 export type DeleteAgentSession = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: AuditPolicy<'agent_session', 'terminated', 'environment'>;
     Method: 'DELETE';
     Path: '/sessions/:sessionId';
     Params: { sessionId: string };

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -1,4 +1,5 @@
 import type {
+    AgentSessionCreatedMetadata,
     ApiKeyUpdatedMetadata,
     AppAuthLoginMetadata,
     AuditTrailFiltersMetadata,
@@ -122,6 +123,10 @@ interface AuditEventTable {
         exported: AuditTrailFiltersMetadata;
         queried: AuditTrailQueriedMetadata;
     };
+    agent_session: {
+        created: AgentSessionCreatedMetadata;
+        terminated: never;
+    };
 }
 
 export type AuditResource = keyof AuditEventTable;
@@ -137,7 +142,7 @@ export type AuditMetadataFor<R extends AuditResource, A> = A extends keyof Audit
 
 export type AuditScope = 'account' | 'environment';
 
-export type AuditTargetType = 'connection' | 'sync' | 'function' | 'integration' | 'api_key' | 'member' | 'team' | 'user' | 'environment';
+export type AuditTargetType = 'connection' | 'sync' | 'function' | 'integration' | 'api_key' | 'member' | 'team' | 'user' | 'environment' | 'agent_session';
 
 export interface AuditActor {
     type: AuditActorType;

--- a/packages/types/lib/audit-trail/metadata.ts
+++ b/packages/types/lib/audit-trail/metadata.ts
@@ -131,3 +131,7 @@ export interface MfaVerifiedMetadata {
 export interface BillingSpendAlertChangedMetadata {
     thresholdInCents?: number;
 }
+
+export interface AgentSessionCreatedMetadata {
+    expiresAt?: string;
+}

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -29,7 +29,8 @@ const actionsByResource = {
         'spend_alert_changed',
         'spend_alert_removed'
     ],
-    audit_trail: ['exported', 'queried']
+    audit_trail: ['exported', 'queried'],
+    agent_session: ['created', 'terminated']
 } as const satisfies { [R in AuditResource]: readonly AuditActionOf<R>[] };
 
 type ListedEvent = { [R in AuditResource]: `${R}.${(typeof actionsByResource)[R][number]}` }[AuditResource];
@@ -48,7 +49,8 @@ const resourceLabels: Record<AuditResource, string> = {
     app_auth: 'Authentication',
     mfa: 'MFA',
     billing: 'Billing',
-    audit_trail: 'Audit trail'
+    audit_trail: 'Audit trail',
+    agent_session: 'Agent session'
 };
 
 export const ALL = 'all';


### PR DESCRIPTION
NAN-6751

Audits agent session creation and termination. POST /sessions and DELETE /sessions/:sessionId both shipped declaring no-audit, and this flips them onto a real policy.

Adds an agent_session audit resource with created and terminated actions. The event records the actor key, account, environment and session id.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

