### PR TITLE
feat(functions): support deployment of function with schedule trigger

### DIFF
--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -15,6 +15,9 @@ import type { OrchestratorTask } from '@nangohq/nango-orchestrator';
 import type { Result } from '@nangohq/utils';
 
 export async function handler(task: OrchestratorTask): Promise<Result<void>> {
+    if (task.isScheduleFunction()) {
+        return Err(new Error('not implemented'));
+    }
     if (task.isSync()) {
         const span = tracer.startSpan('jobs.handler.sync');
         return await tracer.scope().activate(span, async () => {

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -762,13 +762,4 @@ export function isDuplicateTaskNameClientError(err: unknown): boolean {
     return error.name === 'duplicate_task_name';
 }
 
-export function isDuplicateScheduleNameClientError(err: unknown): boolean {
-    if (!err || typeof err !== 'object') {
-        return false;
-    }
-
-    const error = err as { name?: string };
-    return error.name === 'duplicate_schedule_name';
-}
-
 export type ExecuteBatchEntryResult = Result<{ taskId: string; retryKey: string }, ClientError>;

--- a/packages/server/lib/controllers/functions/deployments/bundle/format.ts
+++ b/packages/server/lib/controllers/functions/deployments/bundle/format.ts
@@ -4,7 +4,7 @@ import type { FunctionDeploymentBundleSuccess, PostFunctionDeploymentBundlePrevi
 export function toResponse(reconciliation: DeploymentBundleReconciliation): FunctionDeploymentBundleSuccess {
     return {
         created: reconciliation.created.map(({ integrationId, name }) => ({ integrationId, name })),
-        updated: reconciliation.updated.map(({ integrationId, name }) => ({ integrationId, name })),
+        updated: reconciliation.updated.map(({ after: { integrationId, name } }) => ({ integrationId, name })),
         unchanged: reconciliation.unchanged.map(({ integrationId, name }) => ({ integrationId, name })),
         deleted: reconciliation.deleted.map((current) => ({ integrationId: current.integration.unique_key, name: current.config.name }))
     };

--- a/packages/server/lib/controllers/functions/deployments/bundle/postBundle.integration.test.ts
+++ b/packages/server/lib/controllers/functions/deployments/bundle/postBundle.integration.test.ts
@@ -3,7 +3,6 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import db from '@nangohq/database';
 import { getLocking } from '@nangohq/kvstore';
 import { configService, functionConfigService, remoteFileService, seeders } from '@nangohq/shared';
-import { Err } from '@nangohq/utils';
 
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
 
@@ -212,10 +211,10 @@ describe('function deployment bundle endpoints', () => {
         const uploadSpy = vi.spyOn(remoteFileService, 'upload').mockImplementation(({ destinationPath }) => Promise.resolve(destinationPath));
         const originalUpsert = functionConfigService.upsert;
         const upsertSpy = vi.spyOn(functionConfigService, 'upsert').mockImplementation(async (trx, params) => {
-            if (params.integrationId === 'gitlab') {
-                return Err(new Error('Failed to upsert function'));
-            }
-            return await originalUpsert(trx, params);
+            return await originalUpsert(
+                trx,
+                params.map((param) => (param.integrationId === 'gitlab' ? { ...param, integrationId: 'missing-integration' } : param))
+            );
         });
         const secondFunction = {
             ...validFunction,

--- a/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
+++ b/packages/server/lib/controllers/functions/postInvocation.integration.test.ts
@@ -67,12 +67,14 @@ async function seedFunction(trigger?: FunctionTriggerDefinition) {
     const { apiKey, env } = await seedAccount(['environment:functions:invocations']);
     const integration = await seeders.createConfigSeed(env, 'github', 'github');
     const connection = await seeders.createConnectionSeed({ env, provider: integration.unique_key, connectionId: 'test-connection' });
-    await functionConfigService.upsert(db.knex, {
-        environmentId: env.id,
-        integrationId: integration.unique_key,
-        name: 'test-function',
-        version: functionVersion(trigger)
-    });
+    await functionConfigService.upsert(db.knex, [
+        {
+            environmentId: env.id,
+            integrationId: integration.unique_key,
+            name: 'test-function',
+            version: functionVersion(trigger)
+        }
+    ]);
 
     return { apiKey, connection, integration, env };
 }

--- a/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
@@ -73,7 +73,10 @@ export const postDeployInternal = asyncWrapper<PostDeployInternal>(async (req, r
 
                 if (copiedResponse) {
                     const { copiedFromId, copiedToId } = copiedResponse;
-                    const connections = await connectionService.getConnectionsByEnvironmentAndConfigId(devEnvironment.id, copiedFromId);
+                    const connections = await connectionService.getConnectionsByEnvironmentAndConfigId(db.knex, {
+                        environmentId: devEnvironment.id,
+                        configId: copiedFromId
+                    });
                     if (connections.length > 0) {
                         await connectionService.copyConnections(connections, environment.id, copiedToId);
                     }

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -47,6 +47,7 @@ import type {
     DBConnection,
     DBConnectionDecrypted,
     DBEnvironment,
+    DBFunctionInstance,
     DBSyncConfig,
     FunctionTrigger
 } from '@nangohq/types';
@@ -94,6 +95,19 @@ export interface OrchestratorClientInterface {
     searchSchedules({ scheduleNames, limit }: { scheduleNames: string[]; limit: number }): Promise<SchedulesReturn>;
     getOutput({ retryKey, ownerKey }: { retryKey: string; ownerKey: string }): Promise<GetOutputReturn>;
 }
+
+const FunctionScheduleId = {
+    get: ({ environmentId, id }: { environmentId: number; id: number }): string => {
+        return `environment:${environmentId}:function:${id}`;
+    },
+    parse: (id: string): Result<{ environmentId: number; id: number }> => {
+        const parts = id.split(':');
+        if (parts.length !== 4 || parts[0] !== 'environment' || isNaN(Number(parts[1])) || parts[2] !== 'function' || !parts[3] || isNaN(Number(parts[3]))) {
+            return Err(`Invalid function id: ${id}. expected format: environment:<environmentId>:function:<id>`);
+        }
+        return Ok({ environmentId: Number(parts[1]), id: Number(parts[3]) });
+    }
+};
 
 const ScheduleName = {
     get: ({ environmentId, syncId }: { environmentId: number; syncId: string }): string => {
@@ -924,6 +938,52 @@ export class Orchestrator {
             }
             return Err(new Error('Failed to schedule sync', { cause: err }));
         }
+    }
+
+    async scheduleFunctions(
+        functions: {
+            connection: ConnectionInternal;
+            instance: DBFunctionInstance;
+            frequency: string;
+            autoStart: boolean;
+        }[]
+    ): Promise<Result<void>> {
+        try {
+            // TODO: batch recurring
+            for (const { instance, connection, frequency, autoStart } of functions) {
+                const environmentId = connection.environment_id;
+                const frequencyMs = this.getFrequencyMs(instance.frequency || frequency);
+                if (frequencyMs.isErr()) {
+                    return Err(frequencyMs.error);
+                }
+                const schedule = await this.client.recurring({
+                    name: FunctionScheduleId.get({ environmentId: connection.environment_id, id: instance.id }),
+                    state: autoStart ? 'STARTED' : 'PAUSED',
+                    frequencyMs: frequencyMs.value,
+                    group: {
+                        key: `function:scheduled:environment:${environmentId}`,
+                        maxConcurrency: 0
+                    },
+                    retry: { max: 0 },
+                    timeoutSettingsInSecs: {
+                        createdToStarted: 60 * 60, // 1 hour
+                        startedToCompleted: 60 * 60 * 24, // 1 day
+                        heartbeat: 5 * 60 // 5 minutes
+                    },
+                    startsAt: new Date(),
+                    args: {
+                        type: 'function',
+                        instanceId: instance.id
+                    }
+                });
+                if (schedule.isErr()) {
+                    return Err(schedule.error);
+                }
+            }
+        } catch (err) {
+            return Err(new Error('Failed to schedule functions', { cause: err }));
+        }
+        return Ok(undefined);
     }
 
     private getFrequencyMs(runs: string): Result<number> {

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1042,8 +1042,14 @@ export class ConnectionService {
         return result;
     }
 
-    public async getConnectionsByEnvironmentAndConfigId(environment_id: number, config_id: number): Promise<DBConnection[]> {
-        const result = await db.knex.from<DBConnection>(`_nango_connections`).select('*').where({ environment_id, config_id, deleted: false });
+    public async getConnectionsByEnvironmentAndConfigId(
+        trx: Knex,
+        { environmentId, configId }: { environmentId: number; configId: number }
+    ): Promise<DBConnection[]> {
+        const result = await trx
+            .from<DBConnection>(`_nango_connections`)
+            .select('*')
+            .where({ environment_id: environmentId, config_id: configId, deleted: false });
 
         if (!result || result.length == 0 || !result[0]) {
             return [];

--- a/packages/shared/lib/services/functions/deploy.integration.test.ts
+++ b/packages/shared/lib/services/functions/deploy.integration.test.ts
@@ -1,15 +1,18 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
 
 import { createAccount } from '../../seeders/account.seeder.js';
 import { createConfigSeed } from '../../seeders/config.seeder.js';
+import { createConnectionSeed } from '../../seeders/connection.seeder.js';
 import { createEnvironmentSeed } from '../../seeders/environment.seeder.js';
-import { prepareDeploymentBundle } from './deploy.js';
+import remoteFileService from '../file/remote.service.js';
+import { deployBundle, prepareDeploymentBundle } from './deploy.js';
 import { upsert } from './models/functions.js';
+import { CONFIGS_TABLE, INSTANCES_TABLE } from './models/tables.js';
 import { functionVersionHash } from './version.js';
 
-import type { DBFunctionConfigVersion, FunctionDeploymentArtifact } from '@nangohq/types';
+import type { DBFunctionConfigVersion, DBFunctionInstance, FunctionDeploymentArtifact } from '@nangohq/types';
 
 const githubArtifact = {
     name: 'fetchIssues',
@@ -62,16 +65,116 @@ async function seedEnvironmentWithFunctions(): Promise<number> {
     await createConfigSeed(environment, gitlabArtifact.integrationId, 'gitlab');
 
     for (const artifact of [githubArtifact, gitlabArtifact]) {
-        await upsert(db.knex, {
-            environmentId: environment.id,
-            integrationId: artifact.integrationId,
-            name: artifact.name,
-            version: functionVersion(artifact)
-        });
+        await upsert(db.knex, [
+            {
+                environmentId: environment.id,
+                integrationId: artifact.integrationId,
+                name: artifact.name,
+                version: functionVersion(artifact)
+            }
+        ]);
     }
 
     return environment.id;
 }
+
+describe('deployBundle instances', () => {
+    const scheduled: FunctionDeploymentArtifact = { ...githubArtifact, trigger: { kind: 'schedule', frequency: 'every 5 minutes' } };
+
+    beforeAll(async () => {
+        await multipleMigrations();
+    });
+
+    beforeEach(() => {
+        vi.spyOn(remoteFileService, 'upload').mockImplementation(({ destinationPath }) => Promise.resolve(destinationPath));
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    async function setup() {
+        const account = await createAccount();
+        const environment = await createEnvironmentSeed(account.id);
+        await createConfigSeed(environment, 'github', 'github');
+        const connection = await createConnectionSeed({ env: environment, provider: 'github' });
+        const deploy = async (functions: FunctionDeploymentArtifact[]) => {
+            const reconciliation = (
+                await prepareDeploymentBundle({ functions, environmentId: environment.id, reconciliationScope: { kind: 'environment' } })
+            ).unwrap();
+            return deployBundle({ accountId: account.id, environmentId: environment.id, environmentName: environment.name, reconciliation });
+        };
+        const instances = () =>
+            db.knex
+                .from<DBFunctionInstance>(INSTANCES_TABLE)
+                .whereIn('function_config_id', db.knex.from(CONFIGS_TABLE).select('id').where({ environment_id: environment.id }))
+                .orderBy('id');
+        return { environment, connection, deploy, instances };
+    }
+
+    it('creates base instances only for active connections in the matching integration and environment', async () => {
+        const ctx = await setup();
+        const second = await createConnectionSeed({ env: ctx.environment, provider: 'github' });
+        const deleted = await createConnectionSeed({ env: ctx.environment, provider: 'github' });
+        await db.knex.from('_nango_connections').where({ id: deleted.id }).update({ deleted: true });
+        await createConfigSeed(ctx.environment, 'gitlab', 'gitlab');
+        await createConnectionSeed({ env: ctx.environment, provider: 'gitlab' });
+        const other = await setup();
+
+        (await ctx.deploy([scheduled])).unwrap();
+
+        const rows = await ctx.instances();
+        expect(rows).toHaveLength(2);
+        expect(rows.map((row) => row.nango_connection_id).sort((a, b) => a - b)).toEqual([ctx.connection.id, second.id].sort((a, b) => a - b));
+        for (const row of rows) {
+            expect(row).toMatchObject({
+                name: scheduled.name,
+                variant: 'base',
+                frequency: scheduled.trigger.kind === 'schedule' ? scheduled.trigger.frequency : null,
+                deleted_at: null
+            });
+        }
+        expect(await other.instances()).toEqual([]);
+    });
+
+    it('creates instances when a non-scheduled function becomes scheduled', async () => {
+        const ctx = await setup();
+        (await ctx.deploy([githubArtifact])).unwrap();
+        expect(await ctx.instances()).toEqual([]);
+
+        (await ctx.deploy([scheduled])).unwrap();
+        expect(await ctx.instances()).toEqual([expect.objectContaining({ nango_connection_id: ctx.connection.id, variant: 'base', deleted_at: null })]);
+    });
+
+    it('preserves instances and frequency overrides on unchanged and updated scheduled deployments', async () => {
+        const ctx = await setup();
+        (await ctx.deploy([scheduled])).unwrap();
+        await db.knex.from(INSTANCES_TABLE).where({ nango_connection_id: ctx.connection.id }).update({ frequency: 'every 30 minutes' });
+        const before = await ctx.instances();
+
+        (await ctx.deploy([scheduled])).unwrap();
+        expect(await ctx.instances()).toEqual(before);
+        (await ctx.deploy([{ ...scheduled, trigger: { kind: 'schedule', frequency: 'every 10 minutes' } }])).unwrap();
+        expect(await ctx.instances()).toEqual(before);
+    });
+
+    it.each(['trigger change', 'config removal'])('soft-deletes instances on %s without affecting another environment', async (reason) => {
+        const ctx = await setup();
+        const other = await setup();
+        (await ctx.deploy([scheduled])).unwrap();
+        (await other.deploy([scheduled])).unwrap();
+        const before = await ctx.instances();
+        const otherBefore = await other.instances();
+
+        (await ctx.deploy(reason === 'trigger change' ? [githubArtifact] : [])).unwrap();
+
+        const after = await ctx.instances();
+        expect(after).toHaveLength(1);
+        expect(after[0]?.id).toBe(before[0]?.id);
+        expect(after[0]?.deleted_at).toBeInstanceOf(Date);
+        expect(await other.instances()).toEqual(otherBefore);
+    });
+});
 
 describe(prepareDeploymentBundle, () => {
     beforeAll(async () => {

--- a/packages/shared/lib/services/functions/deploy.ts
+++ b/packages/shared/lib/services/functions/deploy.ts
@@ -2,11 +2,15 @@ import db from '@nangohq/database';
 import { Err, Ok } from '@nangohq/utils';
 
 import configService from '../config.service.js';
+import connectionService from '../connection.service.js';
 import remoteFileService from '../file/remote.service.js';
 import * as functionConfigService from './models/functions.js';
+import * as functionInstanceService from './models/instances.js';
 import { reconcile } from './reconcile.js';
 import { functionVersionHash } from './version.js';
 
+import type { CurrentFunctionConfig } from './models/functions.js';
+import type { FunctionInstanceUpsert } from './models/instances.js';
 import type { DeploymentBundleReconciliation } from './reconcile.js';
 import type { FunctionDeploymentArtifact, FunctionReconciliationScope } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -88,10 +92,16 @@ export async function deployBundle({
         // Upload the files first and upsert/delete the configs in a single transaction
         // to make sure every config points to a valid file location.
         // We accept that there might be orphaned files if the transaction fails, favoring correctness and simpler rollback.
-        const prepared: { artifact: FunctionDeploymentArtifact; version: string; fileLocation: string }[] = [];
+        const prepared: {
+            before: CurrentFunctionConfig | undefined;
+            artifact: FunctionDeploymentArtifact;
+            version: string;
+            fileLocation: string;
+        }[] = [];
 
         // TODO: parallelize the uploads to speed up the deployment process
-        for (const artifact of [...reconciliation.created, ...reconciliation.updated]) {
+        for (const f of [...reconciliation.created, ...reconciliation.updated]) {
+            const [before, artifact] = 'before' in f ? [f.before, f.after] : [undefined, f];
             const versionHash = functionVersionHash(artifact);
             if (versionHash.isErr()) {
                 throw versionHash.error;
@@ -116,43 +126,115 @@ export async function deployBundle({
                 throw new Error('file_upload_error', { cause: { integrationId: artifact.integrationId, name: artifact.name } });
             }
 
-            prepared.push({ artifact, version, fileLocation });
+            prepared.push({ before, artifact, version, fileLocation });
         }
 
         await db.knex.transaction(async (trx) => {
-            for (const { artifact, version, fileLocation } of prepared) {
-                const upserted = await functionConfigService.upsert(trx, {
-                    environmentId,
-                    integrationId: artifact.integrationId,
-                    name: artifact.name,
-                    version: {
-                        description: artifact.description,
-                        file_location: fileLocation,
-                        version,
-                        source: 'repo',
-                        trigger: artifact.trigger,
-                        requires: artifact.requires,
-                        capabilities: artifact.capabilities,
-                        limits: artifact.limits,
-                        input_schema_ref: artifact.input_schema_ref,
-                        output_schema_ref: artifact.output_schema_ref,
-                        model_schema_refs: artifact.model_schema_refs,
-                        metadata_schema_ref: artifact.metadata_schema_ref,
-                        checkpoint_schema_ref: artifact.checkpoint_schema_ref,
-                        json_schema: artifact.json_schema
-                    }
-                });
-                if (upserted.isErr()) {
-                    throw upserted.error;
+            // Upsert function configs/versions
+            const configsToUpsert = prepared.map(({ artifact, version, fileLocation }) => ({
+                environmentId,
+                integrationId: artifact.integrationId,
+                name: artifact.name,
+                version: {
+                    description: artifact.description,
+                    file_location: fileLocation,
+                    version,
+                    source: 'repo' as const,
+                    trigger: artifact.trigger,
+                    requires: artifact.requires,
+                    capabilities: artifact.capabilities,
+                    limits: artifact.limits,
+                    input_schema_ref: artifact.input_schema_ref,
+                    output_schema_ref: artifact.output_schema_ref,
+                    model_schema_refs: artifact.model_schema_refs,
+                    metadata_schema_ref: artifact.metadata_schema_ref,
+                    checkpoint_schema_ref: artifact.checkpoint_schema_ref,
+                    json_schema: artifact.json_schema
                 }
+            }));
+            const upserted = await functionConfigService.upsert(trx, configsToUpsert);
+            if (upserted.isErr()) {
+                throw upserted.error;
             }
 
-            const deleted = await functionConfigService.softDelete(trx, {
+            // Delete function configs/versions that are no longer present in the deployment bundle
+            const deletedConfigs = await functionConfigService.softDelete(trx, {
                 environmentId,
-                ids: reconciliation.deleted.map((current) => current.config.id)
+                ids: reconciliation.deleted.map((f) => f.config.id)
             });
-            if (deleted.isErr()) {
-                throw deleted.error;
+            if (deletedConfigs.isErr()) {
+                throw deletedConfigs.error;
+            }
+
+            // reduce the configs to a list of instances to insert and delete,
+            // based on connections and the before and after states of the function configs
+
+            const instancesToUpsert: FunctionInstanceUpsert[] = [];
+            const instancesToDelete: { functionConfigId: number }[] = reconciliation.deleted.map((f) => ({ functionConfigId: f.config.id }));
+            for (const { before, artifact } of prepared) {
+                var upsertCandidate: { functionConfigId: number; integrationId: number; artifact: FunctionDeploymentArtifact; frequency: string } | undefined =
+                    undefined;
+
+                // If the after trigger is a schedule and there is no before store, create a new instance
+                if (artifact.trigger.kind === 'schedule' && !before) {
+                    const functionConfig = upserted.value.find((f) => f.integration.unique_key === artifact.integrationId && f.config.name === artifact.name);
+                    if (functionConfig) {
+                        upsertCandidate = {
+                            functionConfigId: functionConfig.config.id,
+                            integrationId: functionConfig.integration.id,
+                            artifact,
+                            frequency: artifact.trigger.frequency
+                        };
+                    }
+                }
+                // If the after trigger is a schedule and there is a before state with a non-schedule trigger, create a new instance
+                else if (artifact.trigger.kind === 'schedule' && before && before?.currentVersion.trigger.kind !== 'schedule') {
+                    upsertCandidate = {
+                        functionConfigId: before.config.id,
+                        integrationId: before.integration.id,
+                        artifact,
+                        frequency: artifact.trigger.frequency
+                    };
+                }
+
+                if (upsertCandidate) {
+                    const connections = await connectionService.getConnectionsByEnvironmentAndConfigId(trx, {
+                        environmentId,
+                        configId: upsertCandidate.integrationId
+                    });
+                    for (const connection of connections) {
+                        instancesToUpsert.push({
+                            function_config_id: upsertCandidate.functionConfigId,
+                            nango_connection_id: connection.id,
+                            name: upsertCandidate.artifact.name,
+                            variant: 'base',
+                            frequency: upsertCandidate.frequency
+                        });
+                    }
+                }
+
+                // If the after trigger is not a schedule and there is a before state with a schedule, delete the existing schedule
+                if (artifact.trigger.kind !== 'schedule' && before && before?.currentVersion.trigger.kind === 'schedule') {
+                    instancesToDelete.push({ functionConfigId: before.config.id });
+                }
+
+                // Otherwise we do nothing.
+                // This includes the cases where
+                // - both before and after triggers are schedules (in which case we don't update existing instances)
+                // - both are non-schedules.
+            }
+
+            const instances = await functionInstanceService.upsert(trx, instancesToUpsert);
+            if (instances.isErr()) {
+                throw instances.error;
+            }
+
+            const deletedInstances = await functionInstanceService.softDelete(trx, {
+                environmentId: environmentId,
+                functionConfigIds: instancesToDelete.map((i) => i.functionConfigId)
+            });
+            if (deletedInstances.isErr()) {
+                throw deletedInstances.error;
             }
         });
 

--- a/packages/shared/lib/services/functions/models/functions.integration.test.ts
+++ b/packages/shared/lib/services/functions/models/functions.integration.test.ts
@@ -42,18 +42,22 @@ describe(search, () => {
         const firstIntegration = await createConfigSeed(environment, 'github-first', 'github');
         const secondIntegration = await createConfigSeed(environment, 'github-second', 'github');
 
-        await upsert(db.knex, {
-            environmentId: environment.id,
-            integrationId: firstIntegration.unique_key,
-            name: 'firstFunction',
-            version: functionVersion('first-version')
-        });
-        await upsert(db.knex, {
-            environmentId: environment.id,
-            integrationId: secondIntegration.unique_key,
-            name: 'secondFunction',
-            version: functionVersion('second-version')
-        });
+        await upsert(db.knex, [
+            {
+                environmentId: environment.id,
+                integrationId: firstIntegration.unique_key,
+                name: 'firstFunction',
+                version: functionVersion('first-version')
+            }
+        ]);
+        await upsert(db.knex, [
+            {
+                environmentId: environment.id,
+                integrationId: secondIntegration.unique_key,
+                name: 'secondFunction',
+                version: functionVersion('second-version')
+            }
+        ]);
 
         const functions = (
             await search(db.knex, {
@@ -74,12 +78,14 @@ describe(search, () => {
         const account = await createAccount();
         const environment = await createEnvironmentSeed(account.id);
         const github = await createConfigSeed(environment, 'github', 'github');
-        await upsert(db.knex, {
-            environmentId: environment.id,
-            integrationId: github.unique_key,
-            name: 'function',
-            version: functionVersion('version')
-        });
+        await upsert(db.knex, [
+            {
+                environmentId: environment.id,
+                integrationId: github.unique_key,
+                name: 'function',
+                version: functionVersion('version')
+            }
+        ]);
 
         const functions = (await search(db.knex, { environmentId: environment.id, filter: { integrationKey: 'unknown' } })).unwrap();
 
@@ -98,8 +104,7 @@ describe(search, () => {
             version: functionVersion('123')
         };
 
-        await upsert(db.knex, config);
-        await upsert(db.knex, { ...config, name: 'secondFunction', version: functionVersion('456') });
+        await upsert(db.knex, [config, { ...config, name: 'secondFunction', version: functionVersion('456') }]);
 
         const functions = (
             await search(db.knex, {
@@ -120,12 +125,14 @@ describe(search, () => {
         const account = await createAccount();
         const environment = await createEnvironmentSeed(account.id);
         const github = await createConfigSeed(environment, 'github', 'github');
-        await upsert(db.knex, {
-            environmentId: environment.id,
-            integrationId: github.unique_key,
-            name: 'function',
-            version: functionVersion('version')
-        });
+        await upsert(db.knex, [
+            {
+                environmentId: environment.id,
+                integrationId: github.unique_key,
+                name: 'function',
+                version: functionVersion('version')
+            }
+        ]);
 
         const functions = (await search(db.knex, { environmentId: environment.id, filter: { integrationKey: github.unique_key, name: 'unknown' } })).unwrap();
 
@@ -137,33 +144,41 @@ describe(search, () => {
         const environment = await createEnvironmentSeed(account.id);
         const github = await createConfigSeed(environment, 'github', 'github');
 
-        await upsert(db.knex, {
-            environmentId: environment.id,
-            integrationId: github.unique_key,
-            name: 'subscribed',
-            version: functionVersion('subscribed', { kind: 'http', subscriptions: ['push'] })
-        });
-        await upsert(db.knex, {
-            environmentId: environment.id,
-            integrationId: github.unique_key,
-            name: 'empty',
-            version: functionVersion('empty', { kind: 'http', subscriptions: [] })
-        });
-        await upsert(db.knex, {
-            environmentId: environment.id,
-            integrationId: github.unique_key,
-            name: 'none',
-            version: functionVersion('none', { kind: 'http' })
-        });
-        const disabled = (
-            await upsert(db.knex, {
+        await upsert(db.knex, [
+            {
                 environmentId: environment.id,
                 integrationId: github.unique_key,
-                name: 'disabled',
-                version: functionVersion('disabled', { kind: 'http', subscriptions: ['push'] })
-            })
+                name: 'subscribed',
+                version: functionVersion('subscribed', { kind: 'http', subscriptions: ['push'] })
+            }
+        ]);
+        await upsert(db.knex, [
+            {
+                environmentId: environment.id,
+                integrationId: github.unique_key,
+                name: 'empty',
+                version: functionVersion('empty', { kind: 'http', subscriptions: [] })
+            }
+        ]);
+        await upsert(db.knex, [
+            {
+                environmentId: environment.id,
+                integrationId: github.unique_key,
+                name: 'none',
+                version: functionVersion('none', { kind: 'http' })
+            }
+        ]);
+        const disabled = (
+            await upsert(db.knex, [
+                {
+                    environmentId: environment.id,
+                    integrationId: github.unique_key,
+                    name: 'disabled',
+                    version: functionVersion('disabled', { kind: 'http', subscriptions: ['push'] })
+                }
+            ])
         ).unwrap();
-        await db.knex('function_configs').where({ id: disabled.config.id }).update({ enabled: false });
+        await db.knex('function_configs').where({ id: disabled[0]!.config.id }).update({ enabled: false });
 
         const subscribed = (
             await search(db.knex, {
@@ -193,12 +208,14 @@ describe(search, () => {
         const account = await createAccount();
         const environment = await createEnvironmentSeed(account.id);
         const github = await createConfigSeed(environment, 'github', 'github');
-        await upsert(db.knex, {
-            environmentId: environment.id,
-            integrationId: github.unique_key,
-            name: 'function',
-            version: functionVersion('version')
-        });
+        await upsert(db.knex, [
+            {
+                environmentId: environment.id,
+                integrationId: github.unique_key,
+                name: 'function',
+                version: functionVersion('version')
+            }
+        ]);
 
         const emptyIntegrationKey = (await search(db.knex, { environmentId: environment.id, filter: { integrationKey: '' } })).unwrap();
         const emptyName = (await search(db.knex, { environmentId: environment.id, filter: { integrationKey: github.unique_key, name: '' } })).unwrap();

--- a/packages/shared/lib/services/functions/models/functions.ts
+++ b/packages/shared/lib/services/functions/models/functions.ts
@@ -1,12 +1,10 @@
 import { Err, Ok } from '@nangohq/utils';
 
+import { CONFIGS_TABLE, INTEGRATIONS_TABLE, VERSIONS_TABLE } from './tables.js';
+
 import type { DBFunctionConfig, DBFunctionConfigVersion, DBIntegrationDecrypted } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { Knex } from 'knex';
-
-const CONFIGS_TABLE = 'function_configs';
-const VERSIONS_TABLE = 'function_config_versions';
-const INTEGRATIONS_TABLE = '_nango_configs';
 
 const CONFIG_COLUMNS = {
     id: true,
@@ -156,74 +154,72 @@ export async function search(
     }
 }
 
-export async function upsert(
-    db: Knex,
-    {
-        environmentId,
-        integrationId,
-        name,
-        version
-    }: {
-        environmentId: number;
-        integrationId: string;
-        name: string;
-        version: Omit<DBFunctionConfigVersion, 'id' | 'function_config_id' | 'created_at' | 'updated_at' | 'deleted_at'>;
-    }
-): Promise<Result<CurrentFunctionConfig>> {
+export interface FunctionConfigUpsert {
+    environmentId: number;
+    integrationId: string;
+    name: string;
+    version: Omit<DBFunctionConfigVersion, 'id' | 'function_config_id' | 'created_at' | 'updated_at' | 'deleted_at'>;
+}
+
+export async function upsert(db: Knex, inputs: FunctionConfigUpsert[]): Promise<Result<CurrentFunctionConfig[]>> {
     try {
         const upserted = await db.transaction(async (trx) => {
-            // insert and returns new function config or return the existing one
-            const [config] = await trx
-                .with('integration', (qb) =>
-                    qb
-                        .from<DBIntegrationDecrypted>(INTEGRATIONS_TABLE)
-                        .select('id', 'provider')
-                        .where({ environment_id: environmentId, unique_key: integrationId, deleted: false })
-                )
-                .with(
-                    'upserted',
-                    trx.raw(
-                        `INSERT INTO ?? (environment_id, nango_config_id, name)
+            const results: CurrentFunctionConfig[] = [];
+            for (const { environmentId, integrationId, name, version } of inputs) {
+                // insert and returns new function config or return the existing one
+                const [config] = await trx
+                    .with('integration', (qb) =>
+                        qb
+                            .from<DBIntegrationDecrypted>(INTEGRATIONS_TABLE)
+                            .select('id', 'provider')
+                            .where({ environment_id: environmentId, unique_key: integrationId, deleted: false })
+                    )
+                    .with(
+                        'upserted',
+                        trx.raw(
+                            `INSERT INTO ?? (environment_id, nango_config_id, name)
                              SELECT ?, integration.id, ? FROM integration
                              ON CONFLICT (nango_config_id, name) WHERE deleted_at IS NULL
                              DO UPDATE SET nango_config_id = EXCLUDED.nango_config_id
                              RETURNING *`,
-                        [CONFIGS_TABLE, environmentId, name]
+                            [CONFIGS_TABLE, environmentId, name]
+                        )
                     )
-                )
-                .select<(DBFunctionConfig & { provider: string })[]>('upserted.*', 'integration.provider')
-                .from('upserted')
-                .join('integration', 'integration.id', 'upserted.nango_config_id');
+                    .select<(DBFunctionConfig & { provider: string })[]>('upserted.*', 'integration.provider')
+                    .from('upserted')
+                    .join('integration', 'integration.id', 'upserted.nango_config_id');
 
-            if (!config) {
-                throw new Error('failed_to_upsert_function_config', { cause: { integrationId } });
+                if (!config) {
+                    throw new Error('failed_to_upsert_function_config', { cause: { integrationId } });
+                }
+
+                // insert and returns new function config version or return the existing one
+                const [currentVersion] = await trx
+                    .from<DBFunctionConfigVersion>(VERSIONS_TABLE)
+                    .insert({ ...version, function_config_id: config.id })
+                    .onConflict(trx.raw('(function_config_id, version) WHERE deleted_at IS NULL'))
+                    .merge(['function_config_id'])
+                    .returning<DBFunctionConfigVersion[]>('*');
+
+                if (!currentVersion) {
+                    throw new Error('failed_to_upsert_function_config_version');
+                }
+
+                // update the function config to point to the current version if it doesn't already
+                const [updatedConfig] = await trx
+                    .from<DBFunctionConfig>(CONFIGS_TABLE)
+                    .where({ id: config.id })
+                    .whereRaw('current_version_id IS DISTINCT FROM ?', [currentVersion.id])
+                    .update({ current_version_id: currentVersion.id, updated_at: new Date() })
+                    .returning<DBFunctionConfig[]>('*');
+
+                results.push({
+                    integration: { id: config.nango_config_id, unique_key: integrationId, provider: config.provider },
+                    config: updatedConfig ?? config,
+                    currentVersion
+                });
             }
-
-            // insert and returns new function config version or return the existing one
-            const [currentVersion] = await trx
-                .from<DBFunctionConfigVersion>(VERSIONS_TABLE)
-                .insert({ ...version, function_config_id: config.id })
-                .onConflict(trx.raw('(function_config_id, version) WHERE deleted_at IS NULL'))
-                .merge(['function_config_id'])
-                .returning<DBFunctionConfigVersion[]>('*');
-
-            if (!currentVersion) {
-                throw new Error('failed_to_upsert_function_config_version');
-            }
-
-            // update the function config to point to the current version if it doesn't already
-            const [updatedConfig] = await trx
-                .from<DBFunctionConfig>(CONFIGS_TABLE)
-                .where({ id: config.id })
-                .whereRaw('current_version_id IS DISTINCT FROM ?', [currentVersion.id])
-                .update({ current_version_id: currentVersion.id, updated_at: new Date() })
-                .returning<DBFunctionConfig[]>('*');
-
-            return {
-                integration: { id: config.nango_config_id, unique_key: integrationId, provider: config.provider },
-                config: updatedConfig ?? config,
-                currentVersion
-            };
+            return results;
         });
 
         return Ok(upserted);
@@ -237,13 +233,20 @@ export async function softDelete(trx: Knex, { environmentId, ids }: { environmen
         if (ids.length === 0) {
             return Ok(0);
         }
-        const now = new Date();
+        const now = trx.fn.now();
         const deleted = await trx
             .from<DBFunctionConfig>(CONFIGS_TABLE)
             .where({ environment_id: environmentId })
             .whereIn('id', ids)
             .whereNull('deleted_at')
             .update({ deleted_at: now, updated_at: now });
+
+        await trx
+            .from(VERSIONS_TABLE)
+            .whereIn('function_config_id', trx.from(CONFIGS_TABLE).select('id').where({ environment_id: environmentId }).whereIn('id', ids))
+            .whereNull('deleted_at')
+            .update({ deleted_at: now, updated_at: now });
+
         return Ok(deleted);
     } catch (err) {
         return Err(new Error('failed_to_soft_delete_functions', { cause: err }));

--- a/packages/shared/lib/services/functions/models/instances.ts
+++ b/packages/shared/lib/services/functions/models/instances.ts
@@ -1,0 +1,103 @@
+import { Err, Ok } from '@nangohq/utils';
+
+import { CONFIGS_TABLE, INSTANCES_TABLE } from './tables.js';
+
+import type { DBFunctionConfig, DBFunctionInstance } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+import type { Knex } from 'knex';
+
+export type FunctionInstanceUpsert = Pick<DBFunctionInstance, 'nango_connection_id' | 'function_config_id' | 'name' | 'variant' | 'frequency'>;
+
+const UPSERT_BATCH_SIZE = 1000;
+const SOFT_DELETE_BATCH_SIZE = 1000;
+
+export async function upsert(db: Knex, instances: FunctionInstanceUpsert[]): Promise<Result<DBFunctionInstance[]>> {
+    if (instances.length === 0) {
+        return Ok([]);
+    }
+
+    try {
+        const results = await db.transaction(async (trx) => {
+            const upsertedInstances: DBFunctionInstance[] = [];
+            for (let offset = 0; offset < instances.length; offset += UPSERT_BATCH_SIZE) {
+                const batch = instances.slice(offset, offset + UPSERT_BATCH_SIZE);
+                const upserted = await trx
+                    .from<DBFunctionInstance>(INSTANCES_TABLE)
+                    .insert(
+                        batch.map((i) => ({
+                            nango_connection_id: i.nango_connection_id,
+                            function_config_id: i.function_config_id,
+                            name: i.name,
+                            variant: i.variant,
+                            frequency: i.frequency
+                        }))
+                    )
+                    .onConflict(trx.raw('(nango_connection_id, function_config_id, variant) WHERE deleted_at IS NULL'))
+                    // A deployment must not overwrite a connection-level frequency override.
+                    .merge(['name'])
+                    .returning<DBFunctionInstance[]>('*');
+
+                if (!upserted || upserted.length !== batch.length) {
+                    throw new Error('failed_to_upsert_function_instance');
+                }
+                upsertedInstances.push(...upserted);
+            }
+            return upsertedInstances;
+        });
+        return Ok(results);
+    } catch (err) {
+        return Err(new Error('failed_to_upsert_function_instance', { cause: err }));
+    }
+}
+
+export async function search(trx: Knex, { functionConfigIds }: { functionConfigIds: number[] }): Promise<Result<DBFunctionInstance[]>> {
+    if (functionConfigIds.length === 0) {
+        return Ok([]);
+    }
+
+    try {
+        const instances = await trx
+            .from<DBFunctionInstance>(INSTANCES_TABLE)
+            .select('*')
+            .whereIn('function_config_id', functionConfigIds)
+            .whereNull('deleted_at');
+        return Ok(instances);
+    } catch (err) {
+        return Err(new Error('failed_to_search_function_instances', { cause: err }));
+    }
+}
+
+export async function softDelete(
+    db: Knex,
+    { environmentId, functionConfigIds }: { environmentId: number; functionConfigIds: number[] }
+): Promise<Result<DBFunctionInstance[]>> {
+    try {
+        if (functionConfigIds.length === 0) {
+            return Ok([]);
+        }
+        const deleted = await db.transaction(async (trx) => {
+            const now = trx.fn.now();
+            const deletedInstances: DBFunctionInstance[] = [];
+            for (let offset = 0; offset < functionConfigIds.length; offset += SOFT_DELETE_BATCH_SIZE) {
+                const batch = functionConfigIds.slice(offset, offset + SOFT_DELETE_BATCH_SIZE);
+                const rows = await trx
+                    .from<DBFunctionInstance>(INSTANCES_TABLE)
+                    .whereIn(
+                        'function_config_id',
+                        trx.from<DBFunctionConfig>(CONFIGS_TABLE).select('id').where({ environment_id: environmentId }).whereIn('id', batch)
+                    )
+                    .whereNull('deleted_at')
+                    .update({ deleted_at: now, updated_at: now })
+                    .returning('*');
+                for (const row of rows) {
+                    deletedInstances.push(row);
+                }
+            }
+            return deletedInstances;
+        });
+
+        return Ok(deleted);
+    } catch (err) {
+        return Err(new Error('failed_to_soft_delete_function_instances', { cause: err }));
+    }
+}

--- a/packages/shared/lib/services/functions/models/tables.ts
+++ b/packages/shared/lib/services/functions/models/tables.ts
@@ -1,0 +1,4 @@
+export const CONFIGS_TABLE = 'function_configs';
+export const VERSIONS_TABLE = 'function_config_versions';
+export const INSTANCES_TABLE = 'function_instances';
+export const INTEGRATIONS_TABLE = '_nango_configs';

--- a/packages/shared/lib/services/functions/reconcile.ts
+++ b/packages/shared/lib/services/functions/reconcile.ts
@@ -8,7 +8,10 @@ import type { Result } from '@nangohq/utils';
 
 export type DeploymentBundleReconciliation = {
     created: FunctionDeploymentArtifact[];
-    updated: FunctionDeploymentArtifact[];
+    updated: {
+        before: CurrentFunctionConfig;
+        after: FunctionDeploymentArtifact;
+    }[];
     unchanged: FunctionDeploymentArtifact[];
     deleted: CurrentFunctionConfig[];
 };
@@ -37,7 +40,7 @@ export function reconcile({
         );
         const incomingIdentities = new Set<string>();
         const created: FunctionDeploymentArtifact[] = [];
-        const updated: FunctionDeploymentArtifact[] = [];
+        const updated: { before: CurrentFunctionConfig; after: FunctionDeploymentArtifact }[] = [];
         const unchanged: FunctionDeploymentArtifact[] = [];
 
         for (const artifact of functions) {
@@ -57,7 +60,10 @@ export function reconcile({
             } else if (current.currentVersion.version === version.value) {
                 unchanged.push(artifact);
             } else {
-                updated.push(artifact);
+                updated.push({
+                    before: current,
+                    after: artifact
+                });
             }
         }
 

--- a/packages/shared/lib/services/functions/reconcile.unit.test.ts
+++ b/packages/shared/lib/services/functions/reconcile.unit.test.ts
@@ -99,7 +99,7 @@ describe(reconcile, () => {
         expect(result.isOk()).toBe(true);
         if (result.isErr()) return;
         expect(result.value.created.map(({ name }) => name)).toStrictEqual([createdArtifact.name]);
-        expect(result.value.updated.map(({ name }) => name)).toStrictEqual([updatedArtifact.name]);
+        expect(result.value.updated.map(({ after: { name } }) => name)).toStrictEqual([updatedArtifact.name]);
         expect(result.value.unchanged.map(({ name }) => name)).toStrictEqual([artifact.name]);
         expect(result.value.deleted.map(({ config }) => config.name)).toStrictEqual([deletedArtifact.name]);
     });


### PR DESCRIPTION
This commit only manage function instances but doesn't upsert orchestrator schedules. It will come in next PR
Note: 'schedule' triggers are still gated in CLI and cannot be deployed yet.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/7512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

