### PR TITLE
refactor(agent): trim the agent session operation payloads (NAN-6950)

### DIFF
--- a/packages/server/lib/controllers/agent/deleteSession.ts
+++ b/packages/server/lib/controllers/agent/deleteSession.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import { requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { terminatedAgentSessionToPublicApi } from '../../formatters/agentSession.js';
-import { resolveActor } from '../../middleware/audit/auditable.js';
 import * as agentSessionService from '../../services/agentSession.service.js';
 import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 
@@ -36,8 +35,7 @@ export const deleteAgentSession = asyncWrapperWithEnvironment<DeleteAgentSession
     const terminated = await agentSessionService.terminateAgentSession({
         account,
         environment,
-        sessionId: params.data.sessionId,
-        endedBy: resolveActor(res.locals)
+        sessionId: params.data.sessionId
     });
 
     if (terminated.isErr()) {

--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto';
 
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
 import * as keystore from '@nangohq/keystore';
+import { logContextGetter } from '@nangohq/logs';
 import { seeders } from '@nangohq/shared';
 
 import {
@@ -12,9 +13,11 @@ import {
     endAgentSession,
     getAgentSession,
     getAgentSessionByToken,
-    listExpiredAgentSessions
+    listExpiredAgentSessions,
+    terminateAgentSession
 } from './agentSession.service.js';
 
+import type { LogContextOrigin } from '@nangohq/logs';
 import type { AgentSession, AgentSessionCompiledToolset, AgentSessionResolvedConnections, DBEnvironment, DBTeam } from '@nangohq/types';
 
 const table = 'agent_sessions';
@@ -26,6 +29,10 @@ describe('agentSession service', () => {
     beforeAll(async () => {
         await multipleMigrations();
         await keystore.migrate(db.knex);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     beforeEach(async () => {
@@ -171,6 +178,17 @@ describe('agentSession service', () => {
         expect(retried.alreadyEnded).toBe(true);
         expect(retried.session.endedAt).toStrictEqual(terminated.session.endedAt);
         expect(retried.session.endedReason).toBe('terminated');
+    });
+
+    it('records the terminated operation without a payload', async () => {
+        const session = await createSession({ account, environment });
+        const create = vi
+            .spyOn(logContextGetter, 'create')
+            .mockResolvedValue({ enrichOperation: vi.fn(), info: vi.fn(), success: vi.fn() } as unknown as LogContextOrigin);
+
+        (await terminateAgentSession({ account, environment, sessionId: session.id })).unwrap();
+
+        expect(create).toHaveBeenCalledWith({ operation: { type: 'agent_session', action: 'terminate' } }, { account, environment });
     });
 
     it('revokes the session token when the session is terminated', async () => {

--- a/packages/server/lib/services/agentSession.service.ts
+++ b/packages/server/lib/services/agentSession.service.ts
@@ -10,7 +10,6 @@ import type {
     AgentSessionEndedReason,
     AgentSessionMetaTools,
     AgentSessionResolvedConnections,
-    AuditActor,
     DBEnvironment,
     DBTeam
 } from '@nangohq/types';
@@ -55,7 +54,6 @@ export interface TerminateAgentSessionParams {
     account: DBTeam;
     environment: DBEnvironment;
     sessionId: string;
-    endedBy: AuditActor;
 }
 
 type AgentSessionErrorCode = 'not_found' | 'creation_failed' | 'termination_failed' | 'token_creation_failed';
@@ -136,7 +134,7 @@ export async function getAgentSession(
  * not get a second terminated operation.
  */
 export async function terminateAgentSession(params: TerminateAgentSessionParams): Promise<Result<EndedAgentSession, AgentSessionTerminationError>> {
-    const { account, environment, sessionId, endedBy } = params;
+    const { account, environment, sessionId } = params;
 
     const ended = await endAgentSession(db.knex, {
         id: sessionId,
@@ -155,10 +153,7 @@ export async function terminateAgentSession(params: TerminateAgentSessionParams)
 
     const { session, alreadyEnded } = ended.value;
     if (!alreadyEnded) {
-        const logCtx = await logContextGetter.create(
-            { operation: { type: 'agent_session', action: 'terminate' } },
-            { account, environment, meta: { endedBy, endedAt: session.endedAt.toISOString() } }
-        );
+        const logCtx = await logContextGetter.create({ operation: { type: 'agent_session', action: 'terminate' } }, { account, environment });
 
         await logCtx.enrichOperation({ actor: { kind: 'session', id: session.id } });
         void logCtx.info('Agent session terminated');

--- a/packages/server/lib/services/agentSessionCreation.service.ts
+++ b/packages/server/lib/services/agentSessionCreation.service.ts
@@ -18,6 +18,7 @@ import type {
     AgentSessionPinnedTools,
     AgentSessionResolvedConnections,
     AgentSessionTenantConnections,
+    AgentSessionToolNames,
     AgentSessionToolsetPolicy,
     AgentSessionToolsetSummary,
     DBEnvironment,
@@ -127,7 +128,7 @@ export async function createAgentSession(params: CreateAgentSessionParams): Prom
             meta: {
                 requested: requestedConfig(params),
                 resolvedConnections: created.value.session.resolvedConnections,
-                toolset: created.value.session.compiledToolset,
+                toolset: toolsetToolNames(created.value.session.compiledToolset),
                 metaTools: created.value.session.metaTools,
                 expiresAt: created.value.session.expiresAt.toISOString()
             }
@@ -166,6 +167,19 @@ export function toolsetSummary(
                 connected: Object.hasOwn(resolvedConnections, integrationId),
                 tools_pinned: integration.pinned.length,
                 tools_searchable: integration.searchable.length
+            }
+        ])
+    );
+}
+
+export function toolsetToolNames(toolset: AgentSessionCompiledToolset): Record<string, AgentSessionToolNames> {
+    return Object.fromEntries(
+        Object.entries(toolset).map(([integrationId, integration]) => [
+            integrationId,
+            {
+                provider: integration.provider,
+                pinned: integration.pinned.map((tool) => tool.name),
+                searchable: integration.searchable.map((tool) => tool.name)
             }
         ])
     );

--- a/packages/server/lib/services/agentSessionCreation.service.ts
+++ b/packages/server/lib/services/agentSessionCreation.service.ts
@@ -17,6 +17,7 @@ import type {
     AgentSessionMetaToolsSummary,
     AgentSessionPinnedTools,
     AgentSessionResolvedConnections,
+    AgentSessionResolvedConnectionSummary,
     AgentSessionTenantConnections,
     AgentSessionToolNames,
     AgentSessionToolsetPolicy,
@@ -127,7 +128,7 @@ export async function createAgentSession(params: CreateAgentSessionParams): Prom
             actor: { kind: 'session', id: created.value.session.id },
             meta: {
                 requested: requestedConfig(params),
-                resolvedConnections: created.value.session.resolvedConnections,
+                resolvedConnections: resolvedConnectionsSummary(created.value.session.resolvedConnections),
                 toolset: toolsetToolNames(created.value.session.compiledToolset),
                 metaTools: created.value.session.metaTools,
                 expiresAt: created.value.session.expiresAt.toISOString()
@@ -168,6 +169,15 @@ export function toolsetSummary(
                 tools_pinned: integration.pinned.length,
                 tools_searchable: integration.searchable.length
             }
+        ])
+    );
+}
+
+export function resolvedConnectionsSummary(connections: AgentSessionResolvedConnections): Record<string, AgentSessionResolvedConnectionSummary> {
+    return Object.fromEntries(
+        Object.entries(connections).map(([integrationId, connection]) => [
+            integrationId,
+            { integrationId: connection.integrationId, provider: connection.provider, connectionId: connection.connectionId }
         ])
     );
 }

--- a/packages/server/lib/services/agentSessionCreation.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionCreation.service.unit.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { expiresInToMs, metaToolsSummary, parseMetaTools, toolsetSummary, toolsetToolNames } from './agentSessionCreation.service.js';
+import {
+    expiresInToMs,
+    metaToolsSummary,
+    parseMetaTools,
+    resolvedConnectionsSummary,
+    toolsetSummary,
+    toolsetToolNames
+} from './agentSessionCreation.service.js';
 
 describe('expiresInToMs', () => {
     it.each([
@@ -36,6 +43,18 @@ describe('toolsetSummary', () => {
         expect(summary).toStrictEqual({
             notion: { connected: true, tools_pinned: 1, tools_searchable: 1 },
             reddit: { connected: false, tools_pinned: 0, tools_searchable: 1 }
+        });
+    });
+});
+
+describe('resolvedConnectionsSummary', () => {
+    it('drops the internal connection and config ids', () => {
+        expect(
+            resolvedConnectionsSummary({
+                notion: { integrationId: 'notion', provider: 'notion', connectionId: 'notion-1', internalConnectionId: 1, configId: 10 }
+            })
+        ).toStrictEqual({
+            notion: { integrationId: 'notion', provider: 'notion', connectionId: 'notion-1' }
         });
     });
 });

--- a/packages/server/lib/services/agentSessionCreation.service.unit.test.ts
+++ b/packages/server/lib/services/agentSessionCreation.service.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { expiresInToMs, metaToolsSummary, parseMetaTools, toolsetSummary } from './agentSessionCreation.service.js';
+import { expiresInToMs, metaToolsSummary, parseMetaTools, toolsetSummary, toolsetToolNames } from './agentSessionCreation.service.js';
 
 describe('expiresInToMs', () => {
     it.each([
@@ -36,6 +36,24 @@ describe('toolsetSummary', () => {
         expect(summary).toStrictEqual({
             notion: { connected: true, tools_pinned: 1, tools_searchable: 1 },
             reddit: { connected: false, tools_pinned: 0, tools_searchable: 1 }
+        });
+    });
+});
+
+describe('toolsetToolNames', () => {
+    it('keeps the tool names and drops the descriptions', () => {
+        expect(
+            toolsetToolNames({
+                notion: {
+                    provider: 'notion',
+                    pinned: [{ name: 'read_doc', description: 'Read a doc' }],
+                    searchable: [{ name: 'upsert_doc', description: 'Upsert a doc' }]
+                },
+                reddit: { provider: 'reddit', pinned: [], searchable: [{ name: 'search_posts', description: 'Search posts' }] }
+            })
+        ).toStrictEqual({
+            notion: { provider: 'notion', pinned: ['read_doc'], searchable: ['upsert_doc'] },
+            reddit: { provider: 'reddit', pinned: [], searchable: ['search_posts'] }
         });
     });
 });

--- a/packages/types/lib/agent/connections.ts
+++ b/packages/types/lib/agent/connections.ts
@@ -24,6 +24,8 @@ export interface AgentSessionResolvedConnection {
 
 export type AgentSessionResolvedConnections = Record<string, AgentSessionResolvedConnection>;
 
+export type AgentSessionResolvedConnectionSummary = Omit<AgentSessionResolvedConnection, 'internalConnectionId' | 'configId'>;
+
 export type AgentSessionConnectionResolutionErrorCode = 'ambiguous_connections' | 'pinned_connection_not_matched' | 'unknown_pinned_connection';
 
 export interface AgentSessionConnectionCandidateReport {

--- a/packages/types/lib/agent/toolset.ts
+++ b/packages/types/lib/agent/toolset.ts
@@ -24,6 +24,12 @@ export interface AgentSessionCompiledIntegration {
 
 export type AgentSessionCompiledToolset = Record<string, AgentSessionCompiledIntegration>;
 
+export interface AgentSessionToolNames {
+    readonly provider: string;
+    readonly pinned: string[];
+    readonly searchable: string[];
+}
+
 export type AgentSessionToolsetCompilationErrorCode = 'unknown_integration' | 'unknown_tool' | 'unsupported_function_type' | 'tool_not_in_toolset';
 
 export interface AgentSessionUnknownIntegrationsPayload {


### PR DESCRIPTION
NAN-6950

Trims what the two agent session operations put in their payload.

Terminate now logs no payload. Create logs tool names only, dropping the tool descriptions that made up most of it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

