### PR TITLE
feat(agent-sessions): reap expired sessions and their tokens (NAN-6599)

### DIFF
--- a/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
+++ b/packages/server/lib/controllers/agent/mcp/sessionMcp.integration.test.ts
@@ -175,6 +175,13 @@ async function createSession(apiKey: string, body: Partial<PostAgentSessionsBody
     return { sessionId: res.json.data.session_id, token: res.json.data.session_token, mcpPath: new URL(res.json.data.mcp_url).pathname };
 }
 
+async function expireSession(sessionId: string): Promise<void> {
+    await db.knex
+        .from('agent_sessions')
+        .where({ id: sessionId })
+        .update({ expires_at: new Date(Date.now() - 60_000) });
+}
+
 async function disableAction({ environmentId, name }: { environmentId: number; name: string }): Promise<void> {
     await db.knex.from<DBSyncConfig>('_nango_sync_configs').where({ environment_id: environmentId, sync_name: name }).update({ enabled: false });
 }
@@ -227,6 +234,18 @@ describe('/session/:sessionId/mcp', () => {
         const res = await listTools({ token: apiKey, mcpPath });
 
         expect(res.status).toBe(401);
+    });
+
+    it('rejects a session token once the session has expired', async () => {
+        const { apiKey } = await seedTenant();
+        const { sessionId, token, mcpPath } = await createSession(apiKey);
+
+        await expireSession(sessionId);
+
+        const res = await listTools({ token, mcpPath });
+
+        expect(res.status).toBe(401);
+        expect(res.json.error.code).toBe('agent_session_ended');
     });
 
     it('rejects a session token pointed at another session url', async () => {

--- a/packages/server/lib/crons/deleteOldData.ts
+++ b/packages/server/lib/crons/deleteOldData.ts
@@ -23,6 +23,7 @@ import { deleteProviderConfigData } from '../deletion/deleteProviderConfigData.j
 import { deleteSyncConfigData } from '../deletion/deleteSyncConfigData.js';
 import { deleteSyncs } from '../deletion/deleteSyncs.js';
 import { envs } from '../env.js';
+import { expireAgentSessions } from '../services/agentSession.service.js';
 import { deleteExpiredConnectSession } from '../services/connectSession.service.js';
 import oauthSessionService from '../services/oauth-session.service.js';
 
@@ -107,6 +108,13 @@ export async function exec(): Promise<void> {
             ...opts,
             name: 'connect session',
             deleteFn: async () => await deleteExpiredConnectSession(db.knex, { olderThan: deleteConnectionSessionOlderThan, limit })
+        });
+
+        // Expire agent sessions
+        await batchDelete({
+            ...opts,
+            name: 'expired agent sessions',
+            deleteFn: async () => await expireAgentSessions(db.knex, { limit })
         });
 
         // Delete private keys

--- a/packages/server/lib/services/agentSession.service.integration.test.ts
+++ b/packages/server/lib/services/agentSession.service.integration.test.ts
@@ -10,6 +10,7 @@ import {
     createAgentSession,
     createAgentSessionToken,
     endAgentSession,
+    expireAgentSessions,
     getAgentSession,
     getAgentSessionByToken,
     listExpiredAgentSessions
@@ -296,7 +297,35 @@ describe('agentSession service', () => {
         expect(expired.map(({ id }) => id)).not.toContain(expiredEnded.id);
         expect(expired.map(({ id }) => id)).not.toContain(active.id);
     });
+
+    it('ends expired sessions and revokes their tokens', async () => {
+        const expired = await createSession({ account, environment, expiresAt: new Date(Date.now() + 300) });
+        const active = await createSession({ account, environment, expiresAt: new Date(Date.now() + 60_000) });
+        (await createAgentSessionToken(db.knex, expired)).unwrap();
+        (await createAgentSessionToken(db.knex, active)).unwrap();
+
+        await new Promise((resolve) => setTimeout(resolve, 400));
+
+        expect(await expireAgentSessions(db.knex, { limit: 10 })).toBe(1);
+
+        const ended = (await getAgentSession(db.knex, { id: expired.id, accountId: account.id, environmentId: environment.id })).unwrap();
+        expect(ended.endedAt).not.toBeNull();
+        expect(ended.endedReason).toBe('expired');
+
+        expect(await keysFor(expired.id)).toBe(0);
+        expect(await keysFor(active.id)).toBe(1);
+
+        const stillActive = (await getAgentSession(db.knex, { id: active.id, accountId: account.id, environmentId: environment.id })).unwrap();
+        expect(stillActive.endedAt).toBeNull();
+
+        expect(await expireAgentSessions(db.knex, { limit: 10 })).toBe(0);
+    });
 });
+
+async function keysFor(sessionId: string): Promise<number> {
+    const keys = await db.knex.from(keystore.PRIVATE_KEYS_TABLE).where({ entity_type: 'agent_session', entity_uuid: sessionId });
+    return keys.length;
+}
 
 async function createSession({
     account,

--- a/packages/server/lib/services/agentSession.service.ts
+++ b/packages/server/lib/services/agentSession.service.ts
@@ -276,6 +276,28 @@ export async function listExpiredAgentSessions(db: Knex, { limit }: { limit: num
     }));
 }
 
+export async function expireAgentSessions(db: Knex, { limit }: { limit: number }): Promise<number> {
+    const sessions = await listExpiredAgentSessions(db, { limit });
+
+    let expired = 0;
+    for (const session of sessions) {
+        const ended = await endAgentSession(db, {
+            id: session.id,
+            accountId: session.accountId,
+            environmentId: session.environmentId,
+            reason: 'expired'
+        });
+        if (ended.isErr()) {
+            report(ended.error);
+            continue;
+        }
+
+        expired++;
+    }
+
+    return expired;
+}
+
 function jsonb(db: Knex, value: object): Knex.Raw {
     return db.raw('?::jsonb', [JSON.stringify(value)]);
 }


### PR DESCRIPTION
NAN-6599

Expired agent sessions were already rejected at auth time, but their rows and keystore keys stayed around forever.

Adds a reaper that ends expired sessions and deletes their keys, run from the deleteOldData cron alongside the connect session one. No operation is logged for an expiry.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

